### PR TITLE
Add write lock

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -426,7 +426,8 @@ impl Database {
     /// Begins a write transaction
     ///
     /// Returns a [`WriteTransaction`] which may be used to read/write to the database. Only a single
-    /// write may be in progress at a time
+    /// write may be in progress at a time. If a write is in progress, this function will block
+    /// until it completes.
     pub fn begin_write(&self) -> Result<WriteTransaction> {
         let mut guard = self.live_write_transaction.lock().unwrap();
         assert!(guard.is_none());

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -113,9 +113,9 @@ impl<'db> WriteTransaction<'db> {
     pub(crate) fn new(db: &'db Database) -> Result<Self> {
         let mut live_write_transaction = db.live_write_transaction.lock().unwrap();
         assert!(live_write_transaction.is_none());
+        let transaction_id = db.increment_transaction_id();
         #[cfg(feature = "logging")]
         info!("Beginning write transaction id={}", transaction_id);
-        let transaction_id = db.increment_transaction_id();
         *live_write_transaction = Some(transaction_id);
 
         let root_page = db.get_memory().get_data_root();

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -115,7 +115,7 @@ impl<'db> WriteTransaction<'db> {
         let mut live_write_transaction = db.live_write_transaction.lock().unwrap();
         assert!(live_write_transaction.is_none());
         #[cfg(feature = "logging")]
-        info!("Beginning write transaction id={}", id);
+        info!("Beginning write transaction id={}", transaction_id);
         let transaction_id = db.next_transaction_id.fetch_add(1, Ordering::AcqRel);
         *live_write_transaction = Some(transaction_id);
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::mem::size_of;
 use std::panic;
 use std::rc::Rc;
-use std::sync::RwLockWriteGuard;
+use std::sync::MutexGuard;
 
 /// Informational storage stats about the database
 #[derive(Debug)]
@@ -106,7 +106,7 @@ pub struct WriteTransaction<'db> {
     open_tables: RefCell<HashMap<String, &'static panic::Location<'static>>>,
     completed: bool,
     durability: Durability,
-    write_lock: RwLockWriteGuard<'db, Option<TransactionId>>,
+    write_lock: MutexGuard<'db, Option<TransactionId>>,
 }
 
 impl<'db> WriteTransaction<'db> {
@@ -114,7 +114,7 @@ impl<'db> WriteTransaction<'db> {
     // at a time
     pub(crate) unsafe fn new(
         db: &'db Database,
-        write_lock: RwLockWriteGuard<'db, Option<TransactionId>>,
+        write_lock: MutexGuard<'db, Option<TransactionId>>,
         transaction_id: TransactionId,
     ) -> Result<Self> {
         let root_page = db.get_memory().get_data_root();


### PR DESCRIPTION
I replaced the live write transaction `Mutex` with an `RwLock` so that writes can be initiated in parallel on different threads, but will block each other. I'm not sure if this is right, since there are a lot of subtleties with things like this.

Also, I was thinking that `WriteTransaction::new` should be safe, and should only take a reference to the database, and should grab the `RwLock` and allocate a new transaction ID, instead of spreading the safety concerns between `Database::begin_write` and `WriteTransaction::new`.

Depends on #370.