### PR TITLE
Add Database::cache_stats()

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -211,6 +211,23 @@ impl<'a, K: Key + 'static, V: Key + 'static> Display for MultimapTableDefinition
     }
 }
 
+/// Information regarding the usage of the in-memory cache
+///
+/// Note: these metrics are only collected when the "`cache_metrics`" feature is enabled
+#[derive(Debug)]
+pub struct CacheStats {
+    pub(crate) evictions: u64,
+}
+
+impl CacheStats {
+    /// Number of times that data has been evicted, due to the cache being full
+    ///
+    /// To increase the cache size use [`Builder::set_cache_size`]
+    pub fn evictions(&self) -> u64 {
+        self.evictions
+    }
+}
+
 pub(crate) struct TransactionGuard {
     transaction_tracker: Option<Arc<TransactionTracker>>,
     transaction_id: Option<TransactionId>,
@@ -326,6 +343,13 @@ impl Database {
     /// Opens an existing redb database.
     pub fn open(path: impl AsRef<Path>) -> Result<Database, DatabaseError> {
         Self::builder().open(path)
+    }
+
+    /// Information regarding the usage of the in-memory cache
+    ///
+    /// Note: these metrics are only collected when the "`cache_metrics`" feature is enabled
+    pub fn cache_stats(&self) -> CacheStats {
+        self.mem.cache_stats()
     }
 
     pub(crate) fn get_memory(&self) -> Arc<TransactionalMemory> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,8 +68,8 @@
 //! [design]: https://github.com/cberner/redb/blob/master/docs/design.md
 
 pub use db::{
-    Builder, Database, MultimapTableDefinition, MultimapTableHandle, RepairSession, StorageBackend,
-    TableDefinition, TableHandle, UntypedMultimapTableHandle, UntypedTableHandle,
+    Builder, CacheStats, Database, MultimapTableDefinition, MultimapTableHandle, RepairSession,
+    StorageBackend, TableDefinition, TableHandle, UntypedMultimapTableHandle, UntypedTableHandle,
 };
 pub use error::{
     CommitError, CompactionError, DatabaseError, Error, SavepointError, StorageError, TableError,

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -9,7 +9,7 @@ use crate::tree_store::page_store::layout::DatabaseLayout;
 use crate::tree_store::page_store::region::{Allocators, RegionTracker};
 use crate::tree_store::page_store::{hash128_with_seed, PageImpl, PageMut};
 use crate::tree_store::{Page, PageNumber};
-use crate::StorageBackend;
+use crate::{CacheStats, StorageBackend};
 use crate::{DatabaseError, Result, StorageError};
 #[cfg(feature = "logging")]
 use log::warn;
@@ -272,6 +272,10 @@ impl TransactionalMemory {
             region_size,
             region_header_with_padding_size: region_header_size,
         })
+    }
+
+    pub(crate) fn cache_stats(&self) -> CacheStats {
+        self.storage.cache_stats()
     }
 
     pub(crate) fn check_io_errors(&self) -> Result {


### PR DESCRIPTION
When the "cache_metrics" feature is enable this exposes the number of cache evictions

Fixes #910 