### PR TITLE
Rename transactions

### DIFF
--- a/benches/common.rs
+++ b/benches/common.rs
@@ -70,7 +70,7 @@ impl<'a> BenchDatabase for RedbBenchDatabase<'a> {
 }
 
 pub struct RedbBenchReadTransaction<'a> {
-    _txn: redb::ReadOnlyDatabaseTransaction<'a>,
+    _txn: redb::ReadTransaction<'a>,
     table: redb::ReadOnlyTable<'a, [u8], [u8]>,
 }
 
@@ -87,7 +87,7 @@ impl<'a, 'b> BenchReadTransaction<'b> for RedbBenchReadTransaction<'a> {
 }
 
 pub struct RedbBenchWriteTransaction<'a> {
-    txn: redb::DatabaseTransaction<'a>,
+    txn: redb::WriteTransaction<'a>,
 }
 
 impl<'a, 'b> BenchWriteTransaction<'b> for RedbBenchWriteTransaction<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 pub use db::{
-    Database, DatabaseBuilder, DatabaseTransaction, MultimapTableDefinition,
-    ReadOnlyDatabaseTransaction, TableDefinition,
+    Database, DatabaseBuilder, MultimapTableDefinition, ReadTransaction, TableDefinition,
+    WriteTransaction,
 };
 pub use error::Error;
 pub use multimap_table::{

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -132,7 +132,7 @@ fn change_db_size() {
 fn resize_db() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
 
-    let db_size = 128 * 1024;
+    let db_size = 256 * 1024;
     let db = unsafe { Database::create(tmpfile.path(), db_size).unwrap() };
     let mut i = 0u64;
     loop {


### PR DESCRIPTION
I wanted to propose this name change, and it was easy enough that I thought I would just open a PR. The `Database` in `DatabaseTransaction` feel redundant, since it's already part of `redb`. I think in normal speech people usually say "read transaction" and "write transaction", so those seemed like good names.