### PR TITLE
Bump dependencies: pyo3, rusqlite, rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libc = "0.2.174"
 
 # Common test/bench dependencies
 [dev-dependencies]
-rand = "0.9"
+rand = "0.10.0"
 tempfile = "3.5.0"
 # for backwards compatibility testing - pin at 2.6.0
 redb2_6 = { version = "=2.6.0", package = "redb" }

--- a/crates/redb-bench/Cargo.toml
+++ b/crates/redb-bench/Cargo.toml
@@ -23,7 +23,7 @@ ctrlc = "3.2.3"
 heed = "0.22"
 rocksdb = { version = "0.22.0", default-features = false, features = ["lz4"] }
 fjall = "=2.11"
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { version = "0.38.0", features = ["bundled"] }
 comfy-table = "7.0.1"
 env_logger = "0.11"
 

--- a/crates/redb-python/Cargo.toml
+++ b/crates/redb-python/Cargo.toml
@@ -16,10 +16,10 @@ doc = false
 crate-type = ["cdylib"]
 
 [build-dependencies]
-pyo3-build-config = "0.24.1"
+pyo3-build-config = "0.28.1"
 
 [dependencies]
-pyo3 = { version = "0.24.1", features=["extension-module", "abi3-py37"] }
+pyo3 = { version = "0.28.1", features=["extension-module", "abi3-py37"] }
 redb = { path = "../.." }
 
 [dev-dependencies]

--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -344,7 +344,7 @@ mod test {
     use crate::tree_store::page_store::bitmap::BtreeBitmap;
     use rand::prelude::IteratorRandom;
     use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt, SeedableRng};
     use std::collections::HashSet;
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use rand::prelude::SliceRandom;
 use redb::backends::FileBackend;
 use redb::{


### PR DESCRIPTION
From this [report](https://deps.rs/repo/github/cberner/redb), I noticed that a handful of dependencies are outdated, so I updated some, starting from the simplest.
No behavior change, and minimal code change was required.

## Changes Summary
### Dependency Bumps
| Package             | Crate       | Section                | Old    | New    |
|---------------------|-------------|------------------------|--------|--------|
| `rand`              | redb (root) | `[dev-dependencies]`   | 0.9    | 0.10.0 |
| `rusqlite`          | redb-bench  | `[dependencies]`       | 0.37   | 0.38.0 |
| `pyo3`              | redb-python | `[dependencies]`       | 0.24.1 | 0.28.1 |
| `pyo3-build-config` | redb-python | `[build-dependencies]` | 0.24.1 | 0.28.1 |

### Code Adjustments (required by `rand` 0.9 -> 0.10 API change)
In `rand` 0.10, methods `random()`, `random_range()`, and `random_bool()` moved from the
`Rng` trait to the new `RngExt` trait. Two files updated:

- `tests/integration_tests.rs`: `use rand::Rng` -> `use rand::RngExt`
- `src/tree_store/page_store/bitmap.rs`: `use rand::{Rng, SeedableRng}` -> `use rand::{RngExt, SeedableRng}`

### Files Changed (5 total)
1. `Cargo.toml` - bump `rand`
2. `crates/redb-bench/Cargo.toml` - bump `rusqlite`
3. `crates/redb-python/Cargo.toml` - bump `pyo3` + `pyo3-build-config`
4. `src/tree_store/page_store/bitmap.rs` - `rand::Rng` -> `rand::RngExt` (test code)
5. `tests/integration_tests.rs` - `rand::Rng` -> `rand::RngExt`

---

## Verification
All checks performed with `RUSTFLAGS="--deny warnings"`.

- **redb-bench**: Could not build locally due to WSL2 cross-filesystem permission errors in native C library build scripts (`libsqlite3-sys`, `lz4-sys`, `librocksdb-sys`). This is an environment limitation, not a code issue. CI runners on native Ubuntu/macOS/Windows will build this crate without issue. The Rust-level `cargo check` for the bench crate itself succeeded (the failure is only in the C library linking phase).

- **redb-python**: Compilation and clippy verified. Full Python wrapper tests (`just test_py`)
  require CPython 3.12 + maturin which will run in CI.

- **pyo3 0.24 -> 0.28**: No code changes needed; `abi3-py37` feature and `extension-module`
  feature both compile cleanly.

- **rusqlite 0.37 -> 0.38**: No code changes needed in the benchmark crate.