### PR TITLE
perf: avoid Vec->Arc copy and other allocation hygiene in page_store

### DIFF
--- a/src/tree_store/page_store/backends.rs
+++ b/src/tree_store/page_store/backends.rs
@@ -86,16 +86,7 @@ impl StorageBackend for InMemoryBackend {
     fn set_len(&self, len: u64) -> Result<(), io::Error> {
         let mut guard = self.write();
         let len = usize::try_from(len).map_err(|_| Self::out_of_range())?;
-        if guard.len() < len {
-            let additional = len - guard.len();
-            guard.reserve(additional);
-            for _ in 0..additional {
-                guard.push(0);
-            }
-        } else {
-            guard.truncate(len);
-        }
-
+        guard.resize(len, 0);
         Ok(())
     }
 

--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -258,19 +258,20 @@ impl U64GroupedBitmap {
     // 4 bytes: number of elements
     // n bytes: serialized groups
     pub fn to_vec(&self) -> Vec<u8> {
-        let mut result = vec![];
-        result.extend(self.len.to_le_bytes());
-        for x in &self.data[..Self::required_words(self.len)] {
-            result.extend(x.to_le_bytes());
+        let words = Self::required_words(self.len);
+        let mut result = Vec::with_capacity(size_of::<u32>() + words * size_of::<u64>());
+        result.extend_from_slice(&self.len.to_le_bytes());
+        for x in &self.data[..words] {
+            result.extend_from_slice(&x.to_le_bytes());
         }
         result
     }
 
     pub fn from_bytes(serialized: &[u8]) -> Self {
         assert_eq!(0, (serialized.len() - size_of::<u32>()) % size_of::<u64>());
-        let mut data = vec![];
         let len = u32::from_le_bytes(serialized[..size_of::<u32>()].try_into().unwrap());
         let words = (serialized.len() - size_of::<u32>()) / size_of::<u64>();
+        let mut data = Vec::with_capacity(words);
         for i in 0..words {
             let start = size_of::<u32>() + i * size_of::<u64>();
             let value = u64::from_le_bytes(

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -89,21 +89,25 @@ impl BuddyAllocator {
     // free_ends: array of u32, with ending offset for BtreeBitmap structure for the given order
     // ... BtreeBitmap structures
     pub(crate) fn to_vec(&self) -> Vec<u8> {
-        let mut result = vec![];
+        let serialized: Vec<Vec<u8>> = self.free.iter().map(BtreeBitmap::to_vec).collect();
+
+        let header_bytes = 1 + 3 + size_of::<u32>();
+        let offsets_bytes = (self.max_order as usize + 1) * size_of::<u32>();
+        let data_bytes: usize = serialized.iter().map(Vec::len).sum();
+
+        let mut result = Vec::with_capacity(header_bytes + offsets_bytes + data_bytes);
         result.push(self.max_order);
         result.extend([0u8; 3]);
         result.extend(self.len.to_le_bytes());
 
-        let mut data_offset = result.len() + (self.max_order as usize + 1) * size_of::<u32>();
-        let end_metadata = data_offset;
-        for order in &self.free {
-            data_offset += order.to_vec().len();
+        let mut data_offset = header_bytes + offsets_bytes;
+        for bitmap in &serialized {
+            data_offset += bitmap.len();
             let offset_u32: u32 = data_offset.try_into().unwrap();
             result.extend(offset_u32.to_le_bytes());
         }
-        assert_eq!(end_metadata, result.len());
-        for order in &self.free {
-            result.extend(&order.to_vec());
+        for bitmap in &serialized {
+            result.extend_from_slice(bitmap);
         }
 
         result

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -8,6 +8,13 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 
+// Allocates an `Arc<[u8]>` in one step. `Arc::<[u8]>::from(vec![0; len])` would
+// allocate the Vec and then allocate a new Arc and memcpy into it.
+fn zero_filled_arc(len: usize) -> Arc<[u8]> {
+    // This is documented to do a single allocation: https://doc.rust-lang.org/std/sync/struct.Arc.html#iterators-of-known-length
+    std::iter::repeat_n(0u8, len).collect()
+}
+
 pub(super) struct WritablePage {
     buffer: Arc<Mutex<LRUWriteCache>>,
     offset: u64,
@@ -409,6 +416,15 @@ impl PagedCachedFile {
         Ok(buffer)
     }
 
+    // Like `read_direct`, but writes directly into an `Arc<[u8]>` instead of a
+    // `Vec<u8>` that is then copied into an `Arc`. The buffer is zero-filled
+    // because `StorageBackend::read` takes `&mut [u8]`.
+    fn read_direct_into_arc(&self, offset: u64, len: usize) -> Result<Arc<[u8]>> {
+        let mut arc = zero_filled_arc(len);
+        self.file.read(offset, Arc::get_mut(&mut arc).unwrap())?;
+        Ok(arc)
+    }
+
     // Read with caching. Caller must not read overlapping ranges without first calling invalidate_cache().
     // Doing so will not cause UB, but is a logic error.
     pub(super) fn read(&self, offset: u64, len: usize, hint: PageHint) -> Result<Arc<[u8]>> {
@@ -437,7 +453,7 @@ impl PagedCachedFile {
             }
         }
 
-        let buffer: Arc<[u8]> = self.read_direct(offset, len)?.into();
+        let buffer = self.read_direct_into_arc(offset, len)?;
         let cache_size = self.read_cache_bytes.fetch_add(len, Ordering::AcqRel);
         let mut write_lock = self.read_cache[cache_slot].write().unwrap();
         let cache_size = if let Some(replaced) = write_lock.insert(offset, buffer.clone()) {
@@ -580,9 +596,9 @@ impl PagedCachedFile {
             } else if overwrite {
                 #[cfg(feature = "cache_metrics")]
                 self.writes_hits.fetch_add(1, Ordering::AcqRel);
-                vec![0; len].into()
+                zero_filled_arc(len)
             } else {
-                self.read_direct(offset, len)?.into()
+                self.read_direct_into_arc(offset, len)?
             };
             lock.insert(offset, result);
             lock.take_value(offset).unwrap()


### PR DESCRIPTION
Fixes: #1138 