### PR TITLE
Update rand crate to 0.10.1 and migrate to RngExt trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libc = "0.2.174"
 
 # Common test/bench dependencies
 [dev-dependencies]
-rand = "0.10.0"
+rand = "0.10.1"
 tempfile = "3.5.0"
 # for backwards compatibility testing - pin at 2.6.0
 redb2_6 = { version = "=2.6.0", package = "redb" }

--- a/crates/redb-bench/Cargo.toml
+++ b/crates/redb-bench/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace = true
 # Common test/bench dependencies
 [dev-dependencies]
 redb = { path = "../.." }
-rand = "0.9"
+rand = "0.10.1"
 tempfile = "3.5.0"
 walkdir = "2.5.0"
 byte-unit = "5.1.6"

--- a/crates/redb-bench/benches/int_benchmark.rs
+++ b/crates/redb-bench/benches/int_benchmark.rs
@@ -7,7 +7,7 @@ mod common;
 use common::*;
 
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use std::time::{Duration, Instant};
 
 const ELEMENTS: usize = 1_000_000;

--- a/crates/redb-bench/benches/large_values_benchmark.rs
+++ b/crates/redb-bench/benches/large_values_benchmark.rs
@@ -6,7 +6,7 @@ use tempfile::{NamedTempFile, TempDir};
 mod common;
 use common::*;
 
-use rand::RngCore;
+use rand::Rng;
 use std::time::{Duration, Instant};
 
 const ELEMENTS: usize = 1_000_000;

--- a/crates/redb-bench/benches/multithreaded_insert_benchmark.rs
+++ b/crates/redb-bench/benches/multithreaded_insert_benchmark.rs
@@ -3,7 +3,7 @@ use std::{fs, process, thread};
 use tempfile::NamedTempFile;
 
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use redb::{Database, ReadableDatabase, ReadableTableMetadata, TableDefinition};
 use std::time::Instant;
 

--- a/crates/redb-bench/benches/savepoint_benchmark.rs
+++ b/crates/redb-bench/benches/savepoint_benchmark.rs
@@ -3,7 +3,7 @@
 use std::env::current_dir;
 use tempfile::NamedTempFile;
 
-use rand::Rng;
+use rand::RngExt;
 use redb::{Database, TableDefinition};
 use std::time::{Duration, Instant};
 

--- a/crates/redb-bench/benches/syscall_benchmark.rs
+++ b/crates/redb-bench/benches/syscall_benchmark.rs
@@ -1,6 +1,6 @@
 use tempfile::{NamedTempFile, TempDir};
 
-use rand::Rng;
+use rand::RngExt;
 use rand::prelude::SliceRandom;
 use std::env::current_dir;
 use std::fs::OpenOptions;

--- a/crates/redb-bench/benches/userspace_cache_benchmark.rs
+++ b/crates/redb-bench/benches/userspace_cache_benchmark.rs
@@ -5,7 +5,7 @@ use tempfile::NamedTempFile;
 
 #[cfg(target_os = "linux")]
 mod unix {
-    use rand::Rng;
+    use rand::RngExt;
     use rand::prelude::SliceRandom;
     use std::collections::BTreeMap;
     use std::fs::{File, OpenOptions};

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,8 +12,8 @@ cargo-fuzz = true
 arbitrary = { version = "1.1.0", features = ["derive"] }
 libfuzzer-sys = { version = "0.4.0", features = ["arbitrary-derive"] }
 tempfile = "3.2.0"
-rand = "0.8.5"
-rand_distr = "0.4.3"
+rand = "0.10.1"
+rand_distr = "0.6"
 
 [dependencies.redb]
 path = ".."


### PR DESCRIPTION
## Summary
This PR updates the `rand` crate dependency to version 0.10.1 across the workspace and migrates code to use the new `RngExt` trait introduced in this version.

## Key Changes
- Updated `rand` dependency from 0.8.5/0.9/0.10.0 to 0.10.1 in:
  - `fuzz/Cargo.toml`
  - `Cargo.toml` (dev-dependencies)
  - `crates/redb-bench/Cargo.toml`
- Updated `rand_distr` from 0.4.3 to 0.6 in `fuzz/Cargo.toml`
- Migrated trait imports from `Rng` to `RngExt` in benchmark files:
  - `int_benchmark.rs`
  - `multithreaded_insert_benchmark.rs`
  - `savepoint_benchmark.rs`
  - `syscall_benchmark.rs`
  - `userspace_cache_benchmark.rs`
- Changed `RngCore` to `Rng` in `large_values_benchmark.rs`

## Implementation Details
The rand 0.10.1 release reorganized the trait hierarchy, moving the `gen()` and `gen_range()` methods to the `RngExt` trait. All benchmark code that uses these methods has been updated to import `RngExt` instead of `Rng` to maintain compatibility with the new API.

https://claude.ai/code/session_01TdnVequzvPzyEcknzrtDa3