### PR TITLE
lower MSRV to 1.66

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.67
+          toolchain: 1.66
           components: rustfmt, clippy
           default: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 version = "1.1.0"
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.66"
 authors = ["Christopher Berner <christopherberner@gmail.com>"]
 exclude = ["fuzz/"]
 

--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -66,7 +66,7 @@ impl BtreeBitmap {
     pub(crate) fn to_vec(&self) -> Vec<u8> {
         let mut result = vec![];
         let height: u32 = self.heights.len().try_into().unwrap();
-        result.extend(&height.to_le_bytes());
+        result.extend(height.to_le_bytes());
 
         let vecs: Vec<Vec<u8>> = self.heights.iter().map(|x| x.to_vec()).collect();
         let mut data_offset = END_OFFSETS + self.heights.len() * size_of::<u32>();
@@ -302,9 +302,9 @@ impl U64GroupedBitmap {
     // n bytes: serialized groups
     pub fn to_vec(&self) -> Vec<u8> {
         let mut result = vec![];
-        result.extend(&self.len.to_le_bytes());
+        result.extend(self.len.to_le_bytes());
         for x in self.data.iter() {
-            result.extend(&x.to_le_bytes());
+            result.extend(x.to_le_bytes());
         }
         result
     }


### PR DESCRIPTION
matches Debian 13 distributed Rust.

there were no particular dependencies on Rust 1.67.

fixes #670 