### PR TITLE
Don't count the region tracker page when checking for leaks

### DIFF
--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -527,7 +527,7 @@ fn exec_table_crash_support<T: Clone>(config: &FuzzConfig, apply: fn(WriteTransa
     txn.commit().unwrap();
     db.begin_write().unwrap().commit().unwrap();
     let txn = db.begin_write().unwrap();
-    let baseline_allocated_pages = txn.stats().unwrap().allocated_pages();
+    let baseline_allocated_pages = txn.stats().unwrap().allocated_pages() - txn.num_region_tracker_pages();
     txn.abort().unwrap();
     countdown.store(old_countdown, Ordering::SeqCst);
 
@@ -686,7 +686,7 @@ fn exec_table_crash_support<T: Clone>(config: &FuzzConfig, apply: fn(WriteTransa
     }
 
     let txn = db.begin_write().unwrap();
-    let allocated_pages = txn.stats().unwrap().allocated_pages();
+    let allocated_pages = txn.stats().unwrap().allocated_pages() - txn.num_region_tracker_pages();
     txn.abort().unwrap();
     assert_eq!(allocated_pages, baseline_allocated_pages, "Found {} allocated pages at shutdown, expected {}", allocated_pages, baseline_allocated_pages);
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1320,6 +1320,11 @@ impl WriteTransaction {
         })
     }
 
+    #[cfg(any(test, fuzzing))]
+    pub fn num_region_tracker_pages(&self) -> u64 {
+        1 << self.mem.tracker_page().page_order
+    }
+
     #[allow(dead_code)]
     pub(crate) fn print_debug(&self) -> Result {
         // Flush any pending updates to make sure we get the latest root


### PR DESCRIPTION
We never shrink the region tracker page, so it'll show up as a leak any time it grows larger than its initial size.  This isn't a useful leak to report, so just ignore it.