### PR TITLE
Improve performance and fix panic

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -226,6 +226,29 @@ fn large_values() {
 }
 
 #[test]
+fn many_pairs() {
+    let tmpfile = create_tempfile();
+    const TABLE: TableDefinition<u32, u32> = TableDefinition::new("TABLE");
+
+    let db = Database::create(tmpfile.path()).unwrap();
+    let wtx = db.begin_write().unwrap();
+
+    let mut table = wtx.open_table(TABLE).unwrap();
+
+    for i in 0..200_000 {
+        table.insert(i, i).unwrap();
+
+        if i % 10_000 == 0 {
+            eprintln!("{i}");
+        }
+    }
+
+    drop(table);
+
+    wtx.commit().unwrap();
+}
+
+#[test]
 fn large_keys() {
     let tmpfile = create_tempfile();
 


### PR DESCRIPTION
When selecting the page size to allocate when building a leaf(s) page space for offsets were still being allocated for fixed width types. This lead to those types having leaves that were much larger than necessary, and worse they could grow without bound eventually leading to a panic when the page overflowed the maximum 2^16 storable pairs.

Fixes #719 