### PR TITLE
Fix ambiguity comparing against usize

### DIFF
--- a/crates/redb-derive/src/lib.rs
+++ b/crates/redb-derive/src/lib.rs
@@ -278,8 +278,7 @@ fn generate_as_bytes(fields: &Fields) -> proc_macro2::TokenStream {
                         let len = bytes.len();
                         if len < 254 {
                             result.push(len.try_into().unwrap());
-                        } else if len <= u16::MAX.into() {
-                            let u16_len: u16 = len.try_into().unwrap();
+                        } else if let Ok(u16_len) = u16::try_from(len) {
                             result.push(254u8);
                             result.extend_from_slice(&u16_len.to_le_bytes());
                         } else {


### PR DESCRIPTION
I have been getting ambiguity errors due to interaction with a dependency that declares a `PartialOrd` for `usize`. 

I haven't added a test for that case (would require partial ord, which then would be in effect in all the crate), but all the tests in the crate pass, and the change should not controversial enough. In addition, it prevents avoiding an `unwrap`;)



```rust
22 | #[derive(Serialize, Deserialize, Props, redb_derive::Value, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
   |                                         ^^^^^^^^^^^^^^^^^^ cannot infer type
   |
   = note: multiple `impl`s satisfying `usize: std::cmp::PartialOrd<_>` found in the following crates: `actix_web`, `core`:
           - impl std::cmp::PartialOrd for usize;
           - impl std::cmp::PartialOrd<actix_web::http::header::content_length::ContentLength> for usize;
```