### PR TITLE
PoC: easy deriving Key&Value via bincode or raw Value/Key newtypes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ pyo3-build-config = { version = "0.20.0", optional = true }
 [dependencies]
 log = {version = "0.4.17", optional = true }
 pyo3 = {version = "0.20.0", features=["extension-module", "abi3-py37"], optional = true }
+bincode = { version = "1.3.3", optional = true }
+serde = { version = "1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.104"
@@ -56,6 +58,7 @@ python = [ "pyo3", "pyo3-build-config" ]
 logging = ["log"]
 # Enable cache hit metrics
 cache_metrics = []
+bincode = [ "dep:bincode", "dep:serde" ]
 
 [profile.bench]
 debug = true

--- a/src/as_bincode.rs
+++ b/src/as_bincode.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+use std::fmt;
+
+#[derive(Debug)]
+pub struct AsBincode<T>(T);
+
+impl<T> Value for AsBincode<T>
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + Name + fmt::Debug + 'static,
+{
+    type SelfType<'a> = T;
+
+    type AsBytes<'a> = Vec<u8>;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        bincode::deserialize(data).expect("bincode deserialization error")
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'a,
+        Self: 'b,
+    {
+        bincode::serialize(value).expect("bincode serialization error")
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::new(<T as Name>::NAME)
+    }
+}

--- a/src/as_raw.rs
+++ b/src/as_raw.rs
@@ -1,0 +1,46 @@
+use super::*;
+use std::fmt;
+
+pub trait Name {
+    const NAME: &'static str;
+}
+
+pub trait AsRaw:
+    for<'a> AsRef<<Self::Raw as Value>::SelfType<'a>>
+    + for<'a> From<<Self::Raw as Value>::SelfType<'a>>
+    + Name
+{
+    type Raw: Value;
+}
+
+impl<T> Value for T
+where
+    T: AsRaw + fmt::Debug + 'static,
+{
+    type SelfType<'a> = Self;
+
+    type AsBytes<'a> = <<T as AsRaw>::Raw as Value>::AsBytes<'a>;
+
+    fn fixed_width() -> Option<usize> {
+        <T as AsRaw>::Raw::fixed_width()
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        T::from(<<T as AsRaw>::Raw>::from_bytes(data))
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'a,
+        Self: 'b,
+    {
+        <T as AsRaw>::Raw::as_bytes(value.as_ref())
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::new(<T as Name>::NAME)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
 //! [lmdb]: https://www.lmdb.tech/doc/
 //! [design]: https://github.com/cberner/redb/blob/master/docs/design.md
 
+pub use as_raw::{AsRaw, Name};
 pub use db::{
     Builder, Database, MultimapTableDefinition, MultimapTableHandle, RepairSession, StorageBackend,
     TableDefinition, TableHandle, UntypedMultimapTableHandle, UntypedTableHandle,
@@ -78,6 +79,7 @@ type Result<T = (), E = StorageError> = std::result::Result<T, E>;
 #[cfg(feature = "python")]
 pub use crate::python::redb;
 
+pub mod as_raw;
 pub mod backends;
 mod complex_types;
 mod db;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@
 //! [lmdb]: https://www.lmdb.tech/doc/
 //! [design]: https://github.com/cberner/redb/blob/master/docs/design.md
 
+#[cfg(feature = "bincode")]
+pub use as_bincode::AsBincode;
 pub use as_raw::{AsRaw, Name};
 pub use db::{
     Builder, Database, MultimapTableDefinition, MultimapTableHandle, RepairSession, StorageBackend,
@@ -79,6 +81,8 @@ type Result<T = (), E = StorageError> = std::result::Result<T, E>;
 #[cfg(feature = "python")]
 pub use crate::python::redb;
 
+#[cfg(feature = "bincode")]
+pub mod as_bincode;
 pub mod as_raw;
 pub mod backends;
 mod complex_types;


### PR DESCRIPTION
This PR is not meant to be merged as it, but only as a PoC.

One annoyance that I have with using redb is boilerplate of implementing `Key` & `Value`.

I was just playing with how to best improve it, and here is the result.

The corresponding change in my tiny downstream crate using redb is here: https://github.com/rustshop/htmx-sorta/commit/11fed565aea52ef7cf397df5b7cc8ed1e3af3891

There are two cases I' trying to cover:

* a type is a newtype over already supported type,
* a type is a composite value that should be serialized used `serde`

I started with the second case, using bincode (but the approach works for any serde encoding crate). The `AsBincode` approach can be done entirely downstream, but I think it would be handy if `redb` could just support it out of the box as an optional feature.

The first case, can't be done exactly like here downstream due to generic coherenece limitations. Downstream, one would need to introduce an extra newtype, which makes using it a bit more clunky.

The naming as is is provisional, and seems a bit inconsistent.

The `trait Name` is regrettable as it overlaps with `Value::type_name`. If `trait Value` was already a `trait Value : Name`, it would not be necessary. That would be a breaking change, which is not a great thing right afte 2.0.0 is released. :laughing: . If there's ever a `3.0.0`, it could be done. However, it's not too bad like this, and it will only affect people that would want to use `AsRaw` (which BTW. also seems like meh name to me).


#### Off-topic on `Key`

BTW. When looking at it, I had some thoughts about `Key`. I understand that for performance reasons the comparison is one on raw bytes, to avoid any overhead of conversions. But that makes `trait Key` and `Key::compare` very... odd. Because it's not really property of the type ... but kind of ... outside of it. Nothing in `trait Key` actually uses the the `T` that implements `Key`...

I think it's a nice feature, that I already manage to use in my little project for `SortId`. I might be wrong, but it seems to me that typically databases don't even allow customizing the ordering.

First thought that I had is that maybe `Key::compare` should have a default impl, as most cases will kind of not care anyway/will expect the typical order:
 
```
pub trait Key: Value {
    fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
        data1.cmp(data2)
    }
}
```

That would be an easy non-breaking change, and it would just save some typing.

But thinking more along the lines that it's weird, and opening possibility of changing the API, I wonder if it would be better to just get rid of `trait Key`, and move to:

```
pub trait SortOrder {
    fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
        data1.cmp(data2)
    }
}

pub struct MultimapTableDefinition<'a, K: Value + 'static, V: Value + 'static, Ord : SortOrder = Lexicographical> {
  ...
}
```

This would move the `compare` a bit more out of the way, made sorting order a property of a `Table`, have defaults that most people expect, and retain ability to customize the ordering, without tying it weird to type of the key via `Key`.