### PR TITLE
Open benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Cargo.lock
 # Profiling
 perf.data*
 flamegraph.svg
+
+# benchmark temporary files
+/.tmp*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,10 @@ harness = false
 name = "mmap_page_size_benchmark"
 harness = false
 
+[[bench]]
+name = "open_benchmark"
+harness = false
+
 [package.metadata.maturin]
 requires-python = ">= 3.7"
 classifier = ["Development Status :: 4 - Beta",

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -183,6 +183,7 @@ pub struct SledBenchDatabase<'a> {
 }
 
 impl<'a> SledBenchDatabase<'a> {
+    #[allow(dead_code)]
     pub fn new(db: &'a sled::Db, path: &'a Path) -> Self {
         SledBenchDatabase { db, db_dir: path }
     }
@@ -416,6 +417,7 @@ pub struct RocksdbBenchDatabase<'a> {
 }
 
 impl<'a> RocksdbBenchDatabase<'a> {
+    #[allow(dead_code)]
     pub fn new(db: &'a TransactionDB) -> Self {
         Self { db }
     }
@@ -529,6 +531,7 @@ pub struct SanakirjaBenchDatabase<'a> {
 }
 
 impl<'a> SanakirjaBenchDatabase<'a> {
+    #[allow(dead_code)]
     pub fn new(db: &'a sanakirja::Env) -> Self {
         let mut txn = sanakirja::Env::mut_txn_begin(db).unwrap();
         let table =

--- a/benches/open_benchmark.rs
+++ b/benches/open_benchmark.rs
@@ -1,0 +1,309 @@
+use std::env::current_dir;
+use std::fs;
+use std::mem::size_of;
+use tempfile::{NamedTempFile, TempDir};
+
+mod common;
+use common::*;
+
+use redb::WriteStrategy;
+use std::time::{Duration, Instant};
+
+const ITERATIONS: usize = 3;
+const ELEMENTS: usize = 1_000_000;
+const KEY_SIZE: usize = 24;
+const VALUE_SIZE: usize = 150;
+const RNG_SEED: u64 = 3;
+
+fn fill_slice(slice: &mut [u8], rng: &mut fastrand::Rng) {
+    let mut i = 0;
+    while i + size_of::<u128>() < slice.len() {
+        let tmp = rng.u128(..);
+        slice[i..(i + size_of::<u128>())].copy_from_slice(&tmp.to_le_bytes());
+        i += size_of::<u128>()
+    }
+    if i + size_of::<u64>() < slice.len() {
+        let tmp = rng.u64(..);
+        slice[i..(i + size_of::<u64>())].copy_from_slice(&tmp.to_le_bytes());
+        i += size_of::<u64>()
+    }
+    if i + size_of::<u32>() < slice.len() {
+        let tmp = rng.u32(..);
+        slice[i..(i + size_of::<u32>())].copy_from_slice(&tmp.to_le_bytes());
+        i += size_of::<u32>()
+    }
+    if i + size_of::<u16>() < slice.len() {
+        let tmp = rng.u16(..);
+        slice[i..(i + size_of::<u16>())].copy_from_slice(&tmp.to_le_bytes());
+        i += size_of::<u16>()
+    }
+    if i + size_of::<u8>() < slice.len() {
+        slice[i] = rng.u8(..);
+    }
+}
+
+/// Returns pairs of key, value
+fn gen_pair(rng: &mut fastrand::Rng) -> ([u8; KEY_SIZE], Vec<u8>) {
+    let mut key = [0u8; KEY_SIZE];
+    fill_slice(&mut key, rng);
+    let mut value = vec![0u8; VALUE_SIZE];
+    fill_slice(&mut value, rng);
+
+    (key, value)
+}
+
+fn make_rng() -> fastrand::Rng {
+    fastrand::Rng::with_seed(RNG_SEED)
+}
+
+fn benchmark<T: BenchDatabase>(db: T) -> Vec<(&'static str, Duration)> {
+    let mut rng = make_rng();
+    let mut results = Vec::new();
+
+    let start = Instant::now();
+    let mut txn = db.write_transaction();
+    let mut inserter = txn.get_inserter();
+    {
+        for _ in 0..ELEMENTS {
+            let (key, value) = gen_pair(&mut rng);
+            inserter.insert(&key, &value).unwrap();
+        }
+    }
+    drop(inserter);
+    txn.commit().unwrap();
+
+    let end = Instant::now();
+    let duration = end - start;
+    println!(
+        "{}: Bulk loaded {} items in {}ms",
+        T::db_type_name(),
+        ELEMENTS,
+        duration.as_millis()
+    );
+    results.push(("bulk load", duration));
+
+    let start = Instant::now();
+    let writes = 100;
+    {
+        for _ in 0..writes {
+            let mut txn = db.write_transaction();
+            let mut inserter = txn.get_inserter();
+            let (key, value) = gen_pair(&mut rng);
+            inserter.insert(&key, &value).unwrap();
+            drop(inserter);
+            txn.commit().unwrap();
+        }
+    }
+
+    let end = Instant::now();
+    let duration = end - start;
+    println!(
+        "{}: Wrote {} individual items in {}ms",
+        T::db_type_name(),
+        writes,
+        duration.as_millis()
+    );
+    results.push(("individual writes", duration));
+
+    let start = Instant::now();
+    let batch_size = 1000;
+    {
+        for _ in 0..writes {
+            let mut txn = db.write_transaction();
+            let mut inserter = txn.get_inserter();
+            for _ in 0..batch_size {
+                let (key, value) = gen_pair(&mut rng);
+                inserter.insert(&key, &value).unwrap();
+            }
+            drop(inserter);
+            txn.commit().unwrap();
+        }
+    }
+
+    let end = Instant::now();
+    let duration = end - start;
+    println!(
+        "{}: Wrote {} x {} items in {}ms",
+        T::db_type_name(),
+        writes,
+        batch_size,
+        duration.as_millis()
+    );
+    results.push(("batch writes", duration));
+
+    let txn = db.read_transaction();
+    {
+        for _ in 0..ITERATIONS {
+            let mut rng = make_rng();
+            let start = Instant::now();
+            let mut checksum = 0u64;
+            let mut expected_checksum = 0u64;
+            let reader = txn.get_reader();
+            for _ in 0..ELEMENTS {
+                let (key, value) = gen_pair(&mut rng);
+                let result = reader.get(&key).unwrap();
+                checksum += result.as_ref()[0] as u64;
+                expected_checksum += value[0] as u64;
+            }
+            assert_eq!(checksum, expected_checksum);
+            let end = Instant::now();
+            let duration = end - start;
+            println!(
+                "{}: Random read {} items in {}ms",
+                T::db_type_name(),
+                ELEMENTS,
+                duration.as_millis()
+            );
+            results.push(("random reads", duration));
+        }
+
+        for _ in 0..ITERATIONS {
+            let mut rng = make_rng();
+            let start = Instant::now();
+            let reader = txn.get_reader();
+            let mut value_sum = 0;
+            let num_scan = 10;
+            for _ in 0..ELEMENTS {
+                let (key, _value) = gen_pair(&mut rng);
+                let mut iter = reader.range_from(&key);
+                for _ in 0..num_scan {
+                    if let Some((_, value)) = iter.next() {
+                        value_sum += value.as_ref()[0];
+                    } else {
+                        break;
+                    }
+                }
+            }
+            assert!(value_sum > 0);
+            let end = Instant::now();
+            let duration = end - start;
+            println!(
+                "{}: Random range read {} elements in {}ms",
+                T::db_type_name(),
+                ELEMENTS * num_scan,
+                duration.as_millis()
+            );
+            results.push(("random range reads", duration));
+        }
+    }
+    drop(txn);
+
+    let start = Instant::now();
+    let deletes = ELEMENTS / 2;
+    {
+        let mut rng = make_rng();
+        let mut txn = db.write_transaction();
+        let mut inserter = txn.get_inserter();
+        for _ in 0..deletes {
+            let (key, _value) = gen_pair(&mut rng);
+            inserter.remove(&key).unwrap();
+        }
+        drop(inserter);
+        txn.commit().unwrap();
+    }
+
+    let end = Instant::now();
+    let duration = end - start;
+    println!(
+        "{}: Removed {} items in {}ms",
+        T::db_type_name(),
+        deletes,
+        duration.as_millis()
+    );
+    results.push(("removals", duration));
+
+    results
+}
+
+fn main() {
+    let redb_latency_results = {
+        let tmpfile: NamedTempFile = NamedTempFile::new_in(current_dir().unwrap()).unwrap();
+        let db = unsafe {
+            redb::Database::builder()
+                .set_write_strategy(WriteStrategy::Checksum)
+                .create(tmpfile.path(), 4096 * 1024 * 1024)
+                .unwrap()
+        };
+        let table = RedbBenchDatabase::new(&db);
+        benchmark(table)
+    };
+
+    let redb_throughput_results = {
+        let tmpfile: NamedTempFile = NamedTempFile::new_in(current_dir().unwrap()).unwrap();
+        let db = unsafe {
+            redb::Database::builder()
+                .set_write_strategy(WriteStrategy::TwoPhase)
+                .create(tmpfile.path(), 4096 * 1024 * 1024)
+                .unwrap()
+        };
+        let table = RedbBenchDatabase::new(&db);
+        benchmark(table)
+    };
+
+    let lmdb_results = {
+        let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
+        let env = lmdb::Environment::new().open(tmpfile.path()).unwrap();
+        env.set_map_size(4096 * 1024 * 1024).unwrap();
+        let table = LmdbRkvBenchDatabase::new(&env);
+        benchmark(table)
+    };
+
+    let rocksdb_results = {
+        let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
+        let db = rocksdb::TransactionDB::open_default(tmpfile.path()).unwrap();
+        let table = RocksdbBenchDatabase::new(&db);
+        benchmark(table)
+    };
+
+    let sled_results = {
+        let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
+        let db = sled::Config::new().path(tmpfile.path()).open().unwrap();
+        let table = SledBenchDatabase::new(&db, tmpfile.path());
+        benchmark(table)
+    };
+
+    let sanakirja_results = {
+        let tmpfile: NamedTempFile = NamedTempFile::new_in(current_dir().unwrap()).unwrap();
+        fs::remove_file(tmpfile.path()).unwrap();
+        let db = sanakirja::Env::new(tmpfile.path(), 4096 * 1024 * 1024, 2).unwrap();
+        let table = SanakirjaBenchDatabase::new(&db);
+        benchmark(table)
+    };
+
+    let mut rows = Vec::new();
+
+    for (benchmark, _duration) in &redb_latency_results {
+        rows.push(vec![benchmark.to_string()]);
+    }
+
+    for results in [
+        redb_latency_results,
+        redb_throughput_results,
+        lmdb_results,
+        rocksdb_results,
+        sled_results,
+        sanakirja_results,
+    ] {
+        for (i, (_benchmark, duration)) in results.iter().enumerate() {
+            rows[i].push(format!("{}ms", duration.as_millis()));
+        }
+    }
+
+    let mut table = comfy_table::Table::new();
+    table.set_width(100);
+    table.set_header([
+        "",
+        "redb (1PC+C)",
+        "redb (2PC)",
+        "lmdb",
+        "rocksdb",
+        "sled",
+        "sanakirja",
+    ]);
+    for row in rows {
+        table.add_row(row);
+    }
+
+    println!();
+    println!("{table}");
+}

--- a/benches/open_benchmark.rs
+++ b/benches/open_benchmark.rs
@@ -1,5 +1,4 @@
 use std::env::current_dir;
-use std::fs;
 use std::mem::size_of;
 use tempfile::{NamedTempFile, TempDir};
 

--- a/benches/open_benchmark.rs
+++ b/benches/open_benchmark.rs
@@ -9,7 +9,6 @@ use common::*;
 use redb::WriteStrategy;
 use std::time::{Duration, Instant};
 
-const ITERATIONS: usize = 3;
 const ELEMENTS: usize = 1_000_000;
 const KEY_SIZE: usize = 24;
 const VALUE_SIZE: usize = 150;
@@ -56,7 +55,7 @@ fn make_rng() -> fastrand::Rng {
     fastrand::Rng::with_seed(RNG_SEED)
 }
 
-fn benchmark<T: BenchDatabase>(db: T) -> Vec<(&'static str, Duration)> {
+fn populate<T: BenchDatabase>(db: T) -> Vec<(&'static str, Duration)> {
     let mut rng = make_rng();
     let mut results = Vec::new();
 
@@ -82,136 +81,6 @@ fn benchmark<T: BenchDatabase>(db: T) -> Vec<(&'static str, Duration)> {
     );
     results.push(("bulk load", duration));
 
-    let start = Instant::now();
-    let writes = 100;
-    {
-        for _ in 0..writes {
-            let mut txn = db.write_transaction();
-            let mut inserter = txn.get_inserter();
-            let (key, value) = gen_pair(&mut rng);
-            inserter.insert(&key, &value).unwrap();
-            drop(inserter);
-            txn.commit().unwrap();
-        }
-    }
-
-    let end = Instant::now();
-    let duration = end - start;
-    println!(
-        "{}: Wrote {} individual items in {}ms",
-        T::db_type_name(),
-        writes,
-        duration.as_millis()
-    );
-    results.push(("individual writes", duration));
-
-    let start = Instant::now();
-    let batch_size = 1000;
-    {
-        for _ in 0..writes {
-            let mut txn = db.write_transaction();
-            let mut inserter = txn.get_inserter();
-            for _ in 0..batch_size {
-                let (key, value) = gen_pair(&mut rng);
-                inserter.insert(&key, &value).unwrap();
-            }
-            drop(inserter);
-            txn.commit().unwrap();
-        }
-    }
-
-    let end = Instant::now();
-    let duration = end - start;
-    println!(
-        "{}: Wrote {} x {} items in {}ms",
-        T::db_type_name(),
-        writes,
-        batch_size,
-        duration.as_millis()
-    );
-    results.push(("batch writes", duration));
-
-    let txn = db.read_transaction();
-    {
-        for _ in 0..ITERATIONS {
-            let mut rng = make_rng();
-            let start = Instant::now();
-            let mut checksum = 0u64;
-            let mut expected_checksum = 0u64;
-            let reader = txn.get_reader();
-            for _ in 0..ELEMENTS {
-                let (key, value) = gen_pair(&mut rng);
-                let result = reader.get(&key).unwrap();
-                checksum += result.as_ref()[0] as u64;
-                expected_checksum += value[0] as u64;
-            }
-            assert_eq!(checksum, expected_checksum);
-            let end = Instant::now();
-            let duration = end - start;
-            println!(
-                "{}: Random read {} items in {}ms",
-                T::db_type_name(),
-                ELEMENTS,
-                duration.as_millis()
-            );
-            results.push(("random reads", duration));
-        }
-
-        for _ in 0..ITERATIONS {
-            let mut rng = make_rng();
-            let start = Instant::now();
-            let reader = txn.get_reader();
-            let mut value_sum = 0;
-            let num_scan = 10;
-            for _ in 0..ELEMENTS {
-                let (key, _value) = gen_pair(&mut rng);
-                let mut iter = reader.range_from(&key);
-                for _ in 0..num_scan {
-                    if let Some((_, value)) = iter.next() {
-                        value_sum += value.as_ref()[0];
-                    } else {
-                        break;
-                    }
-                }
-            }
-            assert!(value_sum > 0);
-            let end = Instant::now();
-            let duration = end - start;
-            println!(
-                "{}: Random range read {} elements in {}ms",
-                T::db_type_name(),
-                ELEMENTS * num_scan,
-                duration.as_millis()
-            );
-            results.push(("random range reads", duration));
-        }
-    }
-    drop(txn);
-
-    let start = Instant::now();
-    let deletes = ELEMENTS / 2;
-    {
-        let mut rng = make_rng();
-        let mut txn = db.write_transaction();
-        let mut inserter = txn.get_inserter();
-        for _ in 0..deletes {
-            let (key, _value) = gen_pair(&mut rng);
-            inserter.remove(&key).unwrap();
-        }
-        drop(inserter);
-        txn.commit().unwrap();
-    }
-
-    let end = Instant::now();
-    let duration = end - start;
-    println!(
-        "{}: Removed {} items in {}ms",
-        T::db_type_name(),
-        deletes,
-        duration.as_millis()
-    );
-    results.push(("removals", duration));
-
     results
 }
 
@@ -225,7 +94,7 @@ fn main() {
                 .unwrap()
         };
         let table = RedbBenchDatabase::new(&db);
-        benchmark(table)
+        populate(table)
     };
 
     let redb_throughput_results = {
@@ -237,7 +106,7 @@ fn main() {
                 .unwrap()
         };
         let table = RedbBenchDatabase::new(&db);
-        benchmark(table)
+        populate(table)
     };
 
     let lmdb_results = {
@@ -245,21 +114,21 @@ fn main() {
         let env = lmdb::Environment::new().open(tmpfile.path()).unwrap();
         env.set_map_size(4096 * 1024 * 1024).unwrap();
         let table = LmdbRkvBenchDatabase::new(&env);
-        benchmark(table)
+        populate(table)
     };
 
     let rocksdb_results = {
         let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
         let db = rocksdb::TransactionDB::open_default(tmpfile.path()).unwrap();
         let table = RocksdbBenchDatabase::new(&db);
-        benchmark(table)
+        populate(table)
     };
 
     let sled_results = {
         let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
         let db = sled::Config::new().path(tmpfile.path()).open().unwrap();
         let table = SledBenchDatabase::new(&db, tmpfile.path());
-        benchmark(table)
+        populate(table)
     };
 
     let sanakirja_results = {
@@ -267,7 +136,7 @@ fn main() {
         fs::remove_file(tmpfile.path()).unwrap();
         let db = sanakirja::Env::new(tmpfile.path(), 4096 * 1024 * 1024, 2).unwrap();
         let table = SanakirjaBenchDatabase::new(&db);
-        benchmark(table)
+        populate(table)
     };
 
     let mut rows = Vec::new();


### PR DESCRIPTION
I was trying to write a benchmark for opening databases. I didn't finish it, so this shouldn't be merged as-is, but I found at least one interesting result. It looks like `lmdb::Environment::new().open(tmpfile.path()).unwrap()` always returns instantly, whereas `redb::Database::open(tmpfile.path()).unwrap()` takes ~20ms.

I don't know if this is an apples-to-apples comparison, but if it is, it might indicate a difference in syscalls/etc between lmdb and redb.

Below are some results with different key sizes. It seems the difference doesn't depend on the amount of the data in the database.

I'm not going to dig into this further right now, since the main issue I'm running into is the multi-minute slowdown of opening large databases on MacOS, and this might not be that, so I'm going to try to reproduce that first, but wanted to share this anyways.

```
const ELEMENTS: usize = 1_000_000;
const KEY_SIZE: usize = 24;
const VALUE_SIZE: usize = 150;

redb: Bulk loaded 1000000 items in 2911ms
redb: Bulk loaded 1000000 items in 1888ms
lmdb-rkv: Bulk loaded 1000000 items in 1241ms

+-----------+--------------+------------+--------+
|           | redb (1PC+C) | redb (2PC) | lmdb   |
+================================================+
| bulk load | 2911ms       | 1888ms     | 1241ms |
|-----------+--------------+------------+--------|
| open      | 20ms         | 19ms       | 0ms    |
+-----------+--------------+------------+--------+

---

const ELEMENTS: usize = 1_000_000;
const KEY_SIZE: usize = 500;
const VALUE_SIZE: usize = 500;

redb: Bulk loaded 1000000 items in 6308ms
redb: Bulk loaded 1000000 items in 4308ms
lmdb-rkv: Bulk loaded 1000000 items in 2606ms

+-----------+--------------+------------+--------+
|           | redb (1PC+C) | redb (2PC) | lmdb   |
+================================================+
| bulk load | 6308ms       | 4308ms     | 2606ms |
|-----------+--------------+------------+--------|
| open      | 56ms         | 19ms       | 0ms    |
+-----------+--------------+------------+--------+

---

const ELEMENTS: usize = 10_000_000;
const KEY_SIZE: usize = 500;
const VALUE_SIZE: usize = 500;
const RNG_SEED: u64 = 3;

redb: Bulk loaded 10000000 items in 92306ms
redb: Bulk loaded 10000000 items in 54350ms
lmdb-rkv: Bulk loaded 10000000 items in 214621ms

+-----------+--------------+------------+----------+
|           | redb (1PC+C) | redb (2PC) | lmdb     |
+==================================================+
| bulk load | 92306ms      | 54350ms    | 214621ms |
|-----------+--------------+------------+----------|
| open      | 18ms         | 20ms       | 0ms      |
+-----------+--------------+------------+----------+
