### PR TITLE
Disable database shrinking during repair

### DIFF
--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -6,8 +6,8 @@ use crate::table::ReadOnlyUntypedTable;
 use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker};
 use crate::tree_store::{
     Btree, BtreeHeader, BtreeMut, InternalTableDefinition, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page,
-    PageHint, PageListMut, PageNumber, PageTrackerPolicy, SerializedSavepoint, TableTree,
-    TableTreeMut, TableType, TransactionalMemory,
+    PageHint, PageListMut, PageNumber, PageTrackerPolicy, SerializedSavepoint, ShrinkPolicy,
+    TableTree, TableTreeMut, TableType, TransactionalMemory,
 };
 use crate::types::{Key, Value};
 use crate::{
@@ -1593,6 +1593,7 @@ impl WriteTransaction {
             system_root,
             self.transaction_id,
             self.two_phase_commit,
+            ShrinkPolicy::Default,
         )?;
 
         // Mark any pending non-durable commits as fully committed.

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use btree_base::{
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, BtreeExtractIf, BtreeRangeIter};
 pub(crate) use page_store::{
     FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page, PageHint, PageNumber,
-    PageTrackerPolicy, SerializedSavepoint, TransactionalMemory,
+    PageTrackerPolicy, SerializedSavepoint, ShrinkPolicy, TransactionalMemory,
 };
 pub use page_store::{InMemoryBackend, Savepoint, file_backend};
 pub(crate) use table_tree::{PageListMut, TableTree, TableTreeMut};

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -19,7 +19,9 @@ pub(crate) use base::{
 };
 pub(crate) use header::PAGE_SIZE;
 pub use in_memory_backend::InMemoryBackend;
-pub(crate) use page_manager::{FILE_FORMAT_VERSION3, TransactionalMemory, xxh3_checksum};
+pub(crate) use page_manager::{
+    FILE_FORMAT_VERSION3, ShrinkPolicy, TransactionalMemory, xxh3_checksum,
+};
 pub use savepoint::Savepoint;
 pub(crate) use savepoint::SerializedSavepoint;
 


### PR DESCRIPTION
This avoids some scenarios where a dirty database is opened, which causes a repair, but then shrinks in size invalidating the allocator state hash, which then causes check_integrity() to perform a second repair