### PR TITLE
Add containerized benchmark justfile target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*
+!src/
+!crates/
+!tests/
+!examples/
+!cargo/
+!./*.toml
+!./build.rs
+!./rust-toolchain
+!./LICENSE
+**/target/

--- a/Dockerfile.bench
+++ b/Dockerfile.bench
@@ -1,0 +1,15 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt install -y git build-essential curl libclang-dev
+
+ENV PATH=/root/.cargo/bin:$PATH
+
+ADD rust-toolchain /code/redb/rust-toolchain
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=$(cat /code/redb/rust-toolchain)
+
+ADD . /code/redb/
+
+RUN cd /code/redb && cargo bench --no-run -p redb-bench

--- a/justfile
+++ b/justfile
@@ -48,6 +48,13 @@ test_wasi:
 bench bench='redb_benchmark': pre
     cargo bench -p redb-bench --bench {{bench}}
 
+build_bench_container:
+    docker build -t redb-bench:latest -f Dockerfile.bench .
+
+bench_containerized bench='lmdb_benchmark': build_bench_container
+    # Exec the binary directly, because at low memory limits there may not be enough to invoke cargo & rustc
+    docker run --rm -it --memory=4g redb-bench:latest bash -c "cd /code/redb && ./target/release/deps/{{bench}}-*"
+
 watch +args='test':
     cargo watch --clear --exec "{{args}}"
 


### PR DESCRIPTION
This adds a total memory limit to ensure the comparison is apples to apples, since some backends use mmap and rely on the page cache rather than a user space memory limit.