### PR TITLE
Fixed `ReadableMultimapTable::get`'s return type borrowing `key` argument

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -759,7 +759,10 @@ impl<'db, 'txn, K: RedbKey + 'static, V: RedbKey + 'static> ReadableMultimapTabl
     for MultimapTable<'db, 'txn, K, V>
 {
     /// Returns an iterator over all values for the given key. Values are in ascending order.
-    fn get<'a>(&'a self, key: impl Borrow<K::SelfType<'a>>) -> Result<MultimapValue<'a, V>> {
+    fn get<'a: 'b, 'b>(
+        &'a self,
+        key: impl Borrow<K::SelfType<'b>>,
+    ) -> Result<MultimapValue<'a, V>> {
         let iter = if let Some(collection) = self.tree.get(key.borrow())? {
             DynamicCollection::iter(collection, self.mem)?
         } else {
@@ -815,7 +818,7 @@ impl<'db, 'txn, K: RedbKey + 'static, V: RedbKey + 'static> Drop
 
 pub trait ReadableMultimapTable<K: RedbKey + 'static, V: RedbKey + 'static> {
     /// Returns an iterator over all values for the given key. Values are in ascending order.
-    fn get<'a>(&'a self, key: impl Borrow<K::SelfType<'a>>) -> Result<MultimapValue<'a, V>>
+    fn get<'a: 'b, 'b>(&'a self, key: impl Borrow<K::SelfType<'b>>) -> Result<MultimapValue<'a, V>>
     where
         K: 'a;
 
@@ -863,7 +866,10 @@ impl<'txn, K: RedbKey + 'static, V: RedbKey + 'static> ReadableMultimapTable<K, 
     for ReadOnlyMultimapTable<'txn, K, V>
 {
     /// Returns an iterator over all values for the given key. Values are in ascending order.
-    fn get<'a>(&'a self, key: impl Borrow<K::SelfType<'a>>) -> Result<MultimapValue<'a, V>> {
+    fn get<'a: 'b, 'b>(
+        &'a self,
+        key: impl Borrow<K::SelfType<'b>>,
+    ) -> Result<MultimapValue<'a, V>> {
         let iter = if let Some(collection) = self.tree.get(key.borrow())? {
             DynamicCollection::iter(collection, self.mem)?
         } else {


### PR DESCRIPTION
Currently the following code doesn't work:

```rust
fn get_it(&self) -> impl Iterator</* ... */> {
    let key = /* ... */;
    self.table.get(key).expect("Unable to create iterator")
}
```

where `self.table` is a `MultimapTable<K, V>`.

This is because the signature of `ReadableMultimapTable::get` actually borrows it's `key` argument due to using `K::SelfType<'a>`, where the receiver is `&'a self`. This PR adds a new `'b` lifetime to use for the `K::SelfType`, just like the `range` method below it.

This is technically a breaking change due to the `ReadableMultimapTable` trait being public and not sealed. Aside from this however, I believe it doesn't prevent any code that compiled from compiling, nor changes any behavior.