### PR TITLE
Optimize write performance

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -822,7 +822,7 @@ impl std::fmt::Debug for Database {
 
 #[cfg(test)]
 mod test {
-    use crate::{Database, Durability, ReadableTable, StorageError, TableDefinition, TableError};
+    use crate::{Database, Durability, ReadableTable, TableDefinition};
 
     #[test]
     fn small_pages() {
@@ -1003,61 +1003,6 @@ mod test {
             t.insert_reserve(&118749, 734).unwrap().as_mut().fill(0xFF);
         }
         tx.abort().unwrap();
-    }
-
-    #[test]
-    fn crash_regression1() {
-        let tmpfile = crate::create_tempfile();
-
-        let db = Database::builder()
-            .set_cache_size(1024 * 1024)
-            .set_page_size(1024)
-            .create(tmpfile.path())
-            .unwrap();
-        db.set_crash_countdown(0);
-
-        let table_def: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
-
-        let tx = db.begin_write().unwrap();
-        {
-            assert!(matches!(
-                tx.open_table(table_def),
-                Err(TableError::Storage(StorageError::SimulatedIOFailure))
-            ));
-        }
-        tx.abort().unwrap();
-    }
-
-    #[test]
-    fn crash_regression2() {
-        let tmpfile = crate::create_tempfile();
-
-        let db = Database::builder()
-            .set_cache_size(1024 * 1024)
-            .set_page_size(8 * 1024)
-            .set_region_size(32 * 4096)
-            .create(tmpfile.path())
-            .unwrap();
-        db.set_crash_countdown(0);
-
-        let table_def: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
-
-        let tx = db.begin_write().unwrap();
-        {
-            assert!(matches!(
-                tx.open_table(table_def),
-                Err(TableError::Storage(StorageError::SimulatedIOFailure))
-            ));
-        }
-        tx.abort().unwrap();
-
-        drop(db);
-        Database::builder()
-            .set_cache_size(1024 * 1024)
-            .set_page_size(8 * 1024)
-            .set_region_size(32 * 4096)
-            .create(tmpfile.path())
-            .unwrap();
     }
 
     #[test]

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -263,6 +263,7 @@ impl<'db> WriteTransaction<'db> {
         })
     }
 
+    #[track_caller]
     fn open_system_table<'txn, K: RedbKey + 'static, V: RedbValue + 'static>(
         &'txn self,
         definition: SystemTableDefinition<K, V>,
