### PR TITLE
LMDB comparison benchmark improvements

### DIFF
--- a/benches/int_benchmark.rs
+++ b/benches/int_benchmark.rs
@@ -73,7 +73,7 @@ fn main() {
                 .open(tmpfile.path())
                 .unwrap()
         };
-        let table = HeedBenchDatabase::new(&env);
+        let table = HeedBenchDatabase::new(env);
         benchmark(table)
     };
 

--- a/benches/large_values_benchmark.rs
+++ b/benches/large_values_benchmark.rs
@@ -84,7 +84,7 @@ fn main() {
                 .open(tmpfile.path())
                 .unwrap()
         };
-        let table = HeedBenchDatabase::new(&env);
+        let table = HeedBenchDatabase::new(env);
         benchmark(table)
     };
 

--- a/benches/lmdb_benchmark.rs
+++ b/benches/lmdb_benchmark.rs
@@ -373,15 +373,15 @@ fn main() {
     };
 
     let lmdb_results = {
-        let tmpfile: TempDir = tempfile::tempdir_in(&tmpdir).unwrap();
+        let tempdir: TempDir = tempfile::tempdir_in(&tmpdir).unwrap();
         let env = unsafe {
             heed::EnvOpenOptions::new()
                 .map_size(4096 * 1024 * 1024)
-                .open(tmpfile.path())
+                .open(tempdir.path())
                 .unwrap()
         };
-        let table = HeedBenchDatabase::new(&env);
-        benchmark(table, tmpfile.path())
+        let table = HeedBenchDatabase::new(env);
+        benchmark(table, tempdir.path())
     };
 
     let rocksdb_results = {

--- a/benches/lmdb_benchmark.rs
+++ b/benches/lmdb_benchmark.rs
@@ -331,9 +331,9 @@ fn database_size(path: &Path) -> u64 {
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum ResultType {
-    NA,
     Duration(Duration),
     SizeInBytes(u64),
+    NA,
 }
 
 impl std::fmt::Display for ResultType {


### PR DESCRIPTION
In this PR, I introduce the compaction of the LMDB database. It requires compacting the data into another file and reopening the environment afterward.

The following results were run on my iMac M3 computer. I do not understand how the individual writes of LMDB and RocksDB are so low compared to the README you provided on GitHub 🤔

|                           | redb       | lmdb       | rocksdb        | sled       | sanakirja  |
|---------------------------|------------|------------|----------------|------------|------------|
| bulk load                 | 2652ms     | 1513ms     | 8188ms         | 7168ms     | **1346ms** |
| individual writes         | 405ms      | 7ms        | **4ms**        | 426ms      | 68ms       |
| batch writes              | 4880ms     | 2776ms     | **324ms**      | 1338ms     | 4478ms     |
| len()                     | 0ms        | **0ms**    | 273ms          | 727ms      | 54ms       |
| random reads              | **1051ms** | 1130ms     | 3251ms         | 1484ms     | 1293ms     |
| random reads              | **1034ms** | 1117ms     | 3113ms         | 1488ms     | 1271ms     |
| random range reads        | 2538ms     | **1651ms** | 5648ms         | 5844ms     | 1820ms     |
| random range reads        | 2524ms     | **1658ms** | 5655ms         | 5909ms     | 1827ms     |
| random reads (4 threads)  | 370ms      | **333ms**  | 1281ms         | 516ms      | 623ms      |
| random reads (8 threads)  | 247ms      | **179ms**  | 787ms          | 385ms      | 778ms      |
| random reads (16 threads) | 245ms      | **172ms**  | 800ms          | 338ms      | 790ms      |
| random reads (32 threads) | 239ms      | **163ms**  | 583ms          | 322ms      | 772ms      |
| removals                  | 4124ms     | **1221ms** | 3042ms         | 2234ms     | 1236ms     |
| compaction                | 2077ms     | **114ms**      | 522ms          | N/A    | N/A        |
| size after bench          | 311.23 MiB | 283.01 MiB | **106.26 MiB** | 445.50 MiB | 4.00 GiB   |