### PR TITLE
Fix panic in BtreeRangeIter::next_back after forward exhaustion

### DIFF
--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -529,12 +529,17 @@ impl<K: Key, V: Value> Iterator for BtreeRangeIter<K, V> {
             && (left_entry > right_entry
                 || (left_entry == right_entry && (!self.include_left || !self.include_right)))
         {
+            self.close();
             return None;
         }
 
         loop {
             if !self.include_left {
-                match self.left.take()?.next(false, &self.manager, self.hint) {
+                let Some(current) = self.left.take() else {
+                    self.close();
+                    return None;
+                };
+                match current.next(false, &self.manager, self.hint) {
                     Ok(left) => {
                         self.left = left;
                     }
@@ -544,7 +549,10 @@ impl<K: Key, V: Value> Iterator for BtreeRangeIter<K, V> {
                 }
             }
             // Return None if the next state is None
-            self.left.as_ref()?;
+            if self.left.is_none() {
+                self.close();
+                return None;
+            }
 
             if let (
                 Some(Leaf {
@@ -561,6 +569,7 @@ impl<K: Key, V: Value> Iterator for BtreeRangeIter<K, V> {
                 && left_page.get_page_number() == right_page.get_page_number()
                 && (left_entry > right_entry || (left_entry == right_entry && !self.include_right))
             {
+                self.close();
                 return None;
             }
 
@@ -601,12 +610,17 @@ impl<K: Key, V: Value> DoubleEndedIterator for BtreeRangeIter<K, V> {
             && (left_entry > right_entry
                 || (left_entry == right_entry && (!self.include_left || !self.include_right)))
         {
+            self.close();
             return None;
         }
 
         loop {
             if !self.include_right {
-                match self.right.take()?.next(true, &self.manager, self.hint) {
+                let Some(current) = self.right.take() else {
+                    self.close();
+                    return None;
+                };
+                match current.next(true, &self.manager, self.hint) {
                     Ok(right) => {
                         self.right = right;
                     }
@@ -616,7 +630,10 @@ impl<K: Key, V: Value> DoubleEndedIterator for BtreeRangeIter<K, V> {
                 }
             }
             // Return None if the next state is None
-            self.right.as_ref()?;
+            if self.right.is_none() {
+                self.close();
+                return None;
+            }
 
             if let (
                 Some(Leaf {
@@ -633,6 +650,7 @@ impl<K: Key, V: Value> DoubleEndedIterator for BtreeRangeIter<K, V> {
                 && left_page.get_page_number() == right_page.get_page_number()
                 && (left_entry > right_entry || (left_entry == right_entry && !self.include_left))
             {
+                self.close();
                 return None;
             }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2836,3 +2836,34 @@ fn restore_savepoint_abort_after_ephemeral_drop() {
             .is_some()
     );
 }
+
+#[test]
+fn extract_if_next_then_next_back_panic() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let table_def: TableDefinition<u64, u64> = TableDefinition::new("t");
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        table.insert(&1u64, &10u64).unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        let mut iter = table.extract_if(|_, _| true).unwrap();
+
+        let first = iter.next();
+        assert!(first.is_some());
+        let first = first.unwrap();
+        assert!(first.is_ok());
+
+        assert!(iter.next().is_none());
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| iter.next_back()));
+        assert!(result.is_ok());
+    }
+    txn.abort().unwrap();
+}


### PR DESCRIPTION
When a range scan has an unbounded right end, BtreeRangeIter defers computing the right boundary until the first next_back() call (commit 33ea2c6). If the caller drives forward iteration to completion first, self.left becomes None but uninit_right_root remains set, so the lazy init would walk back to the rightmost leaf entry and yield it again.

The iterator is now properly closed when it is exhausted

https://claude.ai/code/session_01VKNmLgVSy9DxrjkTvvhxBG