### PR TITLE
Add specialization for determining serialized byte sizes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ sled = "0.34.7"
 rocksdb = "0.21.0"
 libc = "0.2.99"
 comfy-table = "6.1.0"
+bincode = "1.0"
+serde = "1.0"
+serde_derive = "1.0"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 io-uring = "0.5.1"
@@ -79,4 +82,8 @@ harness = false
 
 [[bench]]
 name = "syscall_benchmark"
+harness = false
+
+[[bench]]
+name = "serde"
 harness = false

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -1,0 +1,102 @@
+use std::{time::Instant, env::current_dir};
+
+use rand::{rngs::StdRng, SeedableRng, Rng};
+use redb::{Database, Error, ReadableTable, TableDefinition, RedbValue};
+use serde_derive::{Serialize, Deserialize};
+use tempfile::NamedTempFile;
+
+const TABLE: TableDefinition<u64, Dynamic> = TableDefinition::new("my_data");
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DynamicData {
+    int_part: u64,
+    part1: Vec<u8>,
+    part2: Vec<u8>
+}
+
+
+#[derive(Debug)]
+struct Dynamic;
+
+impl RedbValue for Dynamic {
+    type SelfType<'a> = DynamicData;
+
+    type AsBytes<'a> = Vec<u8>;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a> where
+    Self: 'a {
+        bincode::deserialize(data).unwrap()
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'a,
+        Self: 'b {
+            bincode::serialize(value).unwrap()
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("Row")
+    }
+}
+
+
+const ELEMENTS: u64 = 10_000;
+
+fn gen_data(count: u64) -> Vec<u8> {
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut random_data = vec![];
+    for _ in 0..count {
+        random_data.push(rng.gen());
+    }
+    random_data
+}
+
+
+fn main() {
+    let tmpfile: NamedTempFile = NamedTempFile::new_in(current_dir().unwrap()).unwrap();
+    let db = Database::create(tmpfile).unwrap();
+
+    let mut all_bytes = 0;
+    let mut test_data = Vec::new();
+    for key in 0..ELEMENTS {
+        let part1_data = key.to_be_bytes();
+        let part2_data = gen_data(key);
+        let dyn_data = DynamicData { 
+            int_part: key,
+            part1: part1_data.to_vec(),
+            part2: part2_data.to_vec(),
+        };
+        all_bytes += Dynamic::as_bytes(&dyn_data).len();
+        test_data.push(dyn_data);
+    }
+
+    {
+        let write_txn = db.begin_write().unwrap();
+        let mut table = write_txn.open_table(TABLE).unwrap();
+        
+        let start = Instant::now();
+        {
+            for dyn_data in test_data {
+                table
+                    .insert(dyn_data.int_part, &dyn_data)
+                    .unwrap();
+            }
+        }
+        drop(table);
+        write_txn.commit().unwrap();
+    
+        let end = Instant::now();
+        let duration = end - start;
+        println!(
+            "Bulk loaded {} Dynamic elements ({} bytes) in {}ms",
+            ELEMENTS,
+            all_bytes,
+            duration.as_millis()
+        );
+    }
+}

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -643,14 +643,14 @@ impl<'db, 'txn, K: RedbKey + 'static, V: RedbKey + 'static> MultimapTable<'db, '
                                 builder.append(
                                     value_bytes_ref,
                                     <() as RedbValue>::as_bytes(&()).as_ref(),
-                                );
+                                )?;
                             }
                             let entry = accessor.entry(i).unwrap();
-                            builder.append(entry.key(), entry.value());
+                            builder.append(entry.key(), entry.value())?;
                         }
                         if position == accessor.num_pairs() {
                             builder
-                                .append(value_bytes_ref, <() as RedbValue>::as_bytes(&()).as_ref());
+                                .append(value_bytes_ref, <() as RedbValue>::as_bytes(&()).as_ref())?;
                         }
                         drop(builder);
                         drop(guard);
@@ -711,7 +711,7 @@ impl<'db, 'txn, K: RedbKey + 'static, V: RedbKey + 'static> MultimapTable<'db, '
                     <() as RedbValue>::fixed_width(),
                     value_bytes_ref.len(),
                 );
