### PR TITLE
Fix aborting restore_savepoint()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   aborted could cause the database file to grow excessively, until the `Database` was dropped.
 * Fix a panic in `check_integrity()` when called while another transaction is still alive.
   The new `DatabaseError::TransactionInProgress` variant is now returned instead.
+* Fix a bug where aborting a transaction that called `restore_savepoint()` with a savepoint
+  when a newer savepoint existed could cause database space to be leaked.
+* Fix a bug where aborting a transaction that called `restore_savepoint()` would leave more
+  recent savepoints invalid.
+  when a newer savepoint existed could cause database space to be leaked.
 * Improve read scaling to multiple threads. Around 15% speedup on some benchmarks.
 * Optimize cache usage, and general write performance. Around 1.5x speedup on some benchmarks.
 * Optimize memory usage

--- a/src/db.rs
+++ b/src/db.rs
@@ -1505,9 +1505,14 @@ mod test {
 
         let mut tx = db.begin_write().unwrap();
         tx.set_two_phase_commit(true);
-        let savepoint5 = tx.ephemeral_savepoint().unwrap();
+        let _savepoint5 = tx.ephemeral_savepoint().unwrap();
         drop(savepoint3);
-        assert!(tx.restore_savepoint(&savepoint4).is_err());
+        // savepoint4 was invalidated by the restore_savepoint(savepoint3) call
+        // above, but that transaction was aborted, so the invalidation is
+        // reversed and savepoint4 is valid again. Restoring it here invalidates
+        // savepoint5 (which is newer), so the next transaction restores
+        // savepoint4 again rather than savepoint5.
+        tx.restore_savepoint(&savepoint4).unwrap();
         {
             tx.open_table(table_def).unwrap();
         }
@@ -1515,7 +1520,7 @@ mod test {
 
         let mut tx = db.begin_write().unwrap();
         tx.set_two_phase_commit(true);
-        tx.restore_savepoint(&savepoint5).unwrap();
+        tx.restore_savepoint(&savepoint4).unwrap();
         tx.set_durability(Durability::None).unwrap();
         {
             tx.open_table(table_def).unwrap();

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -256,12 +256,31 @@ impl TransactionTracker {
             .contains_key(&id)
     }
 
-    pub(crate) fn invalidate_savepoints_after(&self, id: SavepointId) {
+    pub(crate) fn list_savepoints_after(&self, id: SavepointId) -> Vec<SavepointId> {
         self.state
             .lock()
             .unwrap()
             .valid_savepoints
-            .retain(|x, _| *x <= id);
+            .range((
+                std::ops::Bound::Excluded(id),
+                std::ops::Bound::Unbounded::<SavepointId>,
+            ))
+            .map(|(x, _)| *x)
+            .collect()
+    }
+
+    // Removes the given savepoints from the in-memory `valid_savepoints` map without touching
+    // live_read_transactions refs. The caller is responsible for making sure those refs are
+    // released by some other means: ephemeral `Savepoint::drop` or `deallocate_savepoint`
+    // (called via `delete_persistent_savepoint`) do that for their respective savepoint kinds.
+    //
+    // Savepoints that have already been removed (for example, by `deallocate_savepoint` earlier
+    // in the same transaction) are silently skipped.
+    pub(crate) fn invalidate_savepoints(&self, savepoints: impl IntoIterator<Item = SavepointId>) {
+        let mut state = self.state.lock().unwrap();
+        for id in savepoints {
+            state.valid_savepoints.remove(&id);
+        }
     }
 
     pub(crate) fn oldest_savepoint(&self) -> Option<(SavepointId, TransactionId)> {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -21,7 +21,7 @@ use crate::{
 use log::{debug, warn};
 use std::borrow::Borrow;
 use std::cmp::min;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::{Debug, Display, Formatter};
 use std::marker::PhantomData;
 use std::mem::size_of;
@@ -775,6 +775,8 @@ pub struct WriteTransaction {
     // it needs to release the savepoint's TransactionTracker state.
     created_persistent_savepoints: Mutex<HashSet<(SavepointId, TransactionId)>>,
     deleted_persistent_savepoints: Mutex<Vec<(SavepointId, TransactionId)>>,
+    // Savepoints that restore_savepoint() has marked as invalidated within this transaction.
+    invalidated_savepoints: Mutex<BTreeSet<SavepointId>>,
 }
 
 impl WriteTransaction {
@@ -807,6 +809,7 @@ impl WriteTransaction {
             shrink_policy: ShrinkPolicy::Default,
             created_persistent_savepoints: Mutex::new(Default::default()),
             deleted_persistent_savepoints: Mutex::new(vec![]),
+            invalidated_savepoints: Mutex::new(BTreeSet::new()),
         })
     }
 
@@ -1099,6 +1102,11 @@ impl WriteTransaction {
         if !self
             .transaction_tracker
             .is_valid_savepoint(savepoint.get_id())
+            || self
+                .invalidated_savepoints
+                .lock()
+                .unwrap()
+                .contains(&savepoint.get_id())
         {
             return Err(SavepointError::InvalidSavepoint);
         }
@@ -1176,10 +1184,18 @@ impl WriteTransaction {
             }
         }
 
-        // 3) Invalidate all savepoints that are newer than the one being applied to prevent the user
-        // from later trying to restore a savepoint "on another timeline"
-        self.transaction_tracker
-            .invalidate_savepoints_after(savepoint.get_id());
+        // 3) Mark all savepoints newer than the restored one as invalidated for this
+        // transaction, to prevent the user from later trying to restore a savepoint
+        // "on another timeline". The invalidation is purely per-transaction state -
+        // the shared `valid_savepoints` map is only updated if/when commit_inner()
+        // runs, so an abort implicitly reverts the invalidation by dropping this set.
+        let invalidated = self
+            .transaction_tracker
+            .list_savepoints_after(savepoint.get_id());
+        self.invalidated_savepoints
+            .lock()
+            .unwrap()
+            .extend(invalidated);
         for persistent_savepoint in self.list_persistent_savepoints()? {
             if persistent_savepoint > savepoint.get_id().0 {
                 self.delete_persistent_savepoint(persistent_savepoint)?;
@@ -1422,6 +1438,16 @@ impl WriteTransaction {
             self.transaction_tracker
                 .deallocate_savepoint(*savepoint, *transaction);
         }
+        // Apply any savepoint invalidation that restore_savepoint() deferred to commit
+        // time. For persistent savepoints, deallocate_savepoint above has already
+        // removed them from valid_savepoints and decremented live_read_transactions.
+        // For ephemeral savepoints, only the valid_savepoints entry is removed here;
+        // the live_read_transactions ref stays owned by the user's Savepoint handle
+        // until it is dropped.
+        self.transaction_tracker
+            .invalidate_savepoints(std::mem::take(
+                &mut *self.invalidated_savepoints.lock().unwrap(),
+            ));
 
         assert!(
             self.system_tables
@@ -1554,6 +1580,12 @@ impl WriteTransaction {
             self.transaction_tracker
                 .deallocate_savepoint(*savepoint_id, *transaction_id);
         }
+        // restore_savepoint() only recorded the invalidated savepoints in the
+        // per-transaction `invalidated_savepoints` set without touching the shared
+        // `valid_savepoints` map, so dropping the set is sufficient to undo that
+        // invalidation. The SAVEPOINT_TABLE changes are reverted below by
+        // rollback_uncommitted_writes().
+        self.invalidated_savepoints.lock().unwrap().clear();
         self.mem.rollback_uncommitted_writes()?;
         #[cfg(feature = "logging")]
         debug!("Finished abort of transaction id={:?}", self.transaction_id);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2649,3 +2649,190 @@ fn restore_savepoint_partial_revert_commits_as_data_loss() {
     assert_eq!(k2, Some(2));
     assert_eq!(k3, Some(3));
 }
+
+// Regression test for a page leak when a transaction that attempts to
+// restore_savepoint() an older savepoint is aborted instead of committed.
+#[test]
+fn restore_savepoint_abort_unbounded_leak() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let table: TableDefinition<u64, u64> = TableDefinition::new("data");
+
+    // Warm up the persistent-savepoint system tables so the baseline is stable.
+    {
+        let txn = db.begin_write().unwrap();
+        let id = txn.persistent_savepoint().unwrap();
+        txn.commit().unwrap();
+        let txn = db.begin_write().unwrap();
+        txn.delete_persistent_savepoint(id).unwrap();
+        txn.commit().unwrap();
+    }
+
+    // Populate some data so that later writes have something to copy-on-write.
+    {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut t = txn.open_table(table).unwrap();
+            for i in 0..50u64 {
+                t.insert(i, i).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    // Drain pending freed pages so the baseline is stable.
+    for _ in 0..3 {
+        db.begin_write().unwrap().commit().unwrap();
+    }
+    let txn = db.begin_write().unwrap();
+    let baseline = txn.stats().unwrap().allocated_pages();
+    txn.abort().unwrap();
+
+    // Create an older persistent savepoint that will be restored (then aborted).
+    let older = {
+        let txn = db.begin_write().unwrap();
+        let id = txn.persistent_savepoint().unwrap();
+        txn.commit().unwrap();
+        id
+    };
+
+    // One modifying write between the two savepoints, so the newer savepoint
+    // references a different tree root than the older one.
+    {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut t = txn.open_table(table).unwrap();
+            t.insert(0, u64::MAX).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    // The newer persistent savepoint: restore_savepoint(older) tries to
+    // invalidate this one, and the abort leaves it as a ghost.
+    let newer = {
+        let txn = db.begin_write().unwrap();
+        let id = txn.persistent_savepoint().unwrap();
+        txn.commit().unwrap();
+        id
+    };
+
+    {
+        let mut txn = db.begin_write().unwrap();
+        let sp = txn.get_persistent_savepoint(older).unwrap();
+        txn.restore_savepoint(&sp).unwrap();
+        drop(sp);
+        txn.abort().unwrap();
+    }
+
+    {
+        let txn = db.begin_write().unwrap();
+        txn.delete_persistent_savepoint(older).unwrap();
+        txn.commit().unwrap();
+    }
+
+    const ITERATIONS: u64 = 100;
+    for round in 0..ITERATIONS {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut t = txn.open_table(table).unwrap();
+            t.insert(0, round).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    drop(db);
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    {
+        let mut txn = db.begin_write().unwrap();
+        let sp = txn.get_persistent_savepoint(newer).unwrap();
+        txn.restore_savepoint(&sp).unwrap();
+        drop(sp);
+        txn.commit().unwrap();
+    }
+    {
+        let txn = db.begin_write().unwrap();
+        txn.delete_persistent_savepoint(newer).unwrap();
+        txn.commit().unwrap();
+    }
+
+    // Drain pending freed pages so the final measurement is stable.
+    for _ in 0..3 {
+        db.begin_write().unwrap().commit().unwrap();
+    }
+    let txn = db.begin_write().unwrap();
+    let after = txn.stats().unwrap().allocated_pages();
+    txn.abort().unwrap();
+
+    assert_eq!(
+        baseline,
+        after,
+        "After {} iterations of insert+commit between an aborted \
+         restore_savepoint and the next restore_savepoint, page usage grew \
+         from {} to {} ({} pages leaked). The leak per iteration is independent \
+         of N, so running N iterations leaks O(N) pages.",
+        ITERATIONS,
+        baseline,
+        after,
+        after.saturating_sub(baseline),
+    );
+}
+
+#[test]
+fn restore_savepoint_abort_after_ephemeral_drop() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let table: TableDefinition<u64, u64> = TableDefinition::new("data");
+
+    {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut t = txn.open_table(table).unwrap();
+            for i in 0..20u64 {
+                t.insert(i, i).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    let older = {
+        let txn = db.begin_write().unwrap();
+        let sp = txn.ephemeral_savepoint().unwrap();
+        txn.commit().unwrap();
+        sp
+    };
+
+    let newer = {
+        let txn = db.begin_write().unwrap();
+        let sp = txn.ephemeral_savepoint().unwrap();
+        txn.commit().unwrap();
+        sp
+    };
+
+    {
+        let mut txn = db.begin_write().unwrap();
+        txn.restore_savepoint(&older).unwrap();
+        drop(newer);
+        txn.abort().unwrap();
+    }
+
+    {
+        let mut txn = db.begin_write().unwrap();
+        txn.restore_savepoint(&older).unwrap();
+        txn.commit().unwrap();
+    }
+    drop(older);
+    for _ in 0..3 {
+        db.begin_write().unwrap().commit().unwrap();
+    }
+
+    assert!(
+        db.begin_read()
+            .unwrap()
+            .open_table(table)
+            .unwrap()
+            .get(&0u64)
+            .unwrap()
+            .is_some()
+    );
+}


### PR DESCRIPTION
restore_savepoint() invalidates every savepoint whose id is strictly
greater than the restored savepoint's id so that the user cannot later
try to restore one "on another timeline". Previously that invalidation
eagerly mutated the shared TransactionTracker::valid_savepoints map.
rollback_uncommitted_writes() reverts the on-disk SAVEPOINT_TABLE
changes but not that in-memory map edit, and the
deleted_persistent_savepoints queue is dropped on abort without
running deallocate_savepoint, so live_read_transactions retained a
reference for every "ghost" savepoint that was still present on disk.

The concrete leak follows from store_allocated_pages()'s purge loop,
which walks oldest_savepoint() to decide how much of DATA_ALLOCATED_TABLE
to drop. With the ghost savepoint removed from valid_savepoints but
still on disk, a subsequent deletion of the user-known savepoint leaves
valid_savepoints empty. Every later commit then purges
DATA_ALLOCATED_TABLE up to u64::MAX, discarding the allocation history
of any transactions that happened after the on-disk savepoint was
created. When that savepoint is eventually restored (for example, after
a database reopen re-registers it), restore_savepoint() no longer has
the allocation records it needs to move those pages into freed_pages,
so they remain allocated but unreachable from the restored tree root -
an unbounded leak proportional to the number of intervening write
transactions.

Fix by making the invalidation fully transactional:

* TransactionTracker gains a read-only list_savepoints_after() and a
  batch invalidate_savepoints(); the old invalidate_savepoints_after()
  (which mutated on the spot) is removed.
* WriteTransaction carries a per-transaction invalidated_savepoints
  set. restore_savepoint() populates it from list_savepoints_after()
  without touching the shared map. Subsequent checks in
  restore_savepoint() consult both the tracker's is_valid_savepoint
  and this set, so a savepoint that was invalidated earlier in the
  same transaction still cannot be restored.
* commit_inner() applies the invalidation to the shared map by calling
  invalidate_savepoints() after deleted_persistent_savepoints has been
  drained. abort_inner() simply clears the set, so the shared tracker
  is never left out of sync with on-disk state.

Keeping the shared map untouched until commit also means that an
ephemeral Savepoint whose handle is dropped between restore() and
abort() cleans up through its existing Drop path (which decrements
live_read_transactions and removes the valid_savepoints entry) without
any interaction with a stale stashed list.

The existing small_pages2 test encoded the buggy behavior (asserting
savepoint4 was still invalid after an aborted restore); update it to
match, and add restore_savepoint_abort_unbounded_leak plus
restore_savepoint_abort_after_ephemeral_drop as regression tests.

https://claude.ai/code/session_0132hLaqxqUAFHYX4hEWGWcT