### PR TITLE
Add set_quick_repair()

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -31,8 +31,8 @@ database file.
 | magic number                                                                                   |
 | magic con.| god byte  | padding               | page size                                      |
 | region header pages                           | region max data pages                          |
-| region tracker page number                                                                     |
 | number of full regions                        | data pages in trailing region                  |
+| region tracker page number                                                                     |
 | padding                                                                                        |
 | padding                                                                                        |
 | padding                                                                                        |

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -164,6 +164,7 @@ pub(crate) enum FuzzOperation {
 pub(crate) struct FuzzTransaction {
     pub ops: Vec<FuzzOperation>,
     pub durable: bool,
+    pub quick_repair: bool,
     pub commit: bool,
     pub create_ephemeral_savepoint: bool,
     pub create_persistent_savepoint: bool,

--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -583,6 +583,7 @@ fn exec_table_crash_support<T: Clone>(config: &FuzzConfig, apply: fn(WriteTransa
         if !transaction.durable {
             txn.set_durability(Durability::None);
         }
+        txn.set_quick_repair(transaction.quick_repair);
         let mut counter_table = txn.open_table(COUNTER_TABLE).unwrap();
         let uncommitted_id = txn_id as u64 + 1;
         counter_table.insert((), uncommitted_id)?;

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -308,8 +308,8 @@ pub(crate) fn finalize_tree_and_subtree_checksums(
                         value_size,
                         <()>::fixed_width(),
                     );
-                    subtree.finalize_dirty_checksums()?;
-                    sub_root_updates.push((i, entry.key().to_vec(), subtree.get_root().unwrap()));
+                    let subtree_root = subtree.finalize_dirty_checksums()?.unwrap();
+                    sub_root_updates.push((i, entry.key().to_vec(), subtree_root));
                 }
             }
         }
@@ -327,10 +327,10 @@ pub(crate) fn finalize_tree_and_subtree_checksums(
         Ok(())
     })?;
 
-    tree.finalize_dirty_checksums()?;
+    let root = tree.finalize_dirty_checksums()?;
     // No pages should have been freed by this operation
     assert!(freed_pages.lock().unwrap().is_empty());
-    Ok(tree.get_root())
+    Ok(root)
 }
 
 fn parse_subtree_roots<T: Page>(

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -167,9 +167,9 @@ pub enum Durability {
     /// the ability to cause the database process to crash, can cause invalid data to be written
     /// with a valid checksum, leaving the database in an invalid, attacker-controlled state.
     Immediate,
-    /// Commits with this durability level have the same gaurantees as [`Durability::Immediate`]
+    /// Commits with this durability level have the same guarantees as [`Durability::Immediate`]
     ///
-    /// Additionally, aata is written with the following 2-phase commit algorithm:
+    /// Additionally, data is written with the following 2-phase commit algorithm:
     ///
     /// 1. Update the inactive commit slot with the new database state
     /// 2. Call `fsync` to ensure the database slate and commit slot update have been persisted

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1103,7 +1103,6 @@ impl WriteTransaction {
             self.transaction_id,
             eventual,
             two_phase,
-            true,
         )?;
 
         // Mark any pending non-durable commits as fully committed.

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -242,19 +242,12 @@ impl DatabaseHeader {
         Ok((result, repair))
     }
 
-    pub(super) fn to_bytes(
-        &self,
-        include_magic_number: bool,
-        swap_primary: bool,
-    ) -> [u8; DB_HEADER_SIZE] {
+    pub(super) fn to_bytes(&self, include_magic_number: bool) -> [u8; DB_HEADER_SIZE] {
         let mut result = [0; DB_HEADER_SIZE];
         if include_magic_number {
             result[..MAGICNUMBER.len()].copy_from_slice(&MAGICNUMBER);
         }
         result[GOD_BYTE_OFFSET] = self.primary_slot.try_into().unwrap();
-        if swap_primary {
-            result[GOD_BYTE_OFFSET] ^= PRIMARY_BIT;
-        }
         if self.recovery_required {
             result[GOD_BYTE_OFFSET] |= RECOVERY_REQUIRED;
         }

--- a/src/tree_store/table_tree_base.rs
+++ b/src/tree_store/table_tree_base.rs
@@ -441,6 +441,10 @@ impl Value for InternalTableDefinition {
         }
     }
 
+    // Be careful if you change this serialization format! The InternalTableDefinition for
+    // a given table needs to have a consistent serialized length, regardless of the table
+    // contents, so that create_table_and_flush_table_root() can update the allocator state
+    // table without causing more allocations
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Vec<u8>
     where
         Self: 'b,


### PR DESCRIPTION
Here's the PR for #878!

This adds a new durability level above Paranoid that doesn't require repair.  For now, it's just called "ParanoidPlus" -- not the most descriptive name, but it at least makes it very clear where it falls on the scale of commit speed vs. recoverability.  If you have a better name, let me know 😄

To avoid repair, Durability::ParanoidPlus commits need to save the allocator state somewhere.  We can't use the region headers, because we'd be overwriting them in place; we might crash partway through the overwrite, and then we'd need repair.  So we instead save the allocator state to a new table in the system tree.  Writing to the table is slightly tricky, because it needs to be done without allocating (see below), but other than that it's a perfectly ordinary transactional write with all the usual guarantees.

The other requirement to avoid repair is knowing whether the last transaction used 2-phase commit.  For this, we add a new `two_phase_commit` bit to the god byte, which is always updated atomically along with swapping the primary bit.  Old redb versions will ignore the new flag when reading and clear it when writing, which is exactly what we want.

This turns out to also fix a longstanding bug where Durability::Paranoid hasn't been providing any security benefit at all.  The checksum forgery attack described in the Durability::Immediate documentation actually works equally well against Durability::Paranoid!  The problem is that even though 2-phase commit guarantees the primary is valid, redb ignores the primary flag when repairing.  It always picks whichever commit slot is newer, as long as the checksum is valid.  So if you crash partway through a commit, it'll try to recover using the partially-written secondary rather than the fully-written primary, regardless of the durability mode.

The fix for this is exactly the `two_phase_commit` bit described above.  After a crash, we check whether the last transaction used 2-phase commit; if so, we only look at the primary (which is guaranteed to be valid) and ignore the secondary.  Durability::ParanoidPlus needs this check anyway for safety, so we get the Durability::Paranoid bug fix for free.

To write to the allocator state table without allocating, I've introduced a new insert_inplace() function.  It's similar to insert_reserve(), but more general and maybe simpler.  To use it, you have to first do an ordinary insert() with your desired key and a value of the appropriate length; then later in the same transaction you can call insert_inplace() to replace the value with a new one.  Unlike insert_reserve(), this works with values that don't implement MutInPlaceValue, and it lets you hold multiple reservations simultaneously.

insert_inplace() could be safely exposed to users, but I don't think there's any reason to.  Since it doesn't give you a mutable reference, there's no benefit over insert() unless you're storing data that cares about its own position in the database.  So for now it's private, and I haven't bothered making a new error type for it; it just panics if you don't satisfy the preconditions.

The fuzzer is perfect for testing Durability::ParanoidPlus, because it can simulate a crash, reopen the database (skipping repair if possible), and then verify that the resulting allocator state exactly matches what would happen if it ran a full repair.  I've updated the fuzzer to generate Durability::ParanoidPlus commits along with the existing Durability::None and Durability::Immediate.