### PR TITLE
Use pub(crate)

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -305,7 +305,7 @@ pub struct MultimapTable<'s, K: RedbKey + ?Sized, V: RedbKey + ?Sized> {
 }
 
 impl<'s, K: RedbKey + ?Sized, V: RedbKey + ?Sized> MultimapTable<'s, K, V> {
-    pub(in crate) fn new(
+    pub(crate) fn new(
         transaction_id: TransactionId,
         table_root: Rc<Cell<Option<PageNumber>>>,
         storage: &'s Storage,
@@ -320,7 +320,7 @@ impl<'s, K: RedbKey + ?Sized, V: RedbKey + ?Sized> MultimapTable<'s, K, V> {
     }
 
     #[allow(dead_code)]
-    pub(in crate) fn print_debug(&self) {
+    pub(crate) fn print_debug(&self) {
         if let Some(page) = self.table_root.get() {
             self.storage.print_dirty_tree_debug(page);
         }
@@ -477,7 +477,7 @@ pub struct ReadOnlyMultimapTable<'s, K: RedbKey + ?Sized, V: RedbKey + ?Sized> {
 }
 
 impl<'s, K: RedbKey + ?Sized, V: RedbKey + ?Sized> ReadOnlyMultimapTable<'s, K, V> {
-    pub(in crate) fn new(
+    pub(crate) fn new(
         root_page: Option<PageNumber>,
         storage: &'s Storage,
     ) -> ReadOnlyMultimapTable<'s, K, V> {

--- a/src/table.rs
+++ b/src/table.rs
@@ -17,7 +17,7 @@ pub struct Table<'s, K: RedbKey + ?Sized, V: RedbValue + ?Sized> {
 }
 
 impl<'s, K: RedbKey + ?Sized, V: RedbValue + ?Sized> Table<'s, K, V> {
-    pub(in crate) fn new(
+    pub(crate) fn new(
         transaction_id: TransactionId,
         table_root: Rc<Cell<Option<PageNumber>>>,
         storage: &'s Storage,
@@ -32,7 +32,7 @@ impl<'s, K: RedbKey + ?Sized, V: RedbValue + ?Sized> Table<'s, K, V> {
     }
 
     #[allow(dead_code)]
-    pub(in crate) fn print_debug(&self) {
+    pub(crate) fn print_debug(&self) {
         if let Some(page) = self.table_root.get() {
             self.storage.print_dirty_tree_debug(page);
         }
@@ -153,7 +153,7 @@ pub struct ReadOnlyTable<'s, K: RedbKey + ?Sized, V: RedbValue + ?Sized> {
 }
 
 impl<'s, K: RedbKey + ?Sized, V: RedbValue + ?Sized> ReadOnlyTable<'s, K, V> {
-    pub(in crate) fn new(
+    pub(crate) fn new(
         root_page: Option<PageNumber>,
         storage: &'s Storage,
     ) -> ReadOnlyTable<'s, K, V> {

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -235,7 +235,7 @@ impl<'a: 'b, 'b, T: Page + 'a> LeafAccessor<'a, 'b, T> {
         end_offset - start_offset
     }
 
-    pub(in crate) fn total_length(&self) -> usize {
+    pub(crate) fn total_length(&self) -> usize {
         // Values are stored last
         self.value_end(self.num_pairs() - 1).unwrap()
     }
@@ -384,7 +384,7 @@ impl<'a: 'b, 'b, T: Page + 'a> InternalAccessor<'a, 'b, T> {
         }
     }
 
-    pub(in crate) fn total_length(&self) -> usize {
+    pub(crate) fn total_length(&self) -> usize {
         // Keys are stored at the end
         self.key_end(self.num_keys() - 1)
     }

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -203,7 +203,7 @@ impl<'a> Iterator for AllPageNumbersBtreeIter<'a> {
     }
 }
 
-pub(in crate) fn page_numbers_iter_start_state(page: PageImpl) -> RangeIterState {
+pub(crate) fn page_numbers_iter_start_state(page: PageImpl) -> RangeIterState {
     let node_mem = page.memory();
     match node_mem[0] {
         LEAF => Leaf {
@@ -249,7 +249,7 @@ impl<
         V: RedbValue + ?Sized + 'a,
     > BtreeRangeIter<'a, T, KR, K, V>
 {
-    pub(in crate) fn new(
+    pub(crate) fn new(
         state: Option<RangeIterState<'a>>,
         query_range: T,
         manager: &'a TransactionalMemory,
@@ -266,7 +266,7 @@ impl<
         }
     }
 
-    pub(in crate) fn new_reversed(
+    pub(crate) fn new_reversed(
         state: Option<RangeIterState<'a>>,
         query_range: T,
         manager: &'a TransactionalMemory,
@@ -328,7 +328,7 @@ impl<
     }
 }
 
-pub(in crate) fn find_iter_unbounded_start<'a>(
+pub(crate) fn find_iter_unbounded_start<'a>(
     page: PageImpl<'a>,
     mut parent: Option<Box<RangeIterState<'a>>>,
     manager: &'a TransactionalMemory,
@@ -357,7 +357,7 @@ pub(in crate) fn find_iter_unbounded_start<'a>(
     }
 }
 
-pub(in crate) fn find_iter_unbounded_reversed<'a>(
+pub(crate) fn find_iter_unbounded_reversed<'a>(
     page: PageImpl<'a>,
     mut parent: Option<Box<RangeIterState<'a>>>,
     manager: &'a TransactionalMemory,
@@ -393,7 +393,7 @@ pub(in crate) fn find_iter_unbounded_reversed<'a>(
     }
 }
 
-pub(in crate) fn find_iter_start<'a, K: RedbKey + ?Sized>(
+pub(crate) fn find_iter_start<'a, K: RedbKey + ?Sized>(
     page: PageImpl<'a>,
     mut parent: Option<Box<RangeIterState<'a>>>,
     query: &[u8],
@@ -429,7 +429,7 @@ pub(in crate) fn find_iter_start<'a, K: RedbKey + ?Sized>(
     }
 }
 
-pub(in crate) fn find_iter_start_reversed<'a, K: RedbKey + ?Sized>(
+pub(crate) fn find_iter_start_reversed<'a, K: RedbKey + ?Sized>(
     page: PageImpl<'a>,
     mut parent: Option<Box<RangeIterState<'a>>>,
     query: &[u8],

--- a/src/tree_store/btree_utils.rs
+++ b/src/tree_store/btree_utils.rs
@@ -9,7 +9,7 @@ use crate::types::{RedbKey, RedbValue, WithLifetime};
 use crate::Error;
 use std::cmp::max;
 
-pub(in crate) fn tree_height<'a>(page: PageImpl<'a>, manager: &'a TransactionalMemory) -> usize {
+pub(crate) fn tree_height<'a>(page: PageImpl<'a>, manager: &'a TransactionalMemory) -> usize {
     let node_mem = page.memory();
     match node_mem[0] {
         LEAF => 1,
@@ -29,7 +29,7 @@ pub(in crate) fn tree_height<'a>(page: PageImpl<'a>, manager: &'a TransactionalM
     }
 }
 
-pub(in crate) fn stored_bytes<'a>(page: PageImpl<'a>, manager: &'a TransactionalMemory) -> usize {
+pub(crate) fn stored_bytes<'a>(page: PageImpl<'a>, manager: &'a TransactionalMemory) -> usize {
     let node_mem = page.memory();
     match node_mem[0] {
         LEAF => {
@@ -51,7 +51,7 @@ pub(in crate) fn stored_bytes<'a>(page: PageImpl<'a>, manager: &'a Transactional
     }
 }
 
-pub(in crate) fn overhead_bytes<'a>(page: PageImpl<'a>, manager: &'a TransactionalMemory) -> usize {
+pub(crate) fn overhead_bytes<'a>(page: PageImpl<'a>, manager: &'a TransactionalMemory) -> usize {
     let node_mem = page.memory();
     match node_mem[0] {
         LEAF => {
@@ -74,10 +74,7 @@ pub(in crate) fn overhead_bytes<'a>(page: PageImpl<'a>, manager: &'a Transaction
     }
 }
 
-pub(in crate) fn fragmented_bytes<'a>(
-    page: PageImpl<'a>,
-    manager: &'a TransactionalMemory,
-) -> usize {
+pub(crate) fn fragmented_bytes<'a>(page: PageImpl<'a>, manager: &'a TransactionalMemory) -> usize {
     let node_mem = page.memory();
     match node_mem[0] {
         LEAF => {
@@ -100,7 +97,7 @@ pub(in crate) fn fragmented_bytes<'a>(
     }
 }
 
-pub(in crate) fn print_node(page: &impl Page) {
+pub(crate) fn print_node(page: &impl Page) {
     let node_mem = page.memory();
     match node_mem[0] {
         LEAF => {
@@ -133,7 +130,7 @@ pub(in crate) fn print_node(page: &impl Page) {
     }
 }
 
-pub(in crate) fn node_children<'a>(
+pub(crate) fn node_children<'a>(
     page: &PageImpl<'a>,
     manager: &'a TransactionalMemory,
 ) -> Vec<PageImpl<'a>> {
@@ -156,7 +153,7 @@ pub(in crate) fn node_children<'a>(
     }
 }
 
-pub(in crate) fn print_tree<'a>(page: PageImpl<'a>, manager: &'a TransactionalMemory) {
+pub(crate) fn print_tree<'a>(page: PageImpl<'a>, manager: &'a TransactionalMemory) {
     let mut pages = vec![page];
     while !pages.is_empty() {
         let mut next_children = vec![];
@@ -174,7 +171,7 @@ pub(in crate) fn print_tree<'a>(page: PageImpl<'a>, manager: &'a TransactionalMe
 // Returns the new root, bool indicating if the key existed, and a list of freed pages
 // Safety: see tree_delete_helper()
 #[allow(clippy::type_complexity)]
-pub(in crate) unsafe fn tree_delete<'a, K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
+pub(crate) unsafe fn tree_delete<'a, K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
     page: PageImpl<'a>,
     key: &[u8],
     free_uncommitted: bool,
@@ -667,7 +664,7 @@ unsafe fn tree_delete_helper<'a, K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
     }
 }
 
-pub(in crate) fn make_mut_single_leaf<'a>(
+pub(crate) fn make_mut_single_leaf<'a>(
     key: &[u8],
     value: &[u8],
     manager: &'a TransactionalMemory,
@@ -686,7 +683,7 @@ pub(in crate) fn make_mut_single_leaf<'a>(
     Ok((page_num, guard))
 }
 
-pub(in crate) fn make_index(
+pub(crate) fn make_index(
     key: &[u8],
     lte_page: PageNumber,
     gt_page: PageNumber,
@@ -703,7 +700,7 @@ pub(in crate) fn make_index(
 // Returns the page number of the sub-tree into which the key was inserted,
 // and the guard which can be used to access the value, and a list of freed pages
 // Safety: see tree_insert_helper
-pub(in crate) unsafe fn tree_insert<'a, K: RedbKey + ?Sized>(
+pub(crate) unsafe fn tree_insert<'a, K: RedbKey + ?Sized>(
     page: PageImpl<'a>,
     key: &[u8],
     value: &[u8],
@@ -1089,7 +1086,7 @@ unsafe fn tree_insert_helper<'a, K: RedbKey + ?Sized>(
 }
 
 // Returns the (offset, len) of the value for the queried key, if present
-pub(in crate) fn find_key<'a, K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
+pub(crate) fn find_key<'a, K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
     page: PageImpl<'a>,
     query: &[u8],
     manager: &'a TransactionalMemory,

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -3,6 +3,6 @@ mod page_allocator;
 mod page_manager;
 mod utils;
 
-pub(in crate) use page_manager::{expand_db_size, get_db_size, PageNumber};
+pub(crate) use page_manager::{expand_db_size, get_db_size, PageNumber};
 
 pub(in crate::tree_store) use page_manager::{Page, PageImpl, PageMut, TransactionalMemory};

--- a/src/tree_store/storage.rs
+++ b/src/tree_store/storage.rs
@@ -161,7 +161,7 @@ impl<'a> Iterator for TableNameIter<'a> {
     }
 }
 
-pub(in crate) struct Storage {
+pub(crate) struct Storage {
     mem: TransactionalMemory,
     next_transaction_id: AtomicTransactionId,
     live_read_transactions: Mutex<BTreeSet<TransactionId>>,
@@ -171,7 +171,7 @@ pub(in crate) struct Storage {
 }
 
 impl Storage {
-    pub(in crate) fn new(mmap: MmapRaw, page_size: Option<usize>) -> Result<Storage, Error> {
+    pub(crate) fn new(mmap: MmapRaw, page_size: Option<usize>) -> Result<Storage, Error> {
         let mut mem = TransactionalMemory::new(mmap, page_size)?;
         while mem.needs_repair()? {
             let root = mem
@@ -257,7 +257,7 @@ impl Storage {
         self.live_read_transactions.lock().unwrap().remove(&id);
     }
 
-    pub(in crate) fn update_table_root(
+    pub(crate) fn update_table_root(
         &self,
         name: &str,
         table_type: TableType,
@@ -281,7 +281,7 @@ impl Storage {
     }
 
     // root_page: the root of the master table
-    pub(in crate) fn list_tables(
+    pub(crate) fn list_tables(
         &self,
         table_type: TableType,
         master_root_page: Option<PageNumber>,
@@ -294,7 +294,7 @@ impl Storage {
     }
 
     // root_page: the root of the master table
-    pub(in crate) fn get_table(
+    pub(crate) fn get_table(
         &self,
         name: &str,
         table_type: TableType,
@@ -316,7 +316,7 @@ impl Storage {
     }
 
     // root_page: the root of the master table
-    pub(in crate) fn delete_table(
+    pub(crate) fn delete_table(
         &self,
         name: &str,
         table_type: TableType,
@@ -346,7 +346,7 @@ impl Storage {
 
     // Returns a tuple of the table id and the new root page
     // root_page: the root of the master table
-    pub(in crate) fn get_or_create_table(
+    pub(crate) fn get_or_create_table(
         &self,
         name: &str,
         table_type: TableType,
@@ -376,7 +376,7 @@ impl Storage {
     // Returns the new root page number
     // Safety: caller must ensure that no references to uncommitted data in this transaction exist
     // TODO: this method could be made safe, if the transaction_id was not copy and was borrowed mut
-    pub(in crate) unsafe fn insert<K: RedbKey + ?Sized>(
+    pub(crate) unsafe fn insert<K: RedbKey + ?Sized>(
         &self,
         key: &[u8],
         value: &[u8],
@@ -404,7 +404,7 @@ impl Storage {
     // Returns the new root page number, and accessor for writing the value
     // Safety: caller must ensure that no references to uncommitted data in this transaction exist
     // TODO: this method could be made safe, if the transaction_id was not copy and was borrowed mut
-    pub(in crate) unsafe fn insert_reserve<K: RedbKey + ?Sized>(
+    pub(crate) unsafe fn insert_reserve<K: RedbKey + ?Sized>(
         &self,
         key: &[u8],
         value_len: usize,
@@ -430,7 +430,7 @@ impl Storage {
         Ok((new_root, guard))
     }
 
-    pub(in crate) fn len(&self, root_page: Option<PageNumber>) -> Result<usize, Error> {
+    pub(crate) fn len(&self, root_page: Option<PageNumber>) -> Result<usize, Error> {
         let mut iter: BtreeRangeIter<RangeFull, [u8], [u8], [u8]> =
             self.get_range(.., root_page)?;
         let mut count = 0;
@@ -440,11 +440,11 @@ impl Storage {
         Ok(count)
     }
 
-    pub(in crate) fn get_root_page_number(&self) -> Option<PageNumber> {
+    pub(crate) fn get_root_page_number(&self) -> Option<PageNumber> {
         self.mem.get_primary_root_page()
     }
 
-    pub(in crate) fn commit(
+    pub(crate) fn commit(
         &self,
         mut new_master_root: Option<PageNumber>,
         transaction_id: TransactionId,
@@ -487,7 +487,7 @@ impl Storage {
     }
 
     // Commit without a durability guarantee
-    pub(in crate) fn non_durable_commit(
+    pub(crate) fn non_durable_commit(
         &self,
         mut new_master_root: Option<PageNumber>,
         transaction_id: TransactionId,
@@ -640,7 +640,7 @@ impl Storage {
         Ok(master_root)
     }
 
-    pub(in crate) fn rollback_uncommited_writes(
+    pub(crate) fn rollback_uncommited_writes(
         &self,
         transaction_id: TransactionId,
     ) -> Result<(), Error> {
@@ -654,7 +654,7 @@ impl Storage {
         result
     }
 
-    pub(in crate) fn storage_stats(&self) -> Result<DbStats, Error> {
+    pub(crate) fn storage_stats(&self) -> Result<DbStats, Error> {
         let master_tree_height = self
             .get_root_page_number()
             .map(|p| tree_height(self.mem.get_page(p), &self.mem))
@@ -696,7 +696,7 @@ impl Storage {
     }
 
     #[allow(dead_code)]
-    pub(in crate) fn print_debug(&self) {
+    pub(crate) fn print_debug(&self) {
         if let Some(page) = self.get_root_page_number() {
             eprintln!("Master tree:");
             print_tree(self.mem.get_page(page), &self.mem);
@@ -715,11 +715,11 @@ impl Storage {
     }
 
     #[allow(dead_code)]
-    pub(in crate) fn print_dirty_tree_debug(&self, root_page: PageNumber) {
+    pub(crate) fn print_dirty_tree_debug(&self, root_page: PageNumber) {
         print_tree(self.mem.get_page(root_page), &self.mem);
     }
 
-    pub(in crate) fn get<K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
+    pub(crate) fn get<K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
         &self,
         key: &[u8],
         root_page_handle: Option<PageNumber>,
@@ -731,7 +731,7 @@ impl Storage {
         Ok(None)
     }
 
-    pub(in crate) fn get_range<
+    pub(crate) fn get_range<
         'a,
         T: RangeBounds<KR>,
         KR: Borrow<K> + ?Sized + 'a,
@@ -764,7 +764,7 @@ impl Storage {
         }
     }
 
-    pub(in crate) fn get_range_reversed<
+    pub(crate) fn get_range_reversed<
         'a,
         T: RangeBounds<KR>,
         KR: Borrow<K> + ?Sized + 'a,
@@ -801,7 +801,7 @@ impl Storage {
     // Safety: caller must ensure that no references to uncommitted data in this transaction exist,
     // if free_uncommitted = true
     // TODO: this method could be made safe, if the transaction_id was not copy and was borrowed mut
-    pub(in crate) unsafe fn remove<K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
+    pub(crate) unsafe fn remove<K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
         &self,
         key: &[u8],
         transaction_id: TransactionId,


### PR DESCRIPTION
I've never seen `pub(in crate)` before, so I could definitely be wrong about this, but I think it's equivalent to `pub(crate)`.

This was done with `sed -i 's/pub(in crate)/pub(crate)/g' **/*.rs`.