### PR TITLE
Improve write performance by 5-10%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Fixed width tuples, such as `(u32, u64)` are backwards compatible.
 * Remove `Durability::Paranoid`
 * Disallow access to the database from read transactions after the `Database` as been
   dropped. Access will now return `DatabaseClosed`
+* Optimize writes: 5-10% performance improvement on benchmarks
 
 ## 2.6.0 - 2025-05-22
 

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -218,7 +218,7 @@ pub(crate) fn relocate_subtrees(
             );
             // TODO: maybe there's a better abstraction, so that we don't need to call into this low-level method?
             let mut mutator = LeafMutator::new(
-                &mut new_page,
+                new_page.memory_mut(),
                 key_size,
                 UntypedDynamicCollection::fixed_width_with(value_size),
             );
@@ -245,7 +245,7 @@ pub(crate) fn relocate_subtrees(
         }
         BRANCH => {
             let accessor = BranchAccessor::new(&old_page, key_size);
-            let mut mutator = BranchMutator::new(&mut new_page);
+            let mut mutator = BranchMutator::new(new_page.memory_mut());
             for i in 0..accessor.count_children() {
                 if let Some(child) = accessor.child_page(i) {
                     let child_checksum = accessor.child_checksum(i).unwrap();
@@ -318,7 +318,7 @@ pub(crate) fn finalize_tree_and_subtree_checksums(
         }
         // TODO: maybe there's a better abstraction, so that we don't need to call into this low-level method?
         let mut mutator = LeafMutator::new(
-            &mut leaf_page,
+            leaf_page.memory_mut(),
             key_size,
             DynamicCollection::<()>::fixed_width_with(value_size),
         );

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -193,7 +193,7 @@ impl UntypedBtreeMut {
                     }
                 }
 
-                let mut mutator = BranchMutator::new(&mut page);
+                let mut mutator = BranchMutator::new(page.memory_mut());
                 for (child_index, child_page, child_checksum) in new_children.into_iter().flatten()
                 {
                     mutator.write_child_page(child_index, child_page, child_checksum);
@@ -294,7 +294,7 @@ impl UntypedBtreeMut {
             }
             BRANCH => {
                 let accessor = BranchAccessor::new(&old_page, self.key_width);
-                let mut mutator = BranchMutator::new(&mut new_page);
+                let mut mutator = BranchMutator::new(new_page.memory_mut());
                 for i in 0..accessor.count_children() {
                     let child = accessor.child_page(i).unwrap();
                     if let Some((new_child, new_checksum)) =
@@ -579,7 +579,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
                     drop(old_child_page);
                     freed_pages.push(child_page);
 
-                    let mut mutator = BranchMutator::new(&mut page);
+                    let mut mutator = BranchMutator::new(page.memory_mut());
                     mutator.write_child_page(child_index, new_page.get_page_number(), DEFERRED);
                     new_page
                 };


### PR DESCRIPTION
Refactor to reduce the number of calls to memory_mut() which calls into Arc::try_unwrap() which requires atomic operations