### PR TITLE
Optimize leaf node structure

### DIFF
--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -78,7 +78,7 @@ impl<'a: 'b, 'b, T: Page + 'a> LeafAccessor<'a, 'b, T> {
         let mut max_entry = self.num_pairs();
         while min_entry < max_entry {
             let mid = (min_entry + max_entry) / 2;
-            let key = self.entry(mid).unwrap().key();
+            let key = self.key_unchecked(mid);
             match K::compare(query, key) {
                 Ordering::Less => {
                     max_entry = mid;
@@ -179,6 +179,10 @@ impl<'a: 'b, 'b, T: Page + 'a> LeafAccessor<'a, 'b, T> {
         let end_offset = self.key_end(end - 1).unwrap();
         let start_offset = self.key_start(start).unwrap();
         end_offset - start_offset
+    }
+
+    fn key_unchecked(&self, n: usize) -> &[u8] {
+        &self.page.memory()[self.key_start(n).unwrap()..self.key_end(n).unwrap()]
     }
 
     pub(in crate::tree_store) fn entry(&self, n: usize) -> Option<EntryAccessor<'b>> {

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -163,6 +163,10 @@ impl<'a: 'b, 'b, T: Page + 'a> LeafAccessor<'a, 'b, T> {
         self.value_start(n)
     }
 
+    pub(in crate::tree_store) fn value_range(&self, n: usize) -> Option<(usize, usize)> {
+        Some((self.value_start(n)?, self.value_end(n)?))
+    }
+
     // Returns the length of all keys and values between [start, end)
     pub(in crate::tree_store) fn length_of_pairs(&self, start: usize, end: usize) -> usize {
         self.length_of_values(start, end) + self.length_of_keys(start, end)

--- a/src/tree_store/btree_utils.rs
+++ b/src/tree_store/btree_utils.rs
@@ -1040,9 +1040,8 @@ pub(in crate) fn lookup_in_raw<'a, K: RedbKey + ?Sized>(
         LEAF => {
             let accessor = LeafAccessor::new(&page);
             let entry_index = accessor.find_key::<K>(query)?;
-            let offset = accessor.offset_of_value(entry_index).unwrap();
-            let value_len = accessor.entry(entry_index).unwrap().value().len();
-            Some((page, offset, value_len))
+            let (start, end) = accessor.value_range(entry_index).unwrap();
+            Some((page, start, end - start))
         }
         INTERNAL => {
             let accessor = InternalAccessor::new(&page);


### PR DESCRIPTION
Consolidating all the key data improve cache hit rate and increases
lookup performance by ~20%