### PR TITLE
Implement std::error::Error for our custom Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use std::io;
 
 #[derive(Debug)]
@@ -12,3 +13,12 @@ impl From<io::Error> for Error {
         Error::Io(err)
     }
 }
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // TODO: better formatting
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for Error {}


### PR DESCRIPTION
Fixes #87 