### PR TITLE
Add convenience method to return database builder

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -123,6 +123,10 @@ impl Database {
         }
     }
 
+    pub fn builder() -> DatabaseBuilder {
+        DatabaseBuilder::new()
+    }
+
     /// # Safety
     ///
     /// The file referenced by `path` must not be concurrently modified by any other process


### PR DESCRIPTION
This is a pretty common pattern where a type has a `builder` method that returns an instance of the corresponding builder. It's nice because you don't need to know about where the builder is or what it's called, makes it more discoverable, and avoids an extra import.