### PR TITLE
RFC: Avoid double-indirection of Arc<Vec<u8>> by using Arc<[u8]> directly

### DIFF
--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -123,7 +123,7 @@ enum EitherPage {
     Immutable(PageImpl),
     Mutable(PageMut),
     OwnedMemory(Vec<u8>),
-    ArcMemory(Arc<Vec<u8>>),
+    ArcMemory(Arc<[u8]>),
 }
 
 impl EitherPage {
@@ -132,7 +132,7 @@ impl EitherPage {
             EitherPage::Immutable(page) => page.memory(),
             EitherPage::Mutable(page) => page.memory(),
             EitherPage::OwnedMemory(mem) => mem.as_slice(),
-            EitherPage::ArcMemory(mem) => mem.as_slice(),
+            EitherPage::ArcMemory(mem) => mem,
         }
     }
 }
@@ -159,7 +159,7 @@ impl<'a, V: Value + 'static> AccessGuard<'a, V> {
         }
     }
 
-    pub(crate) fn with_arc_page(page: Arc<Vec<u8>>, range: Range<usize>) -> Self {
+    pub(crate) fn with_arc_page(page: Arc<[u8]>, range: Range<usize>) -> Self {
         Self {
             page: EitherPage::ArcMemory(page),
             offset: range.start,

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -24,7 +24,7 @@ enum DeletionResult {
     DeletedLeaf,
     // A leaf with fewer entries than desired
     PartialLeaf {
-        page: Arc<Vec<u8>>,
+        page: Arc<[u8]>,
         deleted_pair: usize,
     },
     // A branch page subtree with fewer children than desired
@@ -316,7 +316,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                     let existing_value = if found {
                         let (start, end) = accessor.value_range(position).unwrap();
                         if self.modify_uncommitted && self.mem.uncommitted(page_number) {
-                            let arc = page.to_arc_vec();
+                            let arc = page.to_arc();
                             drop(page);
                             self.mem.free(page_number);
                             Some(AccessGuard::with_arc_page(arc, start..end))
@@ -350,7 +350,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                     let existing_value = if found {
                         let (start, end) = accessor.value_range(position).unwrap();
                         if self.modify_uncommitted && self.mem.uncommitted(page_number) {
-                            let arc = page.to_arc_vec();
+                            let arc = page.to_arc();
                             drop(page);
                             self.mem.free(page_number);
                             Some(AccessGuard::with_arc_page(arc, start..end))
@@ -546,7 +546,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
             // Merge when less than 33% full. Splits occur when a page is full and produce two 50%
             // full pages, so we use 33% instead of 50% to avoid oscillating
             PartialLeaf {
-                page: page.to_arc_vec(),
+                page: page.to_arc(),
                 deleted_pair: position,
             }
         } else {
@@ -570,7 +570,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
         drop(accessor);
         let guard = if uncommitted && self.modify_uncommitted {
             let page_number = page.get_page_number();
-            let arc = page.to_arc_vec();
+            let arc = page.to_arc();
             drop(page);
             self.mem.free(page_number);
             Some(AccessGuard::with_arc_page(arc, start..end))

--- a/src/tree_store/page_store/base.rs
+++ b/src/tree_store/page_store/base.rs
@@ -149,14 +149,14 @@ pub(crate) trait Page {
 }
 
 pub struct PageImpl {
-    pub(super) mem: Arc<Vec<u8>>,
+    pub(super) mem: Arc<[u8]>,
     pub(super) page_number: PageNumber,
     #[cfg(debug_assertions)]
     pub(super) open_pages: Arc<Mutex<HashMap<PageNumber, u64>>>,
 }
 
 impl PageImpl {
-    pub(crate) fn to_arc_vec(&self) -> Arc<Vec<u8>> {
+    pub(crate) fn to_arc(&self) -> Arc<[u8]> {
         self.mem.clone()
     }
 }


### PR DESCRIPTION
~~The second commit removes any per-access overhead to `WritablePage` but at the cost of some unsafe code relying on the uniqueness that was asserted once by calling `Arc::try_unwrap` before this change.~~