### PR TITLE
Move begin_read() and cache_stats() to trait

### DIFF
--- a/crates/redb-bench/benches/common.rs
+++ b/crates/redb-bench/benches/common.rs
@@ -1,5 +1,5 @@
 use heed::{CompactionOption, EnvInfo};
-use redb::{AccessGuard, ReadableTableMetadata, TableDefinition};
+use redb::{AccessGuard, ReadableDatabase, ReadableTableMetadata, TableDefinition};
 use rocksdb::{
     Direction, IteratorMode, OptimisticTransactionDB, OptimisticTransactionOptions, WriteOptions,
 };

--- a/crates/redb-bench/benches/multithreaded_insert_benchmark.rs
+++ b/crates/redb-bench/benches/multithreaded_insert_benchmark.rs
@@ -4,7 +4,7 @@ use tempfile::NamedTempFile;
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use redb::{Database, ReadableTableMetadata, TableDefinition};
+use redb::{Database, ReadableDatabase, ReadableTableMetadata, TableDefinition};
 use std::time::Instant;
 
 const ELEMENTS: u64 = 1_000_000;

--- a/crates/redb-derive/tests/derive_tests.rs
+++ b/crates/redb-derive/tests/derive_tests.rs
@@ -1,4 +1,4 @@
-use redb::{Database, Key, TableDefinition, Value};
+use redb::{Database, Key, ReadableDatabase, TableDefinition, Value};
 use redb_derive::{Key, Value};
 use std::fmt::Debug;
 use tempfile::NamedTempFile;

--- a/examples/bincode_keys.rs
+++ b/examples/bincode_keys.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use std::fmt::Debug;
 
 use bincode::{Decode, Encode, decode_from_slice, encode_to_vec};
