### PR TITLE
Allow opening a database using a file handle instead of a path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ redb1 = { version = "=1.0.0", package = "redb" }
 # Just benchmarking dependencies
 [target.'cfg(not(target_os = "wasi"))'.dev-dependencies]
 ctrlc = "3.2.3"
-fastrand = "1.9.0"
+fastrand = "2.0.0"
 lmdb-rkv = "0.14.0"
 sanakirja = "1.3.3"
 sled = "0.34.7"

--- a/src/db.rs
+++ b/src/db.rs
@@ -784,6 +784,19 @@ impl Builder {
             Err(StorageError::Io(io::Error::from(ErrorKind::InvalidData)).into())
         }
     }
+
+    /// Open an existing or create a new database in the given `file`.
+    ///
+    /// The file must be empty or contain a valid database.
+    pub fn create_file(&self, file: File) -> Result<Database, DatabaseError> {
+        Database::new(
+            file,
+            self.page_size,
+            self.region_size,
+            self.read_cache_size_bytes,
+            self.write_cache_size_bytes,
+        )
+    }
 }
 
 // This just makes it easier to throw `dbg` etc statements on `Result<Database>`
@@ -1081,5 +1094,14 @@ mod test {
 
         let final_file_size = tmpfile.as_file().metadata().unwrap().len();
         assert!(final_file_size < file_size);
+    }
+
+    #[test]
+    fn create_new_db_in_empty_file() {
+        let tmpfile = crate::create_tempfile();
+
+        let _db = Database::builder()
+            .create_file(tmpfile.into_file())
+            .unwrap();
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -368,7 +368,7 @@ impl Database {
 
     fn mark_persistent_savepoints(
         system_root: Option<(PageNumber, Checksum)>,
-        mem: &mut TransactionalMemory,
+        mem: &TransactionalMemory,
         oldest_unprocessed_free_transaction: TransactionId,
     ) -> Result {
         let freed_list = Arc::new(Mutex::new(vec![]));

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -948,7 +948,7 @@ impl<'db, 'txn, K: RedbKey + 'static, V: RedbKey + 'static> Drop
 {
     fn drop(&mut self) {
         self.transaction
-            .close_table(&self.name, self.system, &mut self.tree);
+            .close_table(&self.name, self.system, &self.tree);
     }
 }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -63,8 +63,7 @@ impl<'db, 'txn, K: RedbKey + 'static, V: RedbValue + 'static> Table<'db, 'txn, K
         // TODO: optimize this
         let last = self
             .iter()?
-            .rev()
-            .next()
+            .next_back()
             .map(|x| x.map(|(key, _)| K::as_bytes(&key.value()).as_ref().to_vec()));
         if let Some(owned_key) = last {
             let owned_key = owned_key?;
@@ -189,7 +188,7 @@ impl<K: RedbKey, V: RedbValue> Sealed for Table<'_, '_, K, V> {}
 impl<'db, 'txn, K: RedbKey + 'static, V: RedbValue + 'static> Drop for Table<'db, 'txn, K, V> {
     fn drop(&mut self) {
         self.transaction
-            .close_table(&self.name, self.system, &mut self.tree);
+            .close_table(&self.name, self.system, &self.tree);
     }
 }
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -644,7 +644,7 @@ impl<'db> WriteTransaction<'db> {
         &self,
         name: &str,
         system: bool,
-        table: &mut BtreeMut<K, V>,
+        table: &BtreeMut<K, V>,
     ) {
         if system {
             self.open_system_tables

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -110,7 +110,7 @@ impl TransactionalMemory {
         let region_size = min(region_size, (MAX_PAGE_INDEX as u64 + 1) * page_size as u64);
         assert!(region_size.is_power_of_two());
 
-        let mut storage = PagedCachedFile::new(
+        let storage = PagedCachedFile::new(
             file,
             page_size as u64,
             read_cache_size_bytes,
@@ -178,7 +178,7 @@ impl TransactionalMemory {
                 .write(0, DB_HEADER_SIZE, true, |_| CachePriority::High)?
                 .mem_mut()
                 .copy_from_slice(&header.to_bytes(false, false));
-            allocators.flush_to(tracker_page, layout, &mut storage)?;
+            allocators.flush_to(tracker_page, layout, &storage)?;
 
             storage.flush()?;
             // Write the magic number only after the data structure is initialized and written to disk
@@ -406,7 +406,7 @@ impl TransactionalMemory {
 
         state
             .allocators
-            .flush_to(tracker_page, state.header.layout(), &mut self.storage)?;
+            .flush_to(tracker_page, state.header.layout(), &self.storage)?;
 
         state.header.recovery_required = false;
         self.write_header(&state.header, false)?;
@@ -1083,7 +1083,7 @@ impl Drop for TransactionalMemory {
             .flush_to(
                 state.header.region_tracker(),
                 state.header.layout(),
-                &mut self.storage,
+                &self.storage,
             )
             .is_err()
         {

--- a/src/tree_store/page_store/region.rs
+++ b/src/tree_store/page_store/region.rs
@@ -177,7 +177,7 @@ impl Allocators {
         &self,
         region_tracker_page: PageNumber,
         layout: DatabaseLayout,
-        storage: &mut PagedCachedFile,
+        storage: &PagedCachedFile,
     ) -> Result {
         let page_size = layout.full_region_layout().page_size();
         let region_header_size =


### PR DESCRIPTION
This enables using this library with e.g. [`cap-std`](https://docs.rs/cap-std) which avoids path-based access in favour of a capability-based approach.

I am not sure about the name, but `open` while probably most fitting is already taken for the path-based approach. Alternatives I considered were `from_file`, `access`, `mount` and `open_or_init`.

I added another commit to ensure that the build is Clippy-clean before submitting the PR. Please let me if know if you like me to drop that from the PR as it is admittedly unrelated. (Bumping `fastrand` resolves a few warnings about unnecessary mutability in the LMDB benchmark.)