### PR TITLE
feat: support `wasm32-unknown-unknown` by disabling certain constructors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,39 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           RUSTFLAGS="" just test_wasi
+
+  wasm32-unknown-unknown:
+    runs-on: ubuntu-latest
+
+    env:
+      RUSTFLAGS: --deny warnings
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache
+        id: rust-cache
+        uses: actions/cache@v4
+        with:
+            path: |
+                ~/.cargo/bin/
+                ~/.cargo/registry/index/
+                ~/.cargo/registry/cache/
+                ~/.cargo/git/db/
+                target/
+                fuzz/target/
+            key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.toml', '.github/workflows/*.yml', 'rust-toolchain') }}
+
+      - name: Install Rust
+        run: |
+            rustup component add rustfmt
+            rustup component add clippy
+            rustup target add wasm32-unknown-unknown
+
+      - name: Compile (default features)
+        run: cargo check -p "$(cargo pkgid)" -p redb-derive --target wasm32-unknown-unknown
+
+      - name: Compile (all features)
+        run: cargo check -p "$(cargo pkgid)" -p redb-derive --target wasm32-unknown-unknown --all-features
+
+      - name: Compile (no features)
+        run: cargo check -p "$(cargo pkgid)" -p redb-derive --target wasm32-unknown-unknown --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ uuid = { version= "1.17.0", optional = true }
 [target.'cfg(target_os = "wasi")'.dependencies]
 libc = "0.2.174"
 
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+wasm_sync = "0.1"
+
 # Common test/bench dependencies
 [dev-dependencies]
 rand = "0.9"

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,9 @@
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
+#[cfg(not(target_os = "unknown"))]
+use crate::tree_store::ReadOnlyBackend;
 use crate::tree_store::{
-    BtreeHeader, InternalTableDefinition, PAGE_SIZE, PageHint, PageNumber, ReadOnlyBackend,
-    ShrinkPolicy, TableTree, TableType, TransactionalMemory,
+    BtreeHeader, InternalTableDefinition, PAGE_SIZE, PageHint, PageNumber, ShrinkPolicy, TableTree,
+    TableType, TransactionalMemory,
 };
 use crate::types::{Key, Value};
 use crate::{
@@ -10,8 +12,10 @@ use crate::{
 use crate::{ReadTransaction, Result, WriteTransaction};
 use std::fmt::{Debug, Display, Formatter};
 
+#[cfg(not(target_os = "unknown"))]
 use std::fs::{File, OpenOptions};
 use std::marker::PhantomData;
+#[cfg(not(target_os = "unknown"))]
 use std::path::Path;
 use std::sync::Arc;
 use std::{io, thread};
@@ -23,6 +27,7 @@ use crate::transactions::{
     DATA_FREED_TABLE, PageList, SYSTEM_FREED_TABLE, SystemTableDefinition,
     TransactionIdWithPagination,
 };
+#[cfg(not(target_os = "unknown"))]
 use crate::tree_store::file_backend::FileBackend;
 #[cfg(feature = "logging")]
 use log::{debug, info, warn};
@@ -381,10 +386,12 @@ impl ReadableDatabase for ReadOnlyDatabase {
 
 impl ReadOnlyDatabase {
     /// Opens an existing redb database.
+    #[cfg(not(target_os = "unknown"))]
     pub fn open(path: impl AsRef<Path>) -> Result<ReadOnlyDatabase, DatabaseError> {
         Builder::new().open_read_only(path)
     }
 
+    #[cfg(not(target_os = "unknown"))]
     fn new(
         file: Box<dyn StorageBackend>,
         page_size: usize,
@@ -484,11 +491,13 @@ impl Database {
     /// * if the file does not exist, or is an empty file, a new database will be initialized in it
     /// * if the file is a valid redb database, it will be opened
     /// * otherwise this function will return an error
+    #[cfg(not(target_os = "unknown"))]
     pub fn create(path: impl AsRef<Path>) -> Result<Database, DatabaseError> {
         Self::builder().create(path)
     }
 
     /// Opens an existing redb database.
+    #[cfg(not(target_os = "unknown"))]
     pub fn open(path: impl AsRef<Path>) -> Result<Database, DatabaseError> {
         Self::builder().open(path)
     }
@@ -1144,6 +1153,7 @@ impl Builder {
     /// * if the file does not exist, or is an empty file, a new database will be initialized in it
     /// * if the file is a valid redb database, it will be opened
     /// * otherwise this function will return an error
+    #[cfg(not(target_os = "unknown"))]
     pub fn create(&self, path: impl AsRef<Path>) -> Result<Database, DatabaseError> {
         let file = OpenOptions::new()
             .read(true)
@@ -1164,6 +1174,7 @@ impl Builder {
     }
 
     /// Opens an existing redb database.
+    #[cfg(not(target_os = "unknown"))]
     pub fn open(&self, path: impl AsRef<Path>) -> Result<Database, DatabaseError> {
         let file = OpenOptions::new().read(true).write(true).open(path)?;
 
@@ -1183,6 +1194,7 @@ impl Builder {
     /// If the file has been opened for writing (i.e. as a [`Database`]) [`DatabaseError::DatabaseAlreadyOpen`]
     /// will be returned on platforms which support file locks (macOS, Windows, Linux). On other platforms,
     /// the caller MUST avoid calling this method when the database is open for writing.
+    #[cfg(not(target_os = "unknown"))]
     pub fn open_read_only(
         &self,
         path: impl AsRef<Path>,
@@ -1200,6 +1212,7 @@ impl Builder {
     /// Open an existing or create a new database in the given `file`.
     ///
     /// The file must be empty or contain a valid database.
+    #[cfg(not(target_os = "unknown"))]
     pub fn create_file(&self, file: File) -> Result<Database, DatabaseError> {
         Database::new(
             Box::new(FileBackend::new(file)?),

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -7,7 +7,13 @@ use std::collections::btree_map::BTreeMap;
 use std::collections::{BTreeSet, HashMap};
 use std::mem;
 use std::mem::size_of;
-use std::sync::{Condvar, Mutex};
+use std::sync::Mutex;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use wasm_sync::Condvar;
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+use std::sync::Condvar;
 
 #[derive(Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub(crate) struct TransactionId(u64);

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use btree_base::{
     LeafMutator, RawLeafBuilder,
 };
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, BtreeExtractIf, BtreeRangeIter};
+#[cfg(not(target_os = "unknown"))]
 pub(crate) use page_store::ReadOnlyBackend;
 pub(crate) use page_store::{
     FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page, PageHint, PageNumber,

--- a/src/tree_store/page_store/backends.rs
+++ b/src/tree_store/page_store/backends.rs
@@ -1,19 +1,23 @@
 use crate::StorageBackend;
 use std::io;
+#[cfg(not(target_os = "unknown"))]
 use std::io::Error;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
+#[cfg(not(target_os = "unknown"))]
 #[derive(Debug)]
 pub(crate) struct ReadOnlyBackend {
     inner: Box<dyn StorageBackend>,
 }
 
+#[cfg(not(target_os = "unknown"))]
 impl ReadOnlyBackend {
     pub fn new(inner: Box<dyn StorageBackend>) -> Self {
         Self { inner }
     }
 }
 
+#[cfg(not(target_os = "unknown"))]
 impl StorageBackend for ReadOnlyBackend {
     fn len(&self) -> Result<u64, Error> {
         self.inner.len()

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -15,6 +15,7 @@ mod savepoint;
 mod xxh3;
 
 pub use backends::InMemoryBackend;
+#[cfg(not(target_os = "unknown"))]
 pub(crate) use backends::ReadOnlyBackend;
 pub(crate) use base::{
     MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTrackerPolicy,


### PR DESCRIPTION
redb doesn't really care about the storage backend; it just needs something that implements the `StorageBackend` trait. That was the point of #707.

However, it doesn't actually build for `wasm32-unknown-unknown`, because there are a bunch of convenience initializers which implicitly instantiate a `FileBackend`, and of course that doesn't work on that target.

This commit simply excludes those initializers where the target os is unknown. As long as it is provided an appropriate `StorageBackend`, redb will just do its thing; it doesn't need to care in that case about how precisely the storage backend is implemented.