### PR TITLE
Fix sync mode in redb benchmark

### DIFF
--- a/crates/redb-bench/benches/common.rs
+++ b/crates/redb-bench/benches/common.rs
@@ -500,7 +500,7 @@ impl BenchDatabase for RedbBenchDatabase<'_> {
     fn connect(&self) -> Self::C<'_> {
         RedbBenchDatabaseConnection {
             db: self.db,
-            sync: false,
+            sync: true,
         }
     }
 


### PR DESCRIPTION
## Summary
Changed the default sync mode for RedbBenchDatabase connections from disabled to enabled.

## Changes
- Modified `RedbBenchDatabase::connect()` to initialize connections with `sync: true` instead of `sync: false`

## Details
This change ensures that database connections created through the benchmark harness will use synchronous mode by default. This may impact benchmark results by ensuring data durability guarantees are enforced during testing.

https://claude.ai/code/session_01Pehvj3sLC7qYbv6pnc4Khj