### PR TITLE
Add iter method for iterating over all values in table

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -740,7 +740,7 @@ pub trait ReadableMultimapTable<K: RedbKey + ?Sized, V: RedbKey + ?Sized> {
 
     /// Returns an double-ended iterator over all elements in the table. Values are in ascending
     /// order.
-    fn iter<'a>(&'a self) -> Result<MultimapRangeIter<'a, K, V>> {
+    fn iter(&self) -> Result<MultimapRangeIter<K, V>> {
         self.range(..)
     }
 }

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -737,6 +737,12 @@ pub trait ReadableMultimapTable<K: RedbKey + ?Sized, V: RedbKey + ?Sized> {
     fn len(&self) -> Result<usize>;
 
     fn is_empty(&self) -> Result<bool>;
+
+    /// Returns an double-ended iterator over all elements in the table. Values are in ascending
+    /// order.
+    fn iter<'a>(&'a self) -> Result<MultimapRangeIter<'a, K, V>> {
+        self.range(..)
+    }
 }
 
 /// A read-only multimap table

--- a/src/table.rs
+++ b/src/table.rs
@@ -144,6 +144,11 @@ pub trait ReadableTable<K: RedbKey + ?Sized, V: RedbValue + ?Sized> {
 
     /// Returns `true` if the table is empty
     fn is_empty(&self) -> Result<bool>;
+
+    /// Returns a double-ended iterator over all elements in the table
+    fn iter(&self) -> Result<RangeIter<K, V>> {
+        self.range::<std::ops::RangeFull, &K>(..)
+    }
 }
 
 /// A read-only table

--- a/src/tree_store/page_store/xxh3.rs
+++ b/src/tree_store/page_store/xxh3.rs
@@ -56,6 +56,7 @@ const INIT_ACCUMULATORS: [u64; 8] = [
     PRIME32[2], PRIME64[0], PRIME64[1], PRIME64[2], PRIME64[3], PRIME32[1], PRIME64[4], PRIME32[0],
 ];
 
+#[allow(clippy::needless_return)]
 pub fn hash64_with_seed(data: &[u8], seed: u64) -> u64 {
     if data.len() <= 240 {
         hash64_0to240(data, &DEFAULT_SECRET, seed)
@@ -85,6 +86,7 @@ pub fn hash64_with_seed(data: &[u8], seed: u64) -> u64 {
     }
 }
 
+#[allow(clippy::needless_return)]
 pub fn hash128_with_seed(data: &[u8], seed: u64) -> u128 {
     if data.len() <= 240 {
         hash128_0to240(data, &DEFAULT_SECRET, seed)


### PR DESCRIPTION
This adds `ReadableTable::iter` and `ReadableMultimapTable::iter` that both just call `self.range(..)`. I was hoping to implement `IntoIter` for both, so that they could be used in for loops, but couldn't because `range` can fail. An `iter` function seems relatively common, c.f. `Vec::iter` and `BTreeMap::iter`. I do `range(..)` a bunch, so this is nice to have. Also, `range(..)` can't infer the type, so you always have to use `range(MINIMUM_VALUE..)` to get it to work.