### PR TITLE
Fix drop order in Btree

### DIFF
--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -886,6 +886,13 @@ impl<K: Key, V: Value> Btree<K, V> {
     }
 }
 
+impl<K: Key, V: Value> Drop for Btree<K, V> {
+    fn drop(&mut self) {
+        // Make sure that we clear our reference to the root page, before the transaction guard goes out of scope
+        self.cached_root = None;
+    }
+}
+
 pub(crate) fn btree_stats(
     root: Option<PageNumber>,
     mem: &TransactionalMemory,


### PR DESCRIPTION
The cached root page must be dropped before the transaction guard. Otherwise, when debug_assertions are enabled it can cause a race where that cached page is still referenced beyond the official end of the transaction. That can cause errors like "Allocated a page that is still referenced"

Fixes #970 