### PR TITLE
feat: make Database `Clone`

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -310,6 +310,7 @@ impl Drop for TransactionGuard {
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Clone)]
 pub struct Database {
     mem: Arc<TransactionalMemory>,
     transaction_tracker: Arc<TransactionTracker>,


### PR DESCRIPTION
I don't know if you require this, feel free to close if not. I added it to my own fork because I need it, as being `Clone` is required to share an instance on axum, for example.

Since all internal tools are already guarded by Arcs, there's no reason to block the user from being able to `clone` the Database.

This PR adds support for it.