### PR TITLE
Change fuzzer value length distribution

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,6 +12,8 @@ cargo-fuzz = true
 arbitrary = { version = "1.1.0", features = ["derive"] }
 libfuzzer-sys = { version = "0.4.0", features = ["arbitrary-derive"] }
 tempfile = "3.2.0"
+rand = "0.8.5"
+rand_distr = "0.4.3"
 
 [dependencies.redb]
 path = ".."


### PR DESCRIPTION
Use a variant of the binomial distribution, instead of the uniform
distirbution. This also makes the fuzzer ~100x faster because the mean
value size is much smaller