### PR TITLE
Differentiate older file format errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use crate::tree_store::FILE_FORMAT_VERSION;
 use std::fmt::{Display, Formatter};
 use std::sync::PoisonError;
 use std::{io, panic};
@@ -8,6 +9,7 @@ pub enum Error {
     /// This savepoint is invalid because an older savepoint was restored after it was created
     InvalidSavepoint,
     Corrupted(String),
+    UpgradeRequired(u8),
     TableTypeMismatch(String),
     TableDoesNotExist(String),
     // Tables cannot be opened for writing multiple times, since they could retrieve immutable &
@@ -34,6 +36,9 @@ impl Display for Error {
         match self {
             Error::Corrupted(msg) => {
                 write!(f, "DB corrupted: {}", msg)
+            }
+            Error::UpgradeRequired(actual) => {
+                write!(f, "Manual upgrade required. Expected file format version {}, but file is version {}", FILE_FORMAT_VERSION, actual)
             }
             Error::TableTypeMismatch(msg) => {
                 write!(f, "{}", msg)

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -12,5 +12,5 @@ pub(crate) use btree_base::Checksum;
 pub(crate) use btree_base::{LeafAccessor, RawLeafBuilder, BRANCH, LEAF};
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, BtreeDrain, BtreeRangeIter};
 pub use page_store::Savepoint;
-pub(crate) use page_store::{Page, PageHint, PageNumber, TransactionalMemory};
+pub(crate) use page_store::{Page, PageHint, PageNumber, TransactionalMemory, FILE_FORMAT_VERSION};
 pub(crate) use table_tree::{FreedTableKey, InternalTableDefinition, TableTree, TableType};

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -14,7 +14,7 @@ mod utils;
 mod xxh3;
 
 pub(crate) use base::{Page, PageHint, PageNumber};
-pub(crate) use page_manager::{ChecksumType, TransactionalMemory};
+pub(crate) use page_manager::{ChecksumType, TransactionalMemory, FILE_FORMAT_VERSION};
 pub use savepoint::Savepoint;
 
 pub(super) use base::{PageImpl, PageMut};


### PR DESCRIPTION
Return UpgradeRequired when the file format is too old instead of Corrupted

Fixes #479 