### PR TITLE
Defer checksum computation to commit()

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1038,7 +1038,7 @@ mod test {
             .set_page_size(512)
             .create(tmpfile.path())
             .unwrap();
-        db.set_crash_countdown(9);
+        db.set_crash_countdown(13);
 
         let table_def: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
 

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -5,10 +5,10 @@ mod btree_mutator;
 mod page_store;
 mod table_tree;
 
-pub(crate) use btree::{Btree, BtreeMut, RawBtree};
+pub(crate) use btree::{Btree, BtreeMut, RawBtree, UntypedBtreeMut};
 pub(crate) use btree_base::Checksum;
 pub use btree_base::{AccessGuard, AccessGuardMut};
-pub(crate) use btree_base::{LeafAccessor, RawLeafBuilder, BRANCH, LEAF};
+pub(crate) use btree_base::{LeafAccessor, LeafMutator, RawLeafBuilder, BRANCH, LEAF};
 pub(crate) use btree_iters::{
     AllPageNumbersBtreeIter, BtreeDrain, BtreeDrainFilter, BtreeRangeIter,
 };


### PR DESCRIPTION
Defers the Merkle-tree checksum updates for all newly allocated pages until commit(). This improves performance on some large write heavy workloads by ~15%, and also simplifies a bunch of code since checksums do not need to be correct when they reference dirty pages