### PR TITLE
Fix panic

### DIFF
--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -402,6 +402,7 @@ pub(crate) struct TransactionalMemory {
     // code path where there is no locking
     region_size: u64,
     region_header_with_padding_size: u64,
+    deferred_error: Mutex<Option<Error>>,
 }
 
 impl TransactionalMemory {
@@ -562,7 +563,12 @@ impl TransactionalMemory {
             page_size: page_size.try_into().unwrap(),
             region_size,
             region_header_with_padding_size: region_header_size,
+            deferred_error: Mutex::new(None),
         })
+    }
+
+    pub(crate) fn set_deferred_error(&self, err: Error) {
+        *self.deferred_error.lock().unwrap() = Some(err);
     }
 
     #[cfg(any(fuzzing, test))]
@@ -774,6 +780,9 @@ impl TransactionalMemory {
         eventual: bool,
         two_phase: bool,
     ) -> Result {
+        if let Some(err) = self.deferred_error.lock().unwrap().take() {
+            return Err(err);
+        }
         let result = self.commit_inner(
             data_root,
             system_root,


### PR DESCRIPTION
If an I/O error occurred while flushing the data for an insert_reserve() value, it could cause a panic in the drop() implementation. Instead we defer the error until the next call to commit()