### PR TITLE
benchmark: increase rocksdb block cache capacity

### DIFF
--- a/benches/lmdb_benchmark.rs
+++ b/benches/lmdb_benchmark.rs
@@ -307,7 +307,15 @@ fn main() {
 
     let rocksdb_results = {
         let tmpfile: TempDir = tempfile::tempdir_in(&tmpdir).unwrap();
-        let db = rocksdb::TransactionDB::open_default(tmpfile.path()).unwrap();
+
+        let mut bb = rocksdb::BlockBasedOptions::default();
+        bb.set_block_cache(&rocksdb::Cache::new_lru_cache(4 * 1_024 * 1_024 * 1_024));
+
+        let mut opts = rocksdb::Options::default();
+        opts.set_block_based_table_factory(&bb);
+        opts.create_if_missing(true);
+
+        let db = rocksdb::TransactionDB::open(&opts, &Default::default(), tmpfile.path()).unwrap();
         let table = RocksdbBenchDatabase::new(&db);
         benchmark(table)
     };


### PR DESCRIPTION
Compared to redb (and sled), RocksDB gets way too little cache capacity (32MB), which negatively impacts its read performance. Setting it to 4 GB (same as redb) gives it a 1.5x read performance boost on my system.

I haven't updated the readme, because it's system dependent, so you would need to rerun it on yours.