### PR TITLE
Fix panic when inserting pair exceeding ~4GiB

### DIFF
--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -7,7 +7,7 @@ use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker}
 use crate::tree_store::{
     Btree, BtreeHeader, BtreeMut, FreedPageList, FreedTableKey, InternalTableDefinition, PageHint,
     PageNumber, SerializedSavepoint, TableTree, TableTreeMut, TableType, TransactionalMemory,
-    MAX_VALUE_LENGTH,
+    MAX_PAIR_LENGTH, MAX_VALUE_LENGTH,
 };
 use crate::types::{Key, Value};
 use crate::{
@@ -243,6 +243,9 @@ impl<'db, 's, K: Key + 'static, V: Value + 'static> SystemTable<'db, 's, K, V> {
         let key_len = K::as_bytes(key.borrow()).as_ref().len();
         if key_len > MAX_VALUE_LENGTH {
             return Err(StorageError::ValueTooLarge(key_len));
+        }
+        if value_len + key_len > MAX_PAIR_LENGTH {
+            return Err(StorageError::ValueTooLarge(value_len + key_len));
         }
         self.tree.insert(key.borrow(), value.borrow())
     }

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use btree_iters::{AllPageNumbersBtreeIter, BtreeExtractIf, BtreeRange
 pub use page_store::{file_backend, InMemoryBackend, Savepoint};
 pub(crate) use page_store::{
     CachePriority, Page, PageHint, PageNumber, SerializedSavepoint, TransactionalMemory,
-    FILE_FORMAT_VERSION2, MAX_VALUE_LENGTH, PAGE_SIZE,
+    FILE_FORMAT_VERSION2, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE,
 };
 pub(crate) use table_tree::{
     FreedPageList, FreedTableKey, InternalTableDefinition, TableTree, TableTreeMut, TableType,

--- a/src/tree_store/page_store/base.rs
+++ b/src/tree_store/page_store/base.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 pub(crate) const MAX_VALUE_LENGTH: usize = 3 * 1024 * 1024 * 1024;
+pub(crate) const MAX_PAIR_LENGTH: usize = 3 * 1024 * 1024 * 1024 + 768 * 1024 * 1024;
 pub(crate) const MAX_PAGE_INDEX: u32 = 0x000F_FFFF;
 
 // On-disk format is:

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -12,7 +12,7 @@ mod savepoint;
 #[allow(dead_code)]
 mod xxh3;
 
-pub(crate) use base::{Page, PageHint, PageNumber, MAX_VALUE_LENGTH};
+pub(crate) use base::{Page, PageHint, PageNumber, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH};
 pub(crate) use header::PAGE_SIZE;
 pub use in_memory_backend::InMemoryBackend;
 pub(crate) use page_manager::{xxh3_checksum, TransactionalMemory, FILE_FORMAT_VERSION2};


### PR DESCRIPTION
StorageError::ValueTooLarge will now be returned for key-value pairs that exceed 3.75GiB

Fixes #819 