### PR TITLE
Introduce LeafPageMut abstraction for safer leaf page mutations

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -4,7 +4,7 @@ use crate::sealed::Sealed;
 use crate::table::{ReadableTableMetadata, TableStats};
 use crate::tree_store::{
     AllPageNumbersBtreeIter, BRANCH, BranchAccessor, BranchMutator, Btree, BtreeHeader, BtreeMut,
-    BtreeRangeIter, BtreeStats, Checksum, DEFERRED, LEAF, LeafAccessor, LeafMutator,
+    BtreeRangeIter, BtreeStats, Checksum, DEFERRED, LEAF, LeafAccessor, LeafPageMut,
     MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PagePath, PageTrackerPolicy,
     RawBtree, RawLeafBuilder, TransactionalMemory, UntypedBtree, UntypedBtreeMut, btree_stats,
 };
@@ -223,14 +223,13 @@ pub(crate) fn relocate_subtrees(
 
     match old_page.memory()[0] {
         LEAF => {
-            let accessor = LeafAccessor::new(
-                old_page.memory(),
+            let mut leaf_page = LeafPageMut::new(
+                new_page,
                 key_size,
                 UntypedDynamicCollection::fixed_width_with(value_size),
             );
-            // TODO: maybe there's a better abstraction, so that we don't need to call into this low-level method?
-            let mut mutator = LeafMutator::new(
-                new_page.memory_mut(),
+            let accessor = LeafAccessor::new(
+                old_page.memory(),
                 key_size,
                 UntypedDynamicCollection::fixed_width_with(value_size),
             );
@@ -250,7 +249,7 @@ pub(crate) fn relocate_subtrees(
                     if sub_root != tree.get_root().unwrap() {
                         let new_collection =
                             UntypedDynamicCollection::make_subtree_data(tree.get_root().unwrap());
-                        mutator.replace(i, &new_collection);
+                        leaf_page.replace_value(i, &new_collection);
                     }
                 }
             }
@@ -305,11 +304,7 @@ pub(crate) fn finalize_tree_and_subtree_checksums(
     );
     tree.dirty_leaf_visitor(|mut leaf_page| {
         let mut sub_root_updates = vec![];
-        let accessor = LeafAccessor::new(
-            leaf_page.memory(),
-            key_size,
-            DynamicCollection::<()>::fixed_width_with(value_size),
-        );
+        let accessor = leaf_page.accessor();
         for i in 0..accessor.num_pairs() {
             let entry = accessor.entry(i).unwrap();
             let collection = <&DynamicCollection<()>>::from_bytes(entry.value());
@@ -328,15 +323,9 @@ pub(crate) fn finalize_tree_and_subtree_checksums(
                 }
             }
         }
-        // TODO: maybe there's a better abstraction, so that we don't need to call into this low-level method?
-        let mut mutator = LeafMutator::new(
-            leaf_page.memory_mut(),
-            key_size,
-            DynamicCollection::<()>::fixed_width_with(value_size),
-        );
         for (i, sub_root) in sub_root_updates {
             let collection = DynamicCollection::<()>::make_subtree_data(sub_root);
-            mutator.replace(i, &collection);
+            leaf_page.replace_value(i, &collection);
         }
 
         Ok(())

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -1,7 +1,7 @@
 use crate::db::TransactionGuard;
 use crate::tree_store::btree_base::{
     AccessGuardMut, BRANCH, BranchAccessor, BranchMutator, BtreeHeader, Checksum, DEFERRED, LEAF,
-    LeafAccessor, branch_checksum, leaf_checksum,
+    LeafAccessor, LeafPageMut, branch_checksum, leaf_checksum,
 };
 use crate::tree_store::btree_iters::BtreeExtractIf;
 use crate::tree_store::btree_mutator::MutateHelper;
@@ -211,7 +211,7 @@ impl UntypedBtreeMut {
     // Applies visitor to all dirty leaf pages in the tree
     pub(crate) fn dirty_leaf_visitor<F>(&mut self, visitor: F) -> Result
     where
-        F: for<'a> Fn(PageMut<'a>) -> Result,
+        F: for<'a> Fn(LeafPageMut<'a>) -> Result,
     {
         if let Some(page_number) = self.root.map(|x| x.root) {
             if !self.mem.uncommitted(page_number) {
@@ -222,7 +222,7 @@ impl UntypedBtreeMut {
             let page = self.mem.get_page_mut(page_number)?;
             match page.memory()[0] {
                 LEAF => {
-                    visitor(page)?;
+                    visitor(LeafPageMut::new(page, self.key_width, self.value_width))?;
                 }
                 BRANCH => {
                     drop(page);
@@ -237,14 +237,14 @@ impl UntypedBtreeMut {
 
     fn dirty_leaf_visitor_helper<F>(&mut self, page_number: PageNumber, visitor: &F) -> Result
     where
-        F: for<'a> Fn(PageMut<'a>) -> Result,
+        F: for<'a> Fn(LeafPageMut<'a>) -> Result,
     {
         assert!(self.mem.uncommitted(page_number));
         let page = self.mem.get_page_mut(page_number)?;
 
         match page.memory()[0] {
             LEAF => {
-                visitor(page)?;
+                visitor(LeafPageMut::new(page, self.key_width, self.value_width))?;
             }
             BRANCH => {
                 let accessor = BranchAccessor::new(&page, self.key_width);

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -932,14 +932,14 @@ impl Drop for RawLeafBuilder<'_> {
     }
 }
 
-pub(crate) struct LeafMutator<'b> {
+pub(super) struct LeafMutator<'b> {
     page: &'b mut [u8],
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
 }
 
 impl<'b> LeafMutator<'b> {
-    pub(crate) fn new(
+    pub(super) fn new(
         page: &'b mut [u8],
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
@@ -1000,7 +1000,7 @@ impl<'b> LeafMutator<'b> {
     }
 
     // Replace the value at index `i` with `value`, leaving the key unchanged.
-    pub(crate) fn replace(&mut self, i: usize, value: &[u8]) {
+    pub(super) fn replace(&mut self, i: usize, value: &[u8]) {
         let accessor = LeafAccessor::new(self.page, self.fixed_key_size, self.fixed_value_size);
         let num_pairs = accessor.num_pairs();
         let last_value_end = accessor.value_end(num_pairs - 1).unwrap();
@@ -1035,7 +1035,7 @@ impl<'b> LeafMutator<'b> {
     }
 
     // Insert the given key, value pair at index i and shift all following pairs to the right
-    pub(crate) fn insert(&mut self, i: usize, key: &[u8], value: &[u8]) {
+    pub(super) fn insert(&mut self, i: usize, key: &[u8], value: &[u8]) {
         let accessor = LeafAccessor::new(self.page, self.fixed_key_size, self.fixed_value_size);
         let required_delta = {
             let mut delta = key.len() + value.len();
@@ -1250,6 +1250,50 @@ impl<'b> LeafMutator<'b> {
         );
         ptr = (isize::try_from(ptr).unwrap() + delta).try_into().unwrap();
         self.page[offset..(offset + size_of::<u32>())].copy_from_slice(&ptr.to_le_bytes());
+    }
+}
+
+// Encapsulates mutation of a leaf page: owns the PageMut along with the key/value
+// widths needed to interpret it, and exposes only the safe operations that callers
+// outside this module need (read access via `accessor`, in-place value replacement via
+// `replace_value`). This keeps the `LeafMutator` construction details from leaking into
+// callers that operate on dynamic-collection leaf pages (e.g., multimap maintenance).
+pub(crate) struct LeafPageMut<'a> {
+    page: PageMut<'a>,
+    fixed_key_size: Option<usize>,
+    fixed_value_size: Option<usize>,
+}
+
+impl<'a> LeafPageMut<'a> {
+    pub(crate) fn new(
+        page: PageMut<'a>,
+        fixed_key_size: Option<usize>,
+        fixed_value_size: Option<usize>,
+    ) -> Self {
+        debug_assert_eq!(page.memory()[0], LEAF);
+        Self {
+            page,
+            fixed_key_size,
+            fixed_value_size,
+        }
+    }
+
+    pub(crate) fn accessor(&self) -> LeafAccessor<'_> {
+        LeafAccessor::new(
+            self.page.memory(),
+            self.fixed_key_size,
+            self.fixed_value_size,
+        )
+    }
+
+    // Replace the value at index `i` in-place, leaving the key unchanged.
+    pub(crate) fn replace_value(&mut self, i: usize, value: &[u8]) {
+        let mut mutator = LeafMutator::new(
+            self.page.memory_mut(),
+            self.fixed_key_size,
+            self.fixed_value_size,
+        );
+        mutator.replace(i, value);
     }
 }
 

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use btree::{
 pub use btree_base::{AccessGuard, AccessGuardMut, AccessGuardMutInPlace};
 pub(crate) use btree_base::{
     BRANCH, BranchAccessor, BranchMutator, BtreeHeader, Checksum, DEFERRED, LEAF, LeafAccessor,
-    LeafMutator, RawLeafBuilder,
+    LeafPageMut, RawLeafBuilder,
 };
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, BtreeExtractIf, BtreeRangeIter};
 pub(crate) use page_store::ReadOnlyBackend;


### PR DESCRIPTION
## Summary
This PR introduces a new `LeafPageMut` abstraction that encapsulates safe mutations of leaf pages in the B-tree, reducing the exposure of low-level `LeafMutator` details to callers outside the tree_store module.

## Key Changes
- **New `LeafPageMut` struct**: A public-to-crate wrapper around `PageMut` that owns the key/value width metadata and exposes only safe operations:
  - `accessor()`: Read-only access to leaf page contents via `LeafAccessor`
  - `replace_value()`: In-place value replacement without exposing internal mutation details
  
- **Visibility adjustments**: Changed `LeafMutator` and its methods from `pub(crate)` to `pub(super)` to restrict access to within the btree_base module, encouraging use of the higher-level `LeafPageMut` abstraction

- **Updated multimap_table.rs**: Refactored to use `LeafPageMut` instead of directly constructing `LeafMutator`, eliminating TODO comments about needing better abstractions

- **Updated btree.rs**: Modified `dirty_leaf_visitor` callback signature to accept `LeafPageMut<'a>` instead of raw `PageMut<'a>`, automatically wrapping pages with the new abstraction

- **Updated exports**: Removed `LeafMutator` from public tree_store exports, replacing it with `LeafPageMut`

## Implementation Details
The `LeafPageMut` abstraction keeps construction details (fixed key/value sizes) encapsulated while providing a clean API for the common use case of replacing values in dynamic-collection leaf pages. This prevents callers from needing to understand or directly interact with `LeafMutator`, improving API clarity and maintainability.

https://claude.ai/code/session_01Eo2eqviVcys4u4V4pG4j9P