### PR TITLE
Use F_BARRIERFSYNC on macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 memmap2 = "0.5.2"
 libc = "0.2.104"
 pyo3 = {version = "0.15", features=["extension-module", "abi3-py36"], optional = true }
+errno = "0.2.8"
 
 [dev-dependencies]
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ crate-type = ["cdylib", "rlib"]
 memmap2 = "0.5.2"
 libc = "0.2.104"
 pyo3 = {version = "0.15", features=["extension-module", "abi3-py36"], optional = true }
-errno = "0.2.8"
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,7 +6,6 @@ use crate::tree_store::{
 };
 use crate::types::{RedbKey, RedbValue};
 use crate::{Error, ReadOnlyMultimapTable};
-use memmap2::MmapRaw;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
@@ -104,8 +103,7 @@ impl Database {
             file
         };
 
-        let mmap = MmapRaw::map_raw(&file)?;
-        let storage = Storage::new(mmap, None)?;
+        let storage = Storage::new(file, None)?;
         Ok(Database { storage })
     }
 
@@ -117,8 +115,7 @@ impl Database {
     pub unsafe fn open(path: impl AsRef<Path>) -> Result<Database, Error> {
         if File::open(path.as_ref())?.metadata()?.len() > 0 {
             let file = OpenOptions::new().read(true).write(true).open(path)?;
-            let mmap = MmapRaw::map_raw(&file)?;
-            let storage = Storage::new(mmap, None)?;
+            let storage = Storage::new(file, None)?;
             Ok(Database { storage })
         } else {
             Err(Error::Io(io::Error::from(ErrorKind::InvalidData)))
@@ -189,8 +186,7 @@ impl DatabaseBuilder {
 
         file.set_len(db_size as u64)?;
 
-        let mmap = MmapRaw::map_raw(&file)?;
-        let storage = Storage::new(mmap, self.page_size)?;
+        let storage = Storage::new(file, self.page_size)?;
         Ok(Database { storage })
     }
 }

--- a/src/tree_store/page_store/mmap.rs
+++ b/src/tree_store/page_store/mmap.rs
@@ -26,6 +26,8 @@ impl Mmap {
 
     #[cfg(target_os = "macos")]
     pub(crate) fn flush(&self) -> Result {
+        // TODO: It may be unsafe to mix F_BARRIERFSYNC with writes to the mmap.
+        //       Investigate switching to `write()`
         let code = unsafe { libc::fcntl(self.file.as_raw_fd(), libc::F_BARRIERFSYNC) };
         if code == -1 {
             return Err(io::Error::new(io::ErrorKind::Other, errno()).into());

--- a/src/tree_store/page_store/mmap.rs
+++ b/src/tree_store/page_store/mmap.rs
@@ -1,5 +1,4 @@
 use crate::Result;
-use errno::errno;
 use memmap2::MmapRaw;
 use std::fs::File;
 use std::io;
@@ -30,7 +29,7 @@ impl Mmap {
         //       Investigate switching to `write()`
         let code = unsafe { libc::fcntl(self.file.as_raw_fd(), libc::F_BARRIERFSYNC) };
         if code == -1 {
-            return Err(io::Error::new(io::ErrorKind::Other, errno()).into());
+            return Err(io::Error::last_os_error().into());
         }
         Ok(())
     }

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -2,7 +2,6 @@ use crate::tree_store::page_store::mmap::Mmap;
 use crate::tree_store::page_store::page_allocator::BuddyAllocator;
 use crate::tree_store::page_store::utils::get_page_size;
 use crate::Error;
-use memmap2::MmapRaw;
 use std::cmp::min;
 use std::collections::HashSet;
 use std::convert::TryInto;
@@ -494,8 +493,8 @@ impl TransactionalMemory {
         guess
     }
 
-    pub(crate) fn new(mmap: MmapRaw, requested_page_size: Option<usize>) -> Result<Self, Error> {
-        let mmap = Mmap::new(mmap);
+    pub(crate) fn new(file: File, requested_page_size: Option<usize>) -> Result<Self, Error> {
+        let mmap = Mmap::new(file)?;
         // Safety: we have exclusive access to the mmap
         let all_memory = unsafe { mmap.get_memory_mut(0..mmap.len()) };
         if all_memory.len() < MAGICNUMBER.len() {
@@ -1103,7 +1102,7 @@ mod test {
     use crate::tree_store::page_store::utils::get_page_size;
     use crate::tree_store::page_store::TransactionalMemory;
     use crate::{Database, Error, ReadableTable};
-    use memmap2::{MmapMut, MmapRaw};
+    use memmap2::MmapMut;
     use std::fs::OpenOptions;
     use std::mem::size_of;
     use tempfile::NamedTempFile;
@@ -1176,9 +1175,7 @@ mod test {
         mmap.flush().unwrap();
         drop(mmap);
 
-        let mmap = MmapRaw::map_raw(&file).unwrap();
-
-        assert!(TransactionalMemory::new(mmap, None)
+        assert!(TransactionalMemory::new(file, None)
             .unwrap()
             .needs_repair()
             .unwrap());

--- a/src/tree_store/storage.rs
+++ b/src/tree_store/storage.rs
@@ -8,11 +8,11 @@ use crate::tree_store::page_store::{Page, PageMut, PageNumber, TransactionalMemo
 use crate::tree_store::{btree_base, AccessGuardMut, BtreeRangeIter};
 use crate::types::{RedbKey, RedbValue, WithLifetime};
 use crate::Error;
-use memmap2::MmapRaw;
 use std::borrow::Borrow;
 use std::cmp::{max, min};
 use std::collections::BTreeSet;
 use std::convert::TryInto;
+use std::fs::File;
 use std::mem::size_of;
 use std::ops::{RangeBounds, RangeFull};
 use std::panic;
@@ -209,8 +209,8 @@ pub(crate) struct Storage {
 }
 
 impl Storage {
-    pub(crate) fn new(mmap: MmapRaw, page_size: Option<usize>) -> Result<Storage, Error> {
-        let mut mem = TransactionalMemory::new(mmap, page_size)?;
+    pub(crate) fn new(file: File, page_size: Option<usize>) -> Result<Storage, Error> {
+        let mut mem = TransactionalMemory::new(file, page_size)?;
         if mem.needs_repair()? {
             let root = mem
                 .get_primary_root_page()


### PR DESCRIPTION
I'm not sure how you wanted to expose this to users, i.e. if it should be the default on macos because msync is awful, or by introducing a different commit type, but wanted to get a draft PR up. This code worked with the simple repo case, and I'll try it with the full ord database soon.