### PR TITLE
Require V: 'static on AccessGuard

### DIFF
--- a/benches/common.rs
+++ b/benches/common.rs
@@ -150,11 +150,11 @@ impl BenchIterator for RedbBenchIterator<'_> {
 }
 
 pub struct RedbAccessGuard<'a> {
-    inner: AccessGuard<'a, &'a [u8]>,
+    inner: AccessGuard<'a, &'static [u8]>,
 }
 
 impl<'a> RedbAccessGuard<'a> {
-    fn new(inner: AccessGuard<'a, &'a [u8]>) -> Self {
+    fn new(inner: AccessGuard<'a, &'static [u8]>) -> Self {
         Self { inner }
     }
 }

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -137,7 +137,7 @@ impl EitherPage {
     }
 }
 
-pub struct AccessGuard<'a, V: Value> {
+pub struct AccessGuard<'a, V: Value + 'static> {
     page: EitherPage,
     offset: usize,
     len: usize,
@@ -147,7 +147,7 @@ pub struct AccessGuard<'a, V: Value> {
     _lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a, V: Value> AccessGuard<'a, V> {
+impl<'a, V: Value + 'static> AccessGuard<'a, V> {
     pub(crate) fn with_page(page: PageImpl, range: Range<usize>) -> Self {
         Self {
             page: EitherPage::Immutable(page),
@@ -207,7 +207,7 @@ impl<'a, V: Value> AccessGuard<'a, V> {
     }
 }
 
-impl<'a, V: Value> Drop for AccessGuard<'a, V> {
+impl<'a, V: Value + 'static> Drop for AccessGuard<'a, V> {
     fn drop(&mut self) {
         match self.on_drop {
             OnDrop::None => {}
@@ -226,7 +226,7 @@ impl<'a, V: Value> Drop for AccessGuard<'a, V> {
     }
 }
 
-pub struct AccessGuardMut<'a, V: Value> {
+pub struct AccessGuardMut<'a, V: Value + 'static> {
     page: PageMut,
     offset: usize,
     len: usize,
@@ -235,7 +235,7 @@ pub struct AccessGuardMut<'a, V: Value> {
     _lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a, V: Value> AccessGuardMut<'a, V> {
+impl<'a, V: Value + 'static> AccessGuardMut<'a, V> {
     pub(crate) fn new(page: PageMut, offset: usize, len: usize) -> Self {
         AccessGuardMut {
             page,
@@ -247,7 +247,7 @@ impl<'a, V: Value> AccessGuardMut<'a, V> {
     }
 }
 
-impl<'a, V: MutInPlaceValue> AsMut<V::BaseRefType> for AccessGuardMut<'a, V> {
+impl<'a, V: MutInPlaceValue + 'static> AsMut<V::BaseRefType> for AccessGuardMut<'a, V> {
     fn as_mut(&mut self) -> &mut V::BaseRefType {
         V::from_bytes_mut(&mut self.page.memory_mut()[self.offset..(self.offset + self.len)])
     }

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -33,7 +33,7 @@ enum DeletionResult {
     DeletedBranch(PageNumber, Checksum),
 }
 
-struct InsertionResult<'a, V: Value> {
+struct InsertionResult<'a, V: Value + 'static> {
     // the new root page
     new_root: PageNumber,
     // checksum of the root page


### PR DESCRIPTION
This matches all our other APIs like TableDefinition