### PR TITLE
Better markdown benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ redb1 = { version = "=1.0.0", package = "redb" }
 redb2 = { version = "=2.0.0", package = "redb" }
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.3"
+walkdir = "2.5.0"
 
 # Just benchmarking dependencies
 [target.'cfg(not(target_os = "wasi"))'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ redb2 = { version = "=2.0.0", package = "redb" }
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.3"
 walkdir = "2.5.0"
+byte-unit = "=5.0.4"
 
 # Just benchmarking dependencies
 [target.'cfg(not(target_os = "wasi"))'.dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -53,20 +53,20 @@ To run all the tests and benchmarks a few extra dependencies are required:
 ## Benchmarks
 redb has similar performance to other top embedded key-value stores such as lmdb and rocksdb
 
-|                           | redb   | lmdb   | rocksdb | sled   | sanakirja |
-|---------------------------|--------|--------|---------|--------|-----------|
-| bulk load                 | 2792ms | 1115ms | 5610ms  | 5005ms | 1161ms    |
-| individual writes         | 462ms  | 1119ms | 1097ms  | 957ms  | 662ms     |
-| batch writes              | 2568ms | 2247ms | 1344ms  | 1622ms | 2713ms    |
-| random reads              | 988ms  | 558ms  | 3469ms  | 1509ms | 678ms     |
-| random reads              | 962ms  | 556ms  | 3377ms  | 1425ms | 671ms     |
-| random range reads        | 2534ms | 985ms  | 6058ms  | 4670ms | 1089ms    |
-| random range reads        | 2493ms | 998ms  | 5801ms  | 4665ms | 1119ms    |
-| random reads (4 threads)  | 344ms  | 141ms  | 1247ms  | 424ms  | 266ms     |
-| random reads (8 threads)  | 192ms  | 72ms   | 673ms   | 230ms  | 620ms     |
-| random reads (16 threads) | 131ms  | 47ms   | 476ms   | 148ms  | 3500ms    |
-| random reads (32 threads) | 118ms  | 44ms   | 412ms   | 129ms  | 4313ms    |
-| removals                  | 2184ms | 784ms  | 2451ms  | 2047ms | 1344ms    |
+|                           |    redb    |    lmdb    |    rocksdb  |  sled  | sanakirja |
+|---------------------------|------------|------------|-------------|--------|-----------|
+| bulk load                 |   2792ms   | **1115ms** |   5610ms    | 5005ms | 1161ms |
+| individual writes         | **462ms**  |   1119ms   |   1097ms    | 957ms  | 662ms  |
+| batch writes              |   2568ms   |   2247ms   | **1344ms**  | 1622ms | 2713ms |
+| random reads              |   988ms    | **558ms**  |   3469ms    | 1509ms | 678ms  |
+| random reads              |   962ms    | **556ms**  |   3377ms    | 1425ms | 671ms  |
+| random range reads        |   2534ms   | **985ms**  |   6058ms    | 4670ms | 1089ms |
+| random range reads        |   2493ms   | **998ms**  |   5801ms    | 4665ms | 1119ms |
+| random reads (4 threads)  |   344ms    | **141ms**  |   1247ms    | 424ms  | 266ms  |
+| random reads (8 threads)  |   192ms    | **72ms**   |   673ms     | 230ms  | 620ms  |
+| random reads (16 threads) |   131ms    | **47ms**   |   476ms     | 148ms  | 3500ms |
+| random reads (32 threads) |   118ms    | **44ms**   |   412ms     | 129ms  | 4313ms |
+| removals                  |   2184ms   | **784ms**  |   2451ms    | 2047ms | 1344ms |
 
 Source code for benchmark [here](./benches/lmdb_benchmark.rs). Results collected on a Ryzen 5900X with Samsung 980 PRO NVMe.
 

--- a/benches/lmdb_benchmark.rs
+++ b/benches/lmdb_benchmark.rs
@@ -425,9 +425,9 @@ fn main() {
     ];
 
     let mut identified_smallests = vec![vec![false; results.len()]; rows.len()];
-    for i in 0..rows.len() {
+    for (i, identified_smallests_row) in identified_smallests.iter_mut().enumerate() {
         let mut smallest = None;
-        for j in 0..results.len() {
+        for (j, _) in identified_smallests_row.iter().enumerate() {
             let (_, rt) = &results[j][i];
             smallest = match smallest {
                 Some((_, prev)) if rt < prev => Some((j, rt)),
@@ -436,7 +436,7 @@ fn main() {
             };
         }
         let (j, _rt) = smallest.unwrap();
-        identified_smallests[i][j] = true;
+        identified_smallests_row[j] = true;
     }
 
     for (j, results) in results.iter().enumerate() {

--- a/benches/lmdb_benchmark.rs
+++ b/benches/lmdb_benchmark.rs
@@ -450,6 +450,7 @@ fn main() {
     }
 
     let mut table = comfy_table::Table::new();
+    table.load_preset(comfy_table::presets::ASCII_MARKDOWN);
     table.set_width(100);
     table.set_header(["", "redb", "lmdb", "rocksdb", "sled", "sanakirja"]);
     for row in rows {


### PR DESCRIPTION
This PR displays the best result in bold and gives you the size of the temporary files after all benchmarks, so you can get a rough idea of their total size. I also make sure the table is in Markdown format, making it easier to copy and paste into the README.

|                           | redb     | lmdb         | rocksdb        | sled       | sanakirja    |
|---------------------------|----------|--------------|----------------|------------|--------------|
| bulk load                 | 3.90s    | 1.25s        | 7.07s          | 5.57s      | **1.13s**    |
| individual writes         | 459.81ms | 8.09ms       | **4.34ms**     | 406.12ms   | 57.15ms      |
| batch writes              | 4.78s    | 2.72s        | **272.26ms**   | 1.41s      | 4.70s        |
| len()                     | 4.42µs   | **416.00ns** | 207.18ms       | 722.56ms   | 46.73ms      |
| random reads              | 882.28ms | 943.44ms     | 2.59s          | 1.15s      | **830.85ms** |
| random reads              | 886.02ms | 980.67ms     | 2.51s          | 1.14s      | **843.01ms** |
| random range reads        | 2.01s    | 1.38s        | 4.65s          | 4.62s      | **1.21s**    |
| random range reads        | 2.37s    | 1.36s        | 4.74s          | 5.82s      | **1.24s**    |
| random reads (4 threads)  | 322.40ms | **251.22ms** | 815.59ms       | 372.30ms   | 335.81ms     |
| random reads (8 threads)  | 239.00ms | **178.85ms** | 619.15ms       | 312.32ms   | 512.79ms     |
| random reads (16 threads) | 271.99ms | **155.67ms** | 550.53ms       | 304.05ms   | 622.27ms     |
| random reads (32 threads) | 268.41ms | **159.45ms** | 511.69ms       | 330.67ms   | 673.09ms     |
| removals                  | 3.60s    | 1.17s        | 3.03s          | 1.91s      | **1.16s**    |
| size after bench          | 1.00 GiB | 584.85 MiB   | **383.33 MiB** | 453.00 MiB | 4.00 GiB     |

Those benchmarks were done on my Macbook Pro M1.