### PR TITLE
Add ReadOnlyDatabase and Builder::open_read_only

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -207,7 +207,7 @@ impl std::error::Error for TableError {}
 pub enum DatabaseError {
     /// The Database is already open. Cannot acquire lock.
     DatabaseAlreadyOpen,
-    /// [`crate::RepairSession::abort`] was called.
+    /// [`crate::RepairSession::abort`] was called or repair was aborted for another reason (such as the database being read-only).
     RepairAborted,
     /// The database file is in an old file format and must be manually upgraded
     UpgradeRequired(u8),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,9 +65,9 @@
 //! [design]: https://github.com/cberner/redb/blob/master/docs/design.md
 
 pub use db::{
-    Builder, CacheStats, Database, MultimapTableDefinition, MultimapTableHandle, ReadableDatabase,
-    RepairSession, StorageBackend, TableDefinition, TableHandle, UntypedMultimapTableHandle,
-    UntypedTableHandle,
+    Builder, CacheStats, Database, MultimapTableDefinition, MultimapTableHandle, ReadOnlyDatabase,
+    ReadableDatabase, RepairSession, StorageBackend, TableDefinition, TableHandle,
+    UntypedMultimapTableHandle, UntypedTableHandle,
 };
 pub use error::{
     CommitError, CompactionError, DatabaseError, Error, SavepointError, SetDurabilityError,

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use btree_base::{
     LeafMutator, RawLeafBuilder,
 };
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, BtreeExtractIf, BtreeRangeIter};
+pub(crate) use page_store::ReadOnlyBackend;
 pub(crate) use page_store::{
     FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page, PageHint, PageNumber,
     PageTrackerPolicy, SerializedSavepoint, ShrinkPolicy, TransactionalMemory,

--- a/src/tree_store/page_store/backends.rs
+++ b/src/tree_store/page_store/backends.rs
@@ -1,6 +1,44 @@
 use crate::StorageBackend;
 use std::io;
+use std::io::Error;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+#[derive(Debug)]
+pub(crate) struct ReadOnlyBackend {
+    inner: Box<dyn StorageBackend>,
+}
+
+impl ReadOnlyBackend {
+    pub fn new(inner: Box<dyn StorageBackend>) -> Self {
+        Self { inner }
+    }
+}
+
+impl StorageBackend for ReadOnlyBackend {
+    fn len(&self) -> Result<u64, Error> {
+        self.inner.len()
+    }
+
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), Error> {
+        self.inner.read(offset, out)
+    }
+
+    fn set_len(&self, _len: u64) -> Result<(), Error> {
+        unreachable!()
+    }
+
+    fn sync_data(&self) -> Result<(), Error> {
+        unreachable!()
+    }
+
+    fn write(&self, _offset: u64, _data: &[u8]) -> Result<(), Error> {
+        unreachable!()
+    }
+
+    fn close(&self) -> Result<(), Error> {
+        self.inner.close()
+    }
+}
 
 /// Acts as temporal in-memory database storage.
 #[derive(Debug, Default)]

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -24,7 +24,17 @@ pub struct FileBackend {
 impl FileBackend {
     /// Creates a new backend which stores data to the given file.
     pub fn new(file: File) -> Result<Self, DatabaseError> {
-        match file.try_lock() {
+        Self::new_internal(file, false)
+    }
+
+    pub(crate) fn new_internal(file: File, read_only: bool) -> Result<Self, DatabaseError> {
+        let result = if read_only {
+            file.try_lock_shared()
+        } else {
+            file.try_lock()
+        };
+
+        match result {
             Ok(()) => Ok(Self {
                 file,
                 lock_supported: true,

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -1,3 +1,4 @@
+mod backends;
 mod base;
 mod bitmap;
 mod buddy_allocator;
@@ -5,7 +6,6 @@ mod cached_file;
 mod fast_hash;
 pub mod file_backend;
 mod header;
-mod in_memory_backend;
 mod layout;
 mod lru_cache;
 mod page_manager;
@@ -14,11 +14,12 @@ mod savepoint;
 #[allow(clippy::pedantic, dead_code)]
 mod xxh3;
 
+pub use backends::InMemoryBackend;
+pub(crate) use backends::ReadOnlyBackend;
 pub(crate) use base::{
     MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTrackerPolicy,
 };
 pub(crate) use header::PAGE_SIZE;
-pub use in_memory_backend::InMemoryBackend;
 pub(crate) use page_manager::{
     FILE_FORMAT_VERSION3, ShrinkPolicy, TransactionalMemory, xxh3_checksum,
 };

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -137,6 +137,7 @@ impl TransactionalMemory {
         requested_region_size: Option<u64>,
         read_cache_size_bytes: usize,
         write_cache_size_bytes: usize,
+        read_only: bool,
     ) -> Result<Self, DatabaseError> {
         assert!(page_size.is_power_of_two() && page_size >= DB_HEADER_SIZE);
 
@@ -237,6 +238,9 @@ impl TransactionalMemory {
         let needs_recovery =
             header.recovery_required || header.layout().len() != storage.raw_file_len()?;
         if needs_recovery {
+            if read_only {
+                return Err(DatabaseError::RepairAborted);
+            }
             let layout = header.layout();
             let region_max_pages = layout.full_region_layout().num_pages();
             let region_header_pages = layout.full_region_layout().get_header_pages();


### PR DESCRIPTION
This allows a database to be opened by multiple processes, concurrently, in read-only mode

Fixes #958

Fixes #811 