### PR TITLE
Pin redb1 at 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ pyo3 = {version = "0.19.0", features=["extension-module", "abi3-py37"], optional
 [dev-dependencies]
 rand = "0.8"
 tempfile = "3.5.0"
-redb1 = { version = "1.0.0", package = "redb" }
+# for backwards compatibility testing - pin at 1.0.0
+redb1 = { version = "=1.0.0", package = "redb" }
 
 # Just benchmarking dependencies
 [target.'cfg(not(target_os = "wasi"))'.dev-dependencies]


### PR DESCRIPTION
without pinning the version, Cargo chooses the latest semver compatible version, which is 1.1.0 - defeating the intention of the backwards-compatibility tests.
