### PR TITLE
chore: add small intro on rustdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,48 @@
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 
+//! # redb
+//!
+//! A simple, portable, high-performance, ACID, embedded key-value store.
+//!
+//! redb is written in pure Rust and is loosely inspired by [lmdb][lmdb]. Data is stored in a collection
+//! of copy-on-write B-trees. For more details, see the [design doc][design].
+//!
+//! # Features
+//!
+//! - Zero-copy, thread-safe, `BTreeMap` based API
+//! - Fully ACID-compliant transactions
+//! - MVCC support for concurrent readers & writer, without blocking
+//! - Crash-safe by default
+//! - Savepoints and rollbacks
+//!
+//! # Example
+//!
+//! ```
+//! use redb::{Database, Error, ReadableTable, TableDefinition};
+//!
+//! const TABLE: TableDefinition<&str, u64> = TableDefinition::new("my_data");
+//!
+//! fn main() -> Result<(), Error> {
+//!     let db = Database::create("my_db.redb")?;
+//!     let write_txn = db.begin_write()?;
+//!     {
+//!         let mut table = write_txn.open_table(TABLE)?;
+//!         table.insert("my_key", &123)?;
+//!     }
+//!     write_txn.commit()?;
+//!
+//!     let read_txn = db.begin_read()?;
+//!     let table = read_txn.open_table(TABLE)?;
+//!     assert_eq!(table.get("my_key")?.unwrap().value(), 123);
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! [lmdb]: https://www.lmdb.tech/doc/
+//! [design]: https://github.com/cberner/redb/blob/master/docs/design.md
+
 pub use db::{
     Builder, Database, MultimapTableDefinition, MultimapTableHandle, TableDefinition, TableHandle,
     UntypedMultimapTableHandle, UntypedTableHandle,


### PR DESCRIPTION
Just copied over some of the readme to the rustdoc page as it is fairly common to just look up crates on docs.rs if you are contributing to a project