-                builder.append(value_bytes_ref, <() as RedbValue>::as_bytes(&()).as_ref());
+                builder.append(value_bytes_ref, <() as RedbValue>::as_bytes(&()).as_ref())?;
                 drop(builder);
                 let inline_data = DynamicCollection::<V>::make_inline_data(&data);
                 self.tree
@@ -784,7 +784,7 @@ impl<'db, 'txn, K: RedbKey + 'static, V: RedbKey + 'static> MultimapTable<'db, '
                         for i in 0..old_num_pairs {
                             if i != position {
                                 let entry = accessor.entry(i).unwrap();
-                                builder.append(entry.key(), entry.value());
+                                builder.append(entry.key(), entry.value())?;
                             }
                         }
                         drop(builder);

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,11 +1,11 @@
 use crate::sealed::Sealed;
 use crate::tree_store::{
     AccessGuardMut, Btree, BtreeDrain, BtreeDrainFilter, BtreeMut, BtreeRangeIter, Checksum,
-    PageHint, PageNumber, TransactionalMemory, MAX_VALUE_LENGTH,
+    PageHint, PageNumber, TransactionalMemory,
 };
 use crate::types::{RedbKey, RedbValue, RedbValueMutInPlace};
 use crate::Result;
-use crate::{AccessGuard, StorageError, WriteTransaction};
+use crate::{AccessGuard, WriteTransaction};
 use std::borrow::Borrow;
 use std::ops::RangeBounds;
 use std::sync::{Arc, Mutex};
