### PR TITLE
Include page size in db stats

### DIFF
--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1021,6 +1021,10 @@ impl TransactionalMemory {
 
         Ok(count)
     }
+
+    pub(crate) fn get_page_size(&self) -> usize {
+        self.page_size
+    }
 }
 
 impl Drop for TransactionalMemory {


### PR DESCRIPTION
It strikes me know that this might actually not belong on DbStats, since it doesn't change during the life of the database, so it might be better as a method on `Database`. What do you think?

Calling `DbStats::new` with a bunch of usizes that are easy to mix up seemed error-prone, so I changed initialization to use the constructor directly, which is harder to mess up.