### PR TITLE
Use result alias

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -5,6 +5,7 @@ use crate::tree_store::{
     FREED_TABLE,
 };
 use crate::types::{RedbKey, RedbValue};
+use crate::Result;
 use crate::{Error, ReadOnlyMultimapTable};
 use memmap2::MmapRaw;
 use std::cell::{Cell, RefCell};
@@ -82,7 +83,7 @@ impl Database {
     /// # Safety
     ///
     /// The file referenced by `path` must not be concurrently modified by any other process
-    pub unsafe fn create(path: impl AsRef<Path>, db_size: usize) -> Result<Database, Error> {
+    pub unsafe fn create(path: impl AsRef<Path>, db_size: usize) -> Result<Database> {
         let file = if path.as_ref().exists() && File::open(path.as_ref())?.metadata()?.len() > 0 {
             let existing_size = get_db_size(path.as_ref())?;
             if existing_size != db_size {
@@ -114,7 +115,7 @@ impl Database {
     /// # Safety
     ///
     /// The file referenced by `path` must not be concurrently modified by any other process
-    pub unsafe fn open(path: impl AsRef<Path>) -> Result<Database, Error> {
+    pub unsafe fn open(path: impl AsRef<Path>) -> Result<Database> {
         if File::open(path.as_ref())?.metadata()?.len() > 0 {
             let file = OpenOptions::new().read(true).write(true).open(path)?;
             let mmap = MmapRaw::map_raw(&file)?;
@@ -128,7 +129,7 @@ impl Database {
     /// # Safety
     ///
     /// The file referenced by `path` must not be concurrently modified by any other process
-    pub unsafe fn resize(path: impl AsRef<Path>, new_size: usize) -> Result<(), Error> {
+    pub unsafe fn resize(path: impl AsRef<Path>, new_size: usize) -> Result {
         expand_db_size(path.as_ref(), new_size)?;
         // Open the database to rebuild the allocator state
         Self::create(path, new_size)?;
@@ -136,15 +137,15 @@ impl Database {
         Ok(())
     }
 
-    pub fn begin_write(&self) -> Result<WriteTransaction, Error> {
+    pub fn begin_write(&self) -> Result<WriteTransaction> {
         WriteTransaction::new(&self.storage)
     }
 
-    pub fn begin_read(&self) -> Result<ReadTransaction, Error> {
+    pub fn begin_read(&self) -> Result<ReadTransaction> {
         Ok(ReadTransaction::new(&self.storage))
     }
 
-    pub fn stats(&self) -> Result<DatabaseStats, Error> {
+    pub fn stats(&self) -> Result<DatabaseStats> {
         self.storage.storage_stats()
     }
 
@@ -180,7 +181,7 @@ impl DatabaseBuilder {
     ///
     /// The file referenced by `path` must only be concurrently modified by compatible versions
     /// of redb
-    pub unsafe fn create(&self, path: impl AsRef<Path>, db_size: usize) -> Result<Database, Error> {
+    pub unsafe fn create(&self, path: impl AsRef<Path>, db_size: usize) -> Result<Database> {
         let file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -206,7 +207,7 @@ pub struct WriteTransaction<'a> {
 }
 
 impl<'a> WriteTransaction<'a> {
-    fn new(storage: &'a Storage) -> Result<Self, Error> {
+    fn new(storage: &'a Storage) -> Result<Self> {
         let transaction_id = storage.allocate_write_transaction()?;
         let root_page = storage.get_root_page_number();
         Ok(Self {
@@ -225,7 +226,7 @@ impl<'a> WriteTransaction<'a> {
     pub fn open_table<K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
         &self,
         definition: TableDefinition<K, V>,
-    ) -> Result<Table<'a, K, V>, Error> {
+    ) -> Result<Table<'a, K, V>> {
         assert!(!definition.name.is_empty());
         assert_ne!(definition.name, FREED_TABLE);
         if let Some(location) = self.open_tables.borrow().get(definition.name) {
@@ -262,7 +263,7 @@ impl<'a> WriteTransaction<'a> {
     pub fn open_multimap_table<K: RedbKey + ?Sized, V: RedbKey + ?Sized>(
         &self,
         definition: MultimapTableDefinition<K, V>,
-    ) -> Result<MultimapTable<'a, K, V>, Error> {
+    ) -> Result<MultimapTable<'a, K, V>> {
         assert!(!definition.name.is_empty());
         assert_ne!(definition.name, FREED_TABLE);
         if let Some(location) = self.open_tables.borrow().get(definition.name) {
@@ -299,7 +300,7 @@ impl<'a> WriteTransaction<'a> {
     pub fn delete_table<K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
         &self,
         definition: TableDefinition<K, V>,
-    ) -> Result<bool, Error> {
+    ) -> Result<bool> {
         assert!(!definition.name.is_empty());
         assert_ne!(definition.name, FREED_TABLE);
         let original_root = self.root_page.get();
@@ -321,7 +322,7 @@ impl<'a> WriteTransaction<'a> {
     pub fn delete_multimap_table<K: RedbKey + ?Sized, V: RedbKey + ?Sized>(
         &self,
         definition: MultimapTableDefinition<K, V>,
-    ) -> Result<bool, Error> {
+    ) -> Result<bool> {
         assert!(!definition.name.is_empty());
         let original_root = self.root_page.get();
         let (root, found) = self.storage.delete_table::<K, V>(
@@ -338,29 +339,29 @@ impl<'a> WriteTransaction<'a> {
 
     /// List all the tables
     // TODO: should return an iterator of &str, once GATs are available
-    pub fn list_tables(&self) -> Result<impl Iterator<Item = String> + '_, Error> {
+    pub fn list_tables(&self) -> Result<impl Iterator<Item = String> + '_> {
         self.storage
             .list_tables(TableType::Normal, self.root_page.get())
     }
 
     /// List all the multimap tables
     // TODO: should return an iterator of &str, once GATs are available
-    pub fn list_multimap_tables(&self) -> Result<impl Iterator<Item = String> + '_, Error> {
+    pub fn list_multimap_tables(&self) -> Result<impl Iterator<Item = String> + '_> {
         self.storage
             .list_tables(TableType::Multimap, self.root_page.get())
     }
 
-    pub fn commit(self) -> Result<(), Error> {
+    pub fn commit(self) -> Result {
         self.commit_helper(false)
     }
 
     /// Note: pages are only freed during commit(). So exclusively using this function may result
     /// in Error::OutOfSpace
-    pub fn non_durable_commit(self) -> Result<(), Error> {
+    pub fn non_durable_commit(self) -> Result {
         self.commit_helper(true)
     }
 
-    fn commit_helper(self, non_durable: bool) -> Result<(), Error> {
+    fn commit_helper(self, non_durable: bool) -> Result {
         match self.commit_helper_inner(non_durable) {
             Ok(_) => Ok(()),
             Err(err) => match err {
@@ -375,7 +376,7 @@ impl<'a> WriteTransaction<'a> {
         }
     }
 
-    fn commit_helper_inner(&self, non_durable: bool) -> Result<(), Error> {
+    fn commit_helper_inner(&self, non_durable: bool) -> Result {
         // Update all the table roots in the master table, before committing
         for (name, update) in self.pending_table_root_changes.borrow_mut().drain() {
             let new_root = self.storage.update_table_root(
@@ -397,7 +398,7 @@ impl<'a> WriteTransaction<'a> {
         Ok(())
     }
 
-    pub fn abort(self) -> Result<(), Error> {
+    pub fn abort(self) -> Result {
         self.storage
             .rollback_uncommited_writes(self.transaction_id)?;
         self.completed.store(true, Ordering::SeqCst);
@@ -435,7 +436,7 @@ impl<'a> ReadTransaction<'a> {
     pub fn open_table<K: RedbKey + ?Sized, V: RedbValue + ?Sized>(
         &self,
         definition: TableDefinition<K, V>,
-    ) -> Result<ReadOnlyTable<'a, K, V>, Error> {
+    ) -> Result<ReadOnlyTable<'a, K, V>> {
         assert!(!definition.name.is_empty());
         assert_ne!(definition.name, FREED_TABLE);
         let header = self
@@ -450,7 +451,7 @@ impl<'a> ReadTransaction<'a> {
     pub fn open_multimap_table<K: RedbKey + ?Sized, V: RedbKey + ?Sized>(
         &self,
         definition: MultimapTableDefinition<K, V>,
-    ) -> Result<ReadOnlyMultimapTable<'a, K, V>, Error> {
+    ) -> Result<ReadOnlyMultimapTable<'a, K, V>> {
         assert!(!definition.name.is_empty());
         assert_ne!(definition.name, FREED_TABLE);
         let header = self
@@ -463,13 +464,13 @@ impl<'a> ReadTransaction<'a> {
 
     /// List all the tables
     // TODO: should return an iterator of &str, once GATs are available
-    pub fn list_tables(&self) -> Result<impl Iterator<Item = String> + '_, Error> {
+    pub fn list_tables(&self) -> Result<impl Iterator<Item = String> + '_> {
         self.storage.list_tables(TableType::Normal, self.root_page)
     }
 
     /// List all the multimap tables
     // TODO: should return an iterator of &str, once GATs are available
-    pub fn list_multimap_tables(&self) -> Result<impl Iterator<Item = String> + '_, Error> {
+    pub fn list_multimap_tables(&self) -> Result<impl Iterator<Item = String> + '_> {
         self.storage
             .list_tables(TableType::Multimap, self.root_page)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub use multimap_table::{
 pub use table::{RangeIter, ReadOnlyTable, ReadableTable, Table};
 pub use tree_store::{AccessGuard, DatabaseStats};
 
+type Result<T = (), E = Error> = std::result::Result<T, E>;
+
 #[cfg(feature = "python")]
 pub use crate::python::redb;
 

--- a/src/tree_store/page_store/mmap.rs
+++ b/src/tree_store/page_store/mmap.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::Result;
 use std::ops::Range;
 use std::slice;
 
@@ -15,7 +15,7 @@ impl Mmap {
         self.inner.len()
     }
 
-    pub(crate) fn flush(&self) -> Result<(), Error> {
+    pub(crate) fn flush(&self) -> Result {
         self.inner.flush()?;
 
         Ok(())

--- a/src/tree_store/page_store/page_allocator.rs
+++ b/src/tree_store/page_store/page_allocator.rs
@@ -1,4 +1,5 @@
 use crate::Error;
+use crate::Result;
 use std::convert::TryInto;
 use std::mem::size_of;
 
@@ -258,7 +259,7 @@ impl PageAllocator {
     }
 
     /// data must have been initialized by Self::init_new()
-    fn alloc(&self, data: &mut [u8]) -> Result<u64, Error> {
+    fn alloc(&self, data: &mut [u8]) -> Result<u64> {
         if let Some(mut entry) = self.get_level_mut(data, 0).first_unset(0, 64) {
             let mut height = 0;
 
@@ -413,7 +414,7 @@ impl BuddyAllocator {
     }
 
     /// data must have been initialized by Self::init_new()
-    pub(crate) fn alloc(&self, data: &mut [u8], order: usize) -> Result<u64, Error> {
+    pub(crate) fn alloc(&self, data: &mut [u8], order: usize) -> Result<u64> {
         if order >= self.orders.len() {
             return Err(Error::OutOfSpace);
         }

--- a/src/tree_store/storage.rs
+++ b/src/tree_store/storage.rs
@@ -8,6 +8,7 @@ use crate::tree_store::page_store::{Page, PageMut, PageNumber, TransactionalMemo
 use crate::tree_store::{btree_base, AccessGuardMut, BtreeRangeIter};
 use crate::types::{RedbKey, RedbValue, WithLifetime};
 use crate::Error;
+use crate::Result;
 use memmap2::MmapRaw;
 use std::borrow::Borrow;
 use std::cmp::{max, min};
@@ -209,7 +210,7 @@ pub(crate) struct Storage {
 }
 
 impl Storage {
-    pub(crate) fn new(mmap: MmapRaw, page_size: Option<usize>) -> Result<Storage, Error> {
+    pub(crate) fn new(mmap: MmapRaw, page_size: Option<usize>) -> Result<Storage> {
         let mut mem = TransactionalMemory::new(mmap, page_size)?;
         if mem.needs_repair()? {
             let root = mem
@@ -292,7 +293,7 @@ impl Storage {
         *self.leaked_write_transaction.lock().unwrap() = Some(panic::Location::caller());
     }
 
-    pub(crate) fn allocate_write_transaction(&self) -> Result<TransactionId, Error> {
+    pub(crate) fn allocate_write_transaction(&self) -> Result<TransactionId> {
         let guard = self.leaked_write_transaction.lock().unwrap();
         if let Some(leaked) = *guard {
             return Err(Error::LeakedWriteTransaction(leaked));
@@ -322,7 +323,7 @@ impl Storage {
         table_root: Option<PageNumber>,
         transaction_id: TransactionId,
         master_root: Option<PageNumber>,
-    ) -> Result<PageNumber, Error> {
+    ) -> Result<PageNumber> {
         // Bypass .get_table() since the table types are dynamic
         // TODO: optimize way this get()
         let bytes = self
@@ -347,7 +348,7 @@ impl Storage {
         &self,
         table_type: TableType,
         master_root_page: Option<PageNumber>,
-    ) -> Result<TableNameIter, Error> {
+    ) -> Result<TableNameIter> {
         let iter = self.get_range::<RangeFull, str, str, [u8]>(.., master_root_page)?;
         Ok(TableNameIter {
             inner: iter,
@@ -361,7 +362,7 @@ impl Storage {
         name: &str,
         table_type: TableType,
         root_page: Option<PageNumber>,
-    ) -> Result<Option<TableHeader>, Error> {
+    ) -> Result<Option<TableHeader>> {
         if let Some(found) = self.get::<str, [u8]>(name.as_bytes(), root_page)? {
             let definition = TableHeader::from_bytes(found);
             if definition.get_type() != table_type {
@@ -396,7 +397,7 @@ impl Storage {
         table_type: TableType,
         transaction_id: TransactionId,
         root_page: Option<PageNumber>,
-    ) -> Result<(Option<PageNumber>, bool), Error> {
+    ) -> Result<(Option<PageNumber>, bool)> {
         if let Some(definition) = self.get_table::<K, V>(name, table_type, root_page)? {
             if let Some(table_root) = definition.get_root() {
                 let page = self.mem.get_page(table_root);
@@ -426,7 +427,7 @@ impl Storage {
         table_type: TableType,
         transaction_id: TransactionId,
         root_page: Option<PageNumber>,
-    ) -> Result<(TableHeader, PageNumber), Error> {
+    ) -> Result<(TableHeader, PageNumber)> {
         if let Some(found) = self.get_table::<K, V>(name, table_type, root_page)? {
             return Ok((found, root_page.unwrap()));
         }
@@ -458,7 +459,7 @@ impl Storage {
         value: &[u8],
         transaction_id: TransactionId,
         root_page: Option<PageNumber>,
-    ) -> Result<PageNumber, Error> {
+    ) -> Result<PageNumber> {
         assert_eq!(
             transaction_id,
             self.live_write_transaction.lock().unwrap().unwrap()
@@ -486,7 +487,7 @@ impl Storage {
         value_len: usize,
         transaction_id: TransactionId,
         root_page: Option<PageNumber>,
-    ) -> Result<(PageNumber, AccessGuardMut), Error> {
+    ) -> Result<(PageNumber, AccessGuardMut)> {
         assert_eq!(
             transaction_id,
             self.live_write_transaction.lock().unwrap().unwrap()
@@ -506,7 +507,7 @@ impl Storage {
         Ok((new_root, guard))
     }
 
-    pub(crate) fn len(&self, root_page: Option<PageNumber>) -> Result<usize, Error> {
+    pub(crate) fn len(&self, root_page: Option<PageNumber>) -> Result<usize> {
         let mut iter: BtreeRangeIter<[u8], [u8]> =
             self.get_range::<RangeFull, [u8], [u8], [u8]>(.., root_page)?;
         let mut count = 0;
@@ -524,7 +525,7 @@ impl Storage {
         &self,
         mut new_master_root: Option<PageNumber>,
         transaction_id: TransactionId,
-    ) -> Result<(), Error> {
+    ) -> Result {
         let oldest_live_read = self
             .live_read_transactions
             .lock()
@@ -567,7 +568,7 @@ impl Storage {
         &self,
         mut new_master_root: Option<PageNumber>,
         transaction_id: TransactionId,
-    ) -> Result<(), Error> {
+    ) -> Result {
         // Store all freed pages for a future commit(), since we can't free pages during a
         // non-durable commit (it's non-durable, so could be rolled back anytime in the future)
         new_master_root = self.store_freed_pages(transaction_id, new_master_root)?;
@@ -593,7 +594,7 @@ impl Storage {
         oldest_live_read: TransactionId,
         transaction_id: TransactionId,
         mut master_root: Option<PageNumber>,
-    ) -> Result<Option<PageNumber>, Error> {
+    ) -> Result<Option<PageNumber>> {
         assert_eq!(
             transaction_id,
             self.live_write_transaction.lock().unwrap().unwrap()
@@ -651,7 +652,7 @@ impl Storage {
         &self,
         transaction_id: TransactionId,
         mut master_root: Option<PageNumber>,
-    ) -> Result<Option<PageNumber>, Error> {
+    ) -> Result<Option<PageNumber>> {
         assert_eq!(
             transaction_id,
             self.live_write_transaction.lock().unwrap().unwrap()
@@ -716,10 +717,7 @@ impl Storage {
         Ok(master_root)
     }
 
-    pub(crate) fn rollback_uncommited_writes(
-        &self,
-        transaction_id: TransactionId,
-    ) -> Result<(), Error> {
+    pub(crate) fn rollback_uncommited_writes(&self, transaction_id: TransactionId) -> Result {
         self.pending_freed_pages.lock().unwrap().clear();
         let result = self.mem.rollback_uncommited_writes();
         assert_eq!(
@@ -730,7 +728,7 @@ impl Storage {
         result
     }
 
-    pub(crate) fn storage_stats(&self) -> Result<DatabaseStats, Error> {
+    pub(crate) fn storage_stats(&self) -> Result<DatabaseStats> {
         let master_tree_height = self
             .get_root_page_number()
             .map(|p| tree_height(self.mem.get_page(p), &self.mem))
@@ -809,7 +807,7 @@ impl Storage {
         &self,
         key: &[u8],
         root_page_handle: Option<PageNumber>,
-    ) -> Result<Option<<<V as RedbValue>::View as WithLifetime>::Out>, Error> {
+    ) -> Result<Option<<<V as RedbValue>::View as WithLifetime>::Out>> {
         if let Some(handle) = root_page_handle {
             let root_page = self.mem.get_page(handle);
             return Ok(find_key::<K, V>(root_page, key, &self.mem));
@@ -827,7 +825,7 @@ impl Storage {
         &'a self,
         range: T,
         root_page: Option<PageNumber>,
-    ) -> Result<BtreeRangeIter<K, V>, Error> {
+    ) -> Result<BtreeRangeIter<K, V>> {
         Ok(BtreeRangeIter::new(range, root_page, &self.mem))
     }
 
@@ -841,7 +839,7 @@ impl Storage {
         transaction_id: TransactionId,
         free_uncommitted: bool,
         root_handle: Option<PageNumber>,
-    ) -> Result<(Option<PageNumber>, Option<AccessGuard<V>>), Error> {
+    ) -> Result<(Option<PageNumber>, Option<AccessGuard<V>>)> {
         assert_eq!(
             transaction_id,
             self.live_write_transaction.lock().unwrap().unwrap()


### PR DESCRIPTION
This is a common pattern where a library will define a `Result` alias that defaults to `()` and the crates error type, so you don't have to write out `Error` everywhere.