### PR TITLE
feat: add per-table stats

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -14,6 +14,7 @@ use std::mem;
 use std::mem::size_of;
 use std::ops::{RangeBounds, RangeFull};
 use std::sync::{Arc, Mutex};
+use crate::table::TableStats;
 
 // Verify all the checksums in the tree, including any Dynamic collection subtrees
 pub(crate) fn verify_tree_and_subtree_checksums(
@@ -922,6 +923,19 @@ impl<'db, 'txn, K: RedbKey + 'static, V: RedbKey + 'static> ReadableMultimapTabl
         Ok(MultimapRange::new(inner, self.mem))
     }
 
+    fn stats(&self) -> Result<TableStats> {
+        let tree_stats = self.tree.stats()?;
+
+        Ok(TableStats {
+            tree_height: tree_stats.tree_height,
+            leaf_pages: tree_stats.leaf_pages,
+            branch_pages: tree_stats.branch_pages,
+            stored_leaf_bytes: tree_stats.stored_leaf_bytes,
+            metadata_bytes: tree_stats.metadata_bytes,
+            fragmented_bytes: tree_stats.fragmented_bytes,
+        })
+    }
+
     /// Returns the number of key-value pairs in the table
     fn len(&self) -> Result<u64> {
         let mut count = 0;
@@ -962,6 +976,9 @@ pub trait ReadableMultimapTable<K: RedbKey + 'static, V: RedbKey + 'static>: Sea
     where
         K: 'a,
         KR: Borrow<K::SelfType<'a>> + 'a;
+
+    /// Retrieves information about storage usage for the table
+    fn stats(&self) -> Result<TableStats>;
 
     fn len(&self) -> Result<u64>;
 
@@ -1023,6 +1040,19 @@ impl<'txn, K: RedbKey + 'static, V: RedbKey + 'static> ReadableMultimapTable<K, 
     {
         let inner = self.tree.range(&range)?;
         Ok(MultimapRange::new(inner, self.mem))
+    }
+
+    fn stats(&self) -> Result<TableStats> {
+        let tree_stats = self.tree.stats()?;
+
+        Ok(TableStats {
+            tree_height: tree_stats.tree_height,
+            leaf_pages: tree_stats.leaf_pages,
+            branch_pages: tree_stats.branch_pages,
+            stored_leaf_bytes: tree_stats.stored_leaf_bytes,
+            metadata_bytes: tree_stats.metadata_bytes,
+            fragmented_bytes: tree_stats.fragmented_bytes,
+        })
     }
 
     fn len(&self) -> Result<u64> {

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -1,5 +1,6 @@
 use crate::multimap_table::DynamicCollectionType::{Inline, Subtree};
 use crate::sealed::Sealed;
+use crate::table::TableStats;
 use crate::tree_store::{
     AllPageNumbersBtreeIter, Btree, BtreeMut, BtreeRangeIter, CachePriority, Checksum,
     LeafAccessor, LeafMutator, Page, PageHint, PageNumber, RawBtree, RawLeafBuilder,
@@ -14,7 +15,6 @@ use std::mem;
 use std::mem::size_of;
 use std::ops::{RangeBounds, RangeFull};
 use std::sync::{Arc, Mutex};
-use crate::table::TableStats;
 
 // Verify all the checksums in the tree, including any Dynamic collection subtrees
 pub(crate) fn verify_tree_and_subtree_checksums(

--- a/src/table.rs
+++ b/src/table.rs
@@ -22,7 +22,7 @@ pub struct TableStats {
 }
 
 impl TableStats {
-    /// Maximum traversal distance to reach the deepest (key, value) pair, across all tables
+    /// Maximum traversal distance to reach the deepest (key, value) pair in the table
     pub fn tree_height(&self) -> u32 {
         self.tree_height
     }
@@ -32,7 +32,7 @@ impl TableStats {
         self.leaf_pages
     }
 
-    /// Number of branch pages in btrees that store user data
+    /// Number of branch pages in the btree that store user data
     pub fn branch_pages(&self) -> u64 {
         self.branch_pages
     }

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -614,6 +614,15 @@ impl<'a, K: RedbKey, V: RedbValue> Btree<'a, K, V> {
         Ok(count)
     }
 
+    pub(crate) fn stats(&self) -> Result<BtreeStats> {
+        btree_stats(
+            self.root.map(|(p, _)| p),
+            self.mem,
+            K::fixed_width(),
+            V::fixed_width(),
+        )
+    }
+
     #[allow(dead_code)]
     pub(crate) fn print_debug(&self, include_values: bool) -> Result {
         if let Some((p, _)) = self.root {


### PR DESCRIPTION
This seems correct to me, but I am not entirely sure. Would these stats be way off?

Adds a `stats` method to `ReadableTable` and `ReadableMultimapTable`.

Closes #671 