### PR TITLE
Dynamic read/write cache partitioning

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -419,7 +419,7 @@ impl ReadOnlyDatabase {
         file: Box<dyn StorageBackend>,
         page_size: usize,
         region_size: Option<u64>,
-        read_cache_size_bytes: usize,
+        cache_size: usize,
     ) -> Result<Self, DatabaseError> {
         #[cfg(feature = "logging")]
         let file_path = format!("{:?}", &file);
@@ -430,8 +430,7 @@ impl ReadOnlyDatabase {
             false,
             page_size,
             region_size,
-            read_cache_size_bytes,
-            0,
+            cache_size,
             true,
         )?;
         let mem = Arc::new(mem);
@@ -881,14 +880,12 @@ impl Database {
         Ok([data_root, system_root])
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn new(
         file: Box<dyn StorageBackend>,
         allow_initialize: bool,
         page_size: usize,
         region_size: Option<u64>,
-        read_cache_size_bytes: usize,
-        write_cache_size_bytes: usize,
+        cache_size: usize,
         repair_callback: &(dyn Fn(&mut RepairSession) + 'static),
     ) -> Result<Self, DatabaseError> {
         #[cfg(feature = "logging")]
@@ -900,8 +897,7 @@ impl Database {
             allow_initialize,
             page_size,
             region_size,
-            read_cache_size_bytes,
-            write_cache_size_bytes,
+            cache_size,
             false,
         )?;
         let mut mem = Arc::new(mem);
@@ -1096,8 +1092,7 @@ impl RepairSession {
 pub struct Builder {
     page_size: usize,
     region_size: Option<u64>,
-    read_cache_size_bytes: usize,
-    write_cache_size_bytes: usize,
+    cache_size: usize,
     repair_callback: Box<dyn Fn(&mut RepairSession)>,
 }
 
@@ -1109,21 +1104,16 @@ impl Builder {
     /// - `cache_size_bytes`: 1GiB
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        let mut result = Self {
+        Self {
             // Default to 4k pages. Benchmarking showed that this was a good default on all platforms,
             // including MacOS with 16k pages. Therefore, users are not allowed to configure it at the moment.
             // It is part of the file format, so can be enabled in the future.
             page_size: PAGE_SIZE,
             region_size: None,
             // TODO: Default should probably take into account the total system memory
-            read_cache_size_bytes: 0,
-            // TODO: Default should probably take into account the total system memory
-            write_cache_size_bytes: 0,
+            cache_size: 1024 * 1024 * 1024,
             repair_callback: Box::new(|_| {}),
-        };
-
-        result.set_cache_size(1024 * 1024 * 1024);
-        result
+        }
     }
 
     /// Set a callback which will be invoked periodically in the event that the database file needs
@@ -1157,9 +1147,7 @@ impl Builder {
 
     /// Set the amount of memory (in bytes) used for caching data
     pub fn set_cache_size(&mut self, bytes: usize) -> &mut Self {
-        // TODO: allow dynamic expansion of the read/write cache
-        self.read_cache_size_bytes = bytes / 10 * 9;
-        self.write_cache_size_bytes = bytes / 10;
+        self.cache_size = bytes;
         self
     }
 
@@ -1187,8 +1175,7 @@ impl Builder {
             true,
             self.page_size,
             self.region_size,
-            self.read_cache_size_bytes,
-            self.write_cache_size_bytes,
+            self.cache_size,
             &self.repair_callback,
         )
     }
@@ -1202,8 +1189,7 @@ impl Builder {
             false,
             self.page_size,
             None,
-            self.read_cache_size_bytes,
-            self.write_cache_size_bytes,
+            self.cache_size,
             &self.repair_callback,
         )
     }
@@ -1223,7 +1209,7 @@ impl Builder {
             Box::new(FileBackend::new_internal(file, true)?),
             self.page_size,
             None,
-            self.read_cache_size_bytes,
+            self.cache_size,
         )
     }
 
@@ -1236,8 +1222,7 @@ impl Builder {
             true,
             self.page_size,
             self.region_size,
-            self.read_cache_size_bytes,
-            self.write_cache_size_bytes,
+            self.cache_size,
             &self.repair_callback,
         )
     }
@@ -1252,8 +1237,7 @@ impl Builder {
             true,
             self.page_size,
             self.region_size,
-            self.read_cache_size_bytes,
-            self.write_cache_size_bytes,
+            self.cache_size,
             &self.repair_callback,
         )
     }

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -6,7 +6,7 @@ use std::slice::SliceIndex;
 #[cfg(feature = "cache_metrics")]
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 
 pub(super) struct WritablePage {
     buffer: Arc<Mutex<LRUWriteCache>>,
@@ -193,10 +193,29 @@ impl CheckedBackend {
 pub(super) struct PagedCachedFile {
     file: CheckedBackend,
     page_size: u64,
-    max_read_cache_bytes: usize,
+    // Dynamic cache partitioning.  Three invariants:
+    //
+    // 1. The write buffer NEVER exceeds 50% of max_cache_size.
+    //    Pages beyond this limit are flushed to disk immediately.
+    // 2. The write buffer evicts from the read cache only when
+    //    write < 50% AND read > 50% (fairness).
+    // 3. write + read never exceeds max_cache_size.
+    //
+    // Together these guarantee that the read cache can grow up to 100% when no
+    // writes are in progress, while write-heavy workloads never starve readers
+    // below 50%.
+    //
+    // We track usage with two atomic counters and compute the total on the fly.
+    // The resulting read is not perfectly atomic (between loading the two
+    // counters a concurrent operation could change one), but the budget is a
+    // soft limit and momentary over-/under-counting by one page is harmless.
+    // A third "total" counter would add contention on every insert/remove for
+    // negligible accuracy gain.
     read_cache_bytes: AtomicUsize,
-    max_write_buffer_bytes: usize,
     write_buffer_bytes: AtomicUsize,
+    max_cache_size: usize,
+    // Rotates the starting stripe for read-cache eviction
+    next_eviction_stripe: AtomicUsize,
     #[cfg(feature = "cache_metrics")]
     reads_total: AtomicU64,
     #[cfg(feature = "cache_metrics")]
@@ -216,8 +235,7 @@ impl PagedCachedFile {
     pub(super) fn new(
         file: Box<dyn StorageBackend>,
         page_size: u64,
-        max_read_cache_bytes: usize,
-        max_write_buffer_bytes: usize,
+        max_cache_size: usize,
     ) -> Result<Self, DatabaseError> {
         let read_cache = (0..Self::lock_stripes())
             .map(|_| RwLock::new(LRUCache::new()))
@@ -226,10 +244,10 @@ impl PagedCachedFile {
         Ok(Self {
             file: CheckedBackend::new(file),
             page_size,
-            max_read_cache_bytes,
             read_cache_bytes: AtomicUsize::new(0),
-            max_write_buffer_bytes,
             write_buffer_bytes: AtomicUsize::new(0),
+            max_cache_size,
+            next_eviction_stripe: AtomicUsize::new(0),
             #[cfg(feature = "cache_metrics")]
             reads_total: Default::default(),
             #[cfg(feature = "cache_metrics")]
@@ -294,19 +312,56 @@ impl PagedCachedFile {
         131
     }
 
+    // Evict entries from the read cache to free at least `bytes_needed` bytes.
+    // Iterates through cache stripes and pops lowest-priority entries.
+    //
+    // Caller must hold the write_buffer mutex to maintain the lock ordering
+    // invariant (write_buffer lock is always acquired before read_cache locks).
+    fn evict_from_read_cache(
+        &self,
+        bytes_needed: usize,
+        _write_lock: &MutexGuard<'_, LRUWriteCache>,
+    ) {
+        let num_stripes = self.read_cache.len();
+        let start = self.next_eviction_stripe.fetch_add(1, Ordering::Relaxed) % num_stripes;
+        let mut freed = 0;
+        for i in 0..num_stripes {
+            if freed >= bytes_needed {
+                break;
+            }
+            let stripe = (start + i) % num_stripes;
+            let mut lock = self.read_cache[stripe].write().unwrap();
+            while freed < bytes_needed {
+                if let Some((_, v)) = lock.pop_lowest_priority() {
+                    #[cfg(feature = "cache_metrics")]
+                    {
+                        self.evictions.fetch_add(1, Ordering::Relaxed);
+                    }
+                    freed += v.len();
+                    self.read_cache_bytes.fetch_sub(v.len(), Ordering::AcqRel);
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
     fn flush_write_buffer(&self) -> Result {
         let mut write_buffer = self.write_buffer.lock().unwrap();
 
         for (offset, buffer) in write_buffer.cache.iter() {
             self.file.write(*offset, buffer.as_ref().unwrap())?;
         }
+        // Transfer flushed pages into the read cache so they are available
+        // for subsequent reads without a file I/O.  The write buffer is being
+        // drained, so the total check only considers the read cache size.
         for (offset, buffer) in write_buffer.cache.iter_mut() {
             let buffer = buffer.take().unwrap();
             let cache_size = self
                 .read_cache_bytes
                 .fetch_add(buffer.len(), Ordering::AcqRel);
 
-            if cache_size + buffer.len() <= self.max_read_cache_bytes {
+            if cache_size + buffer.len() <= self.max_cache_size {
                 let cache_slot: usize = (offset % Self::lock_stripes()).try_into().unwrap();
                 let mut lock = self.read_cache[cache_slot].write().unwrap();
                 if let Some(replaced) = lock.insert(*offset, buffer) {
@@ -392,8 +447,14 @@ impl PagedCachedFile {
         } else {
             cache_size
         };
+
+        // Rule 3: evict from this read-cache slot if the total exceeds the
+        // budget.  We evict exactly `len` bytes (one page) per miss to avoid
+        // over-eviction spikes.
+        let write_bytes = self.write_buffer_bytes.load(Ordering::Acquire);
+        let over_total = cache_size + len + write_bytes > self.max_cache_size;
         let mut removed = 0;
-        if cache_size + len > self.max_read_cache_bytes {
+        if over_total {
             while removed < len {
                 if let Some((_, v)) = write_lock.pop_lowest_priority() {
                     #[cfg(feature = "cache_metrics")]
@@ -476,9 +537,14 @@ impl PagedCachedFile {
             removed
         } else {
             let previous = self.write_buffer_bytes.fetch_add(len, Ordering::AcqRel);
-            if previous + len > self.max_write_buffer_bytes {
-                let mut removed_bytes = 0;
-                while removed_bytes < len {
+            let mut write_bytes = previous + len;
+            let half = self.max_cache_size / 2;
+
+            // Rule 1: write buffer NEVER exceeds 50%.  Flush excess to disk.
+            if write_bytes > half {
+                let excess = write_bytes - half;
+                let mut flushed = 0;
+                while flushed < excess {
                     if let Some((offset, buffer)) = lock.pop_lowest_priority() {
                         let removed_len = buffer.len();
                         let result = self.file.write(offset, &buffer);
@@ -492,11 +558,20 @@ impl PagedCachedFile {
                         {
                             self.evictions.fetch_add(1, Ordering::Relaxed);
                         }
-                        removed_bytes += removed_len;
+                        flushed += removed_len;
                     } else {
                         break;
                     }
                 }
+                write_bytes -= flushed;
+            }
+
+            // Rules 2 + 3: after rule 1, write <= 50%.  If the total still
+            // exceeds the budget then read must be > 50%, so evict from the
+            // read cache (fairness: we only take from read when read > 50%).
+            let read_bytes = self.read_cache_bytes.load(Ordering::Acquire);
+            if write_bytes + read_bytes > self.max_cache_size {
+                self.evict_from_read_cache(write_bytes + read_bytes - self.max_cache_size, &lock);
             }
             let result = if let Some(data) = existing {
                 #[cfg(feature = "cache_metrics")]
@@ -535,7 +610,7 @@ mod test {
     fn cache_leak() {
         let backend = InMemoryBackend::new();
         backend.set_len(1024).unwrap();
-        let cached_file = PagedCachedFile::new(Box::new(backend), 128, 1024, 128).unwrap();
+        let cached_file = PagedCachedFile::new(Box::new(backend), 128, 1024).unwrap();
         let cached_file = Arc::new(cached_file);
 
         let t1 = {

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -129,15 +129,13 @@ pub(crate) struct TransactionalMemory {
 }
 
 impl TransactionalMemory {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         file: Box<dyn StorageBackend>,
         // Allow initializing a new database in an empty file
         allow_initialize: bool,
         page_size: usize,
         requested_region_size: Option<u64>,
-        read_cache_size_bytes: usize,
-        write_cache_size_bytes: usize,
+        cache_size: usize,
         read_only: bool,
     ) -> Result<Self, DatabaseError> {
         assert!(page_size.is_power_of_two() && page_size >= DB_HEADER_SIZE);
@@ -149,12 +147,7 @@ impl TransactionalMemory {
         );
         assert!(region_size.is_power_of_two());
 
-        let storage = PagedCachedFile::new(
-            file,
-            page_size as u64,
-            read_cache_size_bytes,
-            write_cache_size_bytes,
-        )?;
+        let storage = PagedCachedFile::new(file, page_size as u64, cache_size)?;
 
         let initial_storage_len = storage.raw_file_len()?;
 


### PR DESCRIPTION
Previously the cache budget was statically partitioned: 90% for the read cache, 10% for the write buffer.  During large write transactions the dirty-page working set often exceeded the write buffer's 10% allocation, causing constant eviction of dirty pages to disk followed by re-reading them on the next in-place modification — an expensive thrashing pattern dominated by pread/pwrite syscalls.

Replace the static split with dynamic sharing governed by three invariants:

  1. The write buffer never exceeds 50% of the total cache budget. Excess pages are flushed to disk immediately.
  2. The write buffer may evict read-cache entries only while write < 50% AND read > 50% (fairness).
  3. read + write never exceeds 100% of the budget.

These rules guarantee that the read cache can use up to 100% when no writes are active, while write-heavy workloads can grow the write buffer up to 50% without starving readers below 50%.

Enforcement is split across two code paths:

  write() — Two sequential steps:
    (a) If write > 50%, flush write-buffer LRU entries to disk (rule 1).
    (b) After (a), write <= 50%.  If the total still exceeds the budget
        then read must be > 50%, so evict from the read cache (rules 2+3).
        This is done via evict_from_read_cache(), which iterates read-cache
        stripes under the write-buffer mutex (safe because the lock ordering
        is always write_buffer lock → read_cache lock).

  read() — On a cache miss, if read + write > budget, evict one page from
    the local read-cache stripe (rule 3).  The read path cannot evict
    write-buffer entries due to the lock-ordering constraint.

The two usage counters (read_cache_bytes, write_buffer_bytes) are AtomicUsize; the total is computed on the fly.  A non-atomic read of the two counters can briefly over- or under-count by one page, but the budget is a soft limit and the error is self-correcting on the next operation.

Also simplifies the API: Builder, Database::new(), ReadOnlyDatabase::new(), TransactionalMemory::new(), and PagedCachedFile::new() now pass a single `cache_size` instead of separate read/write limits.

https://claude.ai/code/session_013492btiNviPXoEpCqN7wHt