### PR TITLE
Turn on pedantic clippy lints where possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Cargo.lock
 # Profiling
 perf.data*
 flamegraph.svg
+
+# benchmark and test temporary files
+/.tmp*

--- a/src/complex_types.rs
+++ b/src/complex_types.rs
@@ -9,7 +9,6 @@ fn encode_varint_len(len: usize, output: &mut Vec<u8>) {
         output.push(254);
         output.extend_from_slice(&u16_len.to_le_bytes())
     } else {
-        assert!(len <= u32::MAX as usize);
         let u32_len: u32 = len.try_into().unwrap();
         output.push(255);
         output.extend_from_slice(&u32_len.to_le_bytes())

--- a/src/complex_types.rs
+++ b/src/complex_types.rs
@@ -7,11 +7,11 @@ fn encode_varint_len(len: usize, output: &mut Vec<u8>) {
     } else if len <= u16::MAX.into() {
         let u16_len: u16 = len.try_into().unwrap();
         output.push(254);
-        output.extend_from_slice(&u16_len.to_le_bytes())
+        output.extend_from_slice(&u16_len.to_le_bytes());
     } else {
         let u32_len: u32 = len.try_into().unwrap();
         output.push(255);
-        output.extend_from_slice(&u32_len.to_le_bytes())
+        output.extend_from_slice(&u32_len.to_le_bytes());
     }
 }
 

--- a/src/complex_types.rs
+++ b/src/complex_types.rs
@@ -66,7 +66,6 @@ impl<T: Value> Value for Vec<T> {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Vec<T::SelfType<'b>>) -> Vec<u8>
     where
-        Self: 'a,
         Self: 'b,
     {
         let mut result = if let Some(width) = T::fixed_width() {

--- a/src/db.rs
+++ b/src/db.rs
@@ -804,7 +804,7 @@ impl RepairSession {
         self.aborted
     }
 
-    /// Abort the repair process. The coorresponding call to [Builder::open] or [Builder::create] will return an error
+    /// Abort the repair process. The coorresponding call to [`Builder::open`] or [`Builder::create`] will return an error
     pub fn abort(&mut self) {
         self.aborted = true;
     }
@@ -852,7 +852,7 @@ impl Builder {
     /// Set a callback which will be invoked periodically in the event that the database file needs
     /// to be repaired.
     ///
-    /// The [RepairSession] argument can be used to control the repair process.
+    /// The [`RepairSession`] argument can be used to control the repair process.
     ///
     /// If the database file needs repair, the callback will be invoked at least once.
     /// There is no upper limit on the number of times it may be called.

--- a/src/db.rs
+++ b/src/db.rs
@@ -453,9 +453,9 @@ impl Database {
 
             if !progress {
                 break;
-            } else {
-                compacted = true;
             }
+
+            compacted = true;
         }
 
         Ok(compacted)

--- a/src/error.rs
+++ b/src/error.rs
@@ -109,7 +109,7 @@ impl TableError {
             | TableError::TypeDefinitionChanged { .. }
             | TableError::TableDoesNotExist(_)
             | TableError::TableAlreadyOpen(_, _) => {
-                StorageError::Corrupted(format!("{}: {}", msg, &self))
+                StorageError::Corrupted(format!("{msg}: {self}"))
             }
             TableError::Storage(storage) => storage,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
-#![allow(clippy::drop_non_drop, clippy::default_trait_access)]
+#![allow(
+    clippy::drop_non_drop,
+    clippy::default_trait_access,
+    clippy::if_not_else
+)]
 #![deny(
     clippy::all,
     clippy::doc_markdown,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
+#![deny(clippy::all, clippy::pedantic, clippy::disallowed_methods)]
 #![allow(
-    clippy::drop_non_drop,
     clippy::default_trait_access,
     clippy::if_not_else,
     clippy::inline_always,
@@ -8,39 +8,15 @@
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,
     clippy::module_name_repetitions,
+    clippy::must_use_candidate,
     clippy::needless_pass_by_value,
     clippy::option_option,
-    clippy::unnecessary_wraps,
-    clippy::too_many_lines,
+    clippy::redundant_closure_for_method_calls,
     clippy::similar_names,
-    clippy::wildcard_imports,
+    clippy::too_many_lines,
+    clippy::unnecessary_wraps,
     clippy::unreadable_literal,
-    clippy::must_use_candidate,
-    clippy::redundant_closure_for_method_calls
-)]
-#![deny(
-    clippy::all,
-    clippy::doc_markdown,
-    clippy::explicit_iter_loop,
-    clippy::cast_lossless,
-    clippy::checked_conversions,
-    clippy::cloned_instead_of_copied,
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    clippy::cast_precision_loss,
-    clippy::cast_sign_loss,
-    clippy::disallowed_methods,
-    clippy::map_unwrap_or,
-    clippy::match_wildcard_for_single_variants,
-    clippy::range_plus_one,
-    clippy::type_repetition_in_bounds,
-    clippy::uninlined_format_args,
-    clippy::semicolon_if_nothing_returned,
-    clippy::redundant_else,
-    clippy::unused_self,
-    clippy::match_same_arms,
-    clippy::trivially_copy_pass_by_ref,
-    clippy::transmute_ptr_to_ptr
+    clippy::wildcard_imports
 )]
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,8 @@
     clippy::match_wildcard_for_single_variants,
     clippy::range_plus_one,
     clippy::type_repetition_in_bounds,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    clippy::semicolon_if_nothing_returned
 )]
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,8 @@
     clippy::cast_sign_loss,
     clippy::disallowed_methods,
     clippy::map_unwrap_or,
-    clippy::match_wildcard_for_single_variants
+    clippy::match_wildcard_for_single_variants,
+    clippy::range_plus_one
 )]
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::drop_non_drop)]
+#![allow(clippy::drop_non_drop, clippy::default_trait_access)]
 #![deny(
     clippy::all,
     clippy::cast_lossless,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@
     clippy::module_name_repetitions,
     clippy::needless_pass_by_value,
     clippy::option_option,
-    clippy::unnecessary_wraps
+    clippy::unnecessary_wraps,
+    clippy::too_many_lines
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
     clippy::drop_non_drop,
     clippy::default_trait_access,
     clippy::if_not_else,
-    clippy::inline_always
+    clippy::inline_always,
+    clippy::iter_not_returning_iterator
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::drop_non_drop)]
 #![deny(
     clippy::all,
+    clippy::cast_lossless,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@
     clippy::default_trait_access,
     clippy::if_not_else,
     clippy::inline_always,
-    clippy::iter_not_returning_iterator
+    clippy::iter_not_returning_iterator,
+    clippy::let_underscore_drop
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,8 @@
     clippy::map_unwrap_or,
     clippy::match_wildcard_for_single_variants,
     clippy::range_plus_one,
-    clippy::type_repetition_in_bounds
+    clippy::type_repetition_in_bounds,
+    clippy::uninlined_format_args
 )]
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,8 @@
     clippy::redundant_else,
     clippy::unused_self,
     clippy::match_same_arms,
-    clippy::trivially_copy_pass_by_ref
+    clippy::trivially_copy_pass_by_ref,
+    clippy::transmute_ptr_to_ptr
 )]
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::drop_non_drop, clippy::default_trait_access)]
 #![deny(
     clippy::all,
+    clippy::doc_markdown,
     clippy::cast_lossless,
     clippy::checked_conversions,
     clippy::cloned_instead_of_copied,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,8 @@
     clippy::too_many_lines,
     clippy::similar_names,
     clippy::wildcard_imports,
-    clippy::unreadable_literal
+    clippy::unreadable_literal,
+    clippy::must_use_candidate
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,8 @@
     clippy::semicolon_if_nothing_returned,
     clippy::redundant_else,
     clippy::unused_self,
-    clippy::match_same_arms
+    clippy::match_same_arms,
+    clippy::trivially_copy_pass_by_ref
 )]
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,8 @@
     clippy::type_repetition_in_bounds,
     clippy::uninlined_format_args,
     clippy::semicolon_if_nothing_returned,
-    clippy::redundant_else
+    clippy::redundant_else,
+    clippy::unused_self
 )]
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 #![allow(
     clippy::drop_non_drop,
     clippy::default_trait_access,
-    clippy::if_not_else
+    clippy::if_not_else,
+    clippy::inline_always
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::drop_non_drop)]
 #![deny(
+    clippy::all,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,8 @@
     clippy::range_plus_one,
     clippy::type_repetition_in_bounds,
     clippy::uninlined_format_args,
-    clippy::semicolon_if_nothing_returned
+    clippy::semicolon_if_nothing_returned,
+    clippy::redundant_else
 )]
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,8 @@
     clippy::unnecessary_wraps,
     clippy::too_many_lines,
     clippy::similar_names,
-    clippy::wildcard_imports
+    clippy::wildcard_imports,
+    clippy::unreadable_literal
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@
     clippy::iter_not_returning_iterator,
     clippy::let_underscore_drop,
     clippy::missing_errors_doc,
-    clippy::missing_panics_doc
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,8 @@
     clippy::disallowed_methods,
     clippy::map_unwrap_or,
     clippy::match_wildcard_for_single_variants,
-    clippy::range_plus_one
+    clippy::range_plus_one,
+    clippy::type_repetition_in_bounds
 )]
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(
     clippy::all,
     clippy::doc_markdown,
+    clippy::explicit_iter_loop,
     clippy::cast_lossless,
     clippy::checked_conversions,
     clippy::cloned_instead_of_copied,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,8 @@
     clippy::uninlined_format_args,
     clippy::semicolon_if_nothing_returned,
     clippy::redundant_else,
-    clippy::unused_self
+    clippy::unused_self,
+    clippy::match_same_arms
 )]
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
     clippy::disallowed_methods,
