### PR TITLE
Fix MultimapValue::next_back() not decrementing remaining counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # redb - Changelog
 
 ## 4.1.0 - UNRELEASED
+* Fix bug where `MultimapValue::len()` and `is_empty()` returned stale counts after
+  consuming entries via `next_back()`. `next_back()` now decrements the remaining
+  counter, matching the behavior of `next()`.
 * Fix bug where `restore_savepoint()` could fail with `SavepointError::InvalidSavepoint`, but
   the savepoint would actually be partially applied, when called with a non-`Immediate` durability and
   there are persistent savepoints newer than the restored one. The call now fails up front with

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -857,6 +857,7 @@ impl<V: Key + 'static> DoubleEndedIterator for MultimapValue<'_, V> {
             },
             ValueIterState::InlineLeaf(iter) => iter.next_key_back()?.to_vec(),
         };
+        self.remaining -= 1;
         Some(Ok(AccessGuard::with_owned_value(bytes)))
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2867,3 +2867,36 @@ fn extract_if_next_then_next_back_panic() {
     }
     txn.abort().unwrap();
 }
+
+#[test]
+fn multimap_value_next_back_does_not_update_len() {
+    const TABLE: MultimapTableDefinition<u32, u32> = MultimapTableDefinition::new("m");
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_multimap_table(TABLE).unwrap();
+        for i in 0..5u32 {
+            table.insert(&1u32, &i).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_multimap_table(TABLE).unwrap();
+    let mut iter = table.get(&1u32).unwrap();
+    assert_eq!(iter.len(), 5);
+    assert!(!iter.is_empty());
+
+    let _ = iter.next_back().unwrap().unwrap();
+    assert_eq!(iter.len(), 4);
+
+    for expected_remaining in (0..4).rev() {
+        iter.next_back().unwrap().unwrap();
+        assert_eq!(iter.len(), expected_remaining as u64);
+    }
+    assert!(iter.is_empty());
+    assert!(iter.next_back().is_none());
+}


### PR DESCRIPTION
next() decremented self.remaining to keep len()/is_empty() consistent with the documented "number of times this iterator will return Some(Ok(_))" contract, but next_back() did not. As a result, callers iterating a multimap key's values in reverse saw stale len() values and is_empty() stayed false even after the iterator was fully drained.

The fix mirrors next(): decrement remaining immediately before returning the entry.

https://claude.ai/code/session_01N3WA45X12u7yMfAyReEscU