### PR TITLE
Pass table definitions by value

### DIFF
--- a/benches/common.rs
+++ b/benches/common.rs
@@ -64,7 +64,7 @@ impl<'a> BenchDatabase for RedbBenchDatabase<'a> {
 
     fn read_transaction(&self) -> Self::R {
         let txn = self.db.begin_read().unwrap();
-        let table = txn.open_table(&X).unwrap();
+        let table = txn.open_table(X).unwrap();
         RedbBenchReadTransaction { _txn: txn, table }
     }
 }

--- a/examples/int_keys.rs
+++ b/examples/int_keys.rs
@@ -5,12 +5,12 @@ const TABLE: TableDefinition<u64, u64> = TableDefinition::new("my_data");
 fn main() -> Result<(), Error> {
     let db = unsafe { Database::create("int_keys.redb", 1024 * 1024)? };
     let write_txn = db.begin_write()?;
-    let mut table = write_txn.open_table(&TABLE)?;
+    let mut table = write_txn.open_table(TABLE)?;
     table.insert(&0, &0)?;
     write_txn.commit()?;
 
     let read_txn = db.begin_read()?;
-    let table = read_txn.open_table(&TABLE)?;
+    let table = read_txn.open_table(TABLE)?;
     assert_eq!(table.get(&0)?.unwrap(), 0);
 
     Ok(())

--- a/src/db.rs
+++ b/src/db.rs
@@ -35,6 +35,14 @@ impl<'a, K: ?Sized, V: ?Sized> TableDefinition<'a, K, V> {
     }
 }
 
+impl<'a, K: ?Sized, V: ?Sized> Clone for TableDefinition<'a, K, V> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, K: ?Sized, V: ?Sized> Copy for TableDefinition<'a, K, V> {}
+
 pub struct MultimapTableDefinition<'a, K: ?Sized, V: ?Sized> {
     name: &'a str,
     _key_type: PhantomData<K>,
@@ -50,6 +58,14 @@ impl<'a, K: ?Sized, V: ?Sized> MultimapTableDefinition<'a, K, V> {
         }
     }
 }
