### PR TITLE
Add documentation and tests for empty table name validation

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -121,9 +121,11 @@ pub struct TableDefinition<'a, K: Key + 'static, V: Value + 'static> {
 impl<'a, K: Key + 'static, V: Value + 'static> TableDefinition<'a, K, V> {
     /// Construct a new table with given `name`
     ///
-    /// ## Invariant
+    /// # Panics
     ///
-    /// `name` must not be empty.
+    /// Panics if `name` is empty. When `name` is a non-empty string literal
+    /// this is checked at compile time, but callers that build the name at
+    /// runtime are responsible for ensuring it is non-empty.
     pub const fn new(name: &'a str) -> Self {
         assert!(!name.is_empty());
         Self {
@@ -177,6 +179,13 @@ pub struct MultimapTableDefinition<'a, K: Key + 'static, V: Key + 'static> {
 }
 
 impl<'a, K: Key + 'static, V: Key + 'static> MultimapTableDefinition<'a, K, V> {
+    /// Construct a new multimap table with given `name`
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name` is empty. When `name` is a non-empty string literal
+    /// this is checked at compile time, but callers that build the name at
+    /// runtime are responsible for ensuring it is non-empty.
     pub const fn new(name: &'a str) -> Self {
         assert!(!name.is_empty());
         Self {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2900,3 +2900,17 @@ fn multimap_value_next_back_does_not_update_len() {
     assert!(iter.is_empty());
     assert!(iter.next_back().is_none());
 }
+
+#[test]
+#[should_panic(expected = "assertion failed: !name.is_empty()")]
+fn table_definition_new_panics_on_empty_name() {
+    let name = String::new();
+    let _def: TableDefinition<u64, u64> = TableDefinition::new(&name);
+}
+
+#[test]
+#[should_panic(expected = "assertion failed: !name.is_empty()")]
+fn multimap_table_definition_new_panics_on_empty_name() {
+    let name = String::new();
+    let _def: MultimapTableDefinition<u64, u64> = MultimapTableDefinition::new(&name);
+}


### PR DESCRIPTION
## Summary
This PR improves the documentation and test coverage for table name validation in `TableDefinition` and `MultimapTableDefinition`. Both types enforce a requirement that table names must be non-empty, and this change makes that contract clearer and more thoroughly tested.

## Key Changes
- **Updated documentation** for `TableDefinition::new()`: Changed from "Invariant" section to "Panics" section with clearer explanation of when and why panics occur, and guidance for runtime name construction
- **Added documentation** for `MultimapTableDefinition::new()`: Added missing doc comment explaining the panic behavior for empty names
- **Added integration tests**: Two new tests verify that both `TableDefinition` and `MultimapTableDefinition` panic when constructed with empty names

## Implementation Details
- The actual validation logic (the `assert!(!name.is_empty())` calls) was already present in both constructors
- This change focuses on making the validation contract explicit through documentation and test coverage
- The documentation clarifies that compile-time checking occurs for string literals, while runtime callers must ensure non-empty names

https://claude.ai/code/session_01R84XgiumvzhJNy13PYbdq2