### PR TITLE
Add initial Windows support

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -188,7 +188,7 @@ impl Database {
             db_size,
             None,
             None,
-            true,
+            cfg!(unix),
             Some(WriteStrategy::default()),
         )
     }
@@ -202,7 +202,7 @@ impl Database {
         if File::open(path.as_ref())?.metadata()?.len() > 0 {
             let existing_size = get_db_size(path.as_ref())?;
             let file = OpenOptions::new().read(true).write(true).open(path)?;
-            Database::new(file, existing_size, None, None, true, None)
+            Database::new(file, existing_size, None, None, cfg!(unix), None)
         } else {
             Err(Error::Io(io::Error::from(ErrorKind::InvalidData)))
         }
@@ -503,7 +503,7 @@ impl Builder {
         Self {
             page_size: None,
             region_size: None,
-            dynamic_growth: true,
+            dynamic_growth: cfg!(unix),
             write_strategy: WriteStrategy::default(),
         }
     }
@@ -535,6 +535,7 @@ impl Builder {
     /// Whether to grow the database file dynamically.
     /// When set to true, the database file will start at a small size and grow as insertions are made
     /// When set to false, the database file will be statically sized
+    #[cfg(unix)]
     pub fn set_dynamic_growth(&mut self, enabled: bool) -> &mut Self {
         self.dynamic_growth = enabled;
         self

--- a/src/db.rs
+++ b/src/db.rs
@@ -199,7 +199,9 @@ impl Database {
     ///
     /// The file referenced by `path` must not be concurrently modified by any other process
     pub unsafe fn open(path: impl AsRef<Path>) -> Result<Database> {
-        if File::open(path.as_ref())?.metadata()?.len() > 0 {
+        if !path.as_ref().exists() {
+            Err(Error::Io(ErrorKind::NotFound.into()))
+        } else if File::open(path.as_ref())?.metadata()?.len() > 0 {
             let existing_size = Self::get_db_size(path.as_ref())?;
             let file = OpenOptions::new().read(true).write(true).open(path)?;
             Database::new(file, existing_size, None, None, cfg!(unix), None)

--- a/src/db.rs
+++ b/src/db.rs
@@ -166,7 +166,7 @@ impl Database {
     pub unsafe fn create(path: impl AsRef<Path>, db_size: usize) -> Result<Database> {
         let db_size = db_size as u64;
         let file = if path.as_ref().exists() && File::open(path.as_ref())?.metadata()?.len() > 0 {
-            let existing_size = get_db_size(path.as_ref())?;
+            let existing_size = Self::get_db_size(path.as_ref())?;
             if existing_size != db_size {
                 return Err(Error::DbSizeMismatch {
                     path: path.as_ref().to_string_lossy().to_string(),
@@ -200,11 +200,32 @@ impl Database {
     /// The file referenced by `path` must not be concurrently modified by any other process
     pub unsafe fn open(path: impl AsRef<Path>) -> Result<Database> {
         if File::open(path.as_ref())?.metadata()?.len() > 0 {
-            let existing_size = get_db_size(path.as_ref())?;
+            let existing_size = Self::get_db_size(path.as_ref())?;
             let file = OpenOptions::new().read(true).write(true).open(path)?;
             Database::new(file, existing_size, None, None, cfg!(unix), None)
         } else {
             Err(Error::Io(io::Error::from(ErrorKind::InvalidData)))
+        }
+    }
+
+    #[inline]
+    fn get_db_size(path: impl AsRef<Path>) -> Result<u64> {
+        #[cfg(unix)]
+        {
+            Ok(get_db_size(path)?)
+        }
+        #[cfg(windows)]
+        {
+            get_db_size(path).map_err(|err| {
+                // On Windows, an exclusive file lock also applies to reads, unlike on Unix, so
+                // we detect that specific error code and transform it to the correct error
+                // 0x21 - ERROR_LOCK_VIOLATION
+                if matches!(err.raw_os_error(), Some(0x21)) {
+                    Error::DatabaseAlreadyOpen
+                } else {
+                    err.into()
+                }
+            })
         }
     }
 
@@ -566,5 +587,12 @@ impl Builder {
             self.dynamic_growth,
             Some(self.write_strategy),
         )
+    }
+}
+
+// This just makes it easier to throw dbg! etc statements on `Result<Database>`
+impl std::fmt::Debug for Database {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Database").finish()
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -592,7 +592,7 @@ impl Builder {
     }
 }
 
-// This just makes it easier to throw dbg! etc statements on `Result<Database>`
+// This just makes it easier to throw `dbg` etc statements on `Result<Database>`
 impl std::fmt::Debug for Database {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Database").finish()

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -85,13 +85,11 @@ impl<'a> BuddyAllocator<'a> {
         Self { data }
     }
 
+    #[inline]
     pub(crate) fn highest_free_order(&self) -> Option<usize> {
-        for order in (0..=self.get_max_order()).rev() {
-            if self.get_order(order as u32).has_unset() {
-                return Some(order);
-            }
-        }
-        None
+        (0..=self.get_max_order())
+            .rev()
+            .find(|order| self.get_order(*order as u32).has_unset())
     }
 
     pub(crate) fn count_free_pages(&self) -> usize {

--- a/src/tree_store/page_store/mmap.rs
+++ b/src/tree_store/page_store/mmap.rs
@@ -146,18 +146,3 @@ impl Mmap {
         slice::from_raw_parts_mut(ptr, range.len())
     }
 }
-
-#[cfg(test)]
-mod test {
-    #[test]
-    #[cfg(unix)]
-    fn leak() {
-        use crate::tree_store::page_store::mmap::Mmap;
-        use tempfile::NamedTempFile;
-
-        for _ in 0..100_000 {
-            let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
-            Mmap::new(tmpfile.into_file(), 1024 * 1024).unwrap();
-        }
-    }
-}

--- a/src/tree_store/page_store/mmap.rs
+++ b/src/tree_store/page_store/mmap.rs
@@ -149,12 +149,12 @@ impl Mmap {
 
 #[cfg(test)]
 mod test {
-    use crate::tree_store::page_store::mmap::Mmap;
-    use tempfile::NamedTempFile;
-
     #[test]
     #[cfg(unix)]
     fn leak() {
+        use crate::tree_store::page_store::mmap::Mmap;
+        use tempfile::NamedTempFile;
+
         for _ in 0..100_000 {
             let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
             Mmap::new(tmpfile.into_file(), 1024 * 1024).unwrap();

--- a/src/tree_store/page_store/mmap.rs
+++ b/src/tree_store/page_store/mmap.rs
@@ -3,43 +3,25 @@ use std::fs::File;
 use std::io;
 use std::io::ErrorKind;
 use std::ops::Range;
-use std::os::unix::io::AsRawFd;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::{ptr, slice};
 
-struct FileLock {
-    fd: libc::c_int,
-}
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+use unix::*;
 
-impl FileLock {
-    fn new(fd: libc::c_int) -> Result<Self> {
-        let result = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
-        if result != 0 {
-            let err = io::Error::last_os_error();
-            if err.kind() == io::ErrorKind::WouldBlock {
-                Err(Error::DatabaseAlreadyOpen)
-            } else {
-                Err(Error::Io(err))
-            }
-        } else {
-            Ok(Self { fd })
-        }
-    }
-}
-
-impl Drop for FileLock {
-    fn drop(&mut self) {
-        unsafe { libc::flock(self.fd, libc::LOCK_UN) };
-    }
-}
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+use windows::*;
 
 pub(crate) struct Mmap {
     file: File,
     _lock: FileLock,
-    mmap: *mut u8,
+    mmap: MmapInner,
     len: AtomicUsize,
     fsync_failed: AtomicBool,
-    capacity: usize,
 }
 
 // mmap() is documented as being multi-thread safe
@@ -49,36 +31,42 @@ unsafe impl Sync for Mmap {}
 impl Mmap {
     pub(crate) fn new(file: File, max_capacity: usize) -> Result<Self> {
         let len = file.metadata()?.len();
-        assert!(len <= max_capacity as u64);
-        let lock = FileLock::new(file.as_raw_fd())?;
-        let mmap = unsafe {
-            libc::mmap(
-                ptr::null_mut(),
-                max_capacity as libc::size_t,
-                libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_SHARED,
-                file.as_raw_fd(),
-                0,
-            )
-        };
-        if mmap == libc::MAP_FAILED {
-            return Err(io::Error::last_os_error().into());
-        }
 
-        let result = Self {
-            mmap: mmap as *mut u8,
+        assert!(len <= max_capacity as u64);
+        let lock = FileLock::new(&file)?;
+
+        let mmap = MmapInner::create_mapping(&file, max_capacity)?;
+
+        let mapping = Self {
             file,
             _lock: lock,
+            mmap,
             len: AtomicUsize::new(len as usize),
             fsync_failed: AtomicBool::new(false),
-            capacity: max_capacity,
         };
-        // fsync to ensure that the data we read during initialization is stored durably
-        result.flush()?;
 
-        Ok(result)
+        mapping.flush()?;
+
+        Ok(mapping)
     }
 
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.len.load(Ordering::Acquire)
+    }
+
+    pub(crate) unsafe fn resize(&self, new_len: usize) -> Result<()> {
+        assert!(new_len <= self.mmap.capacity);
+        self.check_fsync_failure()?;
+        self.file.set_len(new_len as u64)?;
+
+        self.mmap.resize(self)?;
+
+        self.len.store(new_len, Ordering::Release);
+        Ok(())
+    }
+
+    #[inline]
     fn check_fsync_failure(&self) -> Result<()> {
         if self.fsync_failed.load(Ordering::Acquire) {
             Err(Error::Io(io::Error::from(ErrorKind::Other)))
@@ -87,89 +75,32 @@ impl Mmap {
         }
     }
 
-    pub(crate) fn len(&self) -> usize {
-        self.len.load(Ordering::Acquire)
+    #[inline]
+    fn set_fsync_failed(&self, failed: bool) {
+        self.fsync_failed.store(failed, Ordering::Release);
     }
 
-    // Safety: if new_len < len(), caller must ensure that no references to memory in new_len..len() exist
-    pub(crate) unsafe fn resize(&self, new_len: usize) -> Result<()> {
-        assert!(new_len <= self.capacity);
+    #[inline]
+    pub(crate) fn flush(&self) -> Result<()> {
         self.check_fsync_failure()?;
-        self.file.set_len(new_len as u64)?;
 
-        let mmap = libc::mmap(
-            self.mmap as *mut libc::c_void,
-            self.capacity as libc::size_t,
-            libc::PROT_READ | libc::PROT_WRITE,
-            libc::MAP_SHARED | libc::MAP_FIXED,
-            self.file.as_raw_fd(),
-            0,
-        );
-
-        if mmap == libc::MAP_FAILED {
-            Err(io::Error::last_os_error().into())
-        } else {
-            assert_eq!(mmap as *mut u8, self.mmap);
-            self.len.store(new_len, Ordering::Release);
-            Ok(())
+        let res = self.mmap.flush(self);
+        if res.is_err() {
+            self.set_fsync_failed(true);
         }
+
+        res
     }
 
-    #[cfg(not(target_os = "macos"))]
-    pub(crate) fn flush(&self) -> Result {
-        self.check_fsync_failure()?;
-        // Disable fsync when fuzzing, since it doesn't test crash consistency
-        #[cfg(not(fuzzing))]
-        {
-            let result = unsafe {
-                libc::msync(
-                    self.mmap as *mut libc::c_void,
-                    self.len() as libc::size_t,
-                    libc::MS_SYNC,
-                )
-            };
-            if result != 0 {
-                self.fsync_failed.store(true, Ordering::Release);
-                return Err(io::Error::last_os_error().into());
-            }
-        }
-        Ok(())
-    }
-
-    #[cfg(target_os = "macos")]
-    pub(crate) fn flush(&self) -> Result {
-        self.check_fsync_failure()?;
-        #[cfg(not(fuzzing))]
-        {
-            let code = unsafe { libc::fcntl(self.file.as_raw_fd(), libc::F_FULLFSYNC) };
-            if code == -1 {
-                self.fsync_failed.store(true, Ordering::Release);
-                return Err(io::Error::last_os_error().into());
-            }
-        }
-        Ok(())
-    }
-
-    #[cfg(not(target_os = "macos"))]
+    #[inline]
     pub(crate) fn eventual_flush(&self) -> Result {
         self.check_fsync_failure()?;
-        self.flush()
-    }
-
-    #[cfg(target_os = "macos")]
-    pub(crate) fn eventual_flush(&self) -> Result {
-        self.check_fsync_failure()?;
-        // TODO: It may be unsafe to mix F_BARRIERFSYNC with writes to the mmap.
-        //       Investigate switching to `write()`
-        #[cfg(not(fuzzing))]
-        {
-            let code = unsafe { libc::fcntl(self.file.as_raw_fd(), libc::F_BARRIERFSYNC) };
-            if code == -1 {
-                self.fsync_failed.store(true, Ordering::Release);
-                return Err(io::Error::last_os_error().into());
-            }
+        let res = self.mmap.eventual_flush(self);
+        if res.is_err() {
+            self.set_fsync_failed(true);
         }
-        Ok(())
+
+        res
     }
 
     // Safety: caller must ensure that [start, end) does not alias any existing references returned
@@ -179,7 +110,7 @@ impl Mmap {
         // TODO: propagate the error
         self.check_fsync_failure()
             .expect("fsync previously failed. Connection closed");
-        let ptr = self.mmap.add(range.start);
+        let ptr = self.mmap.mmap.add(range.start);
         slice::from_raw_parts(ptr, range.len())
     }
 
@@ -191,19 +122,8 @@ impl Mmap {
         // TODO: propagate the error
         self.check_fsync_failure()
             .expect("fsync previously failed. Connection closed");
-        let ptr = self.mmap.add(range.start);
+        let ptr = self.mmap.mmap.add(range.start);
         slice::from_raw_parts_mut(ptr, range.len())
-    }
-}
-
-impl Drop for Mmap {
-    fn drop(&mut self) {
-        unsafe {
-            libc::munmap(
-                self.mmap as *mut libc::c_void,
-                self.capacity as libc::size_t,
-            );
-        }
     }
 }
 

--- a/src/tree_store/page_store/mmap.rs
+++ b/src/tree_store/page_store/mmap.rs
@@ -3,8 +3,8 @@ use std::fs::File;
 use std::io;
 use std::io::ErrorKind;
 use std::ops::Range;
+use std::slice;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::{ptr, slice};
 
 #[cfg(unix)]
 mod unix;

--- a/src/tree_store/page_store/mmap/unix.rs
+++ b/src/tree_store/page_store/mmap/unix.rs
@@ -1,5 +1,6 @@
 use super::*;
 use std::os::unix::io::AsRawFd;
+use std::ptr;
 
 pub(super) struct FileLock {
     fd: libc::c_int,
@@ -56,8 +57,9 @@ impl MmapInner {
     }
 
     /// Safety: if new_len < len(), caller must ensure that no references to memory in new_len..len() exist
+    #[inline]
     pub(super) unsafe fn resize(&self, new_len: u64, owner: &Mmap) -> Result<()> {
-        owner.file.set_len(new_len as u64)?;
+        owner.file.set_len(new_len)?;
 
         let mmap = libc::mmap(
             self.mmap as *mut libc::c_void,
@@ -76,6 +78,7 @@ impl MmapInner {
         }
     }
 
+    #[inline]
     pub(super) fn flush(&self, owner: &Mmap) -> Result {
         // Disable fsync when fuzzing, since it doesn't test crash consistency
         #[cfg(not(fuzzing))]
@@ -104,6 +107,7 @@ impl MmapInner {
         Ok(())
     }
 
+    #[inline]
     pub(super) fn eventual_flush(&self, owner: &Mmap) -> Result {
         #[cfg(not(target_os = "macos"))]
         {

--- a/src/tree_store/page_store/mmap/unix.rs
+++ b/src/tree_store/page_store/mmap/unix.rs
@@ -1,0 +1,133 @@
+use super::*;
+use std::os::unix::io::AsRawFd;
+
+pub(super) struct FileLock {
+    fd: libc::c_int,
+}
+
+impl FileLock {
+    pub(super) fn new(file: &File) -> Result<Self> {
+        let fd = file.as_raw_fd();
+        let result = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
+        if result != 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::WouldBlock {
+                Err(Error::DatabaseAlreadyOpen)
+            } else {
+                Err(Error::Io(err))
+            }
+        } else {
+            Ok(Self { fd })
+        }
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        unsafe { libc::flock(self.fd, libc::LOCK_UN) };
+    }
+}
+
+pub(super) struct MmapInner {
+    pub(super) mmap: *mut u8,
+    pub(super) capacity: usize,
+}
+
+impl MmapInner {
+    pub(super) fn create_mapping(file: &File, max_capacity: usize) -> Result<Self> {
+        let mmap = unsafe {
+            libc::mmap(
+                ptr::null_mut(),
+                max_capacity as libc::size_t,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                file.as_raw_fd(),
+                0,
+            )
+        };
+        if mmap == libc::MAP_FAILED {
+            Err(io::Error::last_os_error().into())
+        } else {
+            Ok(Self {
+                mmap: mmap as *mut u8,
+                capacity: max_capacity,
+            })
+        }
+    }
+
+    /// Safety: if new_len < len(), caller must ensure that no references to memory in new_len..len() exist
+    pub(super) unsafe fn resize(&self, owner: &Mmap) -> Result<()> {
+        let mmap = libc::mmap(
+            self.mmap as *mut libc::c_void,
+            self.capacity as libc::size_t,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_SHARED | libc::MAP_FIXED,
+            owner.file.as_raw_fd(),
+            0,
+        );
+
+        if mmap == libc::MAP_FAILED {
+            Err(io::Error::last_os_error().into())
+        } else {
+            assert_eq!(mmap as *mut u8, self.mmap);
+            Ok(())
+        }
+    }
+
+    pub(super) fn flush(&self, owner: &Mmap) -> Result {
+        // Disable fsync when fuzzing, since it doesn't test crash consistency
+        #[cfg(not(fuzzing))]
+        {
+            #[cfg(not(target_os = "macos"))]
+            {
+                let result = unsafe {
+                    libc::msync(
+                        self.mmap as *mut libc::c_void,
+                        owner.len() as libc::size_t,
+                        libc::MS_SYNC,
+                    )
+                };
+                if result != 0 {
+                    return Err(io::Error::last_os_error().into());
+                }
+            }
+            #[cfg(target_os = "macos")]
+            {
+                let code = unsafe { libc::fcntl(self.file.as_raw_fd(), libc::F_FULLFSYNC) };
+                if code == -1 {
+                    return Err(io::Error::last_os_error().into());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn eventual_flush(&self, owner: &Mmap) -> Result {
+        #[cfg(not(target_os = "macos"))]
+        {
+            return self.flush(owner);
+        }
+        #[cfg(all(target_os = "macos", not(fuzzing)))]
+        {
+            // TODO: It may be unsafe to mix F_BARRIERFSYNC with writes to the mmap.
+            //       Investigate switching to `write()`
+            let code = unsafe { libc::fcntl(owner.file.as_raw_fd(), libc::F_BARRIERFSYNC) };
+            if code == -1 {
+                Err(io::Error::last_os_error().into());
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Drop for MmapInner {
+    fn drop(&mut self) {
+        unsafe {
+            libc::munmap(
+                self.mmap as *mut libc::c_void,
+                self.capacity as libc::size_t,
+            );
+        }
+    }
+}

--- a/src/tree_store/page_store/mmap/unix.rs
+++ b/src/tree_store/page_store/mmap/unix.rs
@@ -34,7 +34,7 @@ pub(super) struct MmapInner {
 }
 
 impl MmapInner {
-    pub(super) fn create_mapping(file: &File, max_capacity: usize) -> Result<Self> {
+    pub(super) fn create_mapping(file: &File, _len: u64, max_capacity: usize) -> Result<Self> {
         let mmap = unsafe {
             libc::mmap(
                 ptr::null_mut(),
@@ -56,7 +56,9 @@ impl MmapInner {
     }
 
     /// Safety: if new_len < len(), caller must ensure that no references to memory in new_len..len() exist
-    pub(super) unsafe fn resize(&self, owner: &Mmap) -> Result<()> {
+    pub(super) unsafe fn resize(&self, new_len: u64, owner: &Mmap) -> Result<()> {
+        owner.file.set_len(new_len as u64)?;
+
         let mmap = libc::mmap(
             self.mmap as *mut libc::c_void,
             self.capacity as libc::size_t,

--- a/src/tree_store/page_store/mmap/unix.rs
+++ b/src/tree_store/page_store/mmap/unix.rs
@@ -111,7 +111,7 @@ impl MmapInner {
     pub(super) fn eventual_flush(&self, owner: &Mmap) -> Result {
         #[cfg(not(target_os = "macos"))]
         {
-            return self.flush(owner);
+            self.flush(owner)
         }
         #[cfg(all(target_os = "macos", not(fuzzing)))]
         {

--- a/src/tree_store/page_store/mmap/windows.rs
+++ b/src/tree_store/page_store/mmap/windows.rs
@@ -1,5 +1,6 @@
 use super::*;
 use std::ffi::c_void;
+use std::mem::MaybeUninit;
 use std::os::windows::io::AsRawFd;
 use std::os::windows::io::RawHandle;
 
@@ -26,13 +27,49 @@ struct OVERLAPPED_0_0 {
 const LOCKFILE_EXCLUSIVE_LOCK: u32 = 0x00000002;
 const LOCKFILE_FAIL_IMMEDIATELY: u32 = 0x00000001;
 const ERROR_IO_PENDING: i32 = 997;
-const PAGE_READWRITE: u32 = 0x04;
+const PAGE_READWRITE: u32 = 0x4;
+const SECTION_MAP_READ: u32 = 0x2;
+const SECTION_MAP_READ: u32 = 0x4;
+const SECTION_EXTEND_SIZE: u32 = 0x10;
+const SEC_COMMIT: u32 = 0x8000000;
 
 #[repr(C)]
 struct SECURITY_ATTRIBUTES {
     length: u32,
     descriptor: *mut c_void,
     inherit: u32,
+}
+
+#[repr(C)]
+struct SYSTEM_INFO {
+    processor_arch: u16,
+    reserved: u16,
+    page_size: u16,
+    min_app_address: *mut c_void,
+    max_app_address: *mut c_void,
+    active_processor_mask: usize,
+    number_of_processors: u32,
+    processor_type: u32,
+    allocation_granularity: u32,
+    processor_level: u16,
+    processor_revision: u16,
+}
+
+#[repr(C)]
+struct UNICODE_STRING {
+    length: u16,
+    max_length: u16,
+    buffer: *mut u16,
+}
+
+#[repr(C)]
+struct OBJECT_ATTRIBUTES {
+    length: u32,
+    root_directory: RawHandle,
+    name: *mut UNICODE_STRING,
+    attributes: u32,
+    security_description: *mut c_void,
+    security_quality_of_service: *mut c_void,
 }
 
 extern "system" {
@@ -55,15 +92,50 @@ extern "system" {
         overlapped: *mut OVERLAPPED,
     ) -> i32;
 
-    /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw>
-    fn CreateFileMappingW(
-        file: RawHandle,
-        attributes: *mut SECURITY_ATTRIBUTES,
-        protect: u32,
-        max_size_high: u32,
-        max_size_low: u32,
-        name: *const u16,
-    ) -> RawHandle;
+    /// <https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-zwcreatesection>
+    fn NtCreateSection(
+        section_handle: *mut RawHandle,
+        desired_access: u32,
+        obj_attrs: Option<*mut OBJECT_ATTRIBUTES>,
+        maximum_size: Option<*mut i64>,
+        section_page_protection: u32,
+        allocation_attributes: u32,
+        file_handle: RawHandle,
+    ) -> i32;
+
+    /// Undocumented, see <https://stackoverflow.com/a/41081832>
+    fn NtExtendSection(section: RawHandle, new_size: *mut i64) -> i32;
+
+    // /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw>
+    // fn CreateFileMappingW(
+    //     file: RawHandle,
+    //     attributes: *mut SECURITY_ATTRIBUTES,
+    //     protect: u32,
+    //     max_size_high: u32,
+    //     max_size_low: u32,
+    //     name: *const u16,
+    // ) -> RawHandle;
+
+    // /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffile>
+    // fn MapViewOfFile(
+    //     file_mapping: RawHandle,
+    //     desired_access: u32,
+    //     offset_high: u32,
+    //     offset_low: u32,
+    //     bytes_to_map: usize,
+    // ) -> *mut c_void;
+
+    // /// <https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers>
+    // fn FlushFileBuffers(file: RawHandle) -> u32;
+
+    // /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-flushviewoffile>
+    // fn FlushViewOfFile(base_address: *const c_void, number_of_bytes_to_flush: usize) -> u32;
+
+    // /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-unmapviewoffile>
+    // fn UnmapViewOfFile(base_address: *const c_void) -> u32;
+
+    // /// <https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsysteminfo>
+    // fn GetSystemInfo(system_info: *mut SYSTEM_INFO);
 }
 
 struct FileLock {
@@ -104,19 +176,86 @@ impl Drop for FileLock {
     }
 }
 
+/// Returns a fixed pointer that is valid for `slice::from_raw_parts::<u8>` with `len == 0`.
+#[inline]
+fn empty_slice_ptr() -> *mut c_void {
+    std::ptr::NonNull::<u8>::dangling().cast().as_ptr()
+}
+
 pub(super) struct MmapInner {
     pub(super) mmap: *mut u8,
     pub(super) capacity: usize,
+    mapping: RawHandle,
 }
 
 impl MmapInner {
-    pub(super) fn create_mapping(file: &File, max_capacity: usize) -> Result<*mut u8> {
+    pub(super) fn create_mapping(file: &File, len: u64, max_capacity: usize) -> Result<*mut u8> {
+        // `CreateFileMappingW` documents:
+        //
+        // https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw
+        // > An attempt to map a file with a length of 0 (zero) fails with an error code
+        // > of ERROR_FILE_INVALID. Applications should test for files with a length of 0
+        // > (zero) and reject those files.
+        assert!(len > 0);
+
+        unsafe {
+            let mut max_size = max_capacity as i64;
+            let mut section = MaybeUninit::new();
+            let status = NtCreateSection(
+                section.as_mut_ptr(),
+                SECTION_EXTEND_SIZE | SECTION_MAP_READ | SECTION_MAP_WRITE,
+                0,
+                Some(&mut max_size),
+                PAGE_READWRITE,
+                SEC_COMMIT,
+                file.as_raw_handle(),
+            );
+
+            let mapping = CreateFileMappingW(handle, ptr::null_mut(), protect, 0, 0, ptr::null());
+            if mapping.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+
+            let ptr = MapViewOfFile(
+                mapping,
+                access,
+                (aligned_offset >> 16 >> 16) as DWORD,
+                (aligned_offset & 0xffffffff) as DWORD,
+                aligned_len as SIZE_T,
+            );
+            CloseHandle(mapping);
+            if ptr.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+
+            let mut new_handle = 0 as RawHandle;
+            let cur_proc = GetCurrentProcess();
+            let ok = DuplicateHandle(
+                cur_proc,
+                handle,
+                cur_proc,
+                &mut new_handle,
+                0,
+                0,
+                DUPLICATE_SAME_ACCESS,
+            );
+            if ok == 0 {
+                UnmapViewOfFile(ptr);
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(MmapInner {
+                handle: Some(new_handle),
+                ptr: ptr.offset(alignment as isize),
+                len: len as usize,
+                copy,
+            })
+        }
         // CreateFileMappingW
         // MapViewOfFile
     }
 
-    /// Safety: if new_len < len(), caller must ensure that no references to memory in new_len..len() exist
-    pub(super) unsafe fn resize(&self, owner: &Mmap) -> Result<()> {
+    pub(super) unsafe fn resize(&self, len: u64, owner: &Mmap) -> Result<()> {
         let mmap = libc::mmap(
             self.mmap as *mut libc::c_void,
             self.capacity as libc::size_t,
@@ -157,7 +296,7 @@ impl MmapInner {
 
         #[cfg(not(fuzzing))]
         {
-            let result = unsafe { FlushViewOfFile(self.ptr.add(offset), len as SIZE_T) };
+            let result = unsafe { FlushViewOfFile(self.mmap.add(offset), len as SIZE_T) };
             if result != 0 {
                 Ok(())
             } else {
@@ -165,7 +304,10 @@ impl MmapInner {
             }
         }
 
-        Ok(())
+        #[cfg(fuzzing)]
+        {
+            Ok(())
+        }
     }
 }
 
@@ -176,4 +318,15 @@ impl Drop for MmapInner {
             // CloseHandle
         }
     }
+}
+
+#[inline]
+fn allocation_granularity() -> usize {
+    let info = unsafe {
+        let mut info = std::mem::MaybeUninit::uninit();
+        GetSystemInfo(info.as_mut_ptr());
+        info.assume_init()
+    };
+
+    info.dwAllocationGranularity as usize
 }

--- a/src/tree_store/page_store/mmap/windows.rs
+++ b/src/tree_store/page_store/mmap/windows.rs
@@ -217,6 +217,7 @@ impl MmapInner {
     }
 
     pub(super) unsafe fn resize(&self, len: u64, owner: &Mmap) -> Result<()> {
+        panic!("this should not be called");
         UnmapViewOfFile(self.mmap);
 
         owner.file.set_len(len)?;

--- a/src/tree_store/page_store/mmap/windows.rs
+++ b/src/tree_store/page_store/mmap/windows.rs
@@ -1,8 +1,8 @@
 use super::*;
 use std::ffi::c_void;
-use std::mem::MaybeUninit;
-use std::os::windows::io::AsRawFd;
+use std::os::windows::io::AsRawHandle;
 use std::os::windows::io::RawHandle;
+use std::ptr;
 
 #[repr(C)]
 struct OVERLAPPED {
@@ -18,6 +18,7 @@ union OVERLAPPED_0 {
     pub pointer: *mut c_void,
 }
 
+#[derive(Copy, Clone)]
 #[repr(C)]
 struct OVERLAPPED_0_0 {
     offset: u32,
@@ -28,48 +29,28 @@ const LOCKFILE_EXCLUSIVE_LOCK: u32 = 0x00000002;
 const LOCKFILE_FAIL_IMMEDIATELY: u32 = 0x00000001;
 const ERROR_IO_PENDING: i32 = 997;
 const PAGE_READWRITE: u32 = 0x4;
-const SECTION_MAP_READ: u32 = 0x2;
-const SECTION_MAP_READ: u32 = 0x4;
-const SECTION_EXTEND_SIZE: u32 = 0x10;
-const SEC_COMMIT: u32 = 0x8000000;
+
+const STANDARD_RIGHTS_REQUIRED: u32 = 0x000f0000;
+
+const SECTION_QUERY: u32 = 0x0001;
+const SECTION_MAP_WRITE: u32 = 0x0002;
+const SECTION_MAP_READ: u32 = 0x0004;
+const SECTION_MAP_EXECUTE: u32 = 0x0008;
+const SECTION_EXTEND_SIZE: u32 = 0x0010;
+const SECTION_ALL_ACCESS: u32 = STANDARD_RIGHTS_REQUIRED
+    | SECTION_QUERY
+    | SECTION_MAP_WRITE
+    | SECTION_MAP_READ
+    | SECTION_MAP_EXECUTE
+    | SECTION_EXTEND_SIZE;
+
+const FILE_MAP_ALL_ACCESS: u32 = SECTION_ALL_ACCESS;
 
 #[repr(C)]
 struct SECURITY_ATTRIBUTES {
     length: u32,
     descriptor: *mut c_void,
     inherit: u32,
-}
-
-#[repr(C)]
-struct SYSTEM_INFO {
-    processor_arch: u16,
-    reserved: u16,
-    page_size: u16,
-    min_app_address: *mut c_void,
-    max_app_address: *mut c_void,
-    active_processor_mask: usize,
-    number_of_processors: u32,
-    processor_type: u32,
-    allocation_granularity: u32,
-    processor_level: u16,
-    processor_revision: u16,
-}
-
-#[repr(C)]
-struct UNICODE_STRING {
-    length: u16,
-    max_length: u16,
-    buffer: *mut u16,
-}
-
-#[repr(C)]
-struct OBJECT_ATTRIBUTES {
-    length: u32,
-    root_directory: RawHandle,
-    name: *mut UNICODE_STRING,
-    attributes: u32,
-    security_description: *mut c_void,
-    security_quality_of_service: *mut c_void,
 }
 
 extern "system" {
@@ -92,81 +73,83 @@ extern "system" {
         overlapped: *mut OVERLAPPED,
     ) -> i32;
 
-    /// <https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-zwcreatesection>
-    fn NtCreateSection(
-        section_handle: *mut RawHandle,
+    /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw>
+    fn CreateFileMappingW(
+        file: RawHandle,
+        attributes: *mut SECURITY_ATTRIBUTES,
+        protect: u32,
+        max_size_high: u32,
+        max_size_low: u32,
+        name: *const u16,
+    ) -> RawHandle;
+
+    /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffileex>
+    fn MapViewOfFileEx(
+        file_mapping: RawHandle,
         desired_access: u32,
-        obj_attrs: Option<*mut OBJECT_ATTRIBUTES>,
-        maximum_size: Option<*mut i64>,
-        section_page_protection: u32,
-        allocation_attributes: u32,
-        file_handle: RawHandle,
-    ) -> i32;
+        offset_high: u32,
+        offset_low: u32,
+        bytes_to_map: usize,
+        base_address: *mut u8,
+    ) -> *mut u8;
 
-    /// Undocumented, see <https://stackoverflow.com/a/41081832>
-    fn NtExtendSection(section: RawHandle, new_size: *mut i64) -> i32;
+    /// <https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers>
+    fn FlushFileBuffers(file: RawHandle) -> u32;
 
-    // /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw>
-    // fn CreateFileMappingW(
-    //     file: RawHandle,
-    //     attributes: *mut SECURITY_ATTRIBUTES,
-    //     protect: u32,
-    //     max_size_high: u32,
-    //     max_size_low: u32,
-    //     name: *const u16,
-    // ) -> RawHandle;
+    /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-flushviewoffile>
+    fn FlushViewOfFile(base_address: *const u8, number_of_bytes_to_flush: usize) -> u32;
 
-    // /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffile>
-    // fn MapViewOfFile(
-    //     file_mapping: RawHandle,
-    //     desired_access: u32,
-    //     offset_high: u32,
-    //     offset_low: u32,
-    //     bytes_to_map: usize,
-    // ) -> *mut c_void;
+    /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-unmapviewoffile>
+    fn UnmapViewOfFile(base_address: *const u8) -> u32;
 
-    // /// <https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers>
-    // fn FlushFileBuffers(file: RawHandle) -> u32;
-
-    // /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-flushviewoffile>
-    // fn FlushViewOfFile(base_address: *const c_void, number_of_bytes_to_flush: usize) -> u32;
-
-    // /// <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-unmapviewoffile>
-    // fn UnmapViewOfFile(base_address: *const c_void) -> u32;
-
-    // /// <https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsysteminfo>
-    // fn GetSystemInfo(system_info: *mut SYSTEM_INFO);
+    /// <https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle>
+    fn CloseHandle(handle: RawHandle) -> u32;
 }
 
-struct FileLock {
+struct AutoHandle {
+    inner: RawHandle,
+}
+
+impl Drop for AutoHandle {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.inner);
+        }
+    }
+}
+
+pub(super) struct FileLock {
     handle: RawHandle,
     overlapped: OVERLAPPED,
 }
 
 impl FileLock {
-    fn new(file: &File) -> Result<Self> {
+    pub(super) fn new(file: &File) -> Result<Self> {
         let handle = file.as_raw_handle();
-        let overlapped = std::mem::zeroed();
-        let result = unsafe {
-            LockFileEx(
+        let overlapped = unsafe {
+            let mut overlapped = std::mem::zeroed();
+            let result = LockFileEx(
                 handle,
                 LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
                 0,
                 u32::MAX,
                 u32::MAX,
                 &mut overlapped,
-            )
-        };
-        if result == 0 {
-            let err = io::Error::last_os_error();
-            if err.raw_os_error() == Some(ERROR_IO_PENDING) {
-                Err(Error::DatabaseAlreadyOpen)
-            } else {
-                Err(Error::Io(err))
+            );
+
+            if result == 0 {
+                let err = io::Error::last_os_error();
+                return if err.raw_os_error() == Some(ERROR_IO_PENDING) {
+                    Err(Error::DatabaseAlreadyOpen)
+                } else {
+                    Err(Error::Io(err))
+                };
             }
-        } else {
-            Ok(Self { fd })
-        }
+
+            overlapped
+        };
+
+        Ok(Self { handle, overlapped })
     }
 }
 
@@ -176,20 +159,13 @@ impl Drop for FileLock {
     }
 }
 
-/// Returns a fixed pointer that is valid for `slice::from_raw_parts::<u8>` with `len == 0`.
-#[inline]
-fn empty_slice_ptr() -> *mut c_void {
-    std::ptr::NonNull::<u8>::dangling().cast().as_ptr()
-}
-
 pub(super) struct MmapInner {
     pub(super) mmap: *mut u8,
     pub(super) capacity: usize,
-    mapping: RawHandle,
 }
 
 impl MmapInner {
-    pub(super) fn create_mapping(file: &File, len: u64, max_capacity: usize) -> Result<*mut u8> {
+    pub(super) fn create_mapping(file: &File, len: u64, max_capacity: usize) -> Result<Self> {
         // `CreateFileMappingW` documents:
         //
         // https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw
@@ -198,79 +174,58 @@ impl MmapInner {
         // > (zero) and reject those files.
         assert!(len > 0);
 
-        unsafe {
-            let mut max_size = max_capacity as i64;
-            let mut section = MaybeUninit::new();
-            let status = NtCreateSection(
-                section.as_mut_ptr(),
-                SECTION_EXTEND_SIZE | SECTION_MAP_READ | SECTION_MAP_WRITE,
-                0,
-                Some(&mut max_size),
-                PAGE_READWRITE,
-                SEC_COMMIT,
-                file.as_raw_handle(),
-            );
+        let mmap = unsafe { Self::map_file(file, len, ptr::null_mut())? };
 
-            let mapping = CreateFileMappingW(handle, ptr::null_mut(), protect, 0, 0, ptr::null());
-            if mapping.is_null() {
-                return Err(io::Error::last_os_error());
+        Ok(Self {
+            mmap,
+            capacity: max_capacity,
+        })
+    }
+
+    unsafe fn map_file(file: &File, len: u64, map_addr: *mut u8) -> Result<*mut u8> {
+        let handle = file.as_raw_handle();
+
+        let lo = (len & u32::MAX as u64) as u32;
+        let hi = (len >> 32) as u32;
+
+        let ptr = {
+            let mapping = AutoHandle {
+                inner: CreateFileMappingW(
+                    handle,
+                    ptr::null_mut(),
+                    PAGE_READWRITE,
+                    hi,
+                    lo,
+                    ptr::null(),
+                ),
+            };
+            if mapping.inner.is_null() {
+                return Err(Error::Io(io::Error::last_os_error()));
             }
 
-            let ptr = MapViewOfFile(
-                mapping,
-                access,
-                (aligned_offset >> 16 >> 16) as DWORD,
-                (aligned_offset & 0xffffffff) as DWORD,
-                aligned_len as SIZE_T,
-            );
-            CloseHandle(mapping);
-            if ptr.is_null() {
-                return Err(io::Error::last_os_error());
-            }
-
-            let mut new_handle = 0 as RawHandle;
-            let cur_proc = GetCurrentProcess();
-            let ok = DuplicateHandle(
-                cur_proc,
-                handle,
-                cur_proc,
-                &mut new_handle,
+            MapViewOfFileEx(
+                mapping.inner,
+                FILE_MAP_ALL_ACCESS,
                 0,
                 0,
-                DUPLICATE_SAME_ACCESS,
-            );
-            if ok == 0 {
-                UnmapViewOfFile(ptr);
-                return Err(io::Error::last_os_error());
-            }
+                len.try_into().unwrap(),
+                map_addr,
+            )
+        };
 
-            Ok(MmapInner {
-                handle: Some(new_handle),
-                ptr: ptr.offset(alignment as isize),
-                len: len as usize,
-                copy,
-            })
-        }
-        // CreateFileMappingW
-        // MapViewOfFile
+        Ok(ptr)
     }
 
     pub(super) unsafe fn resize(&self, len: u64, owner: &Mmap) -> Result<()> {
-        let mmap = libc::mmap(
-            self.mmap as *mut libc::c_void,
-            self.capacity as libc::size_t,
-            libc::PROT_READ | libc::PROT_WRITE,
-            libc::MAP_SHARED | libc::MAP_FIXED,
-            owner.file.as_raw_fd(),
-            0,
-        );
+        UnmapViewOfFile(self.mmap);
 
-        if mmap == libc::MAP_FAILED {
-            Err(io::Error::last_os_error().into())
-        } else {
-            assert_eq!(mmap as *mut u8, self.mmap);
-            Ok(())
-        }
+        owner.file.set_len(len)?;
+        let ptr = Self::map_file(&owner.file, len, self.mmap)?;
+
+        // This is the same logic as in unix
+        assert_eq!(ptr, self.mmap);
+
+        Ok(())
     }
 
     pub(super) fn flush(&self, owner: &Mmap) -> Result {
@@ -278,11 +233,8 @@ impl MmapInner {
 
         #[cfg(not(fuzzing))]
         {
-            if let Some(handle) = self.handle {
-                let ok = unsafe { FlushFileBuffers(handle) };
-                if ok == 0 {
-                    return Err(io::Error::last_os_error());
-                }
+            if unsafe { FlushFileBuffers(owner.file.as_raw_handle()) } == 0 {
+                return Err(Error::Io(io::Error::last_os_error()));
             }
         }
         Ok(())
@@ -290,17 +242,13 @@ impl MmapInner {
 
     #[inline]
     pub(super) fn eventual_flush(&self, owner: &Mmap) -> Result {
-        if self.mmap == empty_slice_ptr() {
-            return Ok(());
-        }
-
         #[cfg(not(fuzzing))]
         {
-            let result = unsafe { FlushViewOfFile(self.mmap.add(offset), len as SIZE_T) };
+            let result = unsafe { FlushViewOfFile(self.mmap, owner.len()) };
             if result != 0 {
                 Ok(())
             } else {
-                Err(io::Error::last_os_error())
+                Err(Error::Io(io::Error::last_os_error()))
             }
         }
 
@@ -314,19 +262,7 @@ impl MmapInner {
 impl Drop for MmapInner {
     fn drop(&mut self) {
         unsafe {
-            // UnmapViewOfFile
-            // CloseHandle
+            UnmapViewOfFile(self.mmap);
         }
     }
-}
-
-#[inline]
-fn allocation_granularity() -> usize {
-    let info = unsafe {
-        let mut info = std::mem::MaybeUninit::uninit();
-        GetSystemInfo(info.as_mut_ptr());
-        info.assume_init()
-    };
-
-    info.dwAllocationGranularity as usize
 }

--- a/src/tree_store/page_store/mmap/windows.rs
+++ b/src/tree_store/page_store/mmap/windows.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::upper_case_acronyms)]
+
 use super::*;
 use std::ffi::c_void;
 use std::os::windows::io::AsRawHandle;
@@ -216,17 +218,17 @@ impl MmapInner {
         Ok(ptr)
     }
 
-    pub(super) unsafe fn resize(&self, len: u64, owner: &Mmap) -> Result<()> {
-        panic!("this should not be called");
-        UnmapViewOfFile(self.mmap);
+    pub(super) unsafe fn resize(&self, _len: u64, _owner: &Mmap) -> Result<()> {
+        unreachable!("Mmap resizing is not supported on Windows");
+        // UnmapViewOfFile(self.mmap);
 
-        owner.file.set_len(len)?;
-        let ptr = Self::map_file(&owner.file, len, self.mmap)?;
+        // owner.file.set_len(len)?;
+        // let ptr = Self::map_file(&owner.file, len, self.mmap)?;
 
-        // This is the same logic as in unix
-        assert_eq!(ptr, self.mmap);
+        // // This is the same logic as in unix
+        // assert_eq!(ptr, self.mmap);
 
-        Ok(())
+        // Ok(())
     }
 
     pub(super) fn flush(&self, owner: &Mmap) -> Result {

--- a/src/tree_store/page_store/mmap/windows.rs
+++ b/src/tree_store/page_store/mmap/windows.rs
@@ -1,0 +1,196 @@
+use super::*;
+use std::ffi::c_void;
+use std::os::windows::io::AsRawFd;
+use std::os::windows::io::RawHandle;
+
+#[repr(C)]
+struct OVERLAPPED {
+    internal: usize,
+    internal_high: usize,
+    anonymous: OVERLAPPED_0,
+    event: RawHandle,
+}
+
+#[repr(C)]
+union OVERLAPPED_0 {
+    pub anonymous: OVERLAPPED_0_0,
+    pub pointer: *mut c_void,
+}
+
+#[repr(C)]
+struct OVERLAPPED_0_0 {
+    offset: u32,
+    offset_high: u32,
+}
+
+const LOCKFILE_EXCLUSIVE_LOCK: u32 = 0x00000002;
+const LOCKFILE_FAIL_IMMEDIATELY: u32 = 0x00000001;
+const ERROR_IO_PENDING: i32 = 997;
+
+extern "system" {
+    /// <https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex>
+    fn LockFileEx(
+        file: RawHandle,
+        flags: u32,
+        _reserved: u32,
+        length_low: u32,
+        length_high: u32,
+        overlapped: *mut OVERLAPPED,
+    ) -> i32;
+
+    fn UnlockFileEx(
+        file: RawHandle,
+        _reserved: u32,
+        length_low: u32,
+        length_high: u32,
+        overlapped: *mut OVERLAPPED,
+    ) -> i32;
+}
+
+struct FileLock {
+    handle: RawHandle,
+    overlapped: OVERLAPPED,
+}
+
+impl FileLock {
+    fn new(file: &File) -> Result<Self> {
+        let handle = file.as_raw_handle();
+        let overlapped = std::mem::zeroed();
+        let result = unsafe {
+            LockFileEx(
+                handle,
+                LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+                0,
+                u32::MAX,
+                u32::MAX,
+                &mut overlapped,
+            )
+        };
+        if result == 0 {
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() == Some(ERROR_IO_PENDING) {
+                Err(Error::DatabaseAlreadyOpen)
+            } else {
+                Err(Error::Io(err))
+            }
+        } else {
+            Ok(Self { fd })
+        }
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        unsafe { UnlockFileEx(self.handle, 0, u32::MAX, u32::MAX, &mut self.overlapped) };
+    }
+}
+
+pub(super) struct MmapInner {
+    pub(super) mmap: *mut u8,
+    pub(super) capacity: usize,
+}
+
+impl MmapInner {
+    pub(super) fn create_mapping(file: &File, max_capacity: usize) -> Result<*mut u8> {
+        // CreateFileMappingW
+        // MapViewOfFile
+    }
+
+    // Safety: if new_len < len(), caller must ensure that no references to memory in new_len..len() exist
+    pub(crate) unsafe fn resize(&self, new_len: usize) -> Result<()> {
+        assert!(new_len <= self.capacity);
+        self.check_fsync_failure()?;
+        self.file.set_len(new_len as u64)?;
+
+        let mmap = libc::mmap(
+            self.mmap as *mut libc::c_void,
+            self.capacity as libc::size_t,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_SHARED | libc::MAP_FIXED,
+            self.file.as_raw_fd(),
+            0,
+        );
+
+        if mmap == libc::MAP_FAILED {
+            Err(io::Error::last_os_error().into())
+        } else {
+            assert_eq!(mmap as *mut u8, self.mmap);
+            self.len.store(new_len, Ordering::Release);
+            Ok(())
+        }
+    }
+
+    /// Safety: if new_len < len(), caller must ensure that no references to memory in new_len..len() exist
+    pub(super) unsafe fn resize(&self, owner: &Mmap) -> Result<()> {
+        let mmap = libc::mmap(
+            self.mmap as *mut libc::c_void,
+            self.capacity as libc::size_t,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_SHARED | libc::MAP_FIXED,
+            owner.file.as_raw_fd(),
+            0,
+        );
+
+        if mmap == libc::MAP_FAILED {
+            Err(io::Error::last_os_error().into())
+        } else {
+            assert_eq!(mmap as *mut u8, self.mmap);
+            Ok(())
+        }
+    }
+
+    pub(super) fn flush(&self, owner: &Mmap) -> Result {
+        // Disable fsync when fuzzing, since it doesn't test crash consistency
+        #[cfg(not(fuzzing))]
+        {
+            #[cfg(not(target_os = "macos"))]
+            {
+                let result = unsafe {
+                    libc::msync(
+                        self.mmap as *mut libc::c_void,
+                        owner.len() as libc::size_t,
+                        libc::MS_SYNC,
+                    )
+                };
+                if result != 0 {
+                    return Err(io::Error::last_os_error().into());
+                }
+            }
+            #[cfg(target_os = "macos")]
+            {
+                let code = unsafe { libc::fcntl(self.file.as_raw_fd(), libc::F_FULLFSYNC) };
+                if code == -1 {
+                    return Err(io::Error::last_os_error().into());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn eventual_flush(&self, owner: &Mmap) -> Result {
+        #[cfg(not(target_os = "macos"))]
+        {
+            return self.flush(owner);
+        }
+        #[cfg(all(target_os = "macos", not(fuzzing)))]
+        {
+            // TODO: It may be unsafe to mix F_BARRIERFSYNC with writes to the mmap.
+            //       Investigate switching to `write()`
+            let code = unsafe { libc::fcntl(owner.file.as_raw_fd(), libc::F_BARRIERFSYNC) };
+            if code == -1 {
+                Err(io::Error::last_os_error().into());
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Drop for MmapInner {
+    fn drop(&mut self) {
+        unsafe {
+            // UnmapViewOfFile
+            // CloseHandle
+        }
+    }
+}

--- a/src/tree_store/page_store/xxh3.rs
+++ b/src/tree_store/page_store/xxh3.rs
@@ -70,9 +70,7 @@ pub fn hash64_with_seed(data: &[u8], seed: u64) -> u64 {
         }
         #[cfg(target_arch = "aarch64")]
         {
-            unsafe {
-                return hash64_large_neon(data, seed);
-            }
+            unsafe { hash64_large_neon(data, seed) }
         }
         #[cfg(not(target_arch = "aarch64"))]
         hash64_large_generic(
@@ -99,9 +97,7 @@ pub fn hash128_with_seed(data: &[u8], seed: u64) -> u128 {
         }
         #[cfg(target_arch = "aarch64")]
         {
-            unsafe {
-                return hash128_large_neon(data, seed);
-            }
+            unsafe { hash128_large_neon(data, seed) }
         }
         #[cfg(not(target_arch = "aarch64"))]
         hash128_large_generic(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4,9 +4,11 @@ use tempfile::NamedTempFile;
 
 use rand::prelude::SliceRandom;
 use rand::Rng;
+#[cfg(unix)]
+use redb::ReadableMultimapTable;
 use redb::{
-    Builder, Database, Durability, Error, MultimapTableDefinition, ReadableMultimapTable,
-    ReadableTable, TableDefinition, WriteStrategy,
+    Builder, Database, Durability, Error, MultimapTableDefinition, ReadableTable, TableDefinition,
+    WriteStrategy,
 };
 
 const ELEMENTS: usize = 100;
@@ -143,6 +145,7 @@ fn free() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
 
     let db_size = 8 * 1024 * 1024;
+    #[cfg_attr(windows, allow(unused_mut))]
     let db = unsafe {
         let mut builder = Database::builder();
         #[cfg(unix)]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -144,10 +144,13 @@ fn free() {
 
     let db_size = 8 * 1024 * 1024;
     let db = unsafe {
-        Database::builder()
-            .set_dynamic_growth(false)
-            .create(tmpfile.path(), db_size)
-            .unwrap()
+        let mut builder = Database::builder();
+        #[cfg(unix)]
+        {
+            builder.set_dynamic_growth(false);
+        }
+
+        builder.create(tmpfile.path(), db_size).unwrap()
     };
     let txn = db.begin_write().unwrap();
     {
@@ -271,6 +274,7 @@ fn large_keys() {
 }
 
 #[test]
+#[cfg(unix)]
 fn dynamic_growth() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let table_definition: TableDefinition<u64, [u8]> = TableDefinition::new("x");
@@ -303,6 +307,7 @@ fn dynamic_growth() {
 }
 
 #[test]
+#[cfg(unix)]
 fn dynamic_shrink() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let table_definition: TableDefinition<u64, [u8]> = TableDefinition::new("x");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -779,6 +779,8 @@ fn regression13() {
 }
 
 #[test]
+// Disabling on Windows for now since this requires a minimum of 140GiB of disk space due to lack of resizing
+#[cfg(unix)]
 fn regression14() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
 
@@ -819,6 +821,8 @@ fn regression14() {
 }
 
 #[test]
+// Disabling on Windows for now since this requires a minimum of 400GiB of disk space due to lack of resizing
+#[cfg(unix)]
 fn regression15() {
     let tmpfile: NamedTempFile = NamedTempFile::new().unwrap();
     let db_size = 400998358365;

--- a/tests/mmap_tests.rs
+++ b/tests/mmap_tests.rs
@@ -1,12 +1,11 @@
-use std::sync::mpsc::channel;
-use std::{ptr, slice, thread};
-use tempfile::NamedTempFile;
-
 #[cfg(unix)]
 #[test]
 // Test that reloading an mmap'ed region is thread-safe and atomic
 fn reload_mmap() {
     use std::os::unix::io::AsRawFd;
+    use std::sync::mpsc::channel;
+    use std::{ptr, slice, thread};
+    use tempfile::NamedTempFile;
 
     struct SendPtr(*mut libc::c_void);
     unsafe impl Send for SendPtr {}

--- a/tests/mmap_tests.rs
+++ b/tests/mmap_tests.rs
@@ -1,11 +1,13 @@
-use std::os::unix::io::AsRawFd;
 use std::sync::mpsc::channel;
 use std::{ptr, slice, thread};
 use tempfile::NamedTempFile;
 
+#[cfg(unix)]
 #[test]
 // Test that reloading an mmap'ed region is thread-safe and atomic
 fn reload_mmap() {
+    use std::os::unix::io::AsRawFd;
+
     struct SendPtr(*mut libc::c_void);
     unsafe impl Send for SendPtr {}
 


### PR DESCRIPTION
1. Windows requires that file mappings to files on disk have a length > 0. This means that several tests immediately fail since they start with an empty file.
2. The Unix implementation truncates files to both decrease and increase the size of the mapped memory and then remaps and asserts that the base pointer is the same so that files can be resized while also being read from concurrently. While it's _possible_ that increasing the file size on Windows can be accomplished with [some "lightly" documented internal kernel functions](https://stackoverflow.com/a/55068177), _decreasing_ the size of the file is (AFAIK) impossible without unmapping the file first.

This provides initial support for Windows that passes _almost_ all tests, I've disabled `regression14 + 15` tests since they both allocate huge files and Windows since it doesn't support dynamic resize.

The only substantial change, other than just adding the mmap support for windows itself, was to change `TransactionalMemory::new` a bit so that it sizes the file appropriately _before_ opening the Mmap so that both Unix and Windows can be supported transparently. Since resizing is not supported the `dynamic_growth` toggle is always turned off on Windows with no way to enable it via the public API. I didn't go the more extreme route of removing the resize method from Mmap on Windows, since as I said above, it _could_ be possible to enable at least dynamic _increasing_ growth if wanted, but not be able to decrease it, but if that was wanted that could be moved to a separate PR as a follow up. Also allowing dynamic increasing growth would allow regression14 + 15 to be turned back on since they wouldn't hit disk limits.

There were also a few minor fixups to align the errors expected by tests when running on Windows.

Resolves: #300 