### PR TITLE
Gate cache hit counting with feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ io-uring = "0.5.1"
 python = ["pyo3"]
 # Enables log messages
 logging = ["log"]
+# Enable cache hit metrics
+cache_metrics = []
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
This improves contended read performance by 10-20%, when the feature is disabled