### PR TITLE
chore: use heed for LMDB in benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ bincode = "1.3.3"
 # Pinned to compatibility with MSRV
 ctrlc = "=3.2.3"
 fastrand = "2.0.0"
-lmdb-rkv = "0.14.0"
+heed = "0.20"
 sanakirja = "=1.4.1"
 sanakirja-core = "=1.4.1"
 sled = "0.34.7"

--- a/benches/int_benchmark.rs
+++ b/benches/int_benchmark.rs
@@ -65,9 +65,13 @@ fn main() {
 
     let lmdb_results = {
         let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
-        let env = lmdb::Environment::new().open(tmpfile.path()).unwrap();
-        env.set_map_size(10 * 4096 * 1024 * 1024).unwrap();
-        let table = LmdbRkvBenchDatabase::new(&env);
+        let env = unsafe {
+            heed::EnvOpenOptions::new()
+                .map_size(10 * 4096 * 1024 * 1024)
+                .open(tmpfile.path())
+                .unwrap()
+        };
+        let table = HeedBenchDatabase::new(&env);
         benchmark(table)
     };
 

--- a/benches/large_values_benchmark.rs
+++ b/benches/large_values_benchmark.rs
@@ -76,9 +76,13 @@ fn main() {
 
     let lmdb_results = {
         let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
-        let env = lmdb::Environment::new().open(tmpfile.path()).unwrap();
-        env.set_map_size(10 * 4096 * 1024 * 1024).unwrap();
-        let table = LmdbRkvBenchDatabase::new(&env);
+        let env = unsafe {
+            heed::EnvOpenOptions::new()
+                .map_size(10 * 4096 * 1024 * 1024)
+                .open(tmpfile.path())
+                .unwrap()
+        };
+        let table = HeedBenchDatabase::new(&env);
         benchmark(table)
     };
 

--- a/benches/lmdb_benchmark.rs
+++ b/benches/lmdb_benchmark.rs
@@ -299,9 +299,13 @@ fn main() {
 
     let lmdb_results = {
         let tmpfile: TempDir = tempfile::tempdir_in(&tmpdir).unwrap();
-        let env = lmdb::Environment::new().open(tmpfile.path()).unwrap();
-        env.set_map_size(4096 * 1024 * 1024).unwrap();
-        let table = LmdbRkvBenchDatabase::new(&env);
+        let env = unsafe {
+            heed::EnvOpenOptions::new()
+                .map_size(4096 * 1024 * 1024)
+                .open(tmpfile.path())
+                .unwrap()
+        };
+        let table = HeedBenchDatabase::new(&env);
         benchmark(table)
     };
 


### PR DESCRIPTION
`just bench` failed on my machine (M1 Pro, 32GB RAM)
```console
➜  redb git:(master) ✗ just bench
...
lmdb-rkv: Bulk loaded 1000000 items in 1395ms
lmdb-rkv: Wrote 100 individual items in 11ms
lmdb-rkv: Wrote 100 x 1000 items in 3364ms
lmdb-rkv: len() in 0ms
lmdb-rkv: Random read 1000000 items in 1063ms
lmdb-rkv: Random read 1000000 items in 1045ms
error: bench failed, to rerun pass `--bench lmdb_benchmark`

Caused by:
  process didn't exit successfully: `/Users/shekhirin/Projects/redb/target/release/deps/lmdb_benchmark-9bace23009390253 --bench` (signal: 11, SIGSEGV: invalid memory reference)
error: Recipe `bench` failed on line 34 with exit code 101
```

So I decided to try out [heed](https://github.com/meilisearch/heed) as an alternative LMDB wrapper library. It's more maintained and subjectively has higher code quality. Also, it works 😄

```console
➜  redb git:(lmdb-heed) ✗ just bench
...
heed: Bulk loaded 1000000 items in 1501ms
heed: Wrote 100 individual items in 7ms
heed: Wrote 100 x 1000 items in 2988ms
heed: len() in 0ms
heed: Random read 1000000 items in 1038ms
heed: Random read 1000000 items in 1008ms
heed: Random range read 10000000 elements in 1544ms
heed: Random range read 10000000 elements in 1548ms
heed: Random read (4 threads) 1000000 items in 263ms
heed: Random read (8 threads) 1000000 items in 144ms
heed: Random read (16 threads) 1000000 items in 145ms
heed: Random read (32 threads) 1000000 items in 122ms
heed: Removed 500000 items in 1460ms
...
```