+
+impl<'a, K: ?Sized, V: ?Sized> Clone for MultimapTableDefinition<'a, K, V> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, K: ?Sized, V: ?Sized> Copy for MultimapTableDefinition<'a, K, V> {}
 
 pub struct Database {
     storage: Storage,
@@ -208,7 +224,7 @@ impl<'a> DatabaseTransaction<'a> {
     /// The table will be created if it does not exist
     pub fn open_table<K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
         &self,
-        definition: &TableDefinition<K, V>,
+        definition: TableDefinition<K, V>,
     ) -> Result<Table<'a, K, V>, Error> {
         assert!(!definition.name.is_empty());
         assert_ne!(definition.name, FREED_TABLE);
@@ -245,7 +261,7 @@ impl<'a> DatabaseTransaction<'a> {
     /// The table will be created if it does not exist
     pub fn open_multimap_table<K: RedbKey + ?Sized, V: RedbKey + ?Sized>(
         &self,
-        definition: &MultimapTableDefinition<K, V>,
+        definition: MultimapTableDefinition<K, V>,
     ) -> Result<MultimapTable<'a, K, V>, Error> {
         assert!(!definition.name.is_empty());
         assert_ne!(definition.name, FREED_TABLE);
@@ -282,7 +298,7 @@ impl<'a> DatabaseTransaction<'a> {
     /// Returns a bool indicating whether the table existed
     pub fn delete_table<K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
         &self,
-        definition: &TableDefinition<K, V>,
+        definition: TableDefinition<K, V>,
     ) -> Result<bool, Error> {
         assert!(!definition.name.is_empty());
         assert_ne!(definition.name, FREED_TABLE);
@@ -304,7 +320,7 @@ impl<'a> DatabaseTransaction<'a> {
     /// Returns a bool indicating whether the table existed
     pub fn delete_multimap_table<K: RedbKey + ?Sized, V: RedbKey + ?Sized>(
         &self,
-        definition: &MultimapTableDefinition<K, V>,
+        definition: MultimapTableDefinition<K, V>,
     ) -> Result<bool, Error> {
         assert!(!definition.name.is_empty());
         let original_root = self.root_page.get();
@@ -418,7 +434,7 @@ impl<'a> ReadOnlyDatabaseTransaction<'a> {
     /// Open the given table
     pub fn open_table<K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
         &self,
-        definition: &TableDefinition<K, V>,
+        definition: TableDefinition<K, V>,
     ) -> Result<ReadOnlyTable<'a, K, V>, Error> {
         assert!(!definition.name.is_empty());
         assert_ne!(definition.name, FREED_TABLE);
@@ -433,7 +449,7 @@ impl<'a> ReadOnlyDatabaseTransaction<'a> {
     /// Open the given table
     pub fn open_multimap_table<K: RedbKey + ?Sized, V: RedbKey + ?Sized>(
         &self,
-        definition: &MultimapTableDefinition<K, V>,
+        definition: MultimapTableDefinition<K, V>,
     ) -> Result<ReadOnlyMultimapTable<'a, K, V>, Error> {
         assert!(!definition.name.is_empty());
         assert_ne!(definition.name, FREED_TABLE);
@@ -478,7 +494,7 @@ mod test {
         let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
         let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
         let write_txn = db.begin_write().unwrap();
-        let mut table = write_txn.open_table(&X).unwrap();
+        let mut table = write_txn.open_table(X).unwrap();
         table.insert(b"hello", b"world").unwrap();
         let first_txn_id = write_txn.transaction_id;
         write_txn.commit().unwrap();

--- a/src/table.rs
+++ b/src/table.rs
@@ -251,7 +251,7 @@ mod test {
         let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
         let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
         let write_txn = db.begin_write().unwrap();
-        let mut table = write_txn.open_table(&definition).unwrap();
+        let mut table = write_txn.open_table(definition).unwrap();
         for i in 0..10u8 {
             let key = vec![i];
             table.insert(&ReverseKey(key), b"value").unwrap();
@@ -259,7 +259,7 @@ mod test {
         write_txn.commit().unwrap();
 
         let read_txn = db.begin_read().unwrap();
-        let table = read_txn.open_table(&definition).unwrap();
+        let table = read_txn.open_table(definition).unwrap();
         let start = ReverseKey(vec![7u8]); // ReverseKey is used, so 7 < 3
         let end = ReverseKey(vec![3u8]);
         let mut iter = table.range(start..=end).unwrap();

--- a/src/tree_store/btree_utils.rs
+++ b/src/tree_store/btree_utils.rs
@@ -1139,7 +1139,7 @@ mod test {
 
         let db = unsafe { Database::create(tmpfile.path(), 16 * 1024 * 1024).unwrap() };
         let txn = db.begin_write().unwrap();
-        let mut table = txn.open_table(&X).unwrap();
+        let mut table = txn.open_table(X).unwrap();
 
         let elements = (BTREE_ORDER / 2).pow(2) as usize - num_internal_entries;
 
@@ -1160,7 +1160,7 @@ mod test {
         let reduce_to = BTREE_ORDER / 2 - num_internal_entries;
 
         let txn = db.begin_write().unwrap();
-        let mut table = txn.open_table(&X).unwrap();
+        let mut table = txn.open_table(X).unwrap();
         for i in 0..(elements - reduce_to) {
             table.remove(&i.to_be_bytes()).unwrap();
         }

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1115,7 +1115,7 @@ mod test {
         let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
         let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
         let write_txn = db.begin_write().unwrap();
-        let mut table = write_txn.open_table(&X).unwrap();
+        let mut table = write_txn.open_table(X).unwrap();
         table.insert(b"hello", b"world").unwrap();
         write_txn.commit().unwrap();
         drop(db);
@@ -1146,7 +1146,7 @@ mod test {
 
         let db2 = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
         let read_txn = db2.begin_read().unwrap();
-        let table = read_txn.open_table(&X).unwrap();
+        let table = read_txn.open_table(X).unwrap();
         assert_eq!(b"world", table.get(b"hello").unwrap().unwrap());
     }
 
@@ -1155,7 +1155,7 @@ mod test {
         let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
         let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
         let write_txn = db.begin_write().unwrap();
-        let mut table = write_txn.open_table(&X).unwrap();
+        let mut table = write_txn.open_table(X).unwrap();
         table.insert(b"hello", b"world").unwrap();
         write_txn.commit().unwrap();
         let free_pages = db.stats().unwrap().free_pages();
@@ -1186,7 +1186,7 @@ mod test {
         let db2 = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
         assert_eq!(free_pages, db2.stats().unwrap().free_pages());
         let write_txn = db2.begin_write().unwrap();
-        let mut table = write_txn.open_table(&X).unwrap();
+        let mut table = write_txn.open_table(X).unwrap();
         table.insert(b"hello2", b"world2").unwrap();
         write_txn.commit().unwrap();
     }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -10,14 +10,14 @@ fn len() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
     table.insert(b"hello2", b"world2").unwrap();
     table.insert(b"hi", b"world").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert_eq!(table.len().unwrap(), 3);
 }
 
@@ -26,7 +26,7 @@ fn stored_size() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
     write_txn.commit().unwrap();
 
@@ -40,7 +40,7 @@ fn create_open() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&U64_TABLE).unwrap();
+    let mut table = write_txn.open_table(U64_TABLE).unwrap();
     table.insert(&0, &1).unwrap();
     write_txn.commit().unwrap();
     drop(db);
@@ -48,7 +48,7 @@ fn create_open() {
     let db2 = unsafe { Database::open(tmpfile.path()).unwrap() };
 
     let read_txn = db2.begin_read().unwrap();
-    let table = read_txn.open_table(&U64_TABLE).unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
     assert_eq!(1, table.get(&0).unwrap().unwrap());
 }
 
@@ -60,16 +60,16 @@ fn multiple_tables() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&definition1).unwrap();
-    let mut table2 = write_txn.open_table(&definition2).unwrap();
+    let mut table = write_txn.open_table(definition1).unwrap();
+    let mut table2 = write_txn.open_table(definition2).unwrap();
 
     table.insert(b"hello", b"world").unwrap();
     table2.insert(b"hello", b"world2").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&definition1).unwrap();
-    let table2 = read_txn.open_table(&definition2).unwrap();
+    let table = read_txn.open_table(definition1).unwrap();
+    let table2 = read_txn.open_table(definition2).unwrap();
     assert_eq!(table.len().unwrap(), 1);
     assert_eq!(b"world", table.get(b"hello").unwrap().unwrap());
     assert_eq!(table2.len().unwrap(), 1);
@@ -87,10 +87,10 @@ fn list_tables() {
     let definition_my: MultimapTableDefinition<[u8], [u8]> = MultimapTableDefinition::new("my");
 
     let write_txn = db.begin_write().unwrap();
-    write_txn.open_table(&definition_x).unwrap();
-    write_txn.open_table(&definition_y).unwrap();
-    write_txn.open_multimap_table(&definition_mx).unwrap();
-    write_txn.open_multimap_table(&definition_my).unwrap();
+    write_txn.open_table(definition_x).unwrap();
+    write_txn.open_table(definition_y).unwrap();
+    write_txn.open_multimap_table(definition_mx).unwrap();
+    write_txn.open_multimap_table(definition_my).unwrap();
 
     let tables: Vec<String> = write_txn.list_tables().unwrap().collect();
     let multimap_tables: Vec<String> = write_txn.list_multimap_tables().unwrap().collect();
@@ -111,12 +111,12 @@ fn is_empty() {
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert!(!table.is_empty().unwrap());
 }
 
@@ -126,22 +126,22 @@ fn abort() {
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"aborted").unwrap();
     assert_eq!(b"aborted", table.get(b"hello").unwrap().unwrap());
     write_txn.abort().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE);
+    let table = read_txn.open_table(SLICE_TABLE);
     assert!(table.is_err());
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert_eq!(b"world", table.get(b"hello").unwrap().unwrap());
     assert_eq!(table.len().unwrap(), 1);
 }
@@ -151,21 +151,21 @@ fn insert_overwrite() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert_eq!(b"world", table.get(b"hello").unwrap().unwrap());
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"replaced").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert_eq!(b"replaced", table.get(b"hello").unwrap().unwrap());
 }
 
@@ -174,7 +174,7 @@ fn insert_reserve() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     let value = b"world";
     let mut reserved = table.insert_reserve(b"hello", value.len()).unwrap();
     reserved.as_mut().copy_from_slice(value);
@@ -182,7 +182,7 @@ fn insert_reserve() {
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert_eq!(value, table.get(b"hello").unwrap().unwrap());
 }
 
@@ -191,18 +191,18 @@ fn delete() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
     table.insert(b"hello2", b"world").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert_eq!(b"world", table.get(b"hello").unwrap().unwrap());
     assert_eq!(table.len().unwrap(), 2);
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     assert_eq!(
         b"world",
         table.remove(b"hello").unwrap().unwrap().to_value()
@@ -211,7 +211,7 @@ fn delete() {
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert!(table.get(b"hello").unwrap().is_none());
     assert_eq!(table.len().unwrap(), 1);
 }
@@ -221,16 +221,16 @@ fn no_dirty_reads() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE);
+    let table = read_txn.open_table(SLICE_TABLE);
     assert!(table.is_err());
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert_eq!(b"world", table.get(b"hello").unwrap().unwrap());
 }
 
@@ -239,23 +239,23 @@ fn read_isolation() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert_eq!(b"world", table.get(b"hello").unwrap().unwrap());
 
     let write_txn = db.begin_write().unwrap();
-    let mut write_table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut write_table = write_txn.open_table(SLICE_TABLE).unwrap();
     write_table.remove(b"hello").unwrap();
     write_table.insert(b"hello2", b"world2").unwrap();
     write_table.insert(b"hello3", b"world3").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn2 = db.begin_read().unwrap();
-    let table2 = read_txn2.open_table(&SLICE_TABLE).unwrap();
+    let table2 = read_txn2.open_table(SLICE_TABLE).unwrap();
     assert!(table2.get(b"hello").unwrap().is_none());
     assert_eq!(b"world2", table2.get(b"hello2").unwrap().unwrap());
     assert_eq!(b"world3", table2.get(b"hello3").unwrap().unwrap());
@@ -272,12 +272,12 @@ fn u64_type() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&U64_TABLE).unwrap();
+    let mut table = write_txn.open_table(U64_TABLE).unwrap();
     table.insert(&0, &1).unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&U64_TABLE).unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
     assert_eq!(1, table.get(&0).unwrap().unwrap());
 }
 
@@ -289,14 +289,14 @@ fn i128_type() {
 
     let definition: TableDefinition<i128, i128> = TableDefinition::new("x");
 
-    let mut table = write_txn.open_table(&definition).unwrap();
+    let mut table = write_txn.open_table(definition).unwrap();
     for i in -10..=10 {
         table.insert(&i, &(i - 1)).unwrap();
     }
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&definition).unwrap();
+    let table = read_txn.open_table(definition).unwrap();
     assert_eq!(-2, table.get(&-1).unwrap().unwrap());
     let mut iter: RangeIter<i128, i128> = table.range::<RangeFull, i128>(..).unwrap();
     for i in -11..10 {
@@ -313,12 +313,12 @@ fn f32_type() {
     let definition: TableDefinition<u8, f32> = TableDefinition::new("x");
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&definition).unwrap();
+    let mut table = write_txn.open_table(definition).unwrap();
     table.insert(&0, &0.3).unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&definition).unwrap();
+    let table = read_txn.open_table(definition).unwrap();
     assert_eq!(0.3, table.get(&0).unwrap().unwrap());
 }
 
@@ -330,12 +330,12 @@ fn str_type() {
     let definition: TableDefinition<str, str> = TableDefinition::new("x");
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&definition).unwrap();
+    let mut table = write_txn.open_table(definition).unwrap();
     table.insert("hello", "world").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&definition).unwrap();
+    let table = read_txn.open_table(definition).unwrap();
     let hello = "hello".to_string();
     assert_eq!("world", table.get(&hello).unwrap().unwrap());
 
@@ -360,14 +360,14 @@ fn owned_get_signatures() {
     let definition: TableDefinition<u32, u32> = TableDefinition::new("x");
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&definition).unwrap();
+    let mut table = write_txn.open_table(definition).unwrap();
     for i in 0..10 {
         table.insert(&i, &(i + 1)).unwrap();
     }
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&definition).unwrap();
+    let table = read_txn.open_table(definition).unwrap();
 
     assert_eq!(2, table.get(&1).unwrap().unwrap());
 
