### PR TITLE
Fix potential panic in repair

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -504,18 +504,6 @@ impl Database {
                 if let Some(header) = savepoint.get_user_root() {
                     Self::check_pages_allocated_recursive(header.root, mem.clone())?;
                 }
-                if let Some(header) = savepoint.get_freed_root() {
-                    let freed_pages_iter = AllPageNumbersBtreeIter::new(
-                        header.root,
-                        FreedTableKey::fixed_width(),
-                        FreedPageList::fixed_width(),
-                        mem.clone(),
-                    )?;
-                    for page_number in freed_pages_iter {
-                        let page = page_number?;
-                        assert!(mem.is_allocated(page));
-                    }
-                }
             }
         }
 

--- a/src/tree_store/page_store/savepoint.rs
+++ b/src/tree_store/page_store/savepoint.rs
@@ -78,10 +78,6 @@ impl Savepoint {
         self.user_root
     }
 
-    pub(crate) fn get_freed_root(&self) -> Option<BtreeHeader> {
-        self.freed_root
-    }
-
     pub(crate) fn db_address(&self) -> *const TransactionTracker {
         self.transaction_tracker.as_ref() as *const _
     }


### PR DESCRIPTION
The freed tree referenced by a savepoint should not be accessed, because its pages are not versioned -- they are immediately freed after a durable commit