### PR TITLE
Optimize restore_savepoint()

### DIFF
--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -383,13 +383,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
     where
         F: FnMut(&PagePath) -> Result,
     {
-        let tree = UntypedBtree::new(
-            self.root,
-            self.mem.clone(),
-            K::fixed_width(),
-            V::fixed_width(),
-        );
-        tree.visit_all_pages(visitor)
+        self.read_tree()?.visit_all_pages(visitor)
     }
 
     pub(crate) fn get_root(&self) -> Option<BtreeHeader> {
@@ -719,6 +713,19 @@ impl<K: Key, V: Value> Btree<K, V> {
 
     pub(crate) fn get_root(&self) -> Option<BtreeHeader> {
         self.root
+    }
+
+    pub(crate) fn visit_all_pages<F>(&self, visitor: F) -> Result
+    where
+        F: FnMut(&PagePath) -> Result,
+    {
+        let tree = UntypedBtree::new(
+            self.root,
+            self.mem.clone(),
+            K::fixed_width(),
+            V::fixed_width(),
+        );
+        tree.visit_all_pages(visitor)
     }
 
     pub(crate) fn get(&self, key: &K::SelfType<'_>) -> Result<Option<AccessGuard<'static, V>>> {

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -17,8 +17,8 @@ pub(crate) use btree_base::{
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, BtreeExtractIf, BtreeRangeIter};
 pub use page_store::{file_backend, InMemoryBackend, Savepoint};
 pub(crate) use page_store::{
-    Page, PageHint, PageNumber, SerializedSavepoint, TransactionalMemory, FILE_FORMAT_VERSION2,
-    MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE,
+    BuddyAllocator, Page, PageHint, PageNumber, SerializedSavepoint, TransactionalMemory,
+    FILE_FORMAT_VERSION2, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE,
 };
 pub(crate) use table_tree::{FreedPageList, FreedTableKey, TableTree, TableTreeMut};
 pub(crate) use table_tree_base::{InternalTableDefinition, TableType};

--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -346,7 +346,6 @@ impl U64GroupedBitmap {
         U64GroupedBitmapDifference::new(&self.data, &exclusion.data)
     }
 
-    #[allow(dead_code)]
     pub fn iter(&self) -> U64GroupedBitmapIter {
         U64GroupedBitmapIter::new(self.len, &self.data)
     }

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -21,6 +21,5 @@ pub use savepoint::Savepoint;
 pub(crate) use savepoint::SerializedSavepoint;
 
 pub(super) use base::{PageImpl, PageMut};
-pub(super) use buddy_allocator::BuddyAllocator;
-pub(super) use region::new_allocators;
+pub(crate) use buddy_allocator::BuddyAllocator;
 pub(super) use xxh3::hash128_with_seed;

--- a/src/tree_store/page_store/region.rs
+++ b/src/tree_store/page_store/region.rs
@@ -112,19 +112,6 @@ impl RegionTracker {
     }
 }
 
-pub(crate) fn new_allocators(layout: DatabaseLayout) -> Vec<BuddyAllocator> {
-    let mut result = vec![];
-    for i in 0..layout.num_regions() {
-        let region_layout = layout.region_layout(i);
-        let allocator = BuddyAllocator::new(
-            region_layout.num_pages(),
-            layout.full_region_layout().num_pages(),
-        );
-        result.push(allocator);
-    }
-    result
-}
-
 pub(super) struct Allocators {
     pub(super) region_tracker: RegionTracker,
     pub(super) region_allocators: Vec<BuddyAllocator>,

--- a/src/tree_store/page_store/savepoint.rs
+++ b/src/tree_store/page_store/savepoint.rs
@@ -29,7 +29,6 @@ pub struct Savepoint {
     // are not freed
     transaction_id: TransactionId,
     user_root: Option<BtreeHeader>,
-    // For future use. This is not used in the restoration protocol.
     system_root: Option<BtreeHeader>,
     freed_root: Option<BtreeHeader>,
     regional_allocators: Vec<Vec<u8>>,
@@ -76,6 +75,18 @@ impl Savepoint {
 
     pub(crate) fn get_user_root(&self) -> Option<BtreeHeader> {
         self.user_root
+    }
+
+    pub(crate) fn get_system_root(&self) -> Option<BtreeHeader> {
+        self.system_root
+    }
+
+    pub(crate) fn get_freed_root(&self) -> Option<BtreeHeader> {
+        self.freed_root
+    }
+
+    pub(crate) fn get_regional_allocators(&self) -> &Vec<Vec<u8>> {
+        &self.regional_allocators
     }
 
     pub(crate) fn db_address(&self) -> *const TransactionTracker {
@@ -147,6 +158,8 @@ impl<'a> SerializedSavepoint<'a> {
                 .to_le_bytes(),
         );
 
+        // TODO: this seems like it is going to fail on databases with > 3GiB of regional allocators
+        // since that is the max size of a single stored value
         for region in &savepoint.regional_allocators {
             result.extend(region);
         }


### PR DESCRIPTION
This restores and fixes the optimization that was removed in baa86e7fe1b6b07acd0568f504d49404a19710d6

restore_savepoint() now scales with the number of database modifications since the savepoint was captured, rather than the size of the database

savepoint_benchmark is now ~35x faster for an 8GiB database file


Benchmarks:
master:
```
+---------+----------+------------------------+---------------------+
| DB size | insert() | persistent_savepoint() | restore_savepoint() |
+===================================================================+
| 129MiB  | 7693ns   | 685us                  | 18807us             |
|---------+----------+------------------------+---------------------|
| 257MiB  | 7456ns   | 510us                  | 62092us             |
|---------+----------+------------------------+---------------------|
| 514MiB  | 7126ns   | 379us                  | 152715us            |
|---------+----------+------------------------+---------------------|
| 1028MiB | 7678ns   | 427us                  | 346066us            |
|---------+----------+------------------------+---------------------|
| 2056MiB | 11429ns  | 1402us                 | 1173873us           |
|---------+----------+------------------------+---------------------|
| 4096MiB | 17383ns  | 2169us                 | 2946756us           |
|---------+----------+------------------------+---------------------|
| 8193MiB | 18706ns  | 672us                  | 5288360us           |
+---------+----------+------------------------+---------------------+
```


Optimized (this PR):
```
+---------+----------+------------------------+---------------------+
| DB size | insert() | persistent_savepoint() | restore_savepoint() |
+===================================================================+
| 129MiB  | 7153ns   | 656us                  | 2097us              |
|---------+----------+------------------------+---------------------|
| 257MiB  | 7613ns   | 498us                  | 3689us              |
|---------+----------+------------------------+---------------------|
| 514MiB  | 7930ns   | 520us                  | 8685us              |
|---------+----------+------------------------+---------------------|
| 1028MiB | 9116ns   | 679us                  | 23494us             |
|---------+----------+------------------------+---------------------|
| 2056MiB | 12111ns  | 1622us                 | 33498us             |
|---------+----------+------------------------+---------------------|
| 4096MiB | 18542ns  | 2163us                 | 67417us             |
|---------+----------+------------------------+---------------------|
| 8193MiB | 20877ns  | 1310us                 | 145174us            |
+---------+----------+------------------------+---------------------+
```