### PR TITLE
Fix page leak when aborting a transaction that created a persistent s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   transaction.
 * Fix a panic in `restore_savepoint()` when passed a `Savepoint` from a different `Database`.
   `SavepointError::InvalidSavepoint` is now returned instead.
+* Fix a bug where a transaction that created a persistent savepoint and was then
+  aborted could cause the database file to grow excessively, until the `Database` was dropped.
 * Improve read scaling to multiple threads. Around 15% speedup on some benchmarks.
 * Optimize cache usage, and general write performance. Around 1.5x speedup on some benchmarks.
 * Optimize memory usage

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -770,8 +770,10 @@ pub struct WriteTransaction {
     two_phase_commit: bool,
     shrink_policy: ShrinkPolicy,
     quick_repair: bool,
-    // Persistent savepoints created during this transaction
-    created_persistent_savepoints: Mutex<HashSet<SavepointId>>,
+    // Persistent savepoints created during this transaction. The tuple is
+    // (savepoint id, read-transaction id) so that abort_inner() has everything
+    // it needs to release the savepoint's TransactionTracker state.
+    created_persistent_savepoints: Mutex<HashSet<(SavepointId, TransactionId)>>,
     deleted_persistent_savepoints: Mutex<Vec<(SavepointId, TransactionId)>>,
 }
 
@@ -970,7 +972,7 @@ impl WriteTransaction {
         self.created_persistent_savepoints
             .lock()
             .unwrap()
-            .insert(savepoint.get_id());
+            .insert((savepoint.get_id(), savepoint.get_transaction_id()));
 
         Ok(savepoint.get_id().0)
     }
@@ -1533,18 +1535,14 @@ impl WriteTransaction {
             .unwrap()
             .table_tree
             .clear_root_updates_and_close();
-        for savepoint in self.created_persistent_savepoints.lock().unwrap().iter() {
-            match self.delete_persistent_savepoint(savepoint.0) {
-                Ok(_) => {}
-                Err(err) => match err {
-                    SavepointError::InvalidSavepoint => {
-                        unreachable!();
-                    }
-                    SavepointError::Storage(storage_err) => {
-                        return Err(storage_err);
-                    }
-                },
-            }
+        // Release any persistent savepoints that were created during this transaction.
+        // The corresponding SAVEPOINT_TABLE / NEXT_SAVEPOINT_TABLE writes are rolled
+        // back below by rollback_uncommitted_writes()
+        for (savepoint_id, transaction_id) in
+            self.created_persistent_savepoints.lock().unwrap().iter()
+        {
+            self.transaction_tracker
+                .deallocate_savepoint(*savepoint_id, *transaction_id);
         }
         self.mem.rollback_uncommitted_writes()?;
         #[cfg(feature = "logging")]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2449,3 +2449,88 @@ fn delete_table_panic_after_modification() {
     let commit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| txn.commit()));
     assert!(commit_result.is_ok() && commit_result.as_ref().unwrap().is_ok());
 }
+
+// Regression test for an unbounded page leak when a persistent savepoint is created in
+// a write transaction and then the transaction is aborted.
+#[test]
+fn persistent_savepoint_abort_unbounded_leak() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let table: TableDefinition<u64, u64> = TableDefinition::new("data");
+
+    // Warm up the persistent-savepoint system tables so that later measurements
+    // reflect only the effect of the aborted savepoint, not one-time initialization.
+    {
+        let txn = db.begin_write().unwrap();
+        let id = txn.persistent_savepoint().unwrap();
+        txn.commit().unwrap();
+        let txn = db.begin_write().unwrap();
+        txn.delete_persistent_savepoint(id).unwrap();
+        txn.commit().unwrap();
+    }
+
+    // Populate some data so that subsequent updates have something to copy-on-write.
+    {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut t = txn.open_table(table).unwrap();
+            for i in 0..20u64 {
+                t.insert(i, i).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    // Drain any pending freed pages so the baseline is stable.
+    for _ in 0..3 {
+        db.begin_write().unwrap().commit().unwrap();
+    }
+    let txn = db.begin_write().unwrap();
+    let baseline = txn.stats().unwrap().allocated_pages();
+    txn.abort().unwrap();
+
+    // Repeat: create persistent savepoint, abort, do one modifying write, drain.
+    // Each iteration permanently leaks pages because the aborted savepoint's
+    // TransactionTracker state is never cleaned up.
+    const ITERATIONS: u64 = 20;
+    for round in 0..ITERATIONS {
+        // Create a persistent savepoint and abort the transaction.
+        {
+            let txn = db.begin_write().unwrap();
+            let _id = txn.persistent_savepoint().unwrap();
+            txn.abort().unwrap();
+        }
+
+        // Perform a modification. Its freed pages cannot be reclaimed because the
+        // ghost savepoint from the aborted transaction still pins an old
+        // oldest_live_read_transaction value.
+        {
+            let txn = db.begin_write().unwrap();
+            {
+                let mut t = txn.open_table(table).unwrap();
+                t.insert(0, round).unwrap();
+            }
+            txn.commit().unwrap();
+        }
+
+        for _ in 0..3 {
+            db.begin_write().unwrap().commit().unwrap();
+        }
+    }
+
+    let txn = db.begin_write().unwrap();
+    let after = txn.stats().unwrap().allocated_pages();
+    txn.abort().unwrap();
+
+    assert_eq!(
+        baseline,
+        after,
+        "After {} iterations of persistent_savepoint+abort+modify, page usage grew \
+         from {} to {} ({} pages leaked). Because the leak per iteration is \
+         independent of N, running N iterations leaks O(N) pages.",
+        ITERATIONS,
+        baseline,
+        after,
+        after.saturating_sub(baseline),
+    );
+}


### PR DESCRIPTION
…avepoint

abort_inner() previously called delete_persistent_savepoint() for each id in created_persistent_savepoints. That only queues the deallocation into deleted_persistent_savepoints, which is drained by commit_inner() - a path abort_inner() never runs. rollback_uncommitted_writes() reverses the on-disk SAVEPOINT_TABLE / NEXT_SAVEPOINT_TABLE mutations, but the savepoint stays alive in the in-memory TransactionTracker: valid_savepoints keeps the SavepointId and live_read_transactions still holds its refcount.

That ghost savepoint pins oldest_live_read_transaction to an old transaction id for the rest of the database's lifetime, so process_freed_pages() stops reclaiming pages in every later commit. Each subsequent write transaction that modifies the data permanently leaks its freed pages.

https://claude.ai/code/session_01UdfyDgiyJyvf8qbAcuWux1