@@ -566,6 +567,7 @@ impl<'db> WriteTransaction<'db> {
     /// Open the given table
     ///
     /// The table will be created if it does not exist
+    #[track_caller]
     pub fn open_table<'txn, K: RedbKey + 'static, V: RedbValue + 'static>(
         &'txn self,
         definition: TableDefinition<K, V>,
@@ -603,6 +605,7 @@ impl<'db> WriteTransaction<'db> {
     /// Open the given table
     ///
     /// The table will be created if it does not exist
+    #[track_caller]
     pub fn open_multimap_table<'txn, K: RedbKey + 'static, V: RedbKey + 'static>(
         &'txn self,
         definition: MultimapTableDefinition<K, V>,

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -283,10 +283,6 @@ impl<'db> WriteTransaction<'db> {
             );
         }
         self.dirty.store(true, Ordering::Release);
-        self.open_system_tables
-            .lock()
-            .unwrap()
-            .insert(definition.name().to_string(), panic::Location::caller());
 
         let internal_table = self
             .system_table_tree
@@ -296,6 +292,10 @@ impl<'db> WriteTransaction<'db> {
             .map_err(|e| {
                 e.into_storage_error_or_corrupted("Internal error. System table is corrupted")
             })?;
+        self.open_system_tables
+            .lock()
+            .unwrap()
+            .insert(definition.name().to_string(), panic::Location::caller());
 
         Ok(Table::new(
             definition.name(),
@@ -581,16 +581,16 @@ impl<'db> WriteTransaction<'db> {
             ));
         }
         self.dirty.store(true, Ordering::Release);
-        self.open_tables
-            .lock()
-            .unwrap()
-            .insert(definition.name().to_string(), panic::Location::caller());
 
         let internal_table = self
             .table_tree
             .write()
             .unwrap()
             .get_or_create_table::<K, V>(definition.name(), TableType::Normal)?;
+        self.open_tables
+            .lock()
+            .unwrap()
+            .insert(definition.name().to_string(), panic::Location::caller());
 
         Ok(Table::new(
             definition.name(),
@@ -619,16 +619,16 @@ impl<'db> WriteTransaction<'db> {
             ));
         }
         self.dirty.store(true, Ordering::Release);
-        self.open_tables
-            .lock()
-            .unwrap()
-            .insert(definition.name().to_string(), panic::Location::caller());
 
         let internal_table = self
             .table_tree
             .write()
             .unwrap()
             .get_or_create_table::<K, V>(definition.name(), TableType::Multimap)?;
+        self.open_tables
+            .lock()
+            .unwrap()
+            .insert(definition.name().to_string(), panic::Location::caller());
 
         Ok(MultimapTable::new(
             definition.name(),

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -170,7 +170,7 @@ impl TransactionalMemory {
 
             header.recovery_required = false;
             storage
-                .write(0, DB_HEADER_SIZE)?
+                .write(0, DB_HEADER_SIZE, true)?
                 .mem_mut()
                 .copy_from_slice(&header.to_bytes(false, false));
             allocators.flush_to(tracker_page, layout, &mut storage)?;
@@ -179,7 +179,7 @@ impl TransactionalMemory {
             // Write the magic number only after the data structure is initialized and written to disk
             // to ensure that it's crash safe
             storage
-                .write(0, DB_HEADER_SIZE)?
+                .write(0, DB_HEADER_SIZE, true)?
                 .mem_mut()
                 .copy_from_slice(&header.to_bytes(true, false));
             storage.flush()?;
@@ -234,7 +234,7 @@ impl TransactionalMemory {
             }
             assert!(!repair_info.invalid_magic_number);
             storage
-                .write(0, DB_HEADER_SIZE)?
+                .write(0, DB_HEADER_SIZE, true)?
                 .mem_mut()
                 .copy_from_slice(&header.to_bytes(true, false));
             storage.flush()?;
@@ -309,7 +309,7 @@ impl TransactionalMemory {
                 return Err(StorageError::Corrupted("Invalid magic number".to_string()));
             }
             self.storage
-                .write(0, DB_HEADER_SIZE)?
+                .write(0, DB_HEADER_SIZE, true)?
                 .mem_mut()
                 .copy_from_slice(&header.to_bytes(true, false));
             self.storage.flush()?;
@@ -371,7 +371,7 @@ impl TransactionalMemory {
 
     fn write_header(&self, header: &DatabaseHeader, swap_primary: bool) -> Result {
         self.storage
-            .write(0, DB_HEADER_SIZE)?
+            .write(0, DB_HEADER_SIZE, true)?
             .mem_mut()
             .copy_from_slice(&header.to_bytes(true, swap_primary));
 
@@ -685,7 +685,7 @@ impl TransactionalMemory {
         let len: usize = (address_range.end - address_range.start)
             .try_into()
             .unwrap();
-        let mem = self.storage.write(address_range.start, len)?;
+        let mem = self.storage.write(address_range.start, len, false)?;
 
         #[cfg(debug_assertions)]
         {
@@ -837,7 +837,7 @@ impl TransactionalMemory {
             .unwrap();
 
         #[allow(unused_mut)]
-        let mut mem = self.storage.write(address_range.start, len)?;
+        let mut mem = self.storage.write(address_range.start, len, true)?;
         debug_assert!(mem.mem().len() >= allocation_size);
 
         #[cfg(debug_assertions)]

--- a/src/tree_store/page_store/region.rs
+++ b/src/tree_store/page_store/region.rs
@@ -192,7 +192,7 @@ impl Allocators {
                 page_size,
             );
             let len: usize = (range.end - range.start).try_into().unwrap();
-            storage.write(range.start, len)?
+            storage.write(range.start, len, false)?
         };
         let tracker_bytes = self.region_tracker.to_vec();
         region_tracker_mem.mem_mut()[..tracker_bytes.len()].copy_from_slice(&tracker_bytes);
@@ -207,7 +207,7 @@ impl Allocators {
                 .try_into()
                 .unwrap();
 
-            let mut mem = storage.write(base, len)?;
+            let mut mem = storage.write(base, len, false)?;
             RegionHeader::serialize(&self.region_allocators[i as usize], mem.mem_mut());
         }
 


### PR DESCRIPTION
This remove an unncessary file read on cache misses when a page is allocated for re-use. Benchmarks show a 3-10% improvement in throughput