### PR TITLE
Fix Makefile warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,11 @@ fuzz: pre
 	rustup toolchain install $(NIGHTLY)
 	cargo +$(NIGHTLY) fuzz run fuzz_redb -- -max_len=1000000 -timeout=60
 
-RUST_SYSROOT := $(shell cargo +$(NIGHTLY) rustc -- --print sysroot 2>/dev/null)
-LLVM_COV := $(shell find $(RUST_SYSROOT) -name llvm-cov)
 .PHONY: fuzz_coverage
 fuzz_coverage: pre
+	rustup toolchain install $(NIGHTLY)
+	$(eval RUST_SYSROOT := $(shell cargo +$(NIGHTLY) rustc -- --print sysroot 2>/dev/null))
+	$(eval LLVM_COV := $(shell find $(RUST_SYSROOT) -name llvm-cov))
 	echo $(LLVM_COV)
 	rustup component add llvm-tools-preview --toolchain $(NIGHTLY)
 	cargo +$(NIGHTLY) fuzz coverage fuzz_redb


### PR DESCRIPTION
Makefile no longer requires nightly toolchain to be installed for all recipes, and now only requires it for the fuzz and fuzz_coverage targets

Fixes #372 