-use redb::{Database, Error, Key, Range, TableDefinition, TypeName, Value};
+use redb::{Database, Error, Key, Range, ReadableDatabase, TableDefinition, TypeName, Value};
 
 #[derive(Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord)]
 struct SomeKey {

--- a/examples/int_keys.rs
+++ b/examples/int_keys.rs
@@ -1,4 +1,4 @@
-use redb::{Database, Error, TableDefinition};
+use redb::{Database, Error, ReadableDatabase, TableDefinition};
 
 const TABLE: TableDefinition<u64, u64> = TableDefinition::new("my_data");
 

--- a/examples/multithread.rs
+++ b/examples/multithread.rs
@@ -1,5 +1,5 @@
-use redb::TableHandle;
 use redb::{Database, Error, TableDefinition};
+use redb::{ReadableDatabase, TableHandle};
 use std::time::Instant;
 use std::{sync::Arc, time::Duration};
 

--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -3,7 +3,7 @@
 use libfuzzer_sys::fuzz_target;
 use redb::{
     AccessGuard, Database, Durability, Error, MultimapTable, MultimapTableDefinition,
-    MultimapValue, ReadableMultimapTable, ReadableTable, ReadableTableMetadata, Savepoint,
+    MultimapValue, ReadableDatabase, ReadableMultimapTable, ReadableTable, ReadableTableMetadata, Savepoint,
     StorageBackend, Table, TableDefinition, WriteTransaction,
 };
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! # Example
 //!
 //! ```
-//! use redb::{Database, Error, ReadableTable, TableDefinition};
+//! use redb::{Database, Error, ReadableDatabase, ReadableTable, TableDefinition};
 //!
 //! const TABLE: TableDefinition<&str, u64> = TableDefinition::new("my_data");
 //!
@@ -63,8 +63,9 @@
 //! [design]: https://github.com/cberner/redb/blob/master/docs/design.md
 
 pub use db::{
-    Builder, CacheStats, Database, MultimapTableDefinition, MultimapTableHandle, RepairSession,
-    StorageBackend, TableDefinition, TableHandle, UntypedMultimapTableHandle, UntypedTableHandle,
+    Builder, CacheStats, Database, MultimapTableDefinition, MultimapTableHandle, ReadableDatabase,
+    RepairSession, StorageBackend, TableDefinition, TableHandle, UntypedMultimapTableHandle,
+    UntypedTableHandle,
 };
 pub use error::{
     CommitError, CompactionError, DatabaseError, Error, SavepointError, SetDurabilityError,

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -397,7 +397,6 @@ impl TransactionHeader {
 
 #[cfg(test)]
 mod test {
-    use crate::StorageError;
     use crate::backends::FileBackend;
     use crate::db::TableDefinition;
     use crate::tree_store::page_store::TransactionalMemory;
@@ -406,6 +405,7 @@ mod test {
         TRANSACTION_0_OFFSET, TRANSACTION_1_OFFSET, TWO_PHASE_COMMIT, USER_ROOT_OFFSET,
     };
     use crate::{Database, DatabaseError, ReadableTable};
+    use crate::{ReadableDatabase, StorageError};
     use std::fs::OpenOptions;
     use std::io::{Read, Seek, SeekFrom, Write};
     use std::mem::size_of;

--- a/src/types/chrono_v0_4.rs
+++ b/src/types/chrono_v0_4.rs
@@ -337,7 +337,7 @@ fn time_from_bytes(data: &[u8]) -> NaiveTime {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Database, Key, TableDefinition, Value};
+    use crate::{Database, Key, ReadableDatabase, TableDefinition, Value};
     use chrono_v0_4::{
         DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone,
     };

--- a/src/types/uuid.rs
+++ b/src/types/uuid.rs
@@ -43,7 +43,7 @@ impl Key for Uuid {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Database, Key, TableDefinition, Value};
+    use crate::{Database, Key, ReadableDatabase, TableDefinition, Value};
     use tempfile::NamedTempFile;
     use uuid::Uuid;
 

--- a/tests/backward_compatibility.rs
+++ b/tests/backward_compatibility.rs
@@ -1,4 +1,4 @@
-use redb::{Legacy, ReadableTableMetadata, TableError};
+use redb::{Legacy, ReadableDatabase, ReadableTableMetadata, TableError};
 
 const ELEMENTS: usize = 3;
 

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1,8 +1,9 @@
 use rand::random;
 use redb::backends::InMemoryBackend;
 use redb::{
-    Database, Key, Legacy, MultimapTableDefinition, MultimapTableHandle, Range, ReadableTable,
-    ReadableTableMetadata, TableDefinition, TableError, TableHandle, TypeName, Value,
+    Database, Key, Legacy, MultimapTableDefinition, MultimapTableHandle, Range, ReadableDatabase,
+    ReadableTable, ReadableTableMetadata, TableDefinition, TableError, TableHandle, TypeName,
+    Value,
 };
 use std::cmp::Ordering;
 #[cfg(not(target_os = "wasi"))]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3,8 +3,9 @@ use rand::prelude::SliceRandom;
 use redb::backends::FileBackend;
 use redb::{
     AccessGuard, Builder, CompactionError, Database, Durability, Key, MultimapRange,
-    MultimapTableDefinition, MultimapValue, Range, ReadableTable, ReadableTableMetadata,
-    SetDurabilityError, StorageBackend, TableDefinition, TableStats, TransactionError, Value,
+    MultimapTableDefinition, MultimapValue, Range, ReadableDatabase, ReadableTable,
+    ReadableTableMetadata, SetDurabilityError, StorageBackend, TableDefinition, TableStats,
+    TransactionError, Value,
 };
 use redb::{DatabaseError, ReadableMultimapTable, SavepointError, StorageError, TableError};
 use std::borrow::Borrow;

--- a/tests/multimap_tests.rs
+++ b/tests/multimap_tests.rs
@@ -1,5 +1,6 @@
 use redb::{
-    Database, MultimapTableDefinition, ReadableMultimapTable, ReadableTableMetadata, TableError,
+    Database, MultimapTableDefinition, ReadableDatabase, ReadableMultimapTable,
+    ReadableTableMetadata, TableError,
 };
 
 const STR_TABLE: MultimapTableDefinition<&str, &str> = MultimapTableDefinition::new("str_to_str");

--- a/tests/multithreading_tests.rs
+++ b/tests/multithreading_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(not(target_os = "wasi"))]
 mod multithreading_test {
-    use redb::{Database, ReadableTable, ReadableTableMetadata, TableDefinition};
+    use redb::{Database, ReadableDatabase, ReadableTable, ReadableTableMetadata, TableDefinition};
     use std::sync::Arc;
     use std::thread;
 


### PR DESCRIPTION
This prepares the API to support opening databases in read-only mode, where multiple processes can open the same database