-    clippy::map_unwrap_or
+    clippy::map_unwrap_or,
+    clippy::match_wildcard_for_single_variants
 )]
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(
     clippy::all,
     clippy::cast_lossless,
+    clippy::checked_conversions,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,8 @@
     clippy::missing_panics_doc,
     clippy::module_name_repetitions,
     clippy::needless_pass_by_value,
-    clippy::option_option
+    clippy::option_option,
+    clippy::unnecessary_wraps
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@
     clippy::similar_names,
     clippy::wildcard_imports,
     clippy::unreadable_literal,
-    clippy::must_use_candidate
+    clippy::must_use_candidate,
+    clippy::redundant_closure_for_method_calls
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,8 @@
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
-    clippy::disallowed_methods
+    clippy::disallowed_methods,
+    clippy::map_unwrap_or
 )]
 // TODO remove this once wasi no longer requires nightly
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@
     clippy::option_option,
     clippy::unnecessary_wraps,
     clippy::too_many_lines,
-    clippy::similar_names
+    clippy::similar_names,
+    clippy::wildcard_imports
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
     clippy::all,
     clippy::cast_lossless,
     clippy::checked_conversions,
+    clippy::cloned_instead_of_copied,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@
     clippy::needless_pass_by_value,
     clippy::option_option,
     clippy::unnecessary_wraps,
-    clippy::too_many_lines
+    clippy::too_many_lines,
+    clippy::similar_names
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@
     clippy::let_underscore_drop,
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,
-    clippy::module_name_repetitions
+    clippy::module_name_repetitions,
+    clippy::needless_pass_by_value
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,9 @@
     clippy::if_not_else,
     clippy::inline_always,
     clippy::iter_not_returning_iterator,
-    clippy::let_underscore_drop
+    clippy::let_underscore_drop,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc
 )]
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,
     clippy::module_name_repetitions,
