### PR TITLE
Support WASI preview 2 and all WASI platforms on stable toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ log = { version = "0.4.17", optional = true }
 chrono_v0_4 = { package = "chrono", version= "0.4.41", optional = true }
 uuid = { version= "1.17.0", optional = true }
 
+[target.'cfg(target_os = "wasi")'.dependencies]
+libc = "0.2.174"
+
 # Common test/bench dependencies
 [dev-dependencies]
 rand = "0.9"

--- a/justfile
+++ b/justfile
@@ -40,10 +40,10 @@ test_all: build_all
     RUST_BACKTRACE=1 cargo test --all --all-features
 
 test_wasi:
-    rustup install nightly-2025-06-17 --target wasm32-wasip1-threads
+    rustup install nightly-2025-07-26 --target wasm32-wasip1-threads
     # Uses cargo pkgid because "redb" is ambiguous with the test dependency on an old version of redb
-    cargo +nightly-2025-06-17 test -p $(cargo pkgid) --target=wasm32-wasip1-threads -- --nocapture
-    cargo +nightly-2025-06-17 test -p redb-derive --target=wasm32-wasip1-threads -- --nocapture
+    cargo +nightly-2025-07-26 test -p $(cargo pkgid) --target=wasm32-wasip1-threads -- --nocapture
+    cargo +nightly-2025-07-26 test -p redb-derive --target=wasm32-wasip1-threads -- --nocapture
 
 bench bench='redb_benchmark': pre
     cargo bench -p redb-bench --bench {{bench}}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,6 @@
     clippy::unnecessary_wraps,
     clippy::unreadable_literal
 )]
-// TODO remove this once wasi no longer requires nightly
-#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 
 //! # redb
 //!


### PR DESCRIPTION
As `FileExt` trait is not getting stabilized [anytime soon](https://github.com/rust-lang/rust/issues/71213#issuecomment-1097758095) on WASI, I added the implementations of `read_exact_at` and `write_all_at` in `redb` itself as these are the only two functions that being used from the trait implementation. WASIp2 currently does not have this trait implemented as all, so with this addition, we get support for WASIp2 and we also eliminate the requirement of nightly toolchain for compiling on WASI platforms.