### PR TITLE
Add watch recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,6 +30,9 @@ test: pre
 bench bench='lmdb_benchmark': pre
     cargo bench --bench {{bench}}
 
+watch +args='test':
+  cargo watch --clear --exec "{{args}}"
+
 # Nightly version selected from: https://rust-lang.github.io/rustup-components-history/
 NIGHTLY := "nightly-2022-11-01"
 fuzz: pre


### PR DESCRIPTION
This is nice for development. `just watch` re-runs the tests whenever it detects that a file has changed using `cargo-watch`. (`cargo install cargo-watch`) You can pass any cargo command, e.g.,`just watch check` if you just want to check for compilation errors.