@@ -394,14 +394,14 @@ fn ref_get_signatures() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     for i in 0..10 {
         table.insert(&[i], &[i + 1]).unwrap();
     }
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
 
     let zero = vec![0u8];
     assert_eq!(&[1], table.get(&[0]).unwrap().unwrap());

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -132,7 +132,7 @@ fn change_db_size() {
 fn resize_db() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
 
-    let db_size = 128 * 1024;
+    let db_size = 256 * 1024;
     let db = unsafe { Database::create(tmpfile.path(), db_size).unwrap() };
     let mut i = 0u64;
     loop {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -34,7 +34,7 @@ fn mixed_durable_commit() {
     let db_size = 129 * 4096;
     let db = unsafe { Database::create(tmpfile.path(), db_size).unwrap() };
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&U64_TABLE).unwrap();
+    let mut table = txn.open_table(U64_TABLE).unwrap();
 
     table.insert(&0, &0).unwrap();
     txn.non_durable_commit().unwrap();
@@ -50,7 +50,7 @@ fn non_durable_commit_persistence() {
     let db_size = 16 * 1024 * 1024;
     let db = unsafe { Database::create(tmpfile.path(), db_size).unwrap() };
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = txn.open_table(SLICE_TABLE).unwrap();
 
     let pairs = gen_data(100, 16, 20);
 
@@ -66,7 +66,7 @@ fn non_durable_commit_persistence() {
     drop(db);
     let db = unsafe { Database::create(tmpfile.path(), db_size).unwrap() };
     let txn = db.begin_read().unwrap();
-    let table = txn.open_table(&SLICE_TABLE).unwrap();
+    let table = txn.open_table(SLICE_TABLE).unwrap();
 
     let mut key_order: Vec<usize> = (0..ELEMENTS).collect();
     key_order.shuffle(&mut rand::thread_rng());
@@ -87,7 +87,7 @@ fn persistence() {
     let db_size = 16 * 1024 * 1024;
     let db = unsafe { Database::create(tmpfile.path(), db_size).unwrap() };
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = txn.open_table(SLICE_TABLE).unwrap();
 
     let pairs = gen_data(100, 16, 20);
 
@@ -102,7 +102,7 @@ fn persistence() {
     drop(db);
     let db = unsafe { Database::create(tmpfile.path(), db_size).unwrap() };
     let txn = db.begin_read().unwrap();
-    let table = txn.open_table(&SLICE_TABLE).unwrap();
+    let table = txn.open_table(SLICE_TABLE).unwrap();
 
     let mut key_order: Vec<usize> = (0..ELEMENTS).collect();
     key_order.shuffle(&mut rand::thread_rng());
@@ -137,7 +137,7 @@ fn resize_db() {
     let mut i = 0u64;
     loop {
         let txn = db.begin_write().unwrap();
-        let mut table = txn.open_table(&U64_TABLE).unwrap();
+        let mut table = txn.open_table(U64_TABLE).unwrap();
         // Fill the database
         match table.insert(&i, &i) {
             Ok(_) => {}
@@ -160,7 +160,7 @@ fn resize_db() {
     }
 
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&U64_TABLE).unwrap();
+    let mut table = txn.open_table(U64_TABLE).unwrap();
     let mut found = false;
     let mut j = i;
     for _ in 0..999 {
@@ -180,7 +180,7 @@ fn resize_db() {
 
     let db = unsafe { Database::open(tmpfile.path()).unwrap() };
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&U64_TABLE).unwrap();
+    let mut table = txn.open_table(U64_TABLE).unwrap();
     for k in i..(j + 2) {
         table.insert(&k, &k).unwrap();
     }
@@ -198,7 +198,7 @@ fn regression4() {
     let mut i = 0u64;
     loop {
         let txn = db.begin_write().unwrap();
-        let mut table = txn.open_table(&U64_TABLE).unwrap();
+        let mut table = txn.open_table(U64_TABLE).unwrap();
         // Fill the database
         match table.insert(&i, &i) {
             Ok(_) => {}
@@ -221,7 +221,7 @@ fn regression4() {
     }
 
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&U64_TABLE).unwrap();
+    let mut table = txn.open_table(U64_TABLE).unwrap();
     let mut found = false;
     let mut j = i;
     for _ in 0..999 {
@@ -241,7 +241,7 @@ fn regression4() {
 
     let db = unsafe { Database::open(tmpfile.path()).unwrap() };
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&U64_TABLE).unwrap();
+    let mut table = txn.open_table(U64_TABLE).unwrap();
     for k in i..(j + 2) {
         table.insert(&k, &k).unwrap();
     }
@@ -255,14 +255,14 @@ fn free() {
     let db_size = 8 * 1024 * 1024;
     let db = unsafe { Database::create(tmpfile.path(), db_size).unwrap() };
     let txn = db.begin_write().unwrap();
-    let _table = txn.open_table(&SLICE_TABLE).unwrap();
-    let _table = txn.open_table(&SLICE_TABLE2).unwrap();
+    let _table = txn.open_table(SLICE_TABLE).unwrap();
+    let _table = txn.open_table(SLICE_TABLE2).unwrap();
 
     txn.commit().unwrap();
     let free_pages = db.stats().unwrap().free_pages();
 
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = txn.open_table(SLICE_TABLE).unwrap();
 
     let key = vec![0; 100];
     let value = vec![0; 1024];
@@ -285,7 +285,7 @@ fn free() {
         // Delete in chunks to be sure that we don't run out of pages due to temp allocations
         for chunk in key_range.chunks(10) {
             let txn = db.begin_write().unwrap();
-            let mut table = txn.open_table(&SLICE_TABLE).unwrap();
+            let mut table = txn.open_table(SLICE_TABLE).unwrap();
             for i in chunk {
                 let mut mut_key = key.clone();
                 mut_key.extend_from_slice(&(*i as u64).to_be_bytes());
@@ -305,7 +305,7 @@ fn large_keys() {
     let db_size = 1024_1024;
     let db = unsafe { Database::create(tmpfile.path(), db_size).unwrap() };
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = txn.open_table(SLICE_TABLE).unwrap();
 
     let mut key = vec![0; 1024];
     let value = vec![0; 1];
@@ -318,7 +318,7 @@ fn large_keys() {
     txn.commit().unwrap();
 
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = txn.open_table(SLICE_TABLE).unwrap();
     {
         for i in 0..100 {
             key[0] = i;
@@ -342,7 +342,7 @@ fn multi_page_kv() {
             .unwrap()
     };
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = txn.open_table(SLICE_TABLE).unwrap();
 
     let mut key = vec![0; page_size + 1];
     let mut value = vec![0; page_size + 1];
@@ -356,7 +356,7 @@ fn multi_page_kv() {
     txn.commit().unwrap();
 
     let txn = db.begin_read().unwrap();
-    let table = txn.open_table(&SLICE_TABLE).unwrap();
+    let table = txn.open_table(SLICE_TABLE).unwrap();
     for i in 0..elements {
         key[0] = i;
         value[0] = i;
@@ -364,7 +364,7 @@ fn multi_page_kv() {
     }
 
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = txn.open_table(SLICE_TABLE).unwrap();
     {
         for i in 0..elements {
             key[0] = i;
@@ -382,43 +382,43 @@ fn regression() {
     let db_size = 1024 * 1024;
     let db = unsafe { Database::create(tmpfile.path(), db_size).unwrap() };
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&U64_TABLE).unwrap();
+    let mut table = txn.open_table(U64_TABLE).unwrap();
 
     table.insert(&1, &1).unwrap();
     txn.commit().unwrap();
 
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&U64_TABLE).unwrap();
+    let mut table = txn.open_table(U64_TABLE).unwrap();
     table.insert(&6, &9).unwrap();
     txn.commit().unwrap();
 
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&U64_TABLE).unwrap();
+    let mut table = txn.open_table(U64_TABLE).unwrap();
     table.insert(&12, &10).unwrap();
     txn.commit().unwrap();
 
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&U64_TABLE).unwrap();
+    let mut table = txn.open_table(U64_TABLE).unwrap();
     table.insert(&18, &27).unwrap();
     txn.commit().unwrap();
 
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&U64_TABLE).unwrap();
+    let mut table = txn.open_table(U64_TABLE).unwrap();
     table.insert(&24, &33).unwrap();
     txn.commit().unwrap();
 
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&U64_TABLE).unwrap();
+    let mut table = txn.open_table(U64_TABLE).unwrap();
     table.insert(&30, &14).unwrap();
     txn.commit().unwrap();
 
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&U64_TABLE).unwrap();
+    let mut table = txn.open_table(U64_TABLE).unwrap();
     table.remove(&30).unwrap();
     txn.commit().unwrap();
 
     let txn = db.begin_read().unwrap();
-    let table = txn.open_table(&U64_TABLE).unwrap();
+    let table = txn.open_table(U64_TABLE).unwrap();
     let v = table.get(&6).unwrap().unwrap();
     assert_eq!(v, 9);
 }
@@ -436,9 +436,9 @@ fn regression2() {
     let b_def: TableDefinition<[u8], [u8]> = TableDefinition::new("b");
     let c_def: TableDefinition<[u8], [u8]> = TableDefinition::new("c");
 
-    let _c = tx.open_table(&c_def).unwrap();
-    let b = tx.open_table(&b_def).unwrap();
-    let mut a = tx.open_table(&a_def).unwrap();
+    let _c = tx.open_table(c_def).unwrap();
+    let b = tx.open_table(b_def).unwrap();
+    let mut a = tx.open_table(a_def).unwrap();
     a.insert(b"hi", b"1").unwrap();
     assert!(b.get(b"hi").unwrap().is_none());
 }
@@ -452,7 +452,7 @@ fn regression3() {
     let db_size = 1024 * 1024;
     let db = unsafe { Database::create(tmpfile.path(), db_size).unwrap() };
     let tx = db.begin_write().unwrap();
-    let mut t = tx.open_table(&SLICE_TABLE).unwrap();
+    let mut t = tx.open_table(SLICE_TABLE).unwrap();
     let big_value = vec![0u8; 1000];
     for i in 0..20 {
         t.insert(&[i], &big_value).unwrap();
@@ -471,24 +471,24 @@ fn non_durable_read_isolation() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
 
     table.insert(b"hello", b"world").unwrap();
     write_txn.non_durable_commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let read_table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let read_table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert_eq!(b"world", read_table.get(b"hello").unwrap().unwrap());
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.remove(b"hello").unwrap();
     table.insert(b"hello2", b"world2").unwrap();
     table.insert(b"hello3", b"world3").unwrap();
     write_txn.non_durable_commit().unwrap();
 
     let read_txn2 = db.begin_read().unwrap();
-    let read_table2 = read_txn2.open_table(&SLICE_TABLE).unwrap();
+    let read_table2 = read_txn2.open_table(SLICE_TABLE).unwrap();
     assert!(read_table2.get(b"hello").unwrap().is_none());
     assert_eq!(b"world2", read_table2.get(b"hello2").unwrap().unwrap());
     assert_eq!(b"world3", read_table2.get(b"hello3").unwrap().unwrap());
@@ -505,14 +505,14 @@ fn range_query() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&U64_TABLE).unwrap();
+    let mut table = write_txn.open_table(U64_TABLE).unwrap();
     for i in 0..10 {
         table.insert(&i, &i).unwrap();
     }
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&U64_TABLE).unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
     let mut iter = table.range(3..7).unwrap();
     for i in 3..7u64 {
         let (key, value) = iter.next().unwrap();
@@ -535,14 +535,14 @@ fn range_query_reversed() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&U64_TABLE).unwrap();
+    let mut table = write_txn.open_table(U64_TABLE).unwrap();
     for i in 0..10 {
         table.insert(&i, &i).unwrap();
     }
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&U64_TABLE).unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
     let mut iter = table.range(3..7).unwrap().rev();
     for i in (3..7u64).rev() {
         let (key, value) = iter.next().unwrap();
@@ -575,8 +575,8 @@ fn alias_table() {
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
 
     let write_txn = db.begin_write().unwrap();
-    let table = write_txn.open_table(&SLICE_TABLE).unwrap();
-    let result = write_txn.open_table(&SLICE_TABLE);
+    let table = write_txn.open_table(SLICE_TABLE).unwrap();
+    let result = write_txn.open_table(SLICE_TABLE);
     assert!(matches!(
         result.err().unwrap(),
         Error::TableAlreadyOpen(_, _)
@@ -592,23 +592,23 @@ fn delete_table() {
     let y_def: MultimapTableDefinition<[u8], [u8]> = MultimapTableDefinition::new("y");
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
-    let mut multitable = write_txn.open_multimap_table(&y_def).unwrap();
+    let mut multitable = write_txn.open_multimap_table(y_def).unwrap();
     multitable.insert(b"hello2", b"world2").unwrap();
     write_txn.commit().unwrap();
 
     let write_txn = db.begin_write().unwrap();
-    assert!(write_txn.delete_table(&SLICE_TABLE).unwrap());
-    assert!(!write_txn.delete_table(&SLICE_TABLE).unwrap());
-    assert!(write_txn.delete_multimap_table(&y_def).unwrap());
-    assert!(!write_txn.delete_multimap_table(&y_def).unwrap());
+    assert!(write_txn.delete_table(SLICE_TABLE).unwrap());
+    assert!(!write_txn.delete_table(SLICE_TABLE).unwrap());
+    assert!(write_txn.delete_multimap_table(y_def).unwrap());
+    assert!(!write_txn.delete_multimap_table(y_def).unwrap());
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let result = read_txn.open_table(&SLICE_TABLE);
+    let result = read_txn.open_table(SLICE_TABLE);
     assert!(result.is_err());
-    let result = read_txn.open_multimap_table(&y_def);
+    let result = read_txn.open_multimap_table(y_def);
     assert!(result.is_err());
 }
 
@@ -634,7 +634,7 @@ fn non_page_size_multiple() {
     let db_size = 1024 * 1024 + 1;
     let db = unsafe { Database::create(tmpfile.path(), db_size).unwrap() };
     let txn = db.begin_write().unwrap();
-    let mut table = txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = txn.open_table(SLICE_TABLE).unwrap();
 
     let key = vec![0; 1024];
     let value = vec![0; 1];
@@ -642,7 +642,7 @@ fn non_page_size_multiple() {
     txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert_eq!(table.len().unwrap(), 1);
 }
 
@@ -676,20 +676,20 @@ fn wrong_types() {
     let wrong_definition: TableDefinition<u64, u64> = TableDefinition::new("x");
 
     let txn = db.begin_write().unwrap();
-    txn.open_table(&definition).unwrap();
+    txn.open_table(definition).unwrap();
     txn.commit().unwrap();
 
     let txn = db.begin_write().unwrap();
     assert!(matches!(
-        txn.open_table(&wrong_definition),
+        txn.open_table(wrong_definition),
         Err(Error::TableTypeMismatch(_))
     ));
     txn.abort().unwrap();
 
     let txn = db.begin_read().unwrap();
-    txn.open_table(&definition).unwrap();
+    txn.open_table(definition).unwrap();
     assert!(matches!(
-        txn.open_table(&wrong_definition),
+        txn.open_table(wrong_definition),
         Err(Error::TableTypeMismatch(_))
     ));
 }

--- a/tests/multimap_tests.rs
+++ b/tests/multimap_tests.rs
@@ -22,7 +22,7 @@ fn len() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_multimap_table(SLICE_TABLE).unwrap();
 
     table.insert(b"hello", b"world").unwrap();
     table.insert(b"hello", b"world2").unwrap();
@@ -30,7 +30,7 @@ fn len() {
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_multimap_table(SLICE_TABLE).unwrap();
     assert_eq!(table.len().unwrap(), 3);
 }
 
@@ -40,12 +40,12 @@ fn is_empty() {
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_multimap_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_multimap_table(SLICE_TABLE).unwrap();
     assert!(!table.is_empty().unwrap());
 }
 
@@ -54,13 +54,13 @@ fn insert() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_multimap_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
     table.insert(b"hello", b"world2").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_multimap_table(SLICE_TABLE).unwrap();
     assert_eq!(
         vec![b"world".to_vec(), b"world2".to_vec()],
         get_vec(&table, b"hello")
@@ -73,7 +73,7 @@ fn range_query() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_multimap_table(SLICE_TABLE).unwrap();
     for i in 0..5u8 {
         let value = vec![i];
         table.insert(b"0", &value).unwrap();
@@ -89,7 +89,7 @@ fn range_query() {
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_multimap_table(SLICE_TABLE).unwrap();
     let start = b"0".as_ref();
     let end = b"1".as_ref();
     let mut iter = table.range(start..=end).unwrap();
@@ -110,14 +110,14 @@ fn delete() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_multimap_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
     table.insert(b"hello", b"world2").unwrap();
     table.insert(b"hello", b"world3").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_multimap_table(SLICE_TABLE).unwrap();
     assert_eq!(
         vec![b"world".to_vec(), b"world2".to_vec(), b"world3".to_vec()],
         get_vec(&table, b"hello")
@@ -125,12 +125,12 @@ fn delete() {
     assert_eq!(table.len().unwrap(), 3);
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_multimap_table(SLICE_TABLE).unwrap();
     table.remove(b"hello", b"world2").unwrap();
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_multimap_table(SLICE_TABLE).unwrap();
     assert_eq!(
         vec![b"world".to_vec(), b"world3".to_vec()],
         get_vec(&table, b"hello")
@@ -138,7 +138,7 @@ fn delete() {
     assert_eq!(table.len().unwrap(), 2);
 
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_multimap_table(SLICE_TABLE).unwrap();
     let mut iter = table.remove_all(b"hello").unwrap();
     assert_eq!(b"world", iter.next().unwrap());
     assert_eq!(b"world3", iter.next().unwrap());
@@ -146,7 +146,7 @@ fn delete() {
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_multimap_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_multimap_table(SLICE_TABLE).unwrap();
     assert!(table.is_empty().unwrap());
     let empty: Vec<Vec<u8>> = vec![];
     assert_eq!(empty, get_vec(&table, b"hello"));
@@ -161,20 +161,20 @@ fn wrong_types() {
     let wrong_definition: MultimapTableDefinition<u64, u64> = MultimapTableDefinition::new("x");
 
     let txn = db.begin_write().unwrap();
-    txn.open_multimap_table(&definition).unwrap();
+    txn.open_multimap_table(definition).unwrap();
     txn.commit().unwrap();
 
     let txn = db.begin_write().unwrap();
     assert!(matches!(
-        txn.open_multimap_table(&wrong_definition),
+        txn.open_multimap_table(wrong_definition),
         Err(Error::TableTypeMismatch(_))
     ));
     txn.abort().unwrap();
 
     let txn = db.begin_read().unwrap();
-    txn.open_multimap_table(&definition).unwrap();
+    txn.open_multimap_table(definition).unwrap();
     assert!(matches!(
-        txn.open_multimap_table(&wrong_definition),
+        txn.open_multimap_table(wrong_definition),
         Err(Error::TableTypeMismatch(_))
     ));
 }

--- a/tests/multithreading_tests.rs
+++ b/tests/multithreading_tests.rs
@@ -11,7 +11,7 @@ fn len() {
     let db = unsafe { Database::create(tmpfile.path(), 1024 * 1024).unwrap() };
     let db = Arc::new(db);
     let write_txn = db.begin_write().unwrap();
-    let mut table = write_txn.open_table(&SLICE_TABLE).unwrap();
+    let mut table = write_txn.open_table(SLICE_TABLE).unwrap();
     table.insert(b"hello", b"world").unwrap();
     table.insert(b"hello2", b"world2").unwrap();
     table.insert(b"hi", b"world").unwrap();
@@ -20,12 +20,12 @@ fn len() {
     let db2 = db.clone();
     let t = thread::spawn(move || {
         let read_txn = db2.begin_read().unwrap();
-        let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+        let table = read_txn.open_table(SLICE_TABLE).unwrap();
         assert_eq!(table.len().unwrap(), 3);
     });
     t.join().unwrap();
 
     let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(&SLICE_TABLE).unwrap();
+    let table = read_txn.open_table(SLICE_TABLE).unwrap();
     assert_eq!(table.len().unwrap(), 3);
 }


### PR DESCRIPTION
This PR changes functions that take table definitions to take them by value, so you don't have to add a `&`, and implements `Copy` and `Clone` for table definitions. We have to implement copy and clone ourselves, because the derive macro can't figure out that it can copy and clone the value even when the type arguments aren't copy and clone, because we only use pass them to phantom values.