### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ redb is written in pure Rust and is loosely inspired by [lmdb](http://www.lmdb.t
 of copy-on-write B-trees. For more details, see the [design doc](docs/design.md)
 
 ```rust
-use redb::{Database, Error, ReadableTable, TableDefinition};
+use redb::{Database, Error, ReadableDatabase, TableDefinition};
 
 const TABLE: TableDefinition<&str, u64> = TableDefinition::new("my_data");
 


### PR DESCRIPTION
Example in the README.md results in the following error.

```
error[E0599]: no method named `begin_read` found for struct `Database` in the current scope
```

To fix this, we import `ReadableDatabase`. Since the `ReadableTable` trait is not used, we remove the corresponding import.
