### PR TITLE
Fix type_name classification for single-element tuples and improve Vec capacity estimation

### DIFF
--- a/src/complex_types.rs
+++ b/src/complex_types.rs
@@ -73,7 +73,9 @@ impl<T: Value> Value for Vec<T> {
         let mut result = if let Some(width) = T::fixed_width() {
             Vec::with_capacity(value.len() * width + 5)
         } else {
-            Vec::with_capacity(value.len() * 2 + 5)
+            // For variable-width elements, estimate 8 bytes per element on average
+            // plus varint length prefix (up to 5 bytes each)
+            Vec::with_capacity(value.len() * 8 + 5)
         };
         encode_varint_len(value.len(), &mut result);
 

--- a/src/tuple_types.rs
+++ b/src/tuple_types.rs
@@ -302,7 +302,11 @@ impl<T: Value> Value for (T,) {
     }
 
     fn type_name() -> TypeName {
-        TypeName::internal(&format!("({},)", T::type_name().name()))
+        if Self::fixed_width().is_some() {
+            TypeName::internal(&format!("({},)", T::type_name().name()))
+        } else {
+            TypeName::internal2(&format!("({},)", T::type_name().name()))
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes two issues in the oldest unupdated files in the repository:

1. **tuple_types.rs:302-306** - The `type_name()` implementation for single-element tuples `(T,)` was always using `TypeName::internal` regardless of whether `T` is fixed-width or not. This was inconsistent with the `type_name_impl` macro used for multi-element tuples, which checks `Self::fixed_width().is_some()` to determine the correct TypeClassification.

2. **complex_types.rs:76** - The capacity estimation for `Vec<T>` with variable-width elements was `value.len() * 2 + 5`, which is too small for typical use cases where variable-width elements (like strings) average more than 2 bytes. This could cause excessive reallocations. Changed to `value.len() * 8 + 5` with an explanatory comment.

## Files Changed

- `src/tuple_types.rs`: Fixed `type_name()` for `(T,)` to match macro behavior
- `src/complex_types.rs`: Improved capacity heuristic from `* 2` to `* 8` for variable-width elements

## Test plan

- [x] Code compiles without errors
- [x] Existing tuple tests pass
- [x] Existing Vec serialization tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)