### PR TITLE
Add assert to restore_savepoint()

### DIFF
--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -179,6 +179,12 @@ impl<'db> WriteTransaction<'db> {
     ///
     /// Calling this method invalidates all [`Savepoint`]s created after savepoint
     pub fn restore_savepoint(&mut self, savepoint: &Savepoint) -> Result {
+        // Ensure that user does not try to restore a Savepoint that is from a different Database
+        assert_eq!(
+            self.db.transaction_tracker().as_ref() as *const _,
+            savepoint.db_address()
+        );
+
         if !self
             .transaction_tracker
             .lock()

--- a/src/tree_store/page_store/savepoint.rs
+++ b/src/tree_store/page_store/savepoint.rs
@@ -65,6 +65,10 @@ impl Savepoint {
     pub(crate) fn get_regional_allocator_states(&self) -> &[Vec<u8>] {
         &self.regional_allocators
     }
+
+    pub(crate) fn db_address(&self) -> *const Mutex<TransactionTracker> {
+        self.transaction_tracker.as_ref() as *const _
+    }
 }
 
 impl Drop for Savepoint {


### PR DESCRIPTION
This ensures that the Savepoint being restored was captured from the same Database

Fixes #413 