### PR TITLE
fix(insert sig lifetime): key and value should have different lifetimes

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -585,15 +585,11 @@ impl<'db, 'txn, K: RedbKey + 'static, V: RedbKey + 'static> MultimapTable<'db, '
     /// Add the given value to the mapping of the key
     ///
     /// Returns `true` if the key-value pair was present
-    pub fn insert<'a>(
+    pub fn insert<'k, 'v>(
         &mut self,
-        key: impl Borrow<K::SelfType<'a>>,
-        value: impl Borrow<V::SelfType<'a>>,
-    ) -> Result<bool>
-    where
-        K: 'a,
-        V: 'a,
-    {
+        key: impl Borrow<K::SelfType<'k>>,
+        value: impl Borrow<V::SelfType<'v>>,
+    ) -> Result<bool> {
         let value_bytes = V::as_bytes(value.borrow());
         let value_bytes_ref = value_bytes.as_ref();
         if value_bytes_ref.len() > MAX_VALUE_LENGTH {

--- a/src/table.rs
+++ b/src/table.rs
@@ -105,15 +105,11 @@ impl<'db, 'txn, K: RedbKey + 'static, V: RedbValue + 'static> Table<'db, 'txn, K
     /// Insert mapping of the given key to the given value
     ///
     /// Returns the old value, if the key was present in the table
-    pub fn insert<'a>(
+    pub fn insert<'k, 'v>(
         &mut self,
-        key: impl Borrow<K::SelfType<'a>>,
-        value: impl Borrow<V::SelfType<'a>>,
-    ) -> Result<Option<AccessGuard<V>>>
-    where
-        K: 'a,
-        V: 'a,
-    {
+        key: impl Borrow<K::SelfType<'k>>,
+        value: impl Borrow<V::SelfType<'v>>,
+    ) -> Result<Option<AccessGuard<V>>> {
         let value_len = V::as_bytes(value.borrow()).as_ref().len();
         if value_len > MAX_VALUE_LENGTH {
             return Err(StorageError::ValueTooLarge(value_len));


### PR DESCRIPTION
also add `generic_signature_lifetimes` test for it

---

For the latest version, the `write_key_generic` function won't compile:

```rust
error[E0597]: `buf` does not live long enough
  --> src/main.rs:27:31
   |
20 |         key: K::SelfType<'_>,
   |         --- has type `<K as RedbValue>::SelfType<'1>`
...
23 |         let buf = [1, 2, 3];
   |             --- binding `buf` declared here
...
27 |             table.insert(key, buf.as_slice()).unwrap();
   |             ------------------^^^^^^^^^^^^^^-
   |             |                 |
   |             |                 borrowed value does not live long enough
   |             argument requires that `buf` is borrowed for `'1`
...
30 |     }
   |     - `buf` dropped here while still borrowed
```