### PR TITLE
Disallow usage of usize::to_le_bytes()

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    "usize::to_le_bytes",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,
-    clippy::cast_sign_loss
+    clippy::cast_sign_loss,
+    clippy::disallowed_methods
 )]
 
 pub use db::{

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -158,7 +158,7 @@ fn free() {
         let mut table = txn.open_table(SLICE_TABLE).unwrap();
         for i in 0..num_writes {
             let mut mut_key = key.clone();
-            mut_key.extend_from_slice(&i.to_le_bytes());
+            mut_key.extend_from_slice(&(i as u64).to_le_bytes());
             table.insert(mut_key.as_slice(), value.as_slice()).unwrap();
         }
     }


### PR DESCRIPTION
usize should always be explicitly serialized as u32 or u64