### PR TITLE
Deduplicate read transaction allocation logic

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -289,6 +289,14 @@ impl TransactionGuard {
         }
     }
 
+    pub(crate) fn allocate_read(
+        tracker: Arc<TransactionTracker>,
+        mem: &TransactionalMemory,
+    ) -> Result<Self> {
+        let id = tracker.register_read_transaction(mem)?;
+        Ok(Self::new_read(id, tracker))
+    }
+
     pub(crate) fn new_write(
         transaction_id: TransactionId,
         tracker: Arc<TransactionTracker>,
@@ -506,7 +514,7 @@ pub struct Database {
 
 impl ReadableDatabase for Database {
     fn begin_read(&self) -> Result<ReadTransaction, TransactionError> {
-        let guard = self.allocate_read_transaction()?;
+        let guard = TransactionGuard::allocate_read(self.transaction_tracker.clone(), &self.mem)?;
         #[cfg(feature = "logging")]
         debug!("Beginning read transaction id={:?}", guard.id());
         ReadTransaction::new(self.get_memory(), guard)
@@ -1011,17 +1019,6 @@ impl Database {
         }
 
         Ok(Some(tree))
-    }
-
-    fn allocate_read_transaction(&self) -> Result<TransactionGuard> {
-        let id = self
-            .transaction_tracker
-            .register_read_transaction(&self.mem)?;
-
-        Ok(TransactionGuard::new_read(
-            id,
-            self.transaction_tracker.clone(),
-        ))
     }
 
     /// Convenience method for [`Builder::new`]

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1102,20 +1102,9 @@ impl WriteTransaction {
         Ok(savepoints.into_iter())
     }
 
-    // TODO: deduplicate this with the one in Database
-    fn allocate_read_transaction(&self) -> Result<TransactionGuard> {
-        let id = self
-            .transaction_tracker
-            .register_read_transaction(&self.mem)?;
-
-        Ok(TransactionGuard::new_read(
-            id,
-            self.transaction_tracker.clone(),
-        ))
-    }
-
     fn allocate_savepoint(&self) -> Result<(SavepointId, TransactionId)> {
-        let transaction_id = self.allocate_read_transaction()?.leak();
+        let transaction_id =
+            TransactionGuard::allocate_read(self.transaction_tracker.clone(), &self.mem)?.leak();
         let id = self.transaction_tracker.allocate_savepoint(transaction_id);
         Ok((id, transaction_id))
     }


### PR DESCRIPTION
## Summary
This PR eliminates code duplication by consolidating the read transaction allocation logic into a single implementation in `TransactionGuard`. Previously, the same allocation logic was duplicated across `Database` and `WriteTransaction`.

## Key Changes
- Added `TransactionGuard::allocate_read()` as a public crate method that encapsulates read transaction allocation
- Removed `Database::allocate_read_transaction()` private method and updated its call site to use the new `TransactionGuard::allocate_read()`
- Removed `WriteTransaction::allocate_read_transaction()` private method and updated its call site to use the new `TransactionGuard::allocate_read()`

## Implementation Details
The new `TransactionGuard::allocate_read()` method takes the transaction tracker and transactional memory as parameters, registers a read transaction, and returns a new `TransactionGuard` instance. This centralizes the allocation logic and makes it reusable across different contexts while maintaining the same behavior.

https://claude.ai/code/session_01RuG9z4w8xtFinSYoG6RYB8