### PR TITLE
Move len() and is_empty() methods to ReadTransaction

### DIFF
--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -72,4 +72,12 @@ impl<'mmap> ReadOnlyTransaction<'mmap> {
     pub fn get(&self, key: &[u8]) -> Result<Option<AccessGuard<'mmap>>, Error> {
         self.storage.get(key)
     }
+
+    pub fn len(&self) -> Result<usize, Error> {
+        self.storage.len()
+    }
+
+    pub fn is_empty(&self) -> Result<bool, Error> {
+        self.storage.len().map(|x| x == 0)
+    }
 }


### PR DESCRIPTION
These should only be queried in a transaction, so that they have the
proper isolation level