### PR TITLE
Return TransactionInProgress from check_integrity() instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   `SavepointError::InvalidSavepoint` is now returned instead.
 * Fix a bug where a transaction that created a persistent savepoint and was then
   aborted could cause the database file to grow excessively, until the `Database` was dropped.
+* Fix a panic in `check_integrity()` when called while another transaction is still alive.
+  The new `DatabaseError::TransactionInProgress` variant is now returned instead.
 * Improve read scaling to multiple threads. Around 15% speedup on some benchmarks.
 * Optimize cache usage, and general write performance. Around 1.5x speedup on some benchmarks.
 * Optimize memory usage

--- a/src/db.rs
+++ b/src/db.rs
@@ -557,12 +557,14 @@ impl Database {
     /// externally to redb, or that a redb bug may have left the database in a corrupted state.
     ///
     /// Returns `Ok(true)` if the database passed integrity checks; `Ok(false)` if it failed but was repaired,
-    /// and `Err(Corrupted)` if the check failed and the file could not be repaired
+    /// and `Err(Corrupted)` if the check failed and the file could not be repaired.
+    ///
+    /// Returns [`DatabaseError::TransactionInProgress`] if any read or write transaction is still
+    /// alive when this method is called.
     pub fn check_integrity(&mut self) -> Result<bool, DatabaseError> {
         let allocator_hash = self.mem.allocator_hash();
-        let mut was_clean = Arc::get_mut(&mut self.mem)
-            .unwrap()
-            .clear_cache_and_reload()?;
+        let mem = Arc::get_mut(&mut self.mem).ok_or(DatabaseError::TransactionInProgress)?;
+        let mut was_clean = mem.clear_cache_and_reload()?;
 
         let old_roots = [self.mem.get_data_root(), self.mem.get_system_root()];
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -211,6 +211,8 @@ pub enum DatabaseError {
     RepairAborted,
     /// The database file is in an old file format and must be manually upgraded
     UpgradeRequired(u8),
+    /// A transaction is still in-progress
+    TransactionInProgress,
     /// Error from underlying storage
     Storage(StorageError),
 }
@@ -221,6 +223,7 @@ impl From<DatabaseError> for Error {
             DatabaseError::DatabaseAlreadyOpen => Error::DatabaseAlreadyOpen,
             DatabaseError::RepairAborted => Error::RepairAborted,
             DatabaseError::UpgradeRequired(x) => Error::UpgradeRequired(x),
+            DatabaseError::TransactionInProgress => Error::TransactionInProgress,
             DatabaseError::Storage(storage) => storage.into(),
         }
     }
@@ -252,6 +255,12 @@ impl Display for DatabaseError {
             }
             DatabaseError::DatabaseAlreadyOpen => {
                 write!(f, "Database already open. Cannot acquire lock.")
+            }
+            DatabaseError::TransactionInProgress => {
+                write!(
+                    f,
+                    "A transaction is still in progress. Operation cannot be performed."
+                )
             }
             DatabaseError::Storage(storage) => storage.fmt(f),
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2534,3 +2534,34 @@ fn persistent_savepoint_abort_unbounded_leak() {
         after.saturating_sub(baseline),
     );
 }
+
+#[test]
+fn check_integrity_with_live_read_transaction() {
+    let tmpfile = create_tempfile();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in 0..10u64 {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    // Hold a ReadTransaction, which keeps an Arc<TransactionalMemory> alive.
+    // Note: ReadTransaction does not borrow the Database, so we can still call
+    // `&mut self` methods on `db` while `read_txn` is alive.
+    let read_txn = db.begin_read().unwrap();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| db.check_integrity()));
+    assert!(result.is_ok(), "check_integrity() should not panic");
+    assert!(matches!(
+        result.unwrap(),
+        Err(DatabaseError::TransactionInProgress)
+    ));
+
+    // After the transaction is dropped, check_integrity() should succeed.
+    drop(read_txn);
+    assert!(db.check_integrity().unwrap());
+}


### PR DESCRIPTION
check_integrity() called Arc::get_mut(&mut self.mem).unwrap() to obtain exclusive access to the TransactionalMemory. A live ReadTransaction (or WriteTransaction) holds its own Arc<TransactionalMemory> clone but does not borrow the Database, so the borrow checker allowed callers to invoke check_integrity() while one was alive. Arc::get_mut then returned None and the unwrap panicked.

Add a new DatabaseError::TransactionInProgress variant and return it from check_integrity() when another Arc reference exists.

https://claude.ai/code/session_0157sFdMMJ9DCUeiBpftzBmB