### PR TITLE
Move savepoint methods to WriteTransaction

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -438,6 +438,14 @@ impl Database {
         })
     }
 
+    fn allocate_read_transaction(&self) -> Result<TransactionId> {
+        let mut guard = self.live_read_transactions.lock().unwrap();
+        let id = self.mem.get_last_committed_transaction_id()?;
+        guard.entry(id).and_modify(|x| *x += 1).or_insert(1);
+
+        Ok(id)
+    }
+
     pub(crate) fn deallocate_read_transaction(&self, id: TransactionId) {
         let mut guard = self.live_read_transactions.lock().unwrap();
         let ref_count = guard.get_mut(&id).unwrap();
@@ -447,17 +455,26 @@ impl Database {
         }
     }
 
+    pub(crate) fn allocate_savepoint(&self) -> Result<(SavepointId, TransactionId)> {
+        let id = self.next_savepoint_id.next();
+        self.valid_savepoints.lock().unwrap().insert(id);
+        Ok((id, self.allocate_read_transaction()?))
+    }
+
+    pub(crate) fn is_valid_savepoint(&self, id: SavepointId) -> bool {
+        self.valid_savepoints.lock().unwrap().contains(&id)
+    }
+
+    pub(crate) fn invalidate_savepoints_after(&self, id: SavepointId) {
+        self.valid_savepoints.lock().unwrap().retain(|x| *x <= id);
+    }
+
     pub(crate) fn deallocate_savepoint(&self, savepoint: &Savepoint) {
         self.valid_savepoints
             .lock()
             .unwrap()
             .remove(&savepoint.get_id());
-        let mut guard = self.live_read_transactions.lock().unwrap();
-        let ref_count = guard.get_mut(&savepoint.get_transaction_id()).unwrap();
-        *ref_count -= 1;
-        if *ref_count == 0 {
-            guard.remove(&savepoint.get_transaction_id());
-        }
+        self.deallocate_read_transaction(savepoint.get_transaction_id());
     }
 
     pub(crate) fn oldest_live_read_transaction(&self) -> Option<TransactionId> {
@@ -505,59 +522,6 @@ impl Database {
         Ok(())
     }
 
-    /// Creates a snapshot of the current database state, which can be used to rollback the database
-    pub fn savepoint(&self) -> Result<Savepoint> {
-        let mut valid_savepoints_guard = self.valid_savepoints.lock().unwrap();
-        // Hold write lock to ensure we get a consistent snapshot
-        let guard = self.live_write_transaction.lock().unwrap();
-        assert!(guard.is_none());
-
-        let id = self.next_savepoint_id.next();
-        let mut live_reads = self.live_read_transactions.lock().unwrap();
-
-        let transaction_id = self.mem.get_last_committed_transaction_id()?;
-        live_reads
-            .entry(transaction_id)
-            .and_modify(|x| *x += 1)
-            .or_insert(1);
-
-        #[cfg(feature = "logging")]
-        info!(
-            "Creating savepoint id={:?}, txn_id={:?}",
-            id, transaction_id
-        );
-        let regional_allocators = self.mem.get_raw_allocator_states();
-        let root = self.mem.get_data_root();
-        let freed_root = self.mem.get_freed_root();
-        drop(live_reads);
-        let savepoint = Savepoint::new(
-            self,
-            id,
-            transaction_id,
-            root,
-            freed_root,
-            regional_allocators,
-        );
-        valid_savepoints_guard.insert(savepoint.get_id());
-        drop(guard);
-
-        Ok(savepoint)
-    }
-
-    pub fn restore_savepoint(&self, savepoint: &Savepoint) -> Result {
-        let mut guard = self.valid_savepoints.lock().unwrap();
-        if !guard.contains(&savepoint.get_id()) {
-            return Err(Error::InvalidSavepoint);
-        }
-        WriteTransaction::commit_savepoint(self, savepoint)?;
-
-        // Invalidate all savepoints that are newer than the one being applied to prevent the user
-        // from later trying to restore a savepoint on "another timeline"
-        guard.retain(|x| *x <= savepoint.get_id());
-
-        Ok(())
-    }
-
     /// Begins a write transaction
     ///
     /// Returns a [`WriteTransaction`] which may be used to read/write to the database. Only a single
@@ -575,9 +539,7 @@ impl Database {
     /// Returns a [`ReadTransaction`] which may be used to read from the database. Read transactions
     /// may exist concurrently with writes
     pub fn begin_read(&self) -> Result<ReadTransaction> {
-        let mut guard = self.live_read_transactions.lock().unwrap();
-        let id = self.mem.get_last_committed_transaction_id()?;
-        guard.entry(id).and_modify(|x| *x += 1).or_insert(1);
+        let id = self.allocate_read_transaction()?;
         #[cfg(feature = "logging")]
         info!("Beginning read transaction id={:?}", id);
         Ok(ReadTransaction::new(self, id))


### PR DESCRIPTION
This allows users to construct certain race-free savepoint scenarios, and fixes several races in the fuzzer