### PR TITLE
Fix leak of pages in restore_savepoint()

### DIFF
--- a/src/tree_store/page_store/layout.rs
+++ b/src/tree_store/page_store/layout.rs
@@ -83,7 +83,7 @@ impl RegionLayout {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(super) struct DatabaseLayout {
+pub(crate) struct DatabaseLayout {
     full_region_layout: RegionLayout,
     num_full_regions: u32,
     trailing_partial_region: Option<RegionLayout>,

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -20,5 +20,7 @@ pub use savepoint::Savepoint;
 pub(crate) use savepoint::SerializedSavepoint;
 
 pub(super) use base::{PageImpl, PageMut};
+pub(super) use buddy_allocator::BuddyAllocator;
 pub(crate) use cached_file::CachePriority;
+pub(super) use region::new_allocators;
 pub(super) use xxh3::hash128_with_seed;

--- a/src/tree_store/page_store/savepoint.rs
+++ b/src/tree_store/page_store/savepoint.rs
@@ -82,10 +82,6 @@ impl Savepoint {
         self.freed_root
     }
 
-    pub(crate) fn get_regional_allocator_states(&self) -> &[Vec<u8>] {
-        &self.regional_allocators
-    }
-
     pub(crate) fn db_address(&self) -> *const TransactionTracker {
         self.transaction_tracker.as_ref() as *const _
     }


### PR DESCRIPTION
Pages allocated in the system tree or freed tree when the savepoint was captured are currently leaked, because they are in a pending free state, and so do not appear in the diff of the allocator state, but they are also curretly being dropped from the freed tree.

This fixes the leak, but make restore_savepoint() slower