### PR TITLE
Remove Durability::Eventual

### DIFF
--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -84,7 +84,7 @@ impl StorageBackend for FuzzerBackend {
         self.inner.set_len(len)
     }
 
-    fn sync_data(&self, _eventual: bool) -> Result<(), std::io::Error> {
+    fn sync_data(&self) -> Result<(), std::io::Error> {
         self.decrement_countdown()?;
         // No-op. The fuzzer doesn't test crashes, so fsync is unnecessary
         Ok(())

--- a/src/db.rs
+++ b/src/db.rs
@@ -442,7 +442,7 @@ impl Database {
             let next_transaction_id = self.mem.get_last_committed_transaction_id()?.next();
             let [data_root, system_root] = new_roots;
             self.mem
-                .commit(data_root, system_root, next_transaction_id, false, true)?;
+                .commit(data_root, system_root, next_transaction_id, true)?;
         }
 
         self.mem.begin_writable()?;
@@ -727,7 +727,7 @@ impl Database {
             }
             let [data_root, system_root] = Self::do_repair(&mut mem, repair_callback)?;
             let next_transaction_id = mem.get_last_committed_transaction_id()?.next();
-            mem.commit(data_root, system_root, next_transaction_id, false, true)?;
+            mem.commit(data_root, system_root, next_transaction_id, true)?;
         }
 
         mem.begin_writable()?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -44,11 +44,7 @@ pub trait StorageBackend: 'static + Debug + Send + Sync {
     fn set_len(&self, len: u64) -> std::result::Result<(), io::Error>;
 
     /// Syncs all buffered data with the persistent storage.
-    ///
-    /// If `eventual` is true, data may become persistent at some point after this call returns,
-    /// but the storage must gaurantee that a write barrier is inserted: i.e. all writes before this
-    /// call to `sync_data()` will become persistent before any writes that occur after.
-    fn sync_data(&self, eventual: bool) -> std::result::Result<(), io::Error>;
+    fn sync_data(&self) -> std::result::Result<(), io::Error>;
 
     /// Writes the specified array to the storage.
     fn write(&self, offset: u64, data: &[u8]) -> std::result::Result<(), io::Error>;
@@ -1111,9 +1107,9 @@ mod test {
             self.inner.set_len(len)
         }
 
-        fn sync_data(&self, eventual: bool) -> Result<(), std::io::Error> {
+        fn sync_data(&self) -> Result<(), std::io::Error> {
             self.check_countdown()?;
-            self.inner.sync_data(eventual)
+            self.inner.sync_data()
         }
 
         fn write(&self, offset: u64, data: &[u8]) -> Result<(), std::io::Error> {

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -173,7 +173,7 @@ impl CheckedBackend {
 
     fn sync_data(&self) -> Result<()> {
         self.check_failure()?;
-        let result = self.file.sync_data(false);
+        let result = self.file.sync_data();
         if result.is_err() {
             self.io_failed.store(true, Ordering::Release);
         }

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -171,9 +171,9 @@ impl CheckedBackend {
         result.map_err(StorageError::from)
     }
 
-    fn sync_data(&self, eventual: bool) -> Result<()> {
+    fn sync_data(&self) -> Result<()> {
         self.check_failure()?;
-        let result = self.file.sync_data(eventual);
+        let result = self.file.sync_data(false);
         if result.is_err() {
             self.io_failed.store(true, Ordering::Release);
         }
@@ -303,10 +303,10 @@ impl PagedCachedFile {
         self.file.set_len(len)
     }
 
-    pub(super) fn flush(&self, eventual: bool) -> Result {
+    pub(super) fn flush(&self) -> Result {
         self.flush_write_buffer()?;
 
-        self.file.sync_data(eventual)
+        self.file.sync_data()
     }
 
     // Make writes visible to readers, but does not guarantee any durability

--- a/src/tree_store/page_store/file_backend/fallback.rs
+++ b/src/tree_store/page_store/file_backend/fallback.rs
@@ -35,7 +35,7 @@ impl StorageBackend for FileBackend {
         self.file.lock().unwrap().set_len(len)
     }
 
-    fn sync_data(&self, _eventual: bool) -> Result<(), io::Error> {
+    fn sync_data(&self) -> Result<(), io::Error> {
         self.file.lock().unwrap().sync_data()
     }
 

--- a/src/tree_store/page_store/file_backend/unix.rs
+++ b/src/tree_store/page_store/file_backend/unix.rs
@@ -62,23 +62,8 @@ impl StorageBackend for FileBackend {
         self.file.set_len(len)
     }
 
-    #[cfg(not(target_os = "macos"))]
-    fn sync_data(&self, _: bool) -> Result<(), io::Error> {
+    fn sync_data(&self) -> Result<(), io::Error> {
         self.file.sync_data()
-    }
-
-    #[cfg(target_os = "macos")]
-    fn sync_data(&self, eventual: bool) -> Result<(), io::Error> {
-        if eventual {
-            let code = unsafe { libc::fcntl(self.file.as_raw_fd(), libc::F_BARRIERFSYNC) };
-            if code == -1 {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(())
-            }
-        } else {
-            self.file.sync_data()
-        }
     }
 
     fn write(&self, offset: u64, data: &[u8]) -> Result<(), io::Error> {

--- a/src/tree_store/page_store/file_backend/windows.rs
+++ b/src/tree_store/page_store/file_backend/windows.rs
@@ -79,7 +79,7 @@ impl StorageBackend for FileBackend {
         self.file.set_len(len)
     }
 
-    fn sync_data(&self, _: bool) -> Result<(), io::Error> {
+    fn sync_data(&self) -> Result<(), io::Error> {
         self.file.sync_data()
     }
 

--- a/src/tree_store/page_store/in_memory_backend.rs
+++ b/src/tree_store/page_store/in_memory_backend.rs
@@ -61,7 +61,7 @@ impl StorageBackend for InMemoryBackend {
         Ok(())
     }
 
-    fn sync_data(&self, _: bool) -> Result<(), io::Error> {
+    fn sync_data(&self) -> Result<(), io::Error> {
         Ok(())
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -74,11 +74,11 @@ fn previous_io_error() {
             self.inner.set_len(len)
         }
 
-        fn sync_data(&self, eventual: bool) -> Result<(), std::io::Error> {
+        fn sync_data(&self) -> Result<(), std::io::Error> {
             if self.fail_flag.load(Ordering::SeqCst) {
                 Err(std::io::Error::from(ErrorKind::Other))
             } else {
-                self.inner.sync_data(eventual)
+                self.inner.sync_data()
             }
         }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -193,11 +193,6 @@ fn test_persistence(durability: Durability) {
 }
 
 #[test]
-fn eventual_persistence() {
-    test_persistence(Durability::Eventual);
-}
-
-#[test]
 fn immediate_persistence() {
     test_persistence(Durability::Immediate);
 }
@@ -205,11 +200,6 @@ fn immediate_persistence() {
 #[test]
 fn immediate_free() {
     test_free(Durability::Immediate);
-}
-
-#[test]
-fn eventual_free() {
-    test_free(Durability::Eventual);
 }
 
 #[test]
@@ -1342,10 +1332,6 @@ fn no_downgrade_durability_with_savepoint() {
 
     let mut tx = db.begin_write().unwrap();
     tx.persistent_savepoint().unwrap();
-    assert!(matches!(
-        tx.set_durability(Durability::Eventual),
-        Err(SetDurabilityError::PersistentSavepointModified)
-    ));
     assert!(matches!(
         tx.set_durability(Durability::None),
         Err(SetDurabilityError::PersistentSavepointModified)


### PR DESCRIPTION
The WriteTransaction::commit() API is
problematic when used with barrier sync, since there is no way to report
an error that might occur while writing out the data.

Applications that need this feature can implement it with a custom
StorageBackend. It was only implemented on macOS and called fcntl() with
F_BARRIERFSYNC. On all other platforms Durability::Eventual was
equivalent to Durability::Immediate