### PR TITLE
Don't mark the region tracker page as allocated

### DIFF
--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1129,7 +1129,7 @@ impl TransactionalMemory {
 
 impl Drop for TransactionalMemory {
     fn drop(&mut self) {
-        if thread::panicking() {
+        if thread::panicking() || self.needs_recovery.load(Ordering::Acquire) {
             return;
         }
 


### PR DESCRIPTION
When writing the allocator state table, it's better not to include the region tracker page as one of the allocated pages. Instead, we should allocate the region tracker page during quick-repair after loading the rest of the allocator state, exactly like we do for full repair.

This avoids an unlikely corruption that could happen for databases larger than 4 TB, if we crash on shutdown after writing out a new region tracker page number but before clearing the recovery_required bit. It also means that in the future, when we drop support for the old allocator state format, we'll be able to get rid of the region tracker page entirely instead of having to keep around some of the allocation code for compatibility.