### PR TITLE
Fix panic and return PreviousIo error instead

### DIFF
--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -323,6 +323,10 @@ impl PagedCachedFile {
         })
     }
 
+    pub(crate) fn check_io_errors(&self) -> Result {
+        self.file.check_failure()
+    }
+
     pub(crate) fn raw_file_len(&self) -> Result<u64> {
         self.file.len()
     }

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -82,6 +82,7 @@ pub(crate) struct TransactionalMemory {
     // TODO: maybe this should be moved to WriteTransaction?
     allocated_since_commit: Mutex<HashSet<PageNumber>>,
     // True if the allocator state was corrupted when the file was opened
+    // TODO: maybe we can remove this flag now that CheckedBackend exists?
     needs_recovery: AtomicBool,
     storage: PagedCachedFile,
     state: Mutex<InMemoryState>,
@@ -259,6 +260,10 @@ impl TransactionalMemory {
             region_size,
             region_header_with_padding_size: region_header_size,
         })
+    }
+
+    pub(crate) fn check_io_errors(&self) -> Result {
+        self.storage.check_io_errors()
     }
 
     #[cfg(any(test, fuzzing))]


### PR DESCRIPTION
Fixes a panic in commit() or abort() which would occur if a previous commit() or abort() had failed due to an I/O error

Fixes #857 