### PR TITLE
perf: lazy-size BuddyAllocator bitmaps to reduce memory overhead

### DIFF
--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -41,7 +41,14 @@ impl BuddyAllocator {
         let mut pages_for_order = num_pages;
         let mut free = vec![];
         for _ in 0..=max_order {
-            free.push(BtreeBitmap::new(pages_for_order, capacity_for_order));
+            // Lazily size each bitmap for the actual current pages, but pad the tree
+            // height so resize() can grow to the full region capacity without needing
+            // to insert new tree levels.
+            free.push(BtreeBitmap::new_padded(
+                pages_for_order,
+                pages_for_order,
+                capacity_for_order,
+            ));
 
             pages_for_order = next_higher_order(pages_for_order);
             capacity_for_order = next_higher_order(capacity_for_order);


### PR DESCRIPTION
## Summary

Each region's `BuddyAllocator` currently pre-allocates its per-order bitmaps at the **full region capacity** (up to 1M pages for a 4 GiB region). Small or just-opened databases carry ~256 KB of bitmap data per region that describes pages that don't yet exist.

This PR switches the bitmap construction to `BtreeBitmap::new_padded`, which sizes the bitmap **data** for the actual current page count, while **padding the tree height** to the full capacity so `resize()` can still grow without needing to insert new levels.

It's the same pattern that #1111 already applied to `RegionTracker`.

## Why this is safe

- **On-disk format is unchanged.** `U64GroupedBitmap::to_vec` already only serializes `required_words(self.len)`, not `required_words(capacity)`. Databases written before or after this change round-trip identically.
- **No new allocation in the hot path.** Region growth already calls `BtreeBitmap::resize`, which already calls `U64GroupedBitmap::resize`, which already does `self.data.resize(...)` on Vec. We just let it actually grow a smaller initial Vec (amortized O(n) via Vec's doubling) instead of starting at the full capacity.
- **Tree height is still pre-padded** via `new_padded(..., max_capacity)`, so the existing `assert!(self.get_level(0).len() <= 64)` in `BtreeBitmap::resize` still holds.
- All 211 tests in the workspace pass, including the `resize_beyond_initial_capacity` test that specifically exercises the `new_padded` + grow path.

## Measurements

Two focused benchmarks (attached) measuring:
- `bench_memory`: opens 32 small databases with 64 entries each, 1 MiB cache, holds them all live
- `bench_bulk`: 500K inserts / 100K reads / 50K range scans into a single disk-backed DB with a 4 GiB cache (same cache size as `redb_benchmark`)

### `bench_memory` (direct target of this change — per-region bitmap overhead)

| Metric                            | master      | this PR         | delta    |
| :-------------------------------- | ----------: | --------------: | -------: |
| VmRSS after opening 32 DBs        | 12,892 KB   | **4,112 KB**    | **−68%** |
| Max RSS (`/usr/bin/time -v`)      | 12,812 KB   | **3,960 KB**    | **−69%** |
| Total heap allocated (DHAT)       | 27.2 MB     | **10.1 MB**     | **−63%** |
| Peak live heap (DHAT `at_gmax`)   | 9.92 MB     | **1.17 MB**     | **−88%** |

### `bench_bulk` (regression check — a region that fills up)

| Metric                          | master       | this PR      |
| :------------------------------ | -----------: | -----------: |
| bulk_insert (500K)              | 1,190 ms     | 1,110 ms     |
| random_reads (100K)             | 137 ms       | 126 ms       |
| range_scans (50K × 10)          | 128 ms       | 135 ms       |
| individual_writes (1K)          | 51 ms        | 47 ms        |
| Max RSS                         | 263,720 KB   | 263,372 KB   |
| Total alloc bytes (DHAT)        | 1,200 MB     | 1,200 MB     |

No regression when the region actually fills up — which is when the old pre-allocation was "free" anyway. The wall-clock delta is within run-to-run noise.

## Reproducing

Reproduction archive: **[redb-measure.zip](https://github.com/user-attachments/files/26796089/redb-measure.zip)**

1. Unpack `redb-measure.zip` next to your redb clone (so that `../redb` resolves correctly).
2. `cd redb-measure && ./run_all.sh`

The script checks out each branch in `../redb`, builds and runs each benchmark (with and without DHAT), and writes per-run numbers to `./results/`.