-    clippy::needless_pass_by_value
+    clippy::needless_pass_by_value,
+    clippy::option_option
 )]
 #![deny(
     clippy::all,

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -574,7 +574,7 @@ impl<V: Key> Value for &DynamicCollection<V> {
 
 impl<V: Key> DynamicCollection<V> {
     fn new(data: &[u8]) -> &Self {
-        unsafe { mem::transmute(data) }
+        unsafe { &*(data as *const [u8] as *const DynamicCollection<V>) }
     }
 
     fn collection_type(&self) -> DynamicCollectionType {
@@ -700,7 +700,7 @@ impl UntypedDynamicCollection {
     }
 
     fn new(data: &[u8]) -> &Self {
-        unsafe { mem::transmute(data) }
+        unsafe { &*(data as *const [u8] as *const UntypedDynamicCollection) }
     }
 
     fn make_subtree_data(header: BtreeHeader) -> Vec<u8> {

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -850,7 +850,7 @@ impl<'a, V: Key + 'static> Drop for MultimapValue<'a, V> {
         drop(mem::take(&mut self.inner));
         if !self.free_on_drop.is_empty() {
             let mut freed_pages = self.freed_pages.as_ref().unwrap().lock().unwrap();
-            for page in self.free_on_drop.iter() {
+            for page in &self.free_on_drop {
                 if !self.mem.as_ref().unwrap().free_if_uncommitted(*page) {
                     freed_pages.push(*page);
                 }

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -524,7 +524,7 @@ impl Into<u8> for DynamicCollectionType {
 /// (when type = 2) root (8 bytes): sub tree root page number
 /// (when type = 2) checksum (16 bytes): sub tree checksum
 ///
-/// NOTE: Even though the [PhantomData] is zero-sized, the inner data DST must be placed last.
+/// NOTE: Even though the [`PhantomData`] is zero-sized, the inner data DST must be placed last.
 /// See [Exotically Sized Types](https://doc.rust-lang.org/nomicon/exotic-sizes.html#dynamically-sized-types-dsts)
 /// section of the Rustonomicon for more details.
 #[repr(transparent)]

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -313,7 +313,6 @@ pub(crate) fn finalize_tree_and_subtree_checksums(
                 }
             }
         }
-        drop(accessor);
         // TODO: maybe there's a better abstraction, so that we don't need to call into this low-level method?
         let mut mutator = LeafMutator::new(
             &mut leaf_page,

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -590,7 +590,7 @@ impl<V: Key> DynamicCollection<V> {
     fn as_subtree(&self) -> BtreeHeader {
         assert!(matches!(self.collection_type(), SubtreeV2));
         BtreeHeader::from_le_bytes(
-            self.data[1..(1 + BtreeHeader::serialized_size())]
+            self.data[1..=BtreeHeader::serialized_size()]
                 .try_into()
                 .unwrap(),
         )
@@ -726,7 +726,7 @@ impl UntypedDynamicCollection {
     fn as_subtree(&self) -> BtreeHeader {
         assert!(matches!(self.collection_type(), SubtreeV2));
         BtreeHeader::from_le_bytes(
-            self.data[1..(1 + BtreeHeader::serialized_size())]
+            self.data[1..=BtreeHeader::serialized_size()]
                 .try_into()
                 .unwrap(),
         )

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -562,7 +562,6 @@ impl<V: Key> Value for &DynamicCollection<V> {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a [u8]
     where
-        Self: 'a,
         Self: 'b,
     {
         &value.data

--- a/src/table.rs
+++ b/src/table.rs
@@ -304,7 +304,7 @@ fn debug_helper<K: Key + 'static, V: Value + 'static>(
     first: Result<Option<(AccessGuard<K>, AccessGuard<V>)>>,
     last: Result<Option<(AccessGuard<K>, AccessGuard<V>)>>,
 ) -> std::fmt::Result {
-    write!(f, "Table [ name: \"{}\", ", name)?;
+    write!(f, "Table [ name: \"{name}\", ")?;
     if let Ok(len) = len {
         if len == 0 {
             write!(f, "No entries")?;

--- a/src/table.rs
+++ b/src/table.rs
@@ -223,7 +223,7 @@ impl<'txn, K: Key + 'static, V: MutInPlaceValue + 'static> Table<'txn, K, V> {
     ///
     /// If key is already present it is replaced
     ///
-    /// The returned reference will have length equal to value_length
+    /// The returned reference will have length equal to `value_length`
     pub fn insert_reserve<'a>(
         &mut self,
         key: impl Borrow<K::SelfType<'a>>,

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -243,6 +243,6 @@ impl TransactionTracker {
             .live_read_transactions
             .keys()
             .next()
-            .cloned()
+            .copied()
     }
 }

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -16,11 +16,11 @@ impl TransactionId {
         Self(value)
     }
 
-    pub(crate) fn raw_id(&self) -> u64 {
+    pub(crate) fn raw_id(self) -> u64 {
         self.0
     }
 
-    pub(crate) fn next(&self) -> TransactionId {
+    pub(crate) fn next(self) -> TransactionId {
         TransactionId(self.0 + 1)
     }
 
@@ -30,7 +30,7 @@ impl TransactionId {
         next
     }
 
-    pub(crate) fn parent(&self) -> Option<TransactionId> {
+    pub(crate) fn parent(self) -> Option<TransactionId> {
         if self.0 == 0 {
             None
         } else {
@@ -43,7 +43,7 @@ impl TransactionId {
 pub(crate) struct SavepointId(pub u64);
 
 impl SavepointId {
-    pub(crate) fn next(&self) -> SavepointId {
+    pub(crate) fn next(self) -> SavepointId {
         SavepointId(self.0 + 1)
     }
 }

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -65,7 +65,6 @@ impl Value for SavepointId {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
     where
-        Self: 'a,
         Self: 'b,
     {
         value.0.to_le_bytes()

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -533,7 +533,7 @@ impl WriteTransaction {
         println!("Tables");
         for p in table_pages {
             all_allocated.remove(&p);
-            println!("{p:?}")
+            println!("{p:?}");
         }
 
         let system_table_allocators = self
@@ -550,7 +550,7 @@ impl WriteTransaction {
         println!("System tables");
         for p in system_table_pages {
             all_allocated.remove(&p);
-            println!("{p:?}")
+            println!("{p:?}");
         }
 
         println!("Free table");
@@ -558,7 +558,7 @@ impl WriteTransaction {
             for p in freed_iter {
                 let p = p.unwrap();
                 all_allocated.remove(&p);
-                println!("{p:?}")
+                println!("{p:?}");
             }
         }
         println!("Pending free (i.e. in freed table)");
@@ -574,7 +574,7 @@ impl WriteTransaction {
             for i in 0..value.len() {
                 let p = value.get(i);
                 all_allocated.remove(&p);
-                println!("{p:?}")
+                println!("{p:?}");
             }
         }
         if !all_allocated.is_empty() {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1065,8 +1065,7 @@ impl WriteTransaction {
         let free_until_transaction = self
             .transaction_tracker
             .oldest_live_read_transaction()
-            .map(|x| x.next())
-            .unwrap_or(self.transaction_id);
+            .map_or(self.transaction_id, |x| x.next());
 
         let user_root = self
             .tables

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -551,7 +551,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
 
 impl<'a, K: Key + 'a, V: MutInPlaceValue + 'a> BtreeMut<'a, K, V> {
     /// Reserve space to insert a key-value pair
-    /// The returned reference will have length equal to value_length
+    /// The returned reference will have length equal to `value_length`
     // Return type has the same lifetime as &self, because the tree must not be modified until the mutable guard is dropped
     pub(crate) fn insert_reserve(
         &mut self,

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -611,7 +611,7 @@ impl RawBtree {
     }
 
     pub(crate) fn len(&self) -> Result<u64> {
-        Ok(self.root.map(|x| x.length).unwrap_or(0))
+        Ok(self.root.map_or(0, |x| x.length))
     }
 
     pub(crate) fn verify_checksum(&self) -> Result<bool> {
@@ -809,7 +809,7 @@ impl<K: Key, V: Value> Btree<K, V> {
     }
 
     pub(crate) fn len(&self) -> Result<u64> {
-        Ok(self.root.map(|x| x.length).unwrap_or(0))
+        Ok(self.root.map_or(0, |x| x.length))
     }
 
     pub(crate) fn stats(&self) -> Result<BtreeStats> {

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -192,13 +192,11 @@ impl UntypedBtreeMut {
                     }
                 }
 
-                drop(accessor);
                 let mut mutator = BranchMutator::new(&mut page);
                 for (child_index, child_page, child_checksum) in new_children.into_iter().flatten()
                 {
                     mutator.write_child_page(child_index, child_page, child_checksum);
                 }
-                drop(mutator);
 
                 branch_checksum(&page, self.key_width)
             }

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -871,7 +871,6 @@ impl<'b> LeafMutator<'b> {
             .value_range(i)
             .map(|(start, end)| end - start)
             .unwrap_or_default();
-        drop(accessor);
 
         let value_delta = if overwrite {
             isize::try_from(value.len()).unwrap() - isize::try_from(existing_value_len).unwrap()
@@ -989,7 +988,6 @@ impl<'b> LeafMutator<'b> {
         let value_start = accessor.value_start(i).unwrap();
         let value_end = accessor.value_end(i).unwrap();
         let last_value_end = accessor.value_end(accessor.num_pairs() - 1).unwrap();
-        drop(accessor);
 
         // Update all the pointers
         let key_ptr_size = if self.fixed_key_size.is_none() {
@@ -1086,7 +1084,6 @@ impl<'b> LeafMutator<'b> {
             self.fixed_value_size,
         );
         let num_pairs = accessor.num_pairs();
-        drop(accessor);
         let mut offset = 4 + size_of::<u32>() * i;
         if self.fixed_key_size.is_none() {
             offset += size_of::<u32>() * num_pairs;

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -510,7 +510,7 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
     pub(super) fn push(&mut self, key: &'a [u8], value: &'a [u8]) {
         self.total_key_bytes += key.len();
         self.total_value_bytes += value.len();
-        self.pairs.push((key, value))
+        self.pairs.push((key, value));
     }
 
     pub(super) fn push_all_except(

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -300,9 +300,9 @@ impl<'a> LeafAccessor<'a> {
     pub(super) fn print_node<K: Key, V: Value>(&self, include_value: bool) {
         let mut i = 0;
         while let Some(entry) = self.entry(i) {
-            eprint!(" key_{}={:?}", i, K::from_bytes(entry.key()));
+            eprint!(" key_{i}={:?}", K::from_bytes(entry.key()));
             if include_value {
-                eprint!(" value_{}={:?}", i, V::from_bytes(entry.value()));
+                eprint!(" value_{i}={:?}", V::from_bytes(entry.value()));
             }
             i += 1;
         }
@@ -1129,8 +1129,8 @@ impl<'a: 'b, 'b, T: Page + 'a> BranchAccessor<'a, 'b, T> {
         for i in 0..(self.count_children() - 1) {
             if let Some(child) = self.child_page(i + 1) {
                 let key = self.key(i).unwrap();
-                eprint!(" key_{}={:?}", i, K::from_bytes(key));
-                eprint!(" child_{}={:?}", i + 1, child);
+                eprint!(" key_{i}={:?}", K::from_bytes(key));
+                eprint!(" child_{}={child:?}", i + 1);
             }
         }
         eprint!("]");

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -138,7 +138,7 @@ impl RangeIterState {
                         .entry_ranges(*entry)?;
                 Some(EntryGuard::new(page.clone(), key, value))
             }
-            _ => None,
+            Internal { .. } => None,
         }
     }
 }

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -33,8 +33,7 @@ pub enum RangeIterState {
 impl RangeIterState {
     fn page_number(&self) -> PageNumber {
         match self {
-            Leaf { page, .. } => page.get_page_number(),
-            Internal { page, .. } => page.get_page_number(),
+            Leaf { page, .. } | Internal { page, .. } => page.get_page_number(),
         }
     }
 

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -226,7 +226,6 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                     let new_page_accessor =
                         LeafAccessor::new(new_page.memory(), K::fixed_width(), V::fixed_width());
                     let offset = new_page_accessor.offset_of_first_value();
-                    drop(new_page_accessor);
                     let guard = AccessGuardMut::new(new_page, offset, value.len());
                     return if position == 0 {
                         Ok(InsertionResult {
@@ -280,7 +279,6 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                     let new_page_accessor =
                         LeafAccessor::new(page_mut.memory(), K::fixed_width(), V::fixed_width());
                     let offset = new_page_accessor.offset_of_value(position).unwrap();
-                    drop(new_page_accessor);
                     let guard = AccessGuardMut::new(page_mut, offset, value.len());
                     return Ok(InsertionResult {
                         new_root: page_number,
@@ -567,7 +565,6 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
             Subtree(new_page.get_page_number(), DEFERRED)
         };
         let (start, end) = accessor.value_range(position).unwrap();
-        drop(accessor);
         let guard = if uncommitted && self.modify_uncommitted {
             let page_number = page.get_page_number();
             let arc = page.to_arc();

--- a/src/tree_store/page_store/base.rs
+++ b/src/tree_store/page_store/base.rs
@@ -35,8 +35,8 @@ impl Ord for PageNumber {
         match self.region.cmp(&other.region) {
             Ordering::Less => Ordering::Less,
             Ordering::Equal => {
-                let self_order0 = self.page_index * 2u32.pow(self.page_order as u32);
-                let other_order0 = other.page_index * 2u32.pow(other.page_order as u32);
+                let self_order0 = self.page_index * 2u32.pow(self.page_order.into());
+                let other_order0 = other.page_index * 2u32.pow(other.page_order.into());
                 assert!(
                     self_order0 != other_order0 || self.page_order == other.page_order,
                     "{self:?} overlaps {other:?}, but is not equal"
@@ -72,9 +72,9 @@ impl PageNumber {
     }
 
     pub(crate) fn to_le_bytes(self) -> [u8; 8] {
-        let mut temp = (0x000F_FFFF & self.page_index) as u64;
-        temp |= (0x000F_FFFF & self.region as u64) << 20;
-        temp |= (0b0001_1111 & self.page_order as u64) << 59;
+        let mut temp = 0x000F_FFFF & u64::from(self.page_index);
+        temp |= (0x000F_FFFF & u64::from(self.region)) << 20;
+        temp |= (0b0001_1111 & u64::from(self.page_order)) << 59;
         temp.to_le_bytes()
     }
 
@@ -99,8 +99,8 @@ impl PageNumber {
         if self.region > other.region {
             return false;
         }
-        let self_order0 = self.page_index * 2u32.pow(self.page_order as u32);
-        let other_order0 = other.page_index * 2u32.pow(other.page_order as u32);
+        let self_order0 = self.page_index * 2u32.pow(self.page_order.into());
+        let other_order0 = other.page_index * 2u32.pow(other.page_order.into());
         assert_ne!(self_order0, other_order0, "{self:?} overlaps {other:?}");
         self_order0 < other_order0
     }
@@ -145,9 +145,9 @@ impl PageNumber {
         page_size: u32,
     ) -> Range<u64> {
         let regional_start =
-            region_pages_start + (self.page_index as u64) * self.page_size_bytes(page_size);
+            region_pages_start + u64::from(self.page_index) * self.page_size_bytes(page_size);
         debug_assert!(regional_start < region_size);
-        let region_base = (self.region as u64) * region_size;
+        let region_base = u64::from(self.region) * region_size;
         let start = data_section_offset + region_base + regional_start;
         let end = start + self.page_size_bytes(page_size);
         start..end
@@ -155,7 +155,7 @@ impl PageNumber {
 
     pub(crate) fn page_size_bytes(&self, page_size: u32) -> u64 {
         let pages = 1u64 << self.page_order;
-        pages * (page_size as u64)
+        pages * u64::from(page_size)
     }
 }
 

--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -403,7 +403,7 @@ impl U64GroupedBitmap {
     }
 
     pub fn clear(&mut self, bit: u32) {
-        assert!(bit < self.len, "{} must be less than {}", bit, self.len);
+        assert!(bit < self.len, "{bit} must be less than {}", self.len);
         let (index, bit_index) = self.data_index_of(bit);
         self.data[index] &= !Self::select_mask(bit_index);
     }

--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -533,7 +533,7 @@ mod test {
                 } else {
                     assert_eq!(allocated.len(), num_pages as usize);
                 }
-            } else if let Some(to_free) = allocated.iter().choose(&mut rng).cloned() {
+            } else if let Some(to_free) = allocated.iter().choose(&mut rng).copied() {
                 allocator.clear(to_free);
                 allocated.remove(&to_free);
             }

--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -327,7 +327,7 @@ impl U64GroupedBitmap {
         Self { len, data }
     }
 
-    fn data_index_of(&self, bit: u32) -> (usize, usize) {
+    fn data_index_of(bit: u32) -> (usize, usize) {
         ((bit as usize) / 64, (bit as usize) % 64)
     }
 
@@ -363,7 +363,7 @@ impl U64GroupedBitmap {
     fn first_unset(&self, start_bit: u32, end_bit: u32) -> Option<u32> {
         assert_eq!(end_bit, (start_bit - start_bit % 64) + 64);
 
-        let (index, bit) = self.data_index_of(start_bit);
+        let (index, bit) = Self::data_index_of(start_bit);
         let mask = (1 << bit) - 1;
         let group = self.data[index];
         let group = group | mask;
@@ -386,7 +386,7 @@ impl U64GroupedBitmap {
 
     pub fn get(&self, bit: u32) -> bool {
         assert!(bit < self.len);
-        let (index, bit_index) = self.data_index_of(bit);
+        let (index, bit_index) = Self::data_index_of(bit);
         let group = self.data[index];
         group & U64GroupedBitmap::select_mask(bit_index) != 0
     }
@@ -394,7 +394,7 @@ impl U64GroupedBitmap {
     // Returns true iff the bit's group is all set
     pub fn set(&mut self, bit: u32) -> bool {
         assert!(bit < self.len);
-        let (index, bit_index) = self.data_index_of(bit);
+        let (index, bit_index) = Self::data_index_of(bit);
         let mut group = self.data[index];
         group |= Self::select_mask(bit_index);
         self.data[index] = group;
@@ -404,7 +404,7 @@ impl U64GroupedBitmap {
 
     pub fn clear(&mut self, bit: u32) {
         assert!(bit < self.len, "{bit} must be less than {}", self.len);
-        let (index, bit_index) = self.data_index_of(bit);
+        let (index, bit_index) = Self::data_index_of(bit);
         self.data[index] &= !Self::select_mask(bit_index);
     }
 }

--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -71,14 +71,14 @@ impl BtreeBitmap {
         let vecs: Vec<Vec<u8>> = self.heights.iter().map(|x| x.to_vec()).collect();
         let mut data_offset = END_OFFSETS + self.heights.len() * size_of::<u32>();
         let end_metadata = data_offset;
-        for serialized in vecs.iter() {
+        for serialized in &vecs {
             data_offset += serialized.len();
             let offset_u32: u32 = data_offset.try_into().unwrap();
             result.extend(offset_u32.to_le_bytes());
         }
 
         assert_eq!(end_metadata, result.len());
-        for serialized in vecs.iter() {
+        for serialized in &vecs {
             result.extend(serialized);
         }
 
@@ -303,7 +303,7 @@ impl U64GroupedBitmap {
     pub fn to_vec(&self) -> Vec<u8> {
         let mut result = vec![];
         result.extend(self.len.to_le_bytes());
-        for x in self.data.iter() {
+        for x in &self.data {
             result.extend(x.to_le_bytes());
         }
         result

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -618,7 +618,7 @@ mod test {
         // Check that serialized size is as expected for a full region
         let max_region_pages = 1024 * 1024;
         let allocator = BuddyAllocator::new(max_region_pages, max_region_pages);
-        let max_region_pages = max_region_pages as u64;
+        let max_region_pages = u64::from(max_region_pages);
         // 2x because that's the integral of 1/2^x to account for all the 21 orders
         let allocated_state_bits = 2 * max_region_pages;
         // + u32 * 21 because of the length field

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -87,21 +87,21 @@ impl BuddyAllocator {
 
         let mut data_offset = result.len() + (self.max_order as usize + 1) * 2 * size_of::<u32>();
         let end_metadata = data_offset;
-        for order in self.free.iter() {
+        for order in &self.free {
             data_offset += order.to_vec().len();
             let offset_u32: u32 = data_offset.try_into().unwrap();
             result.extend(offset_u32.to_le_bytes());
         }
-        for order in self.allocated.iter() {
+        for order in &self.allocated {
             data_offset += order.to_vec().len();
             let offset_u32: u32 = data_offset.try_into().unwrap();
             result.extend(offset_u32.to_le_bytes());
         }
         assert_eq!(end_metadata, result.len());
-        for order in self.free.iter() {
+        for order in &self.free {
             result.extend(&order.to_vec());
         }
-        for order in self.allocated.iter() {
+        for order in &self.allocated {
             result.extend(&order.to_vec());
         }
 
@@ -280,7 +280,7 @@ impl BuddyAllocator {
             }
 
             let mut check_result = HashSet::new();
-            for page in allocated_check.iter() {
+            for page in &allocated_check {
                 check_result.extend(page.to_order0());
             }
             assert_eq!(free_check, check_result);

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -463,7 +463,7 @@ impl BuddyAllocator {
         }
     }
 
-    /// data must have been initialized by Self::init_new(), and page_number must be free
+    /// data must have been initialized by `Self::init_new()`, and `page_number` must be free
     pub(crate) fn record_alloc(&mut self, page_number: u32, order: u8) {
         assert!(order <= self.max_order);
         // Only record the allocation for the actual page
@@ -492,7 +492,7 @@ impl BuddyAllocator {
         }
     }
 
-    /// data must have been initialized by Self::init_new()
+    /// data must have been initialized by `Self::init_new()`
     pub(crate) fn free(&mut self, page_number: u32, order: u8) {
         debug_assert!(self.get_order_free_mut(order).get(page_number));
         debug_assert!(

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -92,10 +92,10 @@ impl LRUWriteCache {
             if let Some((k, v)) = self.cache.pop_lowest_priority() {
                 if let Some(v_inner) = v {
                     return Some((k, v_inner));
-                } else {
-                    // Value is borrowed by take_value(). We can't evict it, so put it back.
-                    self.cache.insert(k, v);
                 }
+
+                // Value is borrowed by take_value(). We can't evict it, so put it back.
+                self.cache.insert(k, v);
             } else {
                 break;
             }

--- a/src/tree_store/page_store/layout.rs
+++ b/src/tree_store/page_store/layout.rs
@@ -34,10 +34,10 @@ impl RegionLayout {
         page_capacity: u32,
         page_size: u32,
     ) -> RegionLayout {
-        assert!(desired_usable_bytes <= page_capacity as u64 * page_size as u64);
+        assert!(desired_usable_bytes <= u64::from(page_capacity) * u64::from(page_size));
         let header_pages = RegionHeader::header_pages_expensive(page_size, page_capacity);
         let num_pages =
-            round_up_to_multiple_of(desired_usable_bytes, page_size.into()) / page_size as u64;
+            round_up_to_multiple_of(desired_usable_bytes, page_size.into()) / u64::from(page_size);
 
         Self {
             num_pages: num_pages.try_into().unwrap(),
@@ -57,7 +57,7 @@ impl RegionLayout {
     }
 
     pub(super) fn data_section(&self) -> Range<u64> {
-        let header_bytes = self.header_pages as u64 * self.page_size as u64;
+        let header_bytes = u64::from(self.header_pages) * u64::from(self.page_size);
         header_bytes..(header_bytes + self.usable_bytes())
     }
 
@@ -74,11 +74,11 @@ impl RegionLayout {
     }
 
     pub(super) fn len(&self) -> u64 {
-        (self.header_pages as u64) * (self.page_size as u64) + self.usable_bytes()
+        u64::from(self.header_pages) * u64::from(self.page_size) + self.usable_bytes()
     }
 
     pub(super) fn usable_bytes(&self) -> u64 {
-        self.page_size as u64 * self.num_pages as u64
+        u64::from(self.page_size) * u64::from(self.num_pages)
     }
 }
 
@@ -128,9 +128,9 @@ impl DatabaseLayout {
         region_max_data_pages_u32: u32,
         page_size_u32: u32,
     ) -> Self {
-        let page_size = page_size_u32 as u64;
-        let region_header_pages = region_header_pages_u32 as u64;
-        let region_max_data_pages = region_max_data_pages_u32 as u64;
+        let page_size = u64::from(page_size_u32);
+        let region_header_pages = u64::from(region_header_pages_u32);
+        let region_max_data_pages = u64::from(region_max_data_pages_u32);
         // Super-header
         let mut remaining = file_len - page_size;
         let full_region_size = (region_header_pages + region_max_data_pages) * page_size;
@@ -231,13 +231,13 @@ impl DatabaseLayout {
             .as_ref()
             .map(RegionLayout::usable_bytes)
             .unwrap_or_default();
-        (self.num_full_regions as u64) * self.full_region_layout.usable_bytes() + trailing
+        u64::from(self.num_full_regions) * self.full_region_layout.usable_bytes() + trailing
     }
 
     pub(super) fn region_base_address(&self, region: u32) -> u64 {
         assert!(region < self.num_regions());
-        (self.full_region_layout.page_size() as u64)
-            + (region as u64) * self.full_region_layout.len()
+        u64::from(self.full_region_layout.page_size())
+            + u64::from(region) * self.full_region_layout.len()
     }
 
     pub(super) fn region_layout(&self, region: u32) -> RegionLayout {

--- a/src/tree_store/page_store/lru_cache.rs
+++ b/src/tree_store/page_store/lru_cache.rs
@@ -31,8 +31,8 @@ impl<T> LRUCache<T> {
         result
     }
 
-    pub(crate) fn remove(&mut self, key: &u64) -> Option<T> {
-        if let Some((value, _)) = self.cache.remove(key) {
+    pub(crate) fn remove(&mut self, key: u64) -> Option<T> {
+        if let Some((value, _)) = self.cache.remove(&key) {
             if self.lru_queue.len() > 2 * self.cache.len() {
                 // Cycle two elements of the LRU queue to ensure it doesn't grow without bound
                 for _ in 0..2 {
@@ -50,8 +50,8 @@ impl<T> LRUCache<T> {
         }
     }
 
-    pub(crate) fn get(&self, key: &u64) -> Option<&T> {
-        if let Some((value, second_chance)) = self.cache.get(key) {
+    pub(crate) fn get(&self, key: u64) -> Option<&T> {
+        if let Some((value, second_chance)) = self.cache.get(&key) {
             second_chance.store(true, Ordering::Release);
             Some(value)
         } else {
@@ -59,8 +59,8 @@ impl<T> LRUCache<T> {
         }
     }
 
-    pub(crate) fn get_mut(&mut self, key: &u64) -> Option<&mut T> {
-        if let Some((value, second_chance)) = self.cache.get_mut(key) {
+    pub(crate) fn get_mut(&mut self, key: u64) -> Option<&mut T> {
+        if let Some((value, second_chance)) = self.cache.get_mut(&key) {
             second_chance.store(true, Ordering::Release);
             Some(value)
         } else {

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -10,7 +10,7 @@ mod lru_cache;
 mod page_manager;
 mod region;
 mod savepoint;
-#[allow(dead_code)]
+#[allow(clippy::pedantic, dead_code)]
 mod xxh3;
 
 pub(crate) use base::{Page, PageHint, PageNumber, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH};

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -281,7 +281,7 @@ impl TransactionalMemory {
     }
 
     pub(crate) fn clear_read_cache(&self) {
-        self.storage.invalidate_cache_all()
+        self.storage.invalidate_cache_all();
     }
 
     pub(crate) fn clear_cache_and_reload(&mut self) -> Result<bool, DatabaseError> {

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -504,7 +504,7 @@ impl TransactionalMemory {
         let mut state = self.state.lock().unwrap();
         // Trim surplus file space, before finalizing the commit
         let shrunk = if allow_trim {
-            self.try_shrink(&mut state)?
+            Self::try_shrink(&mut state)?
         } else {
             false
         };
@@ -810,13 +810,12 @@ impl TransactionalMemory {
         let mut state = self.state.lock().unwrap();
 
         let page_number = if let Some(page_number) =
-            self.allocate_helper_retry(&mut state, required_order, lowest)?
+            Self::allocate_helper_retry(&mut state, required_order, lowest)?
         {
             page_number
         } else {
             self.grow(&mut state, required_order)?;
-            self.allocate_helper_retry(&mut state, required_order, lowest)?
-                .unwrap()
+            Self::allocate_helper_retry(&mut state, required_order, lowest)?.unwrap()
         };
 
         #[cfg(debug_assertions)]
@@ -868,7 +867,6 @@ impl TransactionalMemory {
     }
 
     fn allocate_helper_retry(
-        &self,
         state: &mut InMemoryState,
         required_order: u8,
         lowest: bool,
@@ -900,7 +898,7 @@ impl TransactionalMemory {
         }
     }
 
-    fn try_shrink(&self, state: &mut InMemoryState) -> Result<bool> {
+    fn try_shrink(state: &mut InMemoryState) -> Result<bool> {
         let layout = state.header.layout();
         let last_region_index = layout.num_regions() - 1;
         let last_allocator = state.get_region(last_region_index);

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -892,12 +892,11 @@ impl TransactionalMemory {
                     page,
                     required_order,
                 )));
-            } else {
-                // Mark the region, if it's full
-                state
-                    .get_region_tracker_mut()
-                    .mark_full(required_order, candidate_region);
             }
+            // Mark the region, if it's full
+            state
+                .get_region_tracker_mut()
+                .mark_full(required_order, candidate_region);
         }
     }
 

--- a/src/tree_store/page_store/region.rs
+++ b/src/tree_store/page_store/region.rs
@@ -175,13 +175,13 @@ impl Allocators {
         let page_size = header.page_size();
         let region_header_size =
             header.layout().full_region_layout().get_header_pages() * page_size;
-        let region_size = header.layout().full_region_layout().num_pages() as u64
-            * page_size as u64
-            + region_header_size as u64;
+        let region_size = u64::from(header.layout().full_region_layout().num_pages())
+            * u64::from(page_size)
+            + u64::from(region_header_size);
         let range = header.region_tracker().address_range(
-            page_size as u64,
+            page_size.into(),
             region_size,
-            region_header_size as u64,
+            region_header_size.into(),
             page_size,
         );
         let len: usize = (range.end - range.start).try_into().unwrap();
@@ -215,12 +215,12 @@ impl Allocators {
     ) -> Result {
         let page_size = layout.full_region_layout().page_size();
         let region_header_size =
-            (layout.full_region_layout().get_header_pages() * page_size) as u64;
-        let region_size =
-            layout.full_region_layout().num_pages() as u64 * page_size as u64 + region_header_size;
+            u64::from(layout.full_region_layout().get_header_pages() * page_size);
+        let region_size = u64::from(layout.full_region_layout().num_pages()) * u64::from(page_size)
+            + region_header_size;
         let mut region_tracker_mem = {
             let range = region_tracker_page.address_range(
-                page_size as u64,
+                page_size.into(),
                 region_size,
                 region_header_size,
                 page_size,
@@ -325,7 +325,7 @@ pub(crate) struct RegionHeader {}
 
 impl RegionHeader {
     pub(crate) fn header_pages_expensive(page_size: u32, pages_per_region: u32) -> u32 {
-        let page_size = page_size as u64;
+        let page_size = u64::from(page_size);
         // TODO: this is kind of expensive. Maybe it should be cached
         let allocator = BuddyAllocator::new(pages_per_region, pages_per_region);
         let result = 8u64 + allocator.to_vec().len() as u64;

--- a/src/tree_store/page_store/region.rs
+++ b/src/tree_store/page_store/region.rs
@@ -41,7 +41,7 @@ impl RegionTracker {
         let allocator_len: u32 = self.order_trackers[0].to_vec().len().try_into().unwrap();
         result.extend(orders.to_le_bytes());
         result.extend(allocator_len.to_le_bytes());
-        for order in self.order_trackers.iter() {
+        for order in &self.order_trackers {
             result.extend(&order.to_vec());
         }
         result
@@ -165,7 +165,7 @@ impl Allocators {
         // Ignore the region tracker because it is an optimistic cache, and so may not match
         // between repairs of the allocators
         let mut result = 0;
-        for allocator in self.region_allocators.iter() {
+        for allocator in &self.region_allocators {
             result ^= xxh3_checksum(&allocator.to_vec());
         }
         result

--- a/src/tree_store/page_store/savepoint.rs
+++ b/src/tree_store/page_store/savepoint.rs
@@ -276,7 +276,6 @@ impl<'data> Value for SerializedSavepoint<'data> {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
     where
-        Self: 'a,
         Self: 'b,
     {
         value.data()

--- a/src/tree_store/page_store/savepoint.rs
+++ b/src/tree_store/page_store/savepoint.rs
@@ -138,7 +138,7 @@ impl<'a> SerializedSavepoint<'a> {
                 .unwrap()
                 .to_le_bytes(),
         );
-        for region in savepoint.regional_allocators.iter() {
+        for region in &savepoint.regional_allocators {
             assert_eq!(savepoint.regional_allocators[0].len(), region.len());
         }
         result.extend(
@@ -147,7 +147,7 @@ impl<'a> SerializedSavepoint<'a> {
                 .to_le_bytes(),
         );
 
-        for region in savepoint.regional_allocators.iter() {
+        for region in &savepoint.regional_allocators {
             result.extend(region);
         }
         Self::Owned(result)

--- a/src/tree_store/page_store/xxh3.rs
+++ b/src/tree_store/page_store/xxh3.rs
@@ -462,14 +462,14 @@ fn hash64_0(secret: &[u8], seed: u64) -> u64 {
 }
 
 fn hash64_1to3(data: &[u8], secret: &[u8], seed: u64) -> u64 {
-    let x1 = data[0] as u32;
-    let x2 = data[data.len() >> 1] as u32;
-    let x3 = (*data.last().unwrap()) as u32;
+    let x1 = u32::from(data[0]);
+    let x2 = u32::from(data[data.len() >> 1]);
+    let x3 = u32::from(*data.last().unwrap());
     #[allow(clippy::cast_possible_truncation)]
     let x4 = data.len() as u32;
 
-    let combined = ((x1 << 16) | (x2 << 24) | x3 | (x4 << 8)) as u64;
-    let mut result = (get_u32(secret, 0) ^ get_u32(secret, 1)) as u64;
+    let combined = u64::from((x1 << 16) | (x2 << 24) | x3 | (x4 << 8));
+    let mut result = u64::from(get_u32(secret, 0) ^ get_u32(secret, 1));
     result = result.wrapping_add(seed);
     result ^= combined;
     xxh64_avalanche(result)
@@ -479,8 +479,8 @@ fn hash64_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u64 {
     #[allow(clippy::cast_possible_truncation)]
     let truncate_seed = seed as u32;
     seed ^= u64::from(truncate_seed.swap_bytes()) << 32;
-    let x1 = get_u32(data, 0) as u64;
-    let x2 = get_u32(&data[data.len() - 4..], 0) as u64;
+    let x1 = u64::from(get_u32(data, 0));
+    let x2 = u64::from(get_u32(&data[data.len() - 4..], 0));
     let x = x2 | (x1 << 32);
     let s = (get_u64(secret, 1) ^ get_u64(secret, 2)).wrapping_sub(seed);
     rrmxmx(x ^ s, data.len() as u64)
@@ -595,24 +595,24 @@ fn hash64_large_generic(
 }
 
 fn hash128_0(secret: &[u8], seed: u64) -> u128 {
-    let high = (hash64_0(&secret[3 * 8..], seed) as u128) << 64;
-    let low = hash64_0(&secret[8..], seed) as u128;
+    let high = u128::from(hash64_0(&secret[3 * 8..], seed)) << 64;
+    let low = u128::from(hash64_0(&secret[8..], seed));
     high | low
 }
 
 fn hash128_1to3(data: &[u8], secret: &[u8], seed: u64) -> u128 {
-    let x1 = data[0] as u32;
-    let x2 = data[data.len() >> 1] as u32;
-    let x3 = (*data.last().unwrap()) as u32;
+    let x1 = u32::from(data[0]);
+    let x2 = u32::from(data[data.len() >> 1]);
+    let x3 = u32::from(*data.last().unwrap());
     #[allow(clippy::cast_possible_truncation)]
     let x4 = data.len() as u32;
 
     let combined_low = (x1 << 16) | (x2 << 24) | x3 | (x4 << 8);
     let combined_high: u64 = combined_low.swap_bytes().rotate_left(13).into();
-    let s_low = ((get_u32(secret, 0) ^ get_u32(secret, 1)) as u64).wrapping_add(seed);
-    let s_high = ((get_u32(secret, 2) ^ get_u32(secret, 3)) as u64).wrapping_sub(seed);
-    let high = (xxh64_avalanche(combined_high ^ s_high) as u128) << 64;
-    let low = xxh64_avalanche(combined_low as u64 ^ s_low) as u128;
+    let s_low = u64::from(get_u32(secret, 0) ^ get_u32(secret, 1)).wrapping_add(seed);
+    let s_high = u64::from(get_u32(secret, 2) ^ get_u32(secret, 3)).wrapping_sub(seed);
+    let high = (u128::from(xxh64_avalanche(combined_high ^ s_high))) << 64;
+    let low = u128::from(xxh64_avalanche(u64::from(combined_low) ^ s_low));
     high | low
 }
 
@@ -620,13 +620,17 @@ fn hash128_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u128 {
     #[allow(clippy::cast_possible_truncation)]
     let truncate_seed = seed as u32;
     seed ^= u64::from(truncate_seed.swap_bytes()) << 32;
-    let x_low = get_u32(data, 0) as u64;
-    let x_high = u32::from_le_bytes(data[data.len() - 4..].try_into().unwrap()) as u64;
+    let x_low = u64::from(get_u32(data, 0));
+    let x_high = u64::from(u32::from_le_bytes(
+        data[data.len() - 4..].try_into().unwrap(),
+    ));
     let x = x_low | (x_high << 32);
     let s = (get_u64(secret, 2) ^ get_u64(secret, 3)).wrapping_add(seed);
 
-    let mut y = (x ^ s) as u128;
-    y = y.wrapping_mul(PRIME64[0].wrapping_add((data.len() << 2) as u64) as u128);
+    let mut y = u128::from(x ^ s);
+    y = y.wrapping_mul(u128::from(
+        PRIME64[0].wrapping_add((data.len() << 2) as u64),
+    ));
 
     #[allow(clippy::cast_possible_truncation)]
     let mut r_low = y as u64;
@@ -638,7 +642,7 @@ fn hash128_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u128 {
     r_low = xorshift(r_low, 28);
     r_high = xxh3_avalanche(r_high);
 
-    (r_high as u128) << 64 | r_low as u128
+    u128::from(r_high) << 64 | u128::from(r_low)
 }
 
 fn hash128_9to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
@@ -649,7 +653,7 @@ fn hash128_9to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     let mixed = x_low ^ x_high ^ s_low;
     let x_high = x_high ^ s_high;
 
-    let result = (mixed as u128).wrapping_mul(PRIME64[0] as u128);
+    let result = u128::from(mixed).wrapping_mul(u128::from(PRIME64[0]));
     #[allow(clippy::cast_possible_truncation)]
     let mut r_low = result as u64;
     let mut r_high = (result >> 64) as u64;
@@ -658,7 +662,7 @@ fn hash128_9to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     r_high = r_high.wrapping_add((x_high & 0xFFFF_FFFF).wrapping_mul(PRIME32[1] - 1));
     r_low ^= r_high.swap_bytes();
 
-    let result2 = (r_low as u128).wrapping_mul(PRIME64[1] as u128);
+    let result2 = u128::from(r_low).wrapping_mul(u128::from(PRIME64[1]));
     #[allow(clippy::cast_possible_truncation)]
     let mut r2_low = result2 as u64;
     let mut r2_high = (result2 >> 64) as u64;
@@ -666,7 +670,7 @@ fn hash128_9to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     r2_low = xxh3_avalanche(r2_low);
     r2_high = xxh3_avalanche(r2_high);
 
-    (r2_high as u128) << 64 | r2_low as u128
+    u128::from(r2_high) << 64 | u128::from(r2_low)
 }
 
 fn hash128_0to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
@@ -702,7 +706,7 @@ fn hash128_17to128(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     r_low = xxh3_avalanche(r_low);
     r_high = 0u64.wrapping_sub(xxh3_avalanche(r_high));
 
-    (r_high as u128) << 64 | r_low as u128
+    u128::from(r_high) << 64 | u128::from(r_low)
 }
 
 fn hash128_129to240(data: &[u8], secret: &[u8], seed: u64) -> u128 {
@@ -746,7 +750,7 @@ fn hash128_129to240(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     r_low = xxh3_avalanche(r_low);
     r_high = 0u64.wrapping_sub(xxh3_avalanche(r_high));
 
-    (r_high as u128) << 64 | r_low as u128
+    u128::from(r_high) << 64 | u128::from(r_low)
 }
 
 fn hash128_0to240(data: &[u8], secret: &[u8], seed: u64) -> u128 {
@@ -804,7 +808,7 @@ fn hash128_large_generic(
         !(PRIME64[1].wrapping_mul(data.len() as u64)),
     );
 
-    (high as u128) << 64 | low as u128
+    u128::from(high) << 64 | u128::from(low)
 }
 
 #[cfg(test)]

--- a/src/tree_store/page_store/xxh3.rs
+++ b/src/tree_store/page_store/xxh3.rs
@@ -182,7 +182,7 @@ unsafe fn scramble_accumulators_avx2(
         let shifted = _mm256_srli_epi64::<47>(a);
         let b = _mm256_xor_si256(a, shifted);
 
-        let s = _mm256_loadu_si256((secret_ptr.cast::<__m256i>()).add(i));
+        let s = _mm256_loadu_si256((secret_ptr as *const __m256i).add(i));
         let c = _mm256_xor_si256(b, s);
         let c_high = _mm256_shuffle_epi32::<49>(c);
 
@@ -190,7 +190,7 @@ unsafe fn scramble_accumulators_avx2(
         let high = _mm256_mul_epu32(c_high, simd_prime);
         let high = _mm256_slli_epi64::<32>(high);
         let result = _mm256_add_epi64(low, high);
-        _mm256_storeu_si256((accumulators_ptr.cast::<__m256i>()).add(i), result);
+        _mm256_storeu_si256((accumulators_ptr as *mut __m256i).add(i), result);
     }
 }
 
@@ -308,9 +308,9 @@ unsafe fn gen_secret_avx2(seed: u64) -> [u8; DEFAULT_SECRET.len()] {
     let output_ptr = output.as_mut_ptr();
     let secret_ptr = DEFAULT_SECRET.as_ptr();
     for i in 0..6 {
-        let s = _mm256_loadu_si256((secret_ptr.cast::<__m256i>()).add(i));
+        let s = _mm256_loadu_si256((secret_ptr as *const __m256i).add(i));
         let x = _mm256_add_epi64(s, simd_seed);
-        _mm256_storeu_si256((output_ptr.cast::<__m256i>()).add(i), x);
+        _mm256_storeu_si256((output_ptr as *mut __m256i).add(i), x);
     }
 
     output
@@ -361,8 +361,8 @@ unsafe fn accumulate_stripe_avx2(accumulators: &mut [u64; 8], data: &[u8], secre
     assert!(data.len() >= STRIPE_LENGTH);
     assert!(secret.len() >= STRIPE_LENGTH);
     for i in 0..(STRIPE_LENGTH / 32) {
-        let x = _mm256_loadu_si256((data_ptr.cast::<__m256i>()).add(i));
-        let s = _mm256_loadu_si256((secret_ptr.cast::<__m256i>()).add(i));
+        let x = _mm256_loadu_si256((data_ptr as *const __m256i).add(i));
+        let s = _mm256_loadu_si256((secret_ptr as *const __m256i).add(i));
 
         let z = _mm256_xor_si256(x, s);
         let z_low = _mm256_shuffle_epi32::<49>(z);
@@ -373,7 +373,7 @@ unsafe fn accumulate_stripe_avx2(accumulators: &mut [u64; 8], data: &[u8], secre
         let result = _mm256_loadu_si256((accumulator_ptr as *const __m256i).add(i));
         let result = _mm256_add_epi64(result, shuffled);
         let result = _mm256_add_epi64(result, product);
-        _mm256_storeu_si256((accumulator_ptr.cast::<__m256i>()).add(i), result);
+        _mm256_storeu_si256((accumulator_ptr as *mut __m256i).add(i), result);
     }
 }
 
@@ -384,7 +384,7 @@ fn accumulate_stripe_generic(accumulators: &mut [u64; 8], data: &[u8], secret: &
         let y = x ^ get_u64(&secret[i * 8..], 0);
         accumulators[i ^ 1] = accumulators[i ^ 1].wrapping_add(x);
         let z = (y & 0xFFFF_FFFF) * (y >> 32);
-        accumulators[i] = accumulators[i].wrapping_add(z);
+        accumulators[i] = accumulators[i].wrapping_add(z)
     }
 }
 
@@ -462,14 +462,14 @@ fn hash64_0(secret: &[u8], seed: u64) -> u64 {
 }
 
 fn hash64_1to3(data: &[u8], secret: &[u8], seed: u64) -> u64 {
-    let x1 = u32::from(data[0]);
-    let x2 = u32::from(data[data.len() >> 1]);
-    let x3 = u32::from(*data.last().unwrap());
+    let x1 = data[0] as u32;
+    let x2 = data[data.len() >> 1] as u32;
+    let x3 = (*data.last().unwrap()) as u32;
     #[allow(clippy::cast_possible_truncation)]
     let x4 = data.len() as u32;
 
-    let combined = u64::from((x1 << 16) | (x2 << 24) | x3 | (x4 << 8));
-    let mut result = u64::from(get_u32(secret, 0) ^ get_u32(secret, 1));
+    let combined = ((x1 << 16) | (x2 << 24) | x3 | (x4 << 8)) as u64;
+    let mut result = (get_u32(secret, 0) ^ get_u32(secret, 1)) as u64;
     result = result.wrapping_add(seed);
     result ^= combined;
     xxh64_avalanche(result)
@@ -479,8 +479,8 @@ fn hash64_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u64 {
     #[allow(clippy::cast_possible_truncation)]
     let truncate_seed = seed as u32;
     seed ^= u64::from(truncate_seed.swap_bytes()) << 32;
-    let x1 = u64::from(get_u32(data, 0));
-    let x2 = u64::from(get_u32(&data[data.len() - 4..], 0));
+    let x1 = get_u32(data, 0) as u64;
+    let x2 = get_u32(&data[data.len() - 4..], 0) as u64;
     let x = x2 | (x1 << 32);
     let s = (get_u64(secret, 1) ^ get_u64(secret, 2)).wrapping_sub(seed);
     rrmxmx(x ^ s, data.len() as u64)
@@ -595,24 +595,24 @@ fn hash64_large_generic(
 }
 
 fn hash128_0(secret: &[u8], seed: u64) -> u128 {
-    let high = u128::from(hash64_0(&secret[3 * 8..], seed)) << 64;
-    let low = u128::from(hash64_0(&secret[8..], seed));
+    let high = (hash64_0(&secret[3 * 8..], seed) as u128) << 64;
+    let low = hash64_0(&secret[8..], seed) as u128;
     high | low
 }
 
 fn hash128_1to3(data: &[u8], secret: &[u8], seed: u64) -> u128 {
-    let x1 = u32::from(data[0]);
-    let x2 = u32::from(data[data.len() >> 1]);
-    let x3 = u32::from(*data.last().unwrap());
+    let x1 = data[0] as u32;
+    let x2 = data[data.len() >> 1] as u32;
+    let x3 = (*data.last().unwrap()) as u32;
     #[allow(clippy::cast_possible_truncation)]
     let x4 = data.len() as u32;
 
     let combined_low = (x1 << 16) | (x2 << 24) | x3 | (x4 << 8);
     let combined_high: u64 = combined_low.swap_bytes().rotate_left(13).into();
-    let s_low = u64::from(get_u32(secret, 0) ^ get_u32(secret, 1)).wrapping_add(seed);
-    let s_high = u64::from(get_u32(secret, 2) ^ get_u32(secret, 3)).wrapping_sub(seed);
-    let high = (u128::from(xxh64_avalanche(combined_high ^ s_high))) << 64;
-    let low = u128::from(xxh64_avalanche(u64::from(combined_low) ^ s_low));
+    let s_low = ((get_u32(secret, 0) ^ get_u32(secret, 1)) as u64).wrapping_add(seed);
+    let s_high = ((get_u32(secret, 2) ^ get_u32(secret, 3)) as u64).wrapping_sub(seed);
+    let high = (xxh64_avalanche(combined_high ^ s_high) as u128) << 64;
+    let low = xxh64_avalanche(combined_low as u64 ^ s_low) as u128;
     high | low
 }
 
@@ -620,17 +620,13 @@ fn hash128_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u128 {
     #[allow(clippy::cast_possible_truncation)]
     let truncate_seed = seed as u32;
     seed ^= u64::from(truncate_seed.swap_bytes()) << 32;
-    let x_low = u64::from(get_u32(data, 0));
-    let x_high = u64::from(u32::from_le_bytes(
-        data[data.len() - 4..].try_into().unwrap(),
-    ));
+    let x_low = get_u32(data, 0) as u64;
+    let x_high = u32::from_le_bytes(data[data.len() - 4..].try_into().unwrap()) as u64;
     let x = x_low | (x_high << 32);
     let s = (get_u64(secret, 2) ^ get_u64(secret, 3)).wrapping_add(seed);
 
-    let mut y = u128::from(x ^ s);
-    y = y.wrapping_mul(u128::from(
-        PRIME64[0].wrapping_add((data.len() << 2) as u64),
-    ));
+    let mut y = (x ^ s) as u128;
+    y = y.wrapping_mul(PRIME64[0].wrapping_add((data.len() << 2) as u64) as u128);
 
     #[allow(clippy::cast_possible_truncation)]
     let mut r_low = y as u64;
@@ -642,7 +638,7 @@ fn hash128_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u128 {
     r_low = xorshift(r_low, 28);
     r_high = xxh3_avalanche(r_high);
 
-    u128::from(r_high) << 64 | u128::from(r_low)
+    (r_high as u128) << 64 | r_low as u128
 }
 
 fn hash128_9to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
@@ -653,7 +649,7 @@ fn hash128_9to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     let mixed = x_low ^ x_high ^ s_low;
     let x_high = x_high ^ s_high;
 
-    let result = u128::from(mixed).wrapping_mul(u128::from(PRIME64[0]));
+    let result = (mixed as u128).wrapping_mul(PRIME64[0] as u128);
     #[allow(clippy::cast_possible_truncation)]
     let mut r_low = result as u64;
     let mut r_high = (result >> 64) as u64;
@@ -662,7 +658,7 @@ fn hash128_9to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     r_high = r_high.wrapping_add((x_high & 0xFFFF_FFFF).wrapping_mul(PRIME32[1] - 1));
     r_low ^= r_high.swap_bytes();
 
-    let result2 = u128::from(r_low).wrapping_mul(u128::from(PRIME64[1]));
+    let result2 = (r_low as u128).wrapping_mul(PRIME64[1] as u128);
     #[allow(clippy::cast_possible_truncation)]
     let mut r2_low = result2 as u64;
     let mut r2_high = (result2 >> 64) as u64;
@@ -670,7 +666,7 @@ fn hash128_9to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     r2_low = xxh3_avalanche(r2_low);
     r2_high = xxh3_avalanche(r2_high);
 
-    u128::from(r2_high) << 64 | u128::from(r2_low)
+    (r2_high as u128) << 64 | r2_low as u128
 }
 
 fn hash128_0to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
@@ -706,7 +702,7 @@ fn hash128_17to128(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     r_low = xxh3_avalanche(r_low);
     r_high = 0u64.wrapping_sub(xxh3_avalanche(r_high));
 
-    u128::from(r_high) << 64 | u128::from(r_low)
+    (r_high as u128) << 64 | r_low as u128
 }
 
 fn hash128_129to240(data: &[u8], secret: &[u8], seed: u64) -> u128 {
@@ -750,7 +746,7 @@ fn hash128_129to240(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     r_low = xxh3_avalanche(r_low);
     r_high = 0u64.wrapping_sub(xxh3_avalanche(r_high));
 
-    u128::from(r_high) << 64 | u128::from(r_low)
+    (r_high as u128) << 64 | r_low as u128
 }
 
 fn hash128_0to240(data: &[u8], secret: &[u8], seed: u64) -> u128 {
@@ -808,7 +804,7 @@ fn hash128_large_generic(
         !(PRIME64[1].wrapping_mul(data.len() as u64)),
     );
 
-    u128::from(high) << 64 | u128::from(low)
+    (high as u128) << 64 | low as u128
 }
 
 #[cfg(test)]

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -14,7 +14,6 @@ use crate::types::{Key, MutInPlaceValue, TypeName, Value};
 use crate::{DatabaseStats, Result};
 use std::cmp::max;
 use std::collections::{BTreeMap, HashMap};
-use std::mem;
 use std::mem::size_of;
 use std::ops::RangeFull;
 use std::sync::{Arc, Mutex};
@@ -166,7 +165,7 @@ impl MutInPlaceValue for FreedPageList<'_> {
     }
 
     fn from_bytes_mut(data: &mut [u8]) -> &mut Self::BaseRefType {
-        unsafe { mem::transmute(data) }
+        unsafe { &mut *(data as *mut [u8] as *mut FreedPageListMut) }
     }
 }
 

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -51,7 +51,6 @@ impl Value for FreedTableKey {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> [u8; 2 * size_of::<u64>()]
     where
-        Self: 'a,
         Self: 'b,
     {
         let mut result = [0u8; 2 * size_of::<u64>()];
@@ -147,7 +146,6 @@ impl Value for FreedPageList<'_> {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'b [u8]
     where
-        Self: 'a,
         Self: 'b,
     {
         value.data

--- a/src/tree_store/table_tree_base.rs
+++ b/src/tree_store/table_tree_base.rs
@@ -446,7 +446,6 @@ impl Value for InternalTableDefinition {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Vec<u8>
     where
-        Self: 'a,
         Self: 'b,
     {
         let mut result = vec![value.get_type().into()];

--- a/src/tree_store/table_tree_base.rs
+++ b/src/tree_store/table_tree_base.rs
@@ -106,11 +106,8 @@ impl InternalTableDefinition {
                 table_root,
                 table_length,
                 ..
-            } => {
-                *table_root = root;
-                *table_length = length;
             }
-            InternalTableDefinition::Multimap {
+            | InternalTableDefinition::Multimap {
                 table_root,
                 table_length,
                 ..
@@ -261,22 +258,22 @@ impl InternalTableDefinition {
 
     fn private_get_root(&self) -> Option<BtreeHeader> {
         match self {
-            InternalTableDefinition::Normal { table_root, .. } => *table_root,
-            InternalTableDefinition::Multimap { table_root, .. } => *table_root,
+            InternalTableDefinition::Normal { table_root, .. }
+            | InternalTableDefinition::Multimap { table_root, .. } => *table_root,
         }
     }
 
     pub(crate) fn get_length(&self) -> u64 {
         match self {
-            InternalTableDefinition::Normal { table_length, .. } => *table_length,
-            InternalTableDefinition::Multimap { table_length, .. } => *table_length,
+            InternalTableDefinition::Normal { table_length, .. }
+            | InternalTableDefinition::Multimap { table_length, .. } => *table_length,
         }
     }
 
     fn private_get_fixed_key_size(&self) -> Option<usize> {
         match self {
-            InternalTableDefinition::Normal { fixed_key_size, .. } => *fixed_key_size,
-            InternalTableDefinition::Multimap { fixed_key_size, .. } => *fixed_key_size,
+            InternalTableDefinition::Normal { fixed_key_size, .. }
+            | InternalTableDefinition::Multimap { fixed_key_size, .. } => *fixed_key_size,
         }
     }
 
@@ -284,8 +281,8 @@ impl InternalTableDefinition {
         match self {
             InternalTableDefinition::Normal {
                 fixed_value_size, ..
-            } => *fixed_value_size,
-            InternalTableDefinition::Multimap {
+            }
+            | InternalTableDefinition::Multimap {
                 fixed_value_size, ..
             } => *fixed_value_size,
         }
@@ -293,8 +290,8 @@ impl InternalTableDefinition {
 
     fn private_get_key_alignment(&self) -> usize {
         match self {
-            InternalTableDefinition::Normal { key_alignment, .. } => *key_alignment,
-            InternalTableDefinition::Multimap { key_alignment, .. } => *key_alignment,
+            InternalTableDefinition::Normal { key_alignment, .. }
+            | InternalTableDefinition::Multimap { key_alignment, .. } => *key_alignment,
         }
     }
 
@@ -302,8 +299,8 @@ impl InternalTableDefinition {
         match self {
             InternalTableDefinition::Normal {
                 value_alignment, ..
-            } => *value_alignment,
-            InternalTableDefinition::Multimap {
+            }
+            | InternalTableDefinition::Multimap {
                 value_alignment, ..
             } => *value_alignment,
         }
@@ -318,15 +315,15 @@ impl InternalTableDefinition {
 
     fn private_key_type(&self) -> TypeName {
         match self {
-            InternalTableDefinition::Normal { key_type, .. } => key_type.clone(),
-            InternalTableDefinition::Multimap { key_type, .. } => key_type.clone(),
+            InternalTableDefinition::Normal { key_type, .. }
+            | InternalTableDefinition::Multimap { key_type, .. } => key_type.clone(),
         }
     }
 
     fn private_value_type(&self) -> TypeName {
         match self {
-            InternalTableDefinition::Normal { value_type, .. } => value_type.clone(),
-            InternalTableDefinition::Multimap { value_type, .. } => value_type.clone(),
+            InternalTableDefinition::Normal { value_type, .. }
+            | InternalTableDefinition::Multimap { value_type, .. } => value_type.clone(),
         }
     }
 }

--- a/src/tree_store/table_tree_base.rs
+++ b/src/tree_store/table_tree_base.rs
@@ -462,14 +462,14 @@ impl Value for InternalTableDefinition {
             result.extend_from_slice(&u32::try_from(fixed).unwrap().to_le_bytes());
         } else {
             result.push(0);
-            result.extend_from_slice(&[0; size_of::<u32>()])
+            result.extend_from_slice(&[0; size_of::<u32>()]);
         }
         if let Some(fixed) = value.private_get_fixed_value_size() {
             result.push(1);
             result.extend_from_slice(&u32::try_from(fixed).unwrap().to_le_bytes());
         } else {
             result.push(0);
-            result.extend_from_slice(&[0; size_of::<u32>()])
+            result.extend_from_slice(&[0; size_of::<u32>()]);
         }
         result.extend_from_slice(
             &u32::try_from(value.private_get_key_alignment())

--- a/src/types.rs
+++ b/src/types.rs
@@ -93,7 +93,6 @@ pub trait Value: Debug {
     /// Serialize the value to a slice
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
     where
-        Self: 'a,
         Self: 'b;
 
     /// Globally unique identifier for this type
@@ -152,7 +151,6 @@ impl Value for () {
 
     fn as_bytes<'a, 'b: 'a>(_: &'a Self::SelfType<'b>) -> &'a [u8]
     where
-        Self: 'a,
         Self: 'b,
     {
         &[]
@@ -194,7 +192,6 @@ impl Value for bool {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a [u8]
     where
-        Self: 'a,
         Self: 'b,
     {
         match value {
@@ -241,7 +238,6 @@ impl<T: Value> Value for Option<T> {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Vec<u8>
     where
-        Self: 'a,
         Self: 'b,
     {
         let mut result = vec![0];
@@ -299,7 +295,6 @@ impl Value for &[u8] {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a [u8]
     where
-        Self: 'a,
         Self: 'b,
     {
         value
@@ -337,7 +332,6 @@ impl<const N: usize> Value for &[u8; N] {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a [u8; N]
     where
-        Self: 'a,
         Self: 'b,
     {
         value
@@ -390,7 +384,6 @@ impl<const N: usize, T: Value> Value for [T; N] {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Vec<u8>
     where
-        Self: 'a,
         Self: 'b,
     {
         if let Some(fixed) = T::fixed_width() {
@@ -470,7 +463,6 @@ impl Value for &str {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a str
     where
-        Self: 'a,
         Self: 'b,
     {
         value
@@ -510,7 +502,6 @@ impl Value for String {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a str
     where
-        Self: 'a,
         Self: 'b,
     {
         value.as_str()
@@ -546,7 +537,6 @@ impl Value for char {
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> [u8; 3]
     where
-        Self: 'a,
         Self: 'b,
     {
         let bytes = u32::from(*value).to_le_bytes();

--- a/src/types.rs
+++ b/src/types.rs
@@ -141,7 +141,7 @@ impl Value for () {
         Some(0)
     }
 
-    #[allow(clippy::unused_unit)]
+    #[allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned)]
     fn from_bytes<'a>(_data: &'a [u8]) -> ()
     where
         Self: 'a,

--- a/src/types.rs
+++ b/src/types.rs
@@ -72,7 +72,7 @@ impl TypeName {
 }
 
 pub trait Value: Debug {
-    /// SelfType<'a> must be the same type as Self with all lifetimes replaced with 'a
+    /// `SelfType<'a>` must be the same type as Self with all lifetimes replaced with 'a
     type SelfType<'a>: Debug + 'a
     where
         Self: 'a;
@@ -101,9 +101,9 @@ pub trait Value: Debug {
 }
 
 /// Implementing this trait indicates that the type can be mutated in-place as a &mut [u8].
-/// This enables the .insert_reserve() method on Table
+/// This enables the `.insert_reserve()` method on Table
 pub trait MutInPlaceValue: Value {
-    /// The base type such that &mut [u8] can be safely transmuted to &mut BaseRefType
+    /// The base type such that &mut [u8] can be safely transmuted to `&mut BaseRefType`
     type BaseRefType: Debug + ?Sized;
 
     // Initialize `data` to a valid value. This method will be called (at some point, not necessarily immediately)


### PR DESCRIPTION
I like the pedantic clippy lints, since they often turn up things that are either a little suspicious, or which just have better alternatives.

I went through all the `clippy::pedantic` lints which weren't enabled, and one by one either denied or enabled them, usually with some kind of rationale. Sometimes I allowed lints that should probably be denied, either because they're subjective, or would take more knowledge of `redb` than I have to actually fix.

I tried to do each one in a separate commit, to keep things readable and let you review the rationale for each, which are in the commit messages.

Finally, I added `clippy::pedantic` to the `#![deny]` block, and tried to remove any `allow` which was not actually being triggered.

As of Rust 1.74, you can put lints in `Cargo.toml`, which is a nice way to enforce them project wide, but until then putting them at the top of `lib.rs` is reasonable.

Feel free to take or leave anything in this PR, since obviously a lot of it is subjective. And definitely squash this commit before merging!