### PR TITLE
Fix false positive in check_integrity()

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -780,6 +780,8 @@ impl Database {
             transaction_id,
             false,
             true,
+            // don't trim the database file, because we want the allocator hash to match exactly
+            false,
         )?;
 
         Ok(())

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1024,6 +1024,7 @@ impl WriteTransaction {
             self.transaction_id,
             eventual,
             two_phase,
+            true,
         )?;
 
         // Mark any pending non-durable commits as fully committed.


### PR DESCRIPTION
If the database file was truncated because there was excess space, during the repair, check_integrity() returned Ok(false)