@@ -142,13 +142,6 @@ impl<'db, 'txn, K: RedbKey + 'static, V: RedbValueMutInPlace + 'static> Table<'d
     where
         K: 'a,
     {
-        if value_length as usize > MAX_VALUE_LENGTH {
-            return Err(StorageError::ValueTooLarge(value_length as usize));
-        }
-        let key_len = K::as_bytes(key.borrow()).as_ref().len();
-        if key_len > MAX_VALUE_LENGTH {
-            return Err(StorageError::ValueTooLarge(key_len));
-        }
         self.tree.insert_reserve(key.borrow(), value_length)
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -114,14 +114,6 @@ impl<'db, 'txn, K: RedbKey + 'static, V: RedbValue + 'static> Table<'db, 'txn, K
         K: 'a,
         V: 'a,
     {
-        let value_len = V::as_bytes(value.borrow()).as_ref().len();
-        if value_len > MAX_VALUE_LENGTH {
-            return Err(StorageError::ValueTooLarge(value_len));
-        }
-        let key_len = K::as_bytes(key.borrow()).as_ref().len();
-        if key_len > MAX_VALUE_LENGTH {
-            return Err(StorageError::ValueTooLarge(key_len));
-        }
         self.tree.insert(key.borrow(), value.borrow())
     }
 


### PR DESCRIPTION
Hello,

When reviewing the documentation, this crate is designed for dynamically sized values, however the insert function forces an evaluation of the value to bytes to do a size check.

When using serde, you may have to allocate a Vec if the size is dynamic. This causes an unnecessary Vec to be allocated when using serde to check the size. This patch adds a benchmark for serde as well as specializes the insert function to be able to use whatever sizing function you want and defaults to using the fixed size attribute or the old behavior.

Before:
Bulk loaded 10000 Dynamic elements (50075000 bytes) in 379ms

After:
Bulk loaded 10000 Dynamic elements (50075000 bytes) in 312ms

Speedup: ~17%


## Other benchmarks:

Seems to not affect the benchmarks in general because the default implementation is roughly the same as what was there before.

### Bulk Load

Before:

```
+-----------+--------+-------+---------+--------+-----------+
|           | redb   | lmdb  | rocksdb | sled   | sanakirja |
+===========================================================+
| bulk load | 1725ms | 541ms | 5587ms  | 4766ms | 557ms     |
| bulk load (2MB values) | 14278ms | 8639ms | 25223ms | 42551ms |
| bulk load                 | 2928ms | 1280ms | 7444ms  | 7576ms | 1330ms    |
|---------------------------+--------+--------+---------+--------+-----------|
| individual writes         | 25ms   | 38ms   | 37ms    | 27ms   | 41ms      |
|---------------------------+--------+--------+---------+--------+-----------|
| batch writes              | 1718ms | 879ms  | 350ms   | 923ms  | 1396ms    |
|---------------------------+--------+--------+---------+--------+-----------|
| random reads              | 1243ms | 730ms  | 4487ms  | 2230ms | 975ms     |
|---------------------------+--------+--------+---------+--------+-----------|
| random reads              | 1136ms | 727ms  | 4528ms  | 2021ms | 978ms     |
|---------------------------+--------+--------+---------+--------+-----------|
| random range reads        | 3080ms | 1283ms | 7980ms  | 6389ms | 1492ms    |
|---------------------------+--------+--------+---------+--------+-----------|
| random range reads        | 3058ms | 1281ms | 8131ms  | 6287ms | 1493ms    |
|---------------------------+--------+--------+---------+--------+-----------|
| random reads (4 threads)  | 512ms  | 213ms  | 1821ms  | 735ms  | 572ms     |
|---------------------------+--------+--------+---------+--------+-----------|
| random reads (8 threads)  | 337ms  | 122ms  | 1088ms  | 404ms  | 593ms     |
|---------------------------+--------+--------+---------+--------+-----------|
| random reads (16 threads) | 320ms  | 70ms   | 695ms   | 245ms  | 794ms     |
|---------------------------+--------+--------+---------+--------+-----------|
| random reads (32 threads) | 195ms  | 41ms   | 524ms   | 153ms  | 11218ms   |
|---------------------------+--------+--------+---------+--------+-----------|
| removals                  | 2216ms | 873ms  | 3516ms  | 2916ms | 1370ms    |
+---------------------------+--------+--------+---------+--------+-----------+
```

After:
```
+-----------+--------+-------+---------+--------+-----------+
|           | redb   | lmdb  | rocksdb | sled   | sanakirja |
+===========================================================+
| bulk load | 1769ms | 539ms | 5478ms  | 4510ms | 547ms     |
| bulk load (2MB values) | 13654ms | 8458ms | 24619ms | 42652ms |
| bulk load                 | 2940ms | 1268ms | 7368ms  | 7622ms | 1350ms    |
|---------------------------+--------+--------+---------+--------+-----------|
| individual writes         | 25ms   | 39ms   | 37ms    | 28ms   | 39ms      |
|---------------------------+--------+--------+---------+--------+-----------|
| batch writes              | 1725ms | 863ms  | 357ms   | 917ms  | 1368ms    |
|---------------------------+--------+--------+---------+--------+-----------|
| random reads              | 1219ms | 712ms  | 4682ms  | 2223ms | 979ms     |
|---------------------------+--------+--------+---------+--------+-----------|
| random reads              | 1112ms | 712ms  | 4706ms  | 2035ms | 978ms     |
|---------------------------+--------+--------+---------+--------+-----------|
| random range reads        | 3023ms | 1247ms | 8079ms  | 6378ms | 1503ms    |
|---------------------------+--------+--------+---------+--------+-----------|
| random range reads        | 3024ms | 1247ms | 8038ms  | 6274ms | 1503ms    |
|---------------------------+--------+--------+---------+--------+-----------|
| random reads (4 threads)  | 476ms  | 209ms  | 1900ms  | 684ms  | 573ms     |
|---------------------------+--------+--------+---------+--------+-----------|
| random reads (8 threads)  | 313ms  | 118ms  | 1094ms  | 399ms  | 529ms     |
|---------------------------+--------+--------+---------+--------+-----------|
| random reads (16 threads) | 315ms  | 69ms   | 688ms   | 251ms  | 688ms     |
|---------------------------+--------+--------+---------+--------+-----------|
| random reads (32 threads) | 194ms  | 41ms   | 512ms   | 154ms  | 11152ms   |
|---------------------------+--------+--------+---------+--------+-----------|
| removals                  | 2197ms | 865ms  | 3472ms  | 2986ms | 1387ms    |
+---------------------------+--------+--------+---------+--------+-----------+
```

