### PR TITLE
Fix fallback implementation of `FileBackend`

### DIFF
--- a/src/tree_store/page_store/file_backend/fallback.rs
+++ b/src/tree_store/page_store/file_backend/fallback.rs
@@ -13,6 +13,10 @@ pub struct FileBackend {
 impl FileBackend {
     /// Creates a new backend which stores data to the given file.
     pub fn new(file: File) -> Result<Self, DatabaseError> {
+        Self::new_internal(file, false)
+    }
+
+    pub(crate) fn new_internal(file: File, _: bool) -> Result<Self, DatabaseError> {
         Ok(Self {
             file: Mutex::new(file),
         })


### PR DESCRIPTION
Relates to #1065.

Version 3.0 introduced `FileBackend::new_internal` which is used by `Builder::open_read_only`. This method is currently missing from the fallback implementation of `FileBackend` (used when not on Windows, Unix, or WASI), causing compilation failures on targets like WASM (see error log below).

```
> cargo clippy -p redb@3 --target wasm32-unknown-unknown
   Compiling redb v3.0.2 (/projects/redb)
error[E0599]: no function or associated item named `new_internal` found for struct `tree_store::page_store::file_backend::fallback::FileBackend` in the current scope
    --> src/db.rs:1193:35
     |
1193 |             Box::new(FileBackend::new_internal(file, true)?),
     |                                   ^^^^^^^^^^^^ function or associated item not found in `tree_store::page_store::file_backend::fallback::FileBackend`
     |
```

This PR adds a placeholder implementation of `FileBackend::new_internal`, resolving the compilation error and allowing WASM builds to succeed.

@cberner, what do you think? Would you like me to add a check for `wasm32-unknown-unknown` to the CI to prevent regressions?