### PR TITLE
Improve cache flush performance

### DIFF
--- a/src/tree_store/page_store/lru_cache.rs
+++ b/src/tree_store/page_store/lru_cache.rs
@@ -95,7 +95,9 @@ impl<T> LRUCache<T> {
     }
 
     pub(crate) fn clear(&mut self) {
+        self.cache.shrink_to_fit();
         self.cache.clear();
+        self.lru_queue.shrink_to_fit();
         self.lru_queue.clear();
     }
 }


### PR DESCRIPTION
Shrink hash maps used in the page cache because iterating over them takes time proportional to the capacity of the hash map, and they become very large during large transactions, slowing down future small transactions