### PR TITLE
Document Builder and TableDefinition.

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -47,6 +47,11 @@ pub struct TableDefinition<'a, K: RedbKey + ?Sized, V: RedbValue + ?Sized> {
 }
 
 impl<'a, K: RedbKey + ?Sized, V: RedbValue + ?Sized> TableDefinition<'a, K, V> {
+    /// Construct a new table with given `name`
+    ///
+    /// ## Invariant
+    ///
+    /// `name` shall not be empty.
     pub const fn new(name: &'a str) -> Self {
         assert!(!name.is_empty());
         Self {
@@ -56,6 +61,7 @@ impl<'a, K: RedbKey + ?Sized, V: RedbValue + ?Sized> TableDefinition<'a, K, V> {
         }
     }
 
+    /// Returns a reference of the `name` of the current `TableDefinition`.
     pub fn name(&self) -> &str {
         self.name
     }


### PR DESCRIPTION
Hello did some documentation on `Builder` + `TableDefinition`.

Document the defaults, looked a good idea to me, it's one of the "good" part of Berkeley db that I found useful to have default explicitly documented in dev-doc. :)

If it's wasn't necessary or need changes tell me! also i am not the best at spelling. :(

Just a suggestion, I may be wrong: `write_strategy` and `page_size` may be defined without their option and `write_strategy` could be directly set to `Checksum`. Maybe I missed some `public` code path in API that allow other choices, still toying around for now with the database. :)