### PR TITLE
perf: avoid Vec->Arc copy and other allocation hygiene in page_store

### DIFF
--- a/src/tree_store/page_store/backends.rs
+++ b/src/tree_store/page_store/backends.rs
@@ -86,16 +86,7 @@ impl StorageBackend for InMemoryBackend {
     fn set_len(&self, len: u64) -> Result<(), io::Error> {
         let mut guard = self.write();
         let len = usize::try_from(len).map_err(|_| Self::out_of_range())?;
-        if guard.len() < len {
-            let additional = len - guard.len();
-            guard.reserve(additional);
-            for _ in 0..additional {
-                guard.push(0);
-            }
-        } else {
-            guard.truncate(len);
-        }
-
+        guard.resize(len, 0);
         Ok(())
     }
 

--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -258,19 +258,20 @@ impl U64GroupedBitmap {
     // 4 bytes: number of elements
     // n bytes: serialized groups
     pub fn to_vec(&self) -> Vec<u8> {
-        let mut result = vec![];
-        result.extend(self.len.to_le_bytes());
-        for x in &self.data[..Self::required_words(self.len)] {
-            result.extend(x.to_le_bytes());
+        let words = Self::required_words(self.len);
+        let mut result = Vec::with_capacity(size_of::<u32>() + words * size_of::<u64>());
+        result.extend_from_slice(&self.len.to_le_bytes());
+        for x in &self.data[..words] {
+            result.extend_from_slice(&x.to_le_bytes());
         }
         result
     }
 
     pub fn from_bytes(serialized: &[u8]) -> Self {
         assert_eq!(0, (serialized.len() - size_of::<u32>()) % size_of::<u64>());
-        let mut data = vec![];
         let len = u32::from_le_bytes(serialized[..size_of::<u32>()].try_into().unwrap());
         let words = (serialized.len() - size_of::<u32>()) / size_of::<u64>();
+        let mut data = Vec::with_capacity(words);
         for i in 0..words {
             let start = size_of::<u32>() + i * size_of::<u64>();
             let value = u64::from_le_bytes(

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -89,21 +89,25 @@ impl BuddyAllocator {
     // free_ends: array of u32, with ending offset for BtreeBitmap structure for the given order
     // ... BtreeBitmap structures
     pub(crate) fn to_vec(&self) -> Vec<u8> {
-        let mut result = vec![];
+        let serialized: Vec<Vec<u8>> = self.free.iter().map(BtreeBitmap::to_vec).collect();
+
+        let header_bytes = 1 + 3 + size_of::<u32>();
+        let offsets_bytes = (self.max_order as usize + 1) * size_of::<u32>();
+        let data_bytes: usize = serialized.iter().map(Vec::len).sum();
+
+        let mut result = Vec::with_capacity(header_bytes + offsets_bytes + data_bytes);
         result.push(self.max_order);
         result.extend([0u8; 3]);
         result.extend(self.len.to_le_bytes());
 
-        let mut data_offset = result.len() + (self.max_order as usize + 1) * size_of::<u32>();
-        let end_metadata = data_offset;
-        for order in &self.free {
-            data_offset += order.to_vec().len();
+        let mut data_offset = header_bytes + offsets_bytes;
+        for bitmap in &serialized {
+            data_offset += bitmap.len();
             let offset_u32: u32 = data_offset.try_into().unwrap();
             result.extend(offset_u32.to_le_bytes());
         }
-        assert_eq!(end_metadata, result.len());
-        for order in &self.free {
-            result.extend(&order.to_vec());
+        for bitmap in &serialized {
+            result.extend_from_slice(bitmap);
         }
 
         result

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -1,12 +1,22 @@
 use crate::tree_store::page_store::base::PageHint;
 use crate::tree_store::page_store::lru_cache::LRUCache;
 use crate::{CacheStats, DatabaseError, Result, StorageBackend, StorageError};
+use std::mem::MaybeUninit;
 use std::ops::{Index, IndexMut};
 use std::slice::SliceIndex;
 #[cfg(feature = "cache_metrics")]
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock};
+
+// Allocates an `Arc<[u8]>` in one step. `Arc::<[u8]>::from(vec![0; len])` would
+// allocate the Vec and then allocate a new Arc and memcpy into it.
+fn zero_filled_arc(len: usize) -> Arc<[u8]> {
+    let mut uninit: Arc<[MaybeUninit<u8>]> = Arc::new_uninit_slice(len);
+    Arc::get_mut(&mut uninit).unwrap().fill(MaybeUninit::new(0));
+    // SAFETY: every slot was just written to 0.
+    unsafe { uninit.assume_init() }
+}
 
 pub(super) struct WritablePage {
     buffer: Arc<Mutex<LRUWriteCache>>,
@@ -409,6 +419,15 @@ impl PagedCachedFile {
         Ok(buffer)
     }
 
+    // Like `read_direct`, but writes directly into an `Arc<[u8]>` instead of a
+    // `Vec<u8>` that is then copied into an `Arc`. The buffer is zero-filled
+    // because `StorageBackend::read` takes `&mut [u8]`.
+    fn read_direct_into_arc(&self, offset: u64, len: usize) -> Result<Arc<[u8]>> {
+        let mut arc = zero_filled_arc(len);
+        self.file.read(offset, Arc::get_mut(&mut arc).unwrap())?;
+        Ok(arc)
+    }
+
     // Read with caching. Caller must not read overlapping ranges without first calling invalidate_cache().
     // Doing so will not cause UB, but is a logic error.
     pub(super) fn read(&self, offset: u64, len: usize, hint: PageHint) -> Result<Arc<[u8]>> {
@@ -437,7 +456,7 @@ impl PagedCachedFile {
             }
         }
 
-        let buffer: Arc<[u8]> = self.read_direct(offset, len)?.into();
+        let buffer = self.read_direct_into_arc(offset, len)?;
         let cache_size = self.read_cache_bytes.fetch_add(len, Ordering::AcqRel);
         let mut write_lock = self.read_cache[cache_slot].write().unwrap();
         let cache_size = if let Some(replaced) = write_lock.insert(offset, buffer.clone()) {
@@ -580,9 +599,9 @@ impl PagedCachedFile {
             } else if overwrite {
                 #[cfg(feature = "cache_metrics")]
                 self.writes_hits.fetch_add(1, Ordering::AcqRel);
-                vec![0; len].into()
+                zero_filled_arc(len)
             } else {
-                self.read_direct(offset, len)?.into()
+                self.read_direct_into_arc(offset, len)?
             };
             lock.insert(offset, result);
             lock.take_value(offset).unwrap()
@@ -636,5 +655,18 @@ mod test {
         t2.join().unwrap();
         cached_file.invalidate_cache(0, 128);
         assert_eq!(cached_file.read_cache_bytes.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn zero_filled_arc_is_zero() {
+        let a = super::zero_filled_arc(128);
+        assert_eq!(a.len(), 128);
+        assert!(a.iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn zero_filled_arc_empty() {
+        let a = super::zero_filled_arc(0);
+        assert!(a.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

A handful of small, independent allocation fixes in the page cache and bitmap serialization paths. No behavior change — every output is byte-identical to master — and no API changes. The headline win is that every `PagedCachedFile` cache miss and every `overwrite` write used to allocate the buffer **twice**; this PR makes it one allocation.

## Changes

### `PagedCachedFile` page buffers — `cached_file.rs`

`vec![0; len].into()` and `read_direct(..).into()` both allocated a `Vec<u8>` first, then allocated a fresh `Arc<[u8]>` and **copied** the bytes into it, because `Arc::<[u8]>::from(Vec<u8>)` cannot reuse the Vec's allocation (the `ArcInner` header must precede the data buffer).

Two helpers now allocate the `Arc` directly via `Arc::new_uninit_slice` (stable since 1.82):

- `zero_filled_arc(len)` — returns a zero-filled `Arc<[u8]>` in one allocation. Used on the `overwrite` path and as the starting buffer for the read path.
- `read_direct_into_arc(offset, len)` — zero-fills via `zero_filled_arc` and then delegates to `StorageBackend::read` (which takes `&mut [u8]`, so the buffer must be initialized before we call it).

The only `unsafe` block is inside `zero_filled_arc` and is a trivial `assume_init()` after filling every slot with `MaybeUninit::new(0)`. Handing out `&mut [u8]` aliasing `MaybeUninit` storage was proposed in an earlier revision of this PR but is UB even when the backend fully overwrites the buffer — it is intentionally avoided.

### `BuddyAllocator::to_vec` — `buddy_allocator.rs`

Each `BtreeBitmap` was serialized twice — once to measure its length (to write the offset header), then again to copy into the output. Serialize once into a `Vec<Vec<u8>>`, use those sizes for the offsets, then `extend_from_slice` them into a pre-sized output.

### `U64GroupedBitmap::{to_vec, from_bytes}` — `bitmap.rs`

Preallocate with the known final size instead of `vec![]` + repeated `extend`, avoiding cascading Vec reallocations on serialize/restore.

### `InMemoryBackend::set_len` — `backends.rs`

Replace `reserve(n) + push(0)` loop with `resize(len, 0)` — an idiomatic single memset instead of a push-per-byte loop.

## Why this is safe

- No format changes, no API changes, no semantic changes.
- All existing tests pass (unmodified). Two small tests for `zero_filled_arc` are added to document the invariants (length preserved, all bytes zero, `len == 0` works).

## Measurements

Same reproduction crate as #1137. Two focused benchmarks:

- `bench_bulk`: 500K inserts / 100K reads / 50K range scans into a single disk-backed DB with a 4 GiB cache.
- `bench_memory`: 32 small databases opened and held live (shown here as a regression check — this PR doesn't target the per-region bookkeeping).

### `bench_bulk` (direct target — every page cache miss/write benefits)

| Metric                         | master       | this PR      | delta    |
| :----------------------------- | -----------: | -----------: | -------: |
| Total heap allocated (DHAT)    | **1,200 MB** | **755 MB**   | **−37%** |
| Total alloc blocks (DHAT)      | 1,648,756    | 1,538,389    | −6.7%    |
| bulk_insert (500K)             | 1,190 ms     | 968 ms       | ~faster  |
| random_reads (100K)            | 137 ms       | 128 ms       | ~neutral |
| range_scans (50K × 10)         | 128 ms       | 109 ms       | ~faster  |
| individual_writes (1K)         | 51 ms        | 37 ms        | ~neutral |
| Max RSS                        | 263,720 KB   | 263,872 KB   | neutral  |
| Peak live heap (DHAT `gmax`)   | 257.6 MB     | 257.6 MB     | neutral  |

**445 MB fewer bytes allocated** across the run. Wall-clock deltas are within run-to-run noise (redb's own benchmark is noisy this way), but the allocation delta is stable and repeatable.

### `bench_memory` (regression check — not this PR's target)

| Metric                          | master       | this PR      |
| :------------------------------ | -----------: | -----------: |
| VmRSS after 32 DBs              | 12,892 KB    | 12,740 KB    |
| Total heap allocated            | 27.2 MB      | 23.9 MB      |

(#1137 is the one that drops the per-region RSS here.)

## Reproducing

Reproduction archive: [redb-measure.zip](https://github.com/user-attachments/files/26796089/redb-measure.zip) — same archive as #1137.

1. Unpack `redb-measure.zip` next to your redb clone (so `../redb` resolves).
2. `cd redb-measure && BRANCHES="master perf/page-store-allocation-hygiene" ./run_all.sh`

The script builds and runs both benchmarks (with and without DHAT) and writes per-run numbers to `./results/`.
