### PR TITLE
Move benchmark temp files to CWD

### DIFF
--- a/benches/int_benchmark.rs
+++ b/benches/int_benchmark.rs
@@ -1,3 +1,4 @@
+use std::env::current_dir;
 use tempfile::{NamedTempFile, TempDir};
 
 mod common;
@@ -91,7 +92,7 @@ fn benchmark<T: BenchDatabase>(mut db: T) -> Vec<(&'static str, Duration)> {
 
 fn main() {
     let redb_results = {
-        let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
+        let tmpfile: NamedTempFile = NamedTempFile::new_in(current_dir().unwrap()).unwrap();
         let db =
             unsafe { redb::Database::create(tmpfile.path(), 10 * 4096 * 1024 * 1024).unwrap() };
         // let table = RedbBenchDatabase::new(&db);
@@ -99,7 +100,7 @@ fn main() {
     };
 
     let lmdb_results = {
-        let tmpfile: TempDir = tempfile::tempdir().unwrap();
+        let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
         let env = lmdb::Environment::new().open(tmpfile.path()).unwrap();
         env.set_map_size(10 * 4096 * 1024 * 1024).unwrap();
         let table = LmdbRkvBenchDatabase::new(&env);
@@ -107,7 +108,7 @@ fn main() {
     };
 
     let sled_results = {
-        let tmpfile: TempDir = tempfile::tempdir().unwrap();
+        let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
         let db = sled::Config::new().path(tmpfile.path()).open().unwrap();
         let table = SledBenchDatabase::new(&db, tmpfile.path());
         benchmark(table)

--- a/benches/large_values_benchmark.rs
+++ b/benches/large_values_benchmark.rs
@@ -1,3 +1,4 @@
+use std::env::current_dir;
 use tempfile::{NamedTempFile, TempDir};
 
 mod common;
@@ -119,7 +120,7 @@ fn benchmark<T: BenchDatabase>(mut db: T) -> Vec<(&'static str, Duration)> {
 
 fn main() {
     let redb_results = {
-        let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
+        let tmpfile: NamedTempFile = NamedTempFile::new_in(current_dir().unwrap()).unwrap();
         let db =
             unsafe { redb::Database::create(tmpfile.path(), 10 * 4096 * 1024 * 1024).unwrap() };
         // let table = RedbBenchDatabase::new(&db);
@@ -127,7 +128,7 @@ fn main() {
     };
 
     let lmdb_results = {
-        let tmpfile: TempDir = tempfile::tempdir().unwrap();
+        let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
         let env = lmdb::Environment::new().open(tmpfile.path()).unwrap();
         env.set_map_size(10 * 4096 * 1024 * 1024).unwrap();
         let table = LmdbRkvBenchDatabase::new(&env);
@@ -135,7 +136,7 @@ fn main() {
     };
 
     let sled_results = {
-        let tmpfile: TempDir = tempfile::tempdir().unwrap();
+        let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
         let db = sled::Config::new().path(tmpfile.path()).open().unwrap();
         let table = SledBenchDatabase::new(&db, tmpfile.path());
         benchmark(table)

--- a/benches/lmdb_benchmark.rs
+++ b/benches/lmdb_benchmark.rs
@@ -1,3 +1,4 @@
+use std::env::current_dir;
 use tempfile::{NamedTempFile, TempDir};
 
 mod common;
@@ -354,14 +355,14 @@ fn benchmark<T: BenchDatabase>(mut db: T) -> Vec<(&'static str, Duration)> {
 
 fn main() {
     let redb_results = {
-        let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
+        let tmpfile: NamedTempFile = NamedTempFile::new_in(current_dir().unwrap()).unwrap();
         let db = unsafe { redb::Database::create(tmpfile.path(), 4096 * 1024 * 1024).unwrap() };
         // let table = RedbBenchDatabase::new(&db);
         benchmark_redb(db)
     };
 
     let lmdb_results = {
-        let tmpfile: TempDir = tempfile::tempdir().unwrap();
+        let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
         let env = lmdb::Environment::new().open(tmpfile.path()).unwrap();
         env.set_map_size(4096 * 1024 * 1024).unwrap();
         let table = LmdbRkvBenchDatabase::new(&env);
@@ -369,7 +370,7 @@ fn main() {
     };
 
     let sled_results = {
-        let tmpfile: TempDir = tempfile::tempdir().unwrap();
+        let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
         let db = sled::Config::new().path(tmpfile.path()).open().unwrap();
         let table = SledBenchDatabase::new(&db, tmpfile.path());
         benchmark(table)

--- a/benches/syscall_benchmark.rs
+++ b/benches/syscall_benchmark.rs
@@ -3,6 +3,7 @@ use tempfile::{NamedTempFile, TempDir};
 use lmdb::Transaction;
 use rand::prelude::SliceRandom;
 use rand::Rng;
+use std::env::current_dir;
 use std::fs::OpenOptions;
 use std::io::{IoSlice, Read, Seek, SeekFrom, Write};
 use std::os::unix::io::AsRawFd;
@@ -338,20 +339,20 @@ fn mmap_bench(path: &Path) {
 fn main() {
     // Benchmark lmdb against raw read()/write() performance
     {
-        let tmpfile: TempDir = tempfile::tempdir().unwrap();
+        let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
         lmdb_bench(tmpfile.path());
     }
     {
-        let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
+        let tmpfile: NamedTempFile = NamedTempFile::new_in(current_dir().unwrap()).unwrap();
         readwrite_bench(tmpfile.path());
     }
     #[cfg(target_os = "linux")]
     {
-        let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
+        let tmpfile: NamedTempFile = NamedTempFile::new_in(current_dir().unwrap()).unwrap();
         uring_bench(tmpfile.path());
     }
     {
-        let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
+        let tmpfile: NamedTempFile = NamedTempFile::new_in(current_dir().unwrap()).unwrap();
         mmap_bench(tmpfile.path());
     }
 }


### PR DESCRIPTION
/tmp might be mounted as a tmpfs, which would skew the results.

Fixes #282 