### PR TITLE
Thread PageHint through B-tree operations for better caching

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -25,9 +25,10 @@ pub(crate) fn multimap_btree_stats(
     mem: &TransactionalMemory,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
+    hint: PageHint,
 ) -> Result<BtreeStats> {
     if let Some(root) = root {
-        multimap_stats_helper(root, mem, fixed_key_size, fixed_value_size)
+        multimap_stats_helper(root, mem, fixed_key_size, fixed_value_size, hint)
     } else {
         Ok(BtreeStats {
             tree_height: 0,
@@ -45,8 +46,9 @@ fn multimap_stats_helper(
     mem: &TransactionalMemory,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
+    hint: PageHint,
 ) -> Result<BtreeStats> {
-    let page = mem.get_page(page_number)?;
+    let page = mem.get_page(page_number, hint)?;
     let node_mem = page.memory();
     match node_mem[0] {
         LEAF => {
@@ -96,6 +98,7 @@ fn multimap_stats_helper(
                             mem,
                             fixed_value_size,
                             <() as Value>::fixed_width(),
+                            hint,
                         )?;
                         max_child_height = max(max_child_height, stats.tree_height);
                         branch_pages += stats.branch_pages;
@@ -127,7 +130,7 @@ fn multimap_stats_helper(
             for i in 0..accessor.count_children() {
                 if let Some(child) = accessor.child_page(i) {
                     let stats =
-                        multimap_stats_helper(child, mem, fixed_key_size, fixed_value_size)?;
+                        multimap_stats_helper(child, mem, fixed_key_size, fixed_value_size, hint)?;
                     max_child_height = max(max_child_height, stats.tree_height);
                     leaf_pages += stats.leaf_pages;
                     branch_pages += stats.branch_pages;
@@ -156,6 +159,7 @@ pub(crate) fn verify_tree_and_subtree_checksums(
     key_size: Option<usize>,
     value_size: Option<usize>,
     mem: Arc<TransactionalMemory>,
+    hint: PageHint,
 ) -> Result<bool> {
     if let Some(header) = root {
         if !RawBtree::new(
@@ -163,6 +167,7 @@ pub(crate) fn verify_tree_and_subtree_checksums(
             key_size,
             DynamicCollection::<()>::fixed_width_with(value_size),
             mem.clone(),
+            hint,
         )
         .verify_checksum()?
         {
@@ -174,13 +179,20 @@ pub(crate) fn verify_tree_and_subtree_checksums(
             key_size,
             DynamicCollection::<()>::fixed_width_with(value_size),
             mem.clone(),
+            hint,
         )?;
         for table_page in table_pages_iter {
-            let page = mem.get_page(table_page?)?;
+            let page = mem.get_page(table_page?, hint)?;
             let subtree_roots = parse_subtree_roots(&page, key_size, value_size);
             for header in subtree_roots {
-                if !RawBtree::new(Some(header), value_size, <()>::fixed_width(), mem.clone())
-                    .verify_checksum()?
+                if !RawBtree::new(
+                    Some(header),
+                    value_size,
+                    <()>::fixed_width(),
+                    mem.clone(),
+                    hint,
+                )
+                .verify_checksum()?
                 {
                     return Ok(false);
                 }
@@ -200,7 +212,7 @@ pub(crate) fn relocate_subtrees(
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
     relocation_map: &HashMap<PageNumber, PageNumber>,
 ) -> Result<(PageNumber, Checksum)> {
-    let old_page = mem.get_page(root.0)?;
+    let old_page = mem.get_page(root.0, PageHint::None)?;
     let mut new_page = if let Some(new_page_number) = relocation_map.get(&root.0) {
         mem.get_page_mut(*new_page_number)?
     } else {
@@ -369,6 +381,7 @@ fn parse_subtree_roots<T: Page>(
 pub(crate) struct UntypedMultiBtree {
     mem: Arc<TransactionalMemory>,
     root: Option<BtreeHeader>,
+    hint: PageHint,
     key_width: Option<usize>,
     value_width: Option<usize>,
 }
@@ -377,12 +390,14 @@ impl UntypedMultiBtree {
     pub(crate) fn new(
         root: Option<BtreeHeader>,
         mem: Arc<TransactionalMemory>,
+        hint: PageHint,
         key_width: Option<usize>,
         value_width: Option<usize>,
     ) -> Self {
         Self {
             mem,
             root,
+            hint,
             key_width,
             value_width,
         }
@@ -396,18 +411,20 @@ impl UntypedMultiBtree {
         let tree = UntypedBtree::new(
             self.root,
             self.mem.clone(),
+            self.hint,
             self.key_width,
             UntypedDynamicCollection::fixed_width_with(self.value_width),
         );
         tree.visit_all_pages(|path| {
             visitor(path)?;
-            let page = self.mem.get_page(path.page_number())?;
+            let page = self.mem.get_page(path.page_number(), self.hint)?;
             match page.memory()[0] {
                 LEAF => {
                     for header in parse_subtree_roots(&page, self.key_width, self.value_width) {
                         let subtree = UntypedBtree::new(
                             Some(header),
                             self.mem.clone(),
+                            self.hint,
                             self.value_width,
                             <() as Value>::fixed_width(),
                         );
@@ -1254,7 +1271,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                     length: new_length,
                 }) = subtree.get_root()
                 {
-                    let page = self.mem.get_page(new_root)?;
+                    let page = self.mem.get_page(new_root, PageHint::None)?;
                     match page.memory()[0] {
                         LEAF => {
                             let accessor = LeafAccessor::new(
@@ -1327,6 +1344,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                     V::fixed_width(),
                     <() as Value>::fixed_width(),
                     self.mem.clone(),
+                    PageHint::None,
                 )?;
                 for page in all_pages {
                     pages.push(page?);
@@ -1367,6 +1385,7 @@ impl<K: Key + 'static, V: Key + 'static> ReadableTableMetadata for MultimapTable
             &self.mem,
             K::fixed_width(),
             V::fixed_width(),
+            PageHint::None,
         )?;
 
         Ok(TableStats {
@@ -1448,6 +1467,7 @@ pub trait ReadableMultimapTable<K: Key + 'static, V: Key + 'static>: ReadableTab
 pub struct ReadOnlyUntypedMultimapTable {
     num_values: u64,
     tree: RawBtree,
+    hint: PageHint,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
     mem: Arc<TransactionalMemory>,
@@ -1463,6 +1483,7 @@ impl ReadableTableMetadata for ReadOnlyUntypedMultimapTable {
             &self.mem,
             self.fixed_key_size,
             self.fixed_value_size,
+            self.hint,
         )?;
 
         Ok(TableStats {
@@ -1484,6 +1505,7 @@ impl ReadOnlyUntypedMultimapTable {
     pub(crate) fn new(
         root: Option<BtreeHeader>,
         num_values: u64,
+        hint: PageHint,
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
         mem: Arc<TransactionalMemory>,
@@ -1495,7 +1517,9 @@ impl ReadOnlyUntypedMultimapTable {
                 fixed_key_size,
                 DynamicCollection::<()>::fixed_width_with(fixed_value_size),
                 mem.clone(),
+                hint,
             ),
+            hint,
             fixed_key_size,
             fixed_value_size,
             mem,
@@ -1572,6 +1596,7 @@ impl<K: Key + 'static, V: Key + 'static> ReadableTableMetadata for ReadOnlyMulti
             &self.mem,
             K::fixed_width(),
             V::fixed_width(),
+            self.tree.hint(),
         )?;
 
         Ok(TableStats {

--- a/src/table.rs
+++ b/src/table.rs
@@ -455,12 +455,13 @@ impl ReadableTableMetadata for ReadOnlyUntypedTable {
 impl ReadOnlyUntypedTable {
     pub(crate) fn new(
         root_page: Option<BtreeHeader>,
+        hint: PageHint,
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
         mem: Arc<TransactionalMemory>,
     ) -> Self {
         Self {
-            tree: RawBtree::new(root_page, fixed_key_size, fixed_value_size, mem),
+            tree: RawBtree::new(root_page, fixed_key_size, fixed_value_size, mem, hint),
         }
     }
 }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1783,7 +1783,7 @@ impl WriteTransaction {
             if relocation_map.contains_key(&path.page_number()) {
                 continue;
             }
-            let old_page = self.mem.get_page(path.page_number())?;
+            let old_page = self.mem.get_page(path.page_number(), PageHint::None)?;
             let mut new_page = self.mem.allocate_lowest(old_page.memory().len())?;
             let new_page_number = new_page.get_page_number();
             // We have to copy at least the page type into the new page.
@@ -1797,7 +1797,7 @@ impl WriteTransaction {
                     if relocation_map.contains_key(parent) {
                         continue;
                     }
-                    let old_parent = self.mem.get_page(*parent)?;
+                    let old_parent = self.mem.get_page(*parent, PageHint::None)?;
                     let mut new_page = self.mem.allocate_lowest(old_parent.memory().len())?;
                     let new_page_number = new_page.get_page_number();
                     // We have to copy at least the page type into the new page.
@@ -2161,6 +2161,7 @@ impl ReadTransaction {
                 ..
             } => Ok(ReadOnlyUntypedTable::new(
                 table_root,
+                PageHint::Clean,
                 fixed_key_size,
                 fixed_value_size,
                 self.mem.clone(),
@@ -2216,6 +2217,7 @@ impl ReadTransaction {
             } => Ok(ReadOnlyUntypedMultimapTable::new(
                 table_root,
                 table_length,
+                PageHint::Clean,
                 fixed_key_size,
                 fixed_value_size,
                 self.mem.clone(),

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -66,6 +66,7 @@ impl PagePath {
 pub(crate) struct UntypedBtree {
     mem: Arc<TransactionalMemory>,
     root: Option<BtreeHeader>,
+    hint: PageHint,
     key_width: Option<usize>,
     _value_width: Option<usize>,
 }
@@ -74,12 +75,14 @@ impl UntypedBtree {
     pub(crate) fn new(
         root: Option<BtreeHeader>,
         mem: Arc<TransactionalMemory>,
+        hint: PageHint,
         key_width: Option<usize>,
         value_width: Option<usize>,
     ) -> Self {
         Self {
             mem,
             root,
+            hint,
             key_width,
             _value_width: value_width,
         }
@@ -102,7 +105,7 @@ impl UntypedBtree {
         F: FnMut(&PagePath) -> Result,
     {
         visitor(&path)?;
-        let page = self.mem.get_page(path.page_number())?;
+        let page = self.mem.get_page(path.page_number(), self.hint)?;
 
         match page.memory()[0] {
             LEAF => {
@@ -278,7 +281,7 @@ impl UntypedBtreeMut {
         page_number: PageNumber,
         relocation_map: &HashMap<PageNumber, PageNumber>,
     ) -> Result<Option<(PageNumber, Checksum)>> {
-        let old_page = self.mem.get_page(page_number)?;
+        let old_page = self.mem.get_page(page_number, PageHint::None)?;
         let mut new_page = if let Some(new_page_number) = relocation_map.get(&page_number) {
             self.mem.get_page_mut(*new_page_number)?
         } else {
@@ -369,6 +372,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
                 K::fixed_width(),
                 V::fixed_width(),
                 self.mem.clone(),
+                PageHint::None,
             )?))
         } else {
             Ok(None)
@@ -479,6 +483,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
             &self.mem,
             K::fixed_width(),
             V::fixed_width(),
+            PageHint::None,
         )
     }
 
@@ -513,7 +518,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
                     .try_into()
                     .unwrap();
                 let mut new_page = self.mem.allocate(required, &mut allocated)?;
-                let old_page = self.mem.get_page(root.root)?;
+                let old_page = self.mem.get_page(root.root, PageHint::None)?;
                 new_page.memory_mut().copy_from_slice(old_page.memory());
                 drop(old_page);
                 freed_pages.push(root.root);
@@ -571,7 +576,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
                         .try_into()
                         .unwrap();
                     let mut new_page = self.mem.allocate(required, &mut allocated)?;
-                    let old_child_page = self.mem.get_page(child_page)?;
+                    let old_child_page = self.mem.get_page(child_page, PageHint::None)?;
                     new_page
                         .memory_mut()
                         .copy_from_slice(old_child_page.memory());
@@ -709,6 +714,7 @@ impl<'a, K: Key + 'a, V: MutInPlaceValue + 'a> BtreeMut<'a, K, V> {
 pub(crate) struct RawBtree {
     mem: Arc<TransactionalMemory>,
     root: Option<BtreeHeader>,
+    hint: PageHint,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
 }
@@ -719,10 +725,12 @@ impl RawBtree {
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
         mem: Arc<TransactionalMemory>,
+        hint: PageHint,
     ) -> Self {
         Self {
             mem,
             root,
+            hint,
             fixed_key_size,
             fixed_value_size,
         }
@@ -738,6 +746,7 @@ impl RawBtree {
             &self.mem,
             self.fixed_key_size,
             self.fixed_value_size,
+            self.hint,
         )
     }
 
@@ -758,7 +767,7 @@ impl RawBtree {
         page_number: PageNumber,
         expected_checksum: Checksum,
     ) -> Result<bool> {
-        let page = self.mem.get_page(page_number)?;
+        let page = self.mem.get_page(page_number, self.hint)?;
         let node_mem = page.memory();
         Ok(match node_mem[0] {
             LEAF => {
@@ -813,7 +822,7 @@ impl<K: Key, V: Value> Btree<K, V> {
         mem: Arc<TransactionalMemory>,
     ) -> Result<Self> {
         let cached_root = if let Some(header) = root {
-            Some(mem.get_page_extended(header.root, hint)?)
+            Some(mem.get_page(header.root, hint)?)
         } else {
             None
         };
@@ -832,6 +841,10 @@ impl<K: Key, V: Value> Btree<K, V> {
         &self.transaction_guard
     }
 
+    pub(crate) fn hint(&self) -> PageHint {
+        self.hint
+    }
+
     pub(crate) fn get_root(&self) -> Option<BtreeHeader> {
         self.root
     }
@@ -842,6 +855,7 @@ impl<K: Key, V: Value> Btree<K, V> {
             K::fixed_width(),
             V::fixed_width(),
             self.mem.clone(),
+            self.hint,
         )
         .verify_checksum()
     }
@@ -853,6 +867,7 @@ impl<K: Key, V: Value> Btree<K, V> {
         let tree = UntypedBtree::new(
             self.root,
             self.mem.clone(),
+            self.hint,
             K::fixed_width(),
             V::fixed_width(),
         );
@@ -884,7 +899,7 @@ impl<K: Key, V: Value> Btree<K, V> {
             BRANCH => {
                 let accessor = BranchAccessor::new(page, K::fixed_width());
                 let (_, child_page) = accessor.child_for_key::<K>(query);
-                let child_page = self.mem.get_page_extended(child_page, self.hint)?;
+                let child_page = self.mem.get_page(child_page, self.hint)?;
                 self.get_helper(&child_page, query)
             }
             _ => unreachable!(),
@@ -917,7 +932,7 @@ impl<K: Key, V: Value> Btree<K, V> {
             BRANCH => {
                 let accessor = BranchAccessor::new(&page, K::fixed_width());
                 let child_page = accessor.child_page(0).unwrap();
-                self.first_helper(self.mem.get_page_extended(child_page, self.hint)?)
+                self.first_helper(self.mem.get_page(child_page, self.hint)?)
             }
             _ => unreachable!(),
         }
@@ -950,7 +965,7 @@ impl<K: Key, V: Value> Btree<K, V> {
             BRANCH => {
                 let accessor = BranchAccessor::new(&page, K::fixed_width());
                 let child_page = accessor.child_page(accessor.count_children() - 1).unwrap();
-                self.last_helper(self.mem.get_page_extended(child_page, self.hint)?)
+                self.last_helper(self.mem.get_page(child_page, self.hint)?)
             }
             _ => unreachable!(),
         }
@@ -978,13 +993,14 @@ impl<K: Key, V: Value> Btree<K, V> {
             &self.mem,
             K::fixed_width(),
             V::fixed_width(),
+            self.hint,
         )
     }
 
     #[allow(dead_code)]
     pub(crate) fn print_debug(&self, include_values: bool) -> Result {
         if let Some(p) = self.root.map(|x| x.root) {
-            let mut pages = vec![self.mem.get_page(p)?];
+            let mut pages = vec![self.mem.get_page(p, self.hint)?];
             while !pages.is_empty() {
                 let mut next_children = vec![];
                 for page in pages.drain(..) {
@@ -1000,7 +1016,7 @@ impl<K: Key, V: Value> Btree<K, V> {
                             let accessor = BranchAccessor::new(&page, K::fixed_width());
                             for i in 0..accessor.count_children() {
                                 let child = accessor.child_page(i).unwrap();
-                                next_children.push(self.mem.get_page(child)?);
+                                next_children.push(self.mem.get_page(child, self.hint)?);
                             }
                             accessor.print_node::<K>();
                         }
@@ -1030,9 +1046,10 @@ pub(crate) fn btree_stats(
     mem: &TransactionalMemory,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
+    hint: PageHint,
 ) -> Result<BtreeStats> {
     if let Some(root) = root {
-        stats_helper(root, mem, fixed_key_size, fixed_value_size)
+        stats_helper(root, mem, fixed_key_size, fixed_value_size, hint)
     } else {
         Ok(BtreeStats {
             tree_height: 0,
@@ -1050,8 +1067,9 @@ fn stats_helper(
     mem: &TransactionalMemory,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
+    hint: PageHint,
 ) -> Result<BtreeStats> {
-    let page = mem.get_page(page_number)?;
+    let page = mem.get_page(page_number, hint)?;
     let node_mem = page.memory();
     match node_mem[0] {
         LEAF => {
@@ -1078,7 +1096,7 @@ fn stats_helper(
             let mut fragmented_bytes = (page.memory().len() - accessor.total_length()) as u64;
             for i in 0..accessor.count_children() {
                 if let Some(child) = accessor.child_page(i) {
-                    let stats = stats_helper(child, mem, fixed_key_size, fixed_value_size)?;
+                    let stats = stats_helper(child, mem, fixed_key_size, fixed_value_size, hint)?;
                     max_child_height = max(max_child_height, stats.tree_height);
                     leaf_pages += stats.leaf_pages;
                     branch_pages += stats.branch_pages;

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -76,7 +76,7 @@ impl RangeIterState {
             } => {
                 let accessor = BranchAccessor::new(&page, fixed_key_size);
                 let child_page = accessor.child_page(child).unwrap();
-                let child_page = manager.get_page_extended(child_page, hint)?;
+                let child_page = manager.get_page(child_page, hint)?;
                 let direction = if reverse { -1 } else { 1 };
                 let next_child = isize::try_from(child).unwrap() + direction;
                 if 0 <= next_child && next_child < accessor.count_children().try_into().unwrap() {
@@ -187,6 +187,7 @@ impl<K: Key, V: Value> EntryGuard<K, V> {
 pub(crate) struct AllPageNumbersBtreeIter {
     next: Option<RangeIterState>,
     manager: Arc<TransactionalMemory>,
+    hint: PageHint,
 }
 
 impl AllPageNumbersBtreeIter {
@@ -195,8 +196,9 @@ impl AllPageNumbersBtreeIter {
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
         manager: Arc<TransactionalMemory>,
+        hint: PageHint,
     ) -> Result<Self> {
-        let root_page = manager.get_page(root)?;
+        let root_page = manager.get_page(root, hint)?;
         let node_mem = root_page.memory();
         let start = match node_mem[0] {
             LEAF => Leaf {
@@ -218,6 +220,7 @@ impl AllPageNumbersBtreeIter {
         Ok(Self {
             next: Some(start),
             manager,
+            hint,
         })
     }
 }
@@ -234,7 +237,7 @@ impl Iterator for AllPageNumbersBtreeIter {
                 Leaf { entry, .. } => entry == 0,
                 Internal { child, .. } => child == 0,
             };
-            match state.next(false, &self.manager, PageHint::None) {
+            match state.next(false, &self.manager, self.hint) {
                 Ok(next) => {
                     self.next = next;
                 }
@@ -422,7 +425,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
         if let Some(root) = table_root {
             let (include_left, left) = match query_range.start_bound() {
                 Included(k) => find_iter_left::<K, V>(
-                    manager.get_page_extended(root, hint)?,
+                    manager.get_page(root, hint)?,
                     None,
                     K::as_bytes(k.borrow()).as_ref(),
                     true,
@@ -430,7 +433,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
                     hint,
                 )?,
                 Excluded(k) => find_iter_left::<K, V>(
-                    manager.get_page_extended(root, hint)?,
+                    manager.get_page(root, hint)?,
                     None,
                     K::as_bytes(k.borrow()).as_ref(),
                     false,
@@ -439,7 +442,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
                 )?,
                 Unbounded => {
                     let state = find_iter_unbounded::<K, V>(
-                        manager.get_page_extended(root, hint)?,
+                        manager.get_page(root, hint)?,
                         None,
                         false,
                         &manager,
@@ -454,7 +457,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
             let (include_right, right, uninit_right_root) = match query_range.end_bound() {
                 Included(k) => {
                     let (inc, state) = find_iter_right::<K, V>(
-                        manager.get_page_extended(root, hint)?,
+                        manager.get_page(root, hint)?,
                         None,
                         K::as_bytes(k.borrow()).as_ref(),
                         true,
@@ -465,7 +468,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
                 }
                 Excluded(k) => {
                     let (inc, state) = find_iter_right::<K, V>(
-                        manager.get_page_extended(root, hint)?,
+                        manager.get_page(root, hint)?,
                         None,
                         K::as_bytes(k.borrow()).as_ref(),
                         false,
@@ -585,7 +588,7 @@ impl<K: Key, V: Value> DoubleEndedIterator for BtreeRangeIter<K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         // Lazily initialize the unbounded right boundary on first next_back() call.
         if let Some(root) = self.uninit_right_root.take() {
-            let page = match self.manager.get_page_extended(root, self.hint) {
+            let page = match self.manager.get_page(root, self.hint) {
                 Ok(p) => p,
                 Err(e) => return Some(Err(e)),
             };
@@ -690,7 +693,7 @@ fn find_iter_unbounded<K: Key, V: Value>(
                 0
             };
             let child_page_number = accessor.child_page(child_index).unwrap();
-            let child_page = manager.get_page_extended(child_page_number, hint)?;
+            let child_page = manager.get_page(child_page_number, hint)?;
             let direction = if reverse { -1isize } else { 1 };
             parent = Some(Box::new(Internal {
                 page,
@@ -742,7 +745,7 @@ fn find_iter_left<K: Key, V: Value>(
         BRANCH => {
             let accessor = BranchAccessor::new(&page, K::fixed_width());
             let (child_index, child_page_number) = accessor.child_for_key::<K>(query);
-            let child_page = manager.get_page_extended(child_page_number, hint)?;
+            let child_page = manager.get_page(child_page_number, hint)?;
             if child_index < accessor.count_children() - 1 {
                 parent = Some(Box::new(Internal {
                     page,
@@ -791,7 +794,7 @@ fn find_iter_right<K: Key, V: Value>(
         BRANCH => {
             let accessor = BranchAccessor::new(&page, K::fixed_width());
             let (child_index, child_page_number) = accessor.child_for_key::<K>(query);
-            let child_page = manager.get_page_extended(child_page_number, hint)?;
+            let child_page = manager.get_page(child_page_number, hint)?;
             if child_index > 0 && accessor.child_page(child_index - 1).is_some() {
                 parent = Some(Box::new(Internal {
                     page,

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -7,7 +7,7 @@ use crate::tree_store::btree_mutator::DeletionResult::{
 };
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
-    AccessGuardMutInPlace, BtreeHeader, PageNumber, PageTrackerPolicy, RawLeafBuilder,
+    AccessGuardMutInPlace, BtreeHeader, PageHint, PageNumber, PageTrackerPolicy, RawLeafBuilder,
     TransactionalMemory,
 };
 use crate::types::{Key, Value};
@@ -120,8 +120,11 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
             length,
         }) = *self.root
         {
-            let (deletion_result, found) =
-                self.delete_helper(self.mem.get_page(p)?, checksum, K::as_bytes(key).as_ref())?;
+            let (deletion_result, found) = self.delete_helper(
+                self.mem.get_page(p, PageHint::None)?,
+                checksum,
+                K::as_bytes(key).as_ref(),
+            )?;
             let new_length = if found.is_some() { length - 1 } else { length };
             let new_root = match deletion_result {
                 Subtree(page, checksum) => Some(BtreeHeader::new(page, checksum, new_length)),
@@ -188,7 +191,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
         }) = *self.root
         {
             let result = self.insert_helper(
-                self.mem.get_page(p)?,
+                self.mem.get_page(p, PageHint::None)?,
                 checksum,
                 K::as_bytes(key).as_ref(),
                 V::as_bytes(value).as_ref(),
@@ -459,8 +462,12 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                 let accessor = BranchAccessor::new(&page, K::fixed_width());
                 let (child_index, child_page) = accessor.child_for_key::<K>(key);
                 let child_checksum = accessor.child_checksum(child_index).unwrap();
-                let sub_result =
-                    self.insert_helper(self.mem.get_page(child_page)?, child_checksum, key, value)?;
+                let sub_result = self.insert_helper(
+                    self.mem.get_page(child_page, PageHint::None)?,
+                    child_checksum,
+                    key,
+                    value,
+                )?;
 
                 // Skip-path: if child page number and checksum haven't changed,
                 // no branch update is needed. This avoids redundant get_page_mut +
@@ -739,8 +746,11 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
         let original_page_number = page.get_page_number();
         let (child_index, child_page_number) = accessor.child_for_key::<K>(key);
         let child_checksum = accessor.child_checksum(child_index).unwrap();
-        let (result, found) =
-            self.delete_helper(self.mem.get_page(child_page_number)?, child_checksum, key)?;
+        let (result, found) = self.delete_helper(
+            self.mem.get_page(child_page_number, PageHint::None)?,
+            child_checksum,
+            key,
+        )?;
         if found.is_none() {
             return Ok((Subtree(original_page_number, checksum), None));
         }
@@ -823,7 +833,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                 debug_assert!(merge_with < accessor.count_children());
                 let merge_with_page = self
                     .mem
-                    .get_page(accessor.child_page(merge_with).unwrap())?;
+                    .get_page(accessor.child_page(merge_with).unwrap(), PageHint::None)?;
                 let merge_with_accessor =
                     LeafAccessor::new(merge_with_page.memory(), K::fixed_width(), V::fixed_width());
 
@@ -913,7 +923,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                 let merge_with = if child_index == 0 { 1 } else { child_index - 1 };
                 let merge_with_page = self
                     .mem
-                    .get_page(accessor.child_page(merge_with).unwrap())?;
+                    .get_page(accessor.child_page(merge_with).unwrap(), PageHint::None)?;
                 let merge_with_accessor = BranchAccessor::new(&merge_with_page, K::fixed_width());
                 debug_assert!(merge_with < accessor.count_children());
                 for i in 0..accessor.count_children() {
@@ -975,7 +985,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                 let merge_with = if child_index == 0 { 1 } else { child_index - 1 };
                 let merge_with_page = self
                     .mem
-                    .get_page(accessor.child_page(merge_with).unwrap())?;
+                    .get_page(accessor.child_page(merge_with).unwrap(), PageHint::None)?;
                 let merge_with_accessor = BranchAccessor::new(&merge_with_page, K::fixed_width());
                 debug_assert!(merge_with < accessor.count_children());
                 for i in 0..accessor.count_children() {

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -744,16 +744,7 @@ impl TransactionalMemory {
         Ok(())
     }
 
-    // TODO: make all callers explicitly provide a hint
-    pub(crate) fn get_page(&self, page_number: PageNumber) -> Result<PageImpl> {
-        self.get_page_extended(page_number, PageHint::None)
-    }
-
-    pub(crate) fn get_page_extended(
-        &self,
-        page_number: PageNumber,
-        hint: PageHint,
-    ) -> Result<PageImpl> {
+    pub(crate) fn get_page(&self, page_number: PageNumber, hint: PageHint) -> Result<PageImpl> {
         let range = page_number.address_range(
             self.page_size.into(),
             self.region_size,

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -107,6 +107,7 @@ impl TableTree {
                             fixed_key_size,
                             fixed_value_size,
                             self.mem.clone(),
+                            self.tree.hint(),
                         )
                         .verify_checksum()?
                     {
@@ -124,6 +125,7 @@ impl TableTree {
                         fixed_key_size,
                         fixed_value_size,
                         self.mem.clone(),
+                        self.tree.hint(),
                     )? {
                         return Ok(false);
                     }
@@ -192,7 +194,7 @@ impl TableTree {
                 .get_table_untyped(&entry, TableType::Normal)
                 .map_err(|e| e.into_storage_error_or_corrupted("Internal corruption"))?
                 .unwrap();
-            definition.visit_all_pages(self.mem.clone(), |path| visitor(path))?;
+            definition.visit_all_pages(self.mem.clone(), self.tree.hint(), |path| visitor(path))?;
         }
 
         for entry in self.list_tables(TableType::Multimap)? {
@@ -200,7 +202,7 @@ impl TableTree {
                 .get_table_untyped(&entry, TableType::Multimap)
                 .map_err(|e| e.into_storage_error_or_corrupted("Internal corruption"))?
                 .unwrap();
-            definition.visit_all_pages(self.mem.clone(), |path| visitor(path))?;
+            definition.visit_all_pages(self.mem.clone(), self.tree.hint(), |path| visitor(path))?;
         }
 
         Ok(())
@@ -262,7 +264,7 @@ impl TableTreeMut<'_> {
                 .get_table_untyped(&entry, TableType::Normal)
                 .map_err(|e| e.into_storage_error_or_corrupted("Internal corruption"))?
                 .unwrap();
-            definition.visit_all_pages(self.mem.clone(), |path| visitor(path))?;
+            definition.visit_all_pages(self.mem.clone(), PageHint::None, |path| visitor(path))?;
         }
 
         for entry in self.list_tables(TableType::Multimap)? {
@@ -270,7 +272,7 @@ impl TableTreeMut<'_> {
                 .get_table_untyped(&entry, TableType::Multimap)
                 .map_err(|e| e.into_storage_error_or_corrupted("Internal corruption"))?
                 .unwrap();
-            definition.visit_all_pages(self.mem.clone(), |path| visitor(path))?;
+            definition.visit_all_pages(self.mem.clone(), PageHint::None, |path| visitor(path))?;
         }
 
         Ok(())
@@ -559,7 +561,7 @@ impl TableTreeMut<'_> {
             // Collect all pages first, then free them. The walk reads each page to discover
             // its children, so we must not invalidate any page before the walk completes.
             let mut pages = vec![];
-            definition.visit_all_pages(self.mem.clone(), |path| {
+            definition.visit_all_pages(self.mem.clone(), PageHint::None, |path| {
                 pages.push(path.page_number());
                 Ok(())
             })?;
@@ -625,7 +627,7 @@ impl TableTreeMut<'_> {
                 definition.set_header(*updated_root, *updated_length);
             }
 
-            definition.visit_all_pages(self.mem.clone(), |path| {
+            definition.visit_all_pages(self.mem.clone(), PageHint::None, |path| {
                 output.insert(path.page_number(), path.clone());
                 while output.len() > n {
                     output.pop_first();
@@ -706,6 +708,7 @@ impl TableTreeMut<'_> {
                         &self.mem,
                         fixed_key_size,
                         fixed_value_size,
+                        PageHint::None,
                     )?;
                     max_subtree_height = max(max_subtree_height, subtree_stats.tree_height);
                     total_stored_bytes += subtree_stats.stored_leaf_bytes;
@@ -725,6 +728,7 @@ impl TableTreeMut<'_> {
                         &self.mem,
                         fixed_key_size,
                         fixed_value_size,
+                        PageHint::None,
                     )?;
                     max_subtree_height = max(max_subtree_height, subtree_stats.tree_height);
                     total_stored_bytes += subtree_stats.stored_leaf_bytes;

--- a/src/tree_store/table_tree_base.rs
+++ b/src/tree_store/table_tree_base.rs
@@ -1,6 +1,6 @@
 use crate::multimap_table::{UntypedMultiBtree, relocate_subtrees};
 use crate::tree_store::{
-    BtreeHeader, PageNumber, PagePath, TransactionalMemory, UntypedBtree, UntypedBtreeMut,
+    BtreeHeader, PageHint, PageNumber, PagePath, TransactionalMemory, UntypedBtree, UntypedBtreeMut,
 };
 use crate::{Key, Result, TableError, TypeName, Value};
 use std::collections::HashMap;
@@ -181,7 +181,12 @@ impl InternalTableDefinition {
         Ok(())
     }
 
-    pub(crate) fn visit_all_pages<'a, F>(&self, mem: Arc<TransactionalMemory>, visitor: F) -> Result
+    pub(crate) fn visit_all_pages<'a, F>(
+        &self,
+        mem: Arc<TransactionalMemory>,
+        hint: PageHint,
+        visitor: F,
+    ) -> Result
     where
         F: FnMut(&PagePath) -> Result + 'a,
     {
@@ -192,7 +197,8 @@ impl InternalTableDefinition {
                 fixed_value_size,
                 ..
             } => {
-                let tree = UntypedBtree::new(*table_root, mem, *fixed_key_size, *fixed_value_size);
+                let tree =
+                    UntypedBtree::new(*table_root, mem, hint, *fixed_key_size, *fixed_value_size);
                 tree.visit_all_pages(visitor)?;
             }
             InternalTableDefinition::Multimap {
@@ -201,8 +207,13 @@ impl InternalTableDefinition {
                 fixed_value_size,
                 ..
             } => {
-                let tree =
-                    UntypedMultiBtree::new(*table_root, mem, *fixed_key_size, *fixed_value_size);
+                let tree = UntypedMultiBtree::new(
+                    *table_root,
+                    mem,
+                    hint,
+                    *fixed_key_size,
+                    *fixed_value_size,
+                );
                 tree.visit_all_pages(visitor)?;
             }
         }


### PR DESCRIPTION
## Summary
This change threads `PageHint` through B-tree and table operations to enable better page caching strategies. Previously, most page reads used a default `PageHint::None`, but now callers can provide hints about page access patterns (e.g., `PageHint::Clean` for read-only transactions) to optimize caching behavior.

## Key Changes

- **Added `hint` field to B-tree structures**: `UntypedBtree`, `RawBtree`, and `UntypedMultiBtree` now store and propagate a `PageHint` parameter through their operations.

- **Updated `TransactionalMemory::get_page()` signature**: Merged `get_page_extended()` into `get_page()` to require explicit `PageHint` parameters at all call sites, eliminating implicit `PageHint::None` defaults.

- **Propagated hints through B-tree traversal**: All page reads during tree traversal (searches, iterations, statistics gathering) now use the appropriate hint:
  - Read-only operations use `PageHint::Clean` (from read transactions)
  - Mutation operations use `PageHint::None` (from write transactions)
  - Statistics and verification operations use the tree's stored hint

- **Updated table and multimap operations**: `ReadOnlyUntypedTable`, `ReadOnlyUntypedMultimapTable`, and related structures now accept and use `PageHint` parameters.

- **Consistent hint usage in iterators**: Range iterators and page number iterators now use the provided hint instead of hardcoded `PageHint::None`.

## Implementation Details

- The `PageHint` is captured at the transaction level and passed down through the B-tree hierarchy
- Read-only transactions use `PageHint::Clean` to indicate pages won't be modified
- Write transactions use `PageHint::None` for mutation operations
- All recursive tree operations (traversal, statistics, verification) consistently use the same hint throughout the operation
- This enables the page manager to make better caching decisions based on access patterns

https://claude.ai/code/session_01E4WGeh5Zj6a2i5DJPcmmhx