### PR TITLE
Fix data corruption when renaming tables with dirty checksums

### DIFF
--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -211,8 +211,9 @@ pub(crate) struct TableTreeMut<'txn> {
     tree: BtreeMut<'txn, &'static str, InternalTableDefinition>,
     guard: Arc<TransactionGuard>,
     mem: Arc<TransactionalMemory>,
-    // Cached updates from tables that have been closed. These must be flushed to the btree
-    pending_table_updates: HashMap<String, (Option<BtreeHeader>, u64)>,
+    // Cached updates from tables that have been closed. These must be flushed to the btree.
+    // The bool indicates whether the root has dirty (DEFERRED) checksums that need finalization.
+    pending_table_updates: HashMap<String, (Option<BtreeHeader>, u64, bool)>,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
     allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
 }
@@ -280,8 +281,11 @@ impl TableTreeMut<'_> {
         table_root: Option<BtreeHeader>,
         length: u64,
     ) {
+        let dirty = table_root
+            .as_ref()
+            .is_some_and(|header| self.mem.uncommitted(header.root));
         self.pending_table_updates
-            .insert(name.to_string(), (table_root, length));
+            .insert(name.to_string(), (table_root, length, dirty));
     }
 
     pub(crate) fn clear_root_updates_and_close(&mut self) {
@@ -314,15 +318,17 @@ impl TableTreeMut<'_> {
     }
 
     pub(crate) fn flush_table_root_updates(&mut self) -> Result<&mut Self> {
-        for (name, (new_root, new_length)) in self.pending_table_updates.drain() {
+        for (name, (new_root, new_length, dirty)) in self.pending_table_updates.drain() {
             // Bypass .get_table() since the table types are dynamic
             let mut definition = self.tree.get(&name.as_str())?.unwrap().value();
-            // No-op if the root has not changed
-            match definition {
-                InternalTableDefinition::Normal { table_root, .. }
-                | InternalTableDefinition::Multimap { table_root, .. } => {
-                    if table_root == new_root {
-                        continue;
+            // No-op if the root has not changed and checksums are already finalized
+            if !dirty {
+                match definition {
+                    InternalTableDefinition::Normal { table_root, .. }
+                    | InternalTableDefinition::Multimap { table_root, .. } => {
+                        if table_root == new_root {
+                            continue;
+                        }
                     }
                 }
             }
@@ -488,7 +494,7 @@ impl TableTreeMut<'_> {
         let mut result = tree.get_table_untyped(name, table_type);
 
         if let Ok(Some(definition)) = result.as_mut()
-            && let Some((updated_root, updated_length)) = self.pending_table_updates.get(name)
+            && let Some((updated_root, updated_length, _)) = self.pending_table_updates.get(name)
         {
             definition.set_header(*updated_root, *updated_length);
         }
@@ -511,7 +517,7 @@ impl TableTreeMut<'_> {
         let mut result = tree.get_table::<K, V>(name, table_type);
 
         if let Ok(Some(definition)) = result.as_mut()
-            && let Some((updated_root, updated_length)) = self.pending_table_updates.get(name)
+            && let Some((updated_root, updated_length, _)) = self.pending_table_updates.get(name)
         {
             definition.set_header(*updated_root, *updated_length);
         }
@@ -601,7 +607,7 @@ impl TableTreeMut<'_> {
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;
             let mut definition = entry.value();
-            if let Some((updated_root, updated_length)) =
+            if let Some((updated_root, updated_length, _)) =
                 self.pending_table_updates.get(entry.key())
             {
                 definition.set_header(*updated_root, *updated_length);
@@ -634,7 +640,7 @@ impl TableTreeMut<'_> {
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;
             let mut definition = entry.value();
-            if let Some((updated_root, updated_length)) =
+            if let Some((updated_root, updated_length, _)) =
                 self.pending_table_updates.get(entry.key())
             {
                 definition.set_header(*updated_root, *updated_length);
@@ -645,9 +651,10 @@ impl TableTreeMut<'_> {
                 self.freed_pages.clone(),
                 relocation_map,
             )? {
+                // Relocated roots have already-finalized checksums
                 self.pending_table_updates.insert(
                     entry.key().to_string(),
-                    (Some(new_root), definition.get_length()),
+                    (Some(new_root), definition.get_length(), false),
                 );
             }
         }
@@ -672,7 +679,7 @@ impl TableTreeMut<'_> {
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;
             let mut definition = entry.value();
-            if let Some((updated_root, length)) = self.pending_table_updates.get(entry.key()) {
+            if let Some((updated_root, length, _)) = self.pending_table_updates.get(entry.key()) {
                 definition.set_header(*updated_root, *length);
             }
             match definition {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2118,3 +2118,69 @@ fn custom_table_type() {
         table.get(1).unwrap().next().unwrap().unwrap().value()
     );
 }
+
+// Regression test for a bug where renaming a table with pending (dirty) modifications
+// caused database corruption due to unfinalized checksums.
+//
+// Previously, `rename_table` wrote the table definition (with a DEFERRED placeholder
+// checksum) into the master btree AND kept the identical root in `pending_table_updates`.
+// During commit, `flush_table_root_updates()` compared the btree entry's root with the
+// pending update's root, found them equal, and skipped checksum finalization. The fix
+// adds an explicit dirty flag to pending updates so that checksum finalization is never
+// skipped for tables with uncommitted pages.
+#[test]
+fn rename_table_with_modifications_data_loss() {
+    let tmpfile = create_tempfile();
+
+    const ORIGINAL_TABLE: TableDefinition<u64, &str> = TableDefinition::new("original");
+    const RENAMED_TABLE: TableDefinition<u64, &str> = TableDefinition::new("renamed");
+
+    // Step 1: Create initial data in the "original" table and commit.
+    {
+        let db = Database::create(tmpfile.path()).unwrap();
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(ORIGINAL_TABLE).unwrap();
+            table.insert(0, "initial_value_0").unwrap();
+            table.insert(1, "initial_value_1").unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    // Step 2: Modify the table and rename it in the same transaction.
+    {
+        let db = Database::create(tmpfile.path()).unwrap();
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(ORIGINAL_TABLE).unwrap();
+            table.insert(2, "new_value_2").unwrap();
+            table.insert(3, "new_value_3").unwrap();
+            txn.rename_table(table, RENAMED_TABLE).unwrap();
+        }
+        txn.commit().unwrap();
+
+        // Verify data is accessible within the same session.
+        let read_txn = db.begin_read().unwrap();
+        let table = read_txn.open_table(RENAMED_TABLE).unwrap();
+        assert_eq!(table.get(0).unwrap().unwrap().value(), "initial_value_0");
+        assert_eq!(table.get(1).unwrap().unwrap().value(), "initial_value_1");
+        assert_eq!(table.get(2).unwrap().unwrap().value(), "new_value_2");
+        assert_eq!(table.get(3).unwrap().unwrap().value(), "new_value_3");
+        assert_eq!(table.len().unwrap(), 4);
+    }
+
+    // Step 3: Reopen and verify data survives and integrity check passes.
+    {
+        let mut db = Database::builder().create(tmpfile.path()).unwrap();
+        let read_txn = db.begin_read().unwrap();
+        let table = read_txn.open_table(RENAMED_TABLE).unwrap();
+        assert_eq!(table.get(0).unwrap().unwrap().value(), "initial_value_0");
+        assert_eq!(table.get(1).unwrap().unwrap().value(), "initial_value_1");
+        assert_eq!(table.get(2).unwrap().unwrap().value(), "new_value_2");
+        assert_eq!(table.get(3).unwrap().unwrap().value(), "new_value_3");
+        assert_eq!(table.len().unwrap(), 4);
+        drop(table);
+        drop(read_txn);
+        assert!(db.check_integrity().unwrap());
+    }
+}


### PR DESCRIPTION
Add a dirty flag to pending_table_updates so that
flush_table_root_updates() always finalizes checksums for tables with uncommitted pages, even when the btree entry already has the same root (as happens after rename_table writes the pending root into the btree).

The relocated-tables path sets dirty=false since relocate_tree() produces already-finalized roots, preserving the existing optimization that skips finalization when the root hasn't changed.

https://claude.ai/code/session_01CTj3WfgpsqdMAprMQfrJSw