### PR TITLE
Optimize page freeing

### DIFF
--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -51,6 +51,10 @@ impl TransactionTracker {
         }
     }
 
+    pub(crate) fn any_savepoint_exists(&self) -> bool {
+        !self.valid_savepoints.is_empty()
+    }
+
     pub(crate) fn allocate_savepoint(&mut self) -> SavepointId {
         let id = self.next_savepoint_id.next();
         self.next_savepoint_id = id;

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1233,11 +1233,14 @@ impl TransactionalMemory {
             .push(AllocationOp::Allocate(page_number));
         #[cfg(debug_assertions)]
         {
-            assert!(!self
-                .read_page_ref_counts
-                .lock()
-                .unwrap()
-                .contains_key(&page_number));
+            assert!(
+                !self
+                    .read_page_ref_counts
+                    .lock()
+                    .unwrap()
+                    .contains_key(&page_number),
+                "Allocated a page that is still referenced! {page_number:?}"
+            );
             assert!(self.open_dirty_pages.lock().unwrap().insert(page_number));
         }
 


### PR DESCRIPTION
Pages from the freed-tree itself are now immediately freed, when posisble, rather than being deferred to a future transaction. This is possible as long as there are no active savepoints. When there are active savepoints we still have to defer the frees.