### PR TITLE
Return SavepointError for Savepoint from a different Database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   transaction could cause the table to become corrupted in a future transaction.
 * Fix a panic when `delete_table()` was called on a table that had been modified in the same
   transaction.
+* Fix a panic in `restore_savepoint()` when passed a `Savepoint` from a different `Database`.
+  `SavepointError::InvalidSavepoint` is now returned instead.
 * Improve read scaling to multiple threads. Around 15% speedup on some benchmarks.
 * Optimize cache usage, and general write performance. Around 1.5x speedup on some benchmarks.
 * Optimize memory usage

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1087,11 +1087,10 @@ impl WriteTransaction {
     ///
     /// Calling this method invalidates all [`Savepoint`]s created after savepoint
     pub fn restore_savepoint(&mut self, savepoint: &Savepoint) -> Result<(), SavepointError> {
-        // Ensure that user does not try to restore a Savepoint that is from a different Database
-        assert_eq!(
-            std::ptr::from_ref(self.transaction_tracker.as_ref()),
-            savepoint.db_address()
-        );
+        // Reject a Savepoint that is from a different Database
+        if std::ptr::from_ref(self.transaction_tracker.as_ref()) != savepoint.db_address() {
+            return Err(SavepointError::InvalidSavepoint);
+        }
 
         if !self
             .transaction_tracker

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2388,6 +2388,28 @@ fn savepoint_restore_data_loss_stale_freed_pages() {
 }
 
 #[test]
+fn restore_savepoint_from_foreign_database_panics() {
+    let tmpfile1 = create_tempfile();
+    let tmpfile2 = create_tempfile();
+    let db1 = Database::create(tmpfile1.path()).unwrap();
+    let db2 = Database::create(tmpfile2.path()).unwrap();
+
+    let txn1 = db1.begin_write().unwrap();
+    let foreign_savepoint = txn1.ephemeral_savepoint().unwrap();
+    txn1.commit().unwrap();
+
+    let mut txn2 = db2.begin_write().unwrap();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        txn2.restore_savepoint(&foreign_savepoint)
+    }));
+    assert!(result.is_ok());
+    assert!(matches!(
+        result.unwrap(),
+        Err(SavepointError::InvalidSavepoint)
+    ));
+}
+
+#[test]
 fn delete_table_panic_after_modification() {
     let tmpfile = create_tempfile();
     let db = Database::create(tmpfile.path()).unwrap();


### PR DESCRIPTION
WriteTransaction::restore_savepoint used an assert_eq! to reject Savepoints that originated from a different Database, causing a panic instead of the documented SavepointError::InvalidSavepoint return. Replace the assertion with a guarded early return so callers who accidentally mix savepoints across Database instances get a proper error.

https://claude.ai/code/session_01NNvZVWt9EnvywTsMW9yQSP