### PR TITLE
Change StorageBackend::read() to take output arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Fixed width tuples, such as `(u32, u64)` are backwards compatible.
 * Add `chrono_v0_4` feature flag which enables serialization of the `NaiveDate`, `NaiveTime`,
   `NaiveDatetime`, `DateTime<FixedOffset>`, and `FixedOffset` types in the `chrono` crate
 * Add `uuid` feature flag which enables serialization of the `Uuid` type in the `uuid` crate
+* Change `StorageBackend::read()` to accept a `&mut [u8]` output argument instead of returning
+  a `Vec<u8>`
 * Change `TypeName::name()` to be public
 * Change `ReadTransactionStillInUse` to contain a `Box`
 * Change `set_durability()` to return a `Result`

--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -74,9 +74,9 @@ impl StorageBackend for FuzzerBackend {
         self.inner.len()
     }
 
-    fn read(&self, offset: u64, len: usize) -> Result<Vec<u8>, std::io::Error> {
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
         self.check_countdown()?;
-        self.inner.read(offset, len)
+        self.inner.read(offset, out)
     }
 
     fn set_len(&self, len: u64) -> Result<(), std::io::Error> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -35,8 +35,8 @@ pub trait StorageBackend: 'static + Debug + Send + Sync {
 
     /// Reads the specified array of bytes from the storage.
     ///
-    /// If `len` + `offset` exceeds the length of the storage an appropriate `Error` should be returned or a panic may occur.
-    fn read(&self, offset: u64, len: usize) -> std::result::Result<Vec<u8>, io::Error>;
+    /// If `out.len()` + `offset` exceeds the length of the storage an appropriate `Error` should be returned or a panic may occur.
+    fn read(&self, offset: u64, out: &mut [u8]) -> std::result::Result<(), io::Error>;
 
     /// Sets the length of the storage.
     ///
@@ -1101,9 +1101,9 @@ mod test {
             self.inner.len()
         }
 
-        fn read(&self, offset: u64, len: usize) -> Result<Vec<u8>, std::io::Error> {
+        fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
             self.check_countdown()?;
-            self.inner.read(offset, len)
+            self.inner.read(offset, out)
         }
 
         fn set_len(&self, len: u64) -> Result<(), std::io::Error> {

--- a/src/tree_store/page_store/file_backend/fallback.rs
+++ b/src/tree_store/page_store/file_backend/fallback.rs
@@ -24,12 +24,11 @@ impl StorageBackend for FileBackend {
         Ok(self.file.lock().unwrap().metadata()?.len())
     }
 
-    fn read(&self, offset: u64, len: usize) -> Result<Vec<u8>, io::Error> {
-        let mut result = vec![0; len];
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), io::Error> {
         let mut file = self.file.lock().unwrap();
         file.seek(SeekFrom::Start(offset))?;
-        file.read_exact(&mut result)?;
-        Ok(result)
+        file.read_exact(out)?;
+        Ok(())
     }
 
     fn set_len(&self, len: u64) -> Result<(), io::Error> {

--- a/src/tree_store/page_store/file_backend/unix.rs
+++ b/src/tree_store/page_store/file_backend/unix.rs
@@ -53,10 +53,9 @@ impl StorageBackend for FileBackend {
         Ok(self.file.metadata()?.len())
     }
 
-    fn read(&self, offset: u64, len: usize) -> Result<Vec<u8>, io::Error> {
-        let mut buffer = vec![0; len];
-        self.file.read_exact_at(&mut buffer, offset)?;
-        Ok(buffer)
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), io::Error> {
+        self.file.read_exact_at(out, offset)?;
+        Ok(())
     }
 
     fn set_len(&self, len: u64) -> Result<(), io::Error> {

--- a/src/tree_store/page_store/file_backend/windows.rs
+++ b/src/tree_store/page_store/file_backend/windows.rs
@@ -65,15 +65,14 @@ impl StorageBackend for FileBackend {
         Ok(self.file.metadata()?.len())
     }
 
-    fn read(&self, mut offset: u64, len: usize) -> Result<Vec<u8>, io::Error> {
-        let mut buffer = vec![0; len];
+    fn read(&self, mut offset: u64, out: &mut [u8]) -> Result<(), io::Error> {
         let mut data_offset = 0;
-        while data_offset < buffer.len() {
-            let read = self.file.seek_read(&mut buffer[data_offset..], offset)?;
+        while data_offset < out.len() {
+            let read = self.file.seek_read(&mut out[data_offset..], offset)?;
             offset += read as u64;
             data_offset += read;
         }
-        Ok(buffer)
+        Ok(())
     }
 
     fn set_len(&self, len: u64) -> Result<(), io::Error> {

--- a/src/tree_store/page_store/in_memory_backend.rs
+++ b/src/tree_store/page_store/in_memory_backend.rs
@@ -34,11 +34,12 @@ impl StorageBackend for InMemoryBackend {
         Ok(self.read().len() as u64)
     }
 
-    fn read(&self, offset: u64, len: usize) -> Result<Vec<u8>, io::Error> {
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), io::Error> {
         let guard = self.read();
         let offset = usize::try_from(offset).map_err(|_| Self::out_of_range())?;
-        if offset + len <= guard.len() {
-            Ok(guard[offset..offset + len].to_owned())
+        if offset + out.len() <= guard.len() {
+            out.copy_from_slice(&guard[offset..offset + out.len()]);
+            Ok(())
         } else {
             Err(Self::out_of_range())
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -66,8 +66,8 @@ fn previous_io_error() {
             self.inner.len()
         }
 
-        fn read(&self, offset: u64, len: usize) -> Result<Vec<u8>, std::io::Error> {
-            self.inner.read(offset, len)
+        fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
+            self.inner.read(offset, out)
         }
 
         fn set_len(&self, len: u64) -> Result<(), std::io::Error> {


### PR DESCRIPTION
This allows for potential future optimizations that reuse these read buffers