### PR TITLE
Return OutOfSpace instead of panicking when initial size is too small

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -359,7 +359,6 @@ impl<'s, K: RedbKey + ?Sized, V: RedbKey + ?Sized> MultimapTable<'s, K, V> {
         Ok(found.is_some())
     }
 
-    // TODO: maybe this should return all the removed values as an iter?
     pub fn remove_all(&mut self, key: &K) -> Result<bool, Error> {
         // Match only on the key, so that we can remove all the associated values
         let key_only = make_serialized_key_with_op(key, MultimapKeyCompareOp::KeyOnly);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -39,6 +39,14 @@ fn mixed_durable_commit() {
 }
 
 #[test]
+fn small_db() {
+    let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
+
+    let result = unsafe { Database::create(tmpfile.path(), 1024) };
+    assert!(matches!(result, Err(Error::OutOfSpace)))
+}
+
+#[test]
 fn non_durable_commit_persistence() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
 


### PR DESCRIPTION
Fixes #159 