### PR TITLE
Print table of benchmark results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 memmap2 = "0.5.2"
 libc = "0.2.104"
 pyo3 = {version = "0.15", features=["extension-module", "abi3-py36"], optional = true }
+comfy-table = "5.0.1"
 
 [dev-dependencies]
 rand = "0.8"

--- a/benches/lmdb_benchmark.rs
+++ b/benches/lmdb_benchmark.rs
@@ -5,7 +5,7 @@ use common::*;
 
 use rand::prelude::SliceRandom;
 use rand::Rng;
-use std::time::SystemTime;
+use std::time::{Duration, Instant};
 
 const ITERATIONS: usize = 3;
 const ELEMENTS: usize = 1_000_000;
@@ -23,11 +23,12 @@ fn gen_data(count: usize, key_size: usize, value_size: usize) -> Vec<(Vec<u8>, V
     pairs
 }
 
-fn benchmark<T: BenchDatabase>(mut db: T) {
+fn benchmark<T: BenchDatabase>(mut db: T) -> Vec<(&'static str, Duration)> {
+    let mut results = Vec::new();
     let mut pairs = gen_data(1_000_000, 24, 150);
     let mut written = 0;
 
-    let start = SystemTime::now();
+    let start = Instant::now();
     let txn = db.write_transaction();
     let mut inserter = txn.get_inserter();
     {
@@ -42,16 +43,17 @@ fn benchmark<T: BenchDatabase>(mut db: T) {
     drop(inserter);
     txn.commit().unwrap();
 
-    let end = SystemTime::now();
-    let duration = end.duration_since(start).unwrap();
+    let end = Instant::now();
+    let duration = end - start;
     println!(
         "{}: Bulk loaded {} items in {}ms",
         T::db_type_name(),
         ELEMENTS,
         duration.as_millis()
     );
+    results.push(("bulk load", duration));
 
-    let start = SystemTime::now();
+    let start = Instant::now();
     let writes = 100;
     {
         for _ in 0..writes {
@@ -67,16 +69,17 @@ fn benchmark<T: BenchDatabase>(mut db: T) {
         }
     }
 
-    let end = SystemTime::now();
-    let duration = end.duration_since(start).unwrap();
+    let end = Instant::now();
+    let duration = end - start;
     println!(
         "{}: Wrote {} individual items in {}ms",
         T::db_type_name(),
         writes,
         duration.as_millis()
     );
+    results.push(("individual writes", duration));
 
-    let start = SystemTime::now();
+    let start = Instant::now();
     let batch_size = 1000;
     {
         for _ in 0..writes {
@@ -94,8 +97,8 @@ fn benchmark<T: BenchDatabase>(mut db: T) {
         }
     }
 
-    let end = SystemTime::now();
-    let duration = end.duration_since(start).unwrap();
+    let end = Instant::now();
+    let duration = end - start;
     println!(
         "{}: Wrote {} x {} items in {}ms",
         T::db_type_name(),
@@ -103,6 +106,7 @@ fn benchmark<T: BenchDatabase>(mut db: T) {
         batch_size,
         duration.as_millis()
     );
+    results.push(("batch writes", duration));
 
     let mut key_order: Vec<usize> = (0..ELEMENTS).collect();
     key_order.shuffle(&mut rand::thread_rng());
@@ -110,7 +114,7 @@ fn benchmark<T: BenchDatabase>(mut db: T) {
     let txn = db.read_transaction();
     {
         for _ in 0..ITERATIONS {
-            let start = SystemTime::now();
+            let start = Instant::now();
             let mut checksum = 0u64;
             let mut expected_checksum = 0u64;
             for i in &key_order {
@@ -122,36 +126,38 @@ fn benchmark<T: BenchDatabase>(mut db: T) {
                 expected_checksum += value[0] as u64;
             }
             assert_eq!(checksum, expected_checksum);
-            let end = SystemTime::now();
-            let duration = end.duration_since(start).unwrap();
+            let end = Instant::now();
+            let duration = end - start;
             println!(
                 "{}: Random read {} items in {}ms",
                 T::db_type_name(),
                 ELEMENTS,
                 duration.as_millis()
             );
+            results.push(("random reads", duration));
         }
 
         for _ in 0..ITERATIONS {
-            let start = SystemTime::now();
+            let start = Instant::now();
             for i in &key_order {
                 let len = pairs.len();
                 let (key, _) = &mut pairs[i % len];
                 key[16..].copy_from_slice(&(*i as u64).to_be_bytes());
                 txn.exists_after(&key);
             }
-            let end = SystemTime::now();
-            let duration = end.duration_since(start).unwrap();
+            let end = Instant::now();
+            let duration = end - start;
             println!(
                 "{}: Random range read {} starts in {}ms",
                 T::db_type_name(),
                 ELEMENTS,
                 duration.as_millis()
             );
+            results.push(("random range reads", duration));
         }
     }
 
-    let start = SystemTime::now();
+    let start = Instant::now();
     let deletes = key_order.len() / 2;
     {
         let txn = db.write_transaction();
@@ -166,34 +172,62 @@ fn benchmark<T: BenchDatabase>(mut db: T) {
         txn.commit().unwrap();
     }
 
-    let end = SystemTime::now();
-    let duration = end.duration_since(start).unwrap();
+    let end = Instant::now();
+    let duration = end - start;
     println!(
         "{}: Removed {} items in {}ms",
         T::db_type_name(),
         deletes,
         duration.as_millis()
     );
+    results.push(("removals", duration));
+
+    results
 }
 
 fn main() {
-    {
+    let redb_results = {
+        let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
+        let db = unsafe { redb::Database::create(tmpfile.path(), 4096 * 1024 * 1024).unwrap() };
+        let table = RedbBenchDatabase::new(&db);
+        benchmark(table)
+    };
+
+    let lmdb_results = {
         let tmpfile: TempDir = tempfile::tempdir().unwrap();
         let env = lmdb::Environment::new().open(tmpfile.path()).unwrap();
         env.set_map_size(4096 * 1024 * 1024).unwrap();
         let table = LmdbRkvBenchDatabase::new(&env);
-        benchmark(table);
-    }
-    {
-        let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
-        let db = unsafe { redb::Database::create(tmpfile.path(), 4096 * 1024 * 1024).unwrap() };
-        let table = RedbBenchDatabase::new(&db);
-        benchmark(table);
-    }
-    {
+        benchmark(table)
+    };
+
+    let sled_results = {
         let tmpfile: TempDir = tempfile::tempdir().unwrap();
         let db = sled::Config::new().path(tmpfile.path()).open().unwrap();
         let table = SledBenchDatabase::new(&db, tmpfile.path());
-        benchmark(table);
+        benchmark(table)
+    };
+
+    let mut table = comfy_table::Table::new();
+    table.set_table_width(100);
+
+    table.set_header(&["", "redb", "lmdb", "sled"]);
+
+    for (benchmark, _duration) in &redb_results {
+        table.add_row(&[benchmark]);
     }
+
+    for results in [redb_results, lmdb_results, sled_results] {
+        for (i, (_benchmark, duration)) in results.iter().enumerate() {
+            table
+                .get_row_mut(i)
+                .unwrap()
+                .add_cell(comfy_table::Cell::new(format!(
+                    "{}ms",
+                    duration.as_millis()
+                )));
+        }
+    }
+
+    println!("{table}");
 }

--- a/benches/lmdb_benchmark.rs
+++ b/benches/lmdb_benchmark.rs
@@ -208,26 +208,25 @@ fn main() {
         benchmark(table)
     };
 
-    let mut table = comfy_table::Table::new();
-    table.set_table_width(100);
-
-    table.set_header(&["", "redb", "lmdb", "sled"]);
+    let mut rows = Vec::new();
 
     for (benchmark, _duration) in &redb_results {
-        table.add_row(&[benchmark]);
+        rows.push(vec![benchmark.to_string()]);
     }
 
     for results in [redb_results, lmdb_results, sled_results] {
         for (i, (_benchmark, duration)) in results.iter().enumerate() {
-            table
-                .get_row_mut(i)
-                .unwrap()
-                .add_cell(comfy_table::Cell::new(format!(
-                    "{}ms",
-                    duration.as_millis()
-                )));
+            rows[i].push(format!("{}ms", duration.as_millis()));
         }
     }
 
+    let mut table = comfy_table::Table::new();
+    table.set_table_width(100);
+    table.set_header(&["", "redb", "lmdb", "sled"]);
+    for row in rows {
+        table.add_row(row);
+    }
+
+    println!();
     println!("{table}");
 }

--- a/benches/syscall_benchmark.rs
+++ b/benches/syscall_benchmark.rs
@@ -5,6 +5,7 @@ use rand::prelude::SliceRandom;
 use rand::Rng;
 use std::fs::OpenOptions;
 use std::io::{Read, Seek, SeekFrom, Write};
+#[cfg(target_os = "linux")]
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::time::{Duration, SystemTime};


### PR DESCRIPTION
I'm having trouble preventing the table from wrapping, opened an issue about it (https://github.com/Nukesor/comfy-table/issues/66) but here's what it looks like so far:

```
+--------------------+------+------+------+
|                    | redb | lmdb | sled |
+=========================================+
| bulk load          | 4136 | 1235 | 1428 |
|                    | ms   | ms   | 2ms  |
|--------------------+------+------+------|
| individual writes  | 50ms | 10ms | 3547 |
|                    |      |      | ms   |
|--------------------+------+------+------|
| batch writes       | 5495 | 3010 | 1126 |
|                    | ms   | ms   | 8ms  |
|--------------------+------+------+------|
| random reads       | 1106 | 1108 | 1703 |
|                    | ms   | ms   | ms   |
|--------------------+------+------+------|
| random reads       | 926m | 1104 | 1518 |
|                    | s    | ms   | ms   |
|--------------------+------+------+------|
| random reads       | 993m | 1219 | 1495 |
|                    | s    | ms   | ms   |
|--------------------+------+------+------|
| random range reads | 1137 | 1481 | 2264 |
|                    | ms   | ms   | ms   |
|--------------------+------+------+------|
| random range reads | 1144 | 1461 | 2317 |
|                    | ms   | ms   | ms   |
|--------------------+------+------+------|
| random range reads | 1154 | 1422 | 2169 |
|                    | ms   | ms   | ms   |
|--------------------+------+------+------|
| removals           | 2677 | 1004 | 2824 |
|                    | ms   | ms   | ms   |
+--------------------+------+------+------+
```