### PR TITLE
Move cleaned pages into read cache instead of discarding them.

### DIFF
--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -303,6 +303,7 @@ impl PagedCachedFile {
             } else {
                 self.read_cache_bytes
                     .fetch_sub(buffer.len(), Ordering::AcqRel);
+                break;
             }
         }
         for (offset, buffer) in write_buffer.low_pri_cache.iter_mut() {
@@ -318,6 +319,7 @@ impl PagedCachedFile {
             } else {
                 self.read_cache_bytes
                     .fetch_sub(buffer.len(), Ordering::AcqRel);
+                break;
             }
         }
         self.write_buffer_bytes.store(0, Ordering::Release);


### PR DESCRIPTION
Just after dirty pages have been written out to disk, they are currently discard and need to be read in again when these pages are accessed in the future.

This changes moves them into the read cache instead thereby keeping the clean data available and cache hot in memory.

It turned out that this was also what was making direct I/O slower in #808, i.e. this was not that noticeable when buffered I/O is use because the pages were read back in from the kernel page cache most of the time but it should be a win in both scenarios.