### PR TITLE
Refactor multimap btree code into separate module

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -3,437 +3,18 @@ use crate::multimap_table::DynamicCollectionType::{Inline, SubtreeV2};
 use crate::sealed::Sealed;
 use crate::table::{ReadableTableMetadata, TableStats};
 use crate::tree_store::{
-    AllPageNumbersBtreeIter, BRANCH, BranchAccessor, BranchMutator, Btree, BtreeHeader, BtreeMut,
-    BtreeRangeIter, BtreeStats, Checksum, DEFERRED, LEAF, LeafAccessor, LeafPageMut,
-    MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PagePath, PageTrackerPolicy,
-    RawBtree, RawLeafBuilder, TransactionalMemory, UntypedBtree, UntypedBtreeMut, btree_stats,
+    AllPageNumbersBtreeIter, BRANCH, Btree, BtreeHeader, BtreeMut, BtreeRangeIter,
+    DynamicCollection, DynamicCollectionType, LEAF, LeafAccessor, MAX_PAIR_LENGTH,
+    MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTrackerPolicy, RawBtree, RawLeafBuilder,
+    TransactionalMemory, multimap_btree_stats,
 };
-use crate::types::{Key, TypeName, Value};
+use crate::types::{Key, Value};
 use crate::{AccessGuard, MultimapTableHandle, Result, StorageError, WriteTransaction};
 use std::borrow::Borrow;
-use std::cmp::max;
-use std::collections::HashMap;
-use std::convert::TryInto;
 use std::marker::PhantomData;
 use std::mem;
-use std::mem::size_of;
 use std::ops::{RangeBounds, RangeFull};
 use std::sync::{Arc, Mutex};
-
-pub(crate) fn multimap_btree_stats(
-    root: Option<PageNumber>,
-    mem: &TransactionalMemory,
-    fixed_key_size: Option<usize>,
-    fixed_value_size: Option<usize>,
-    hint: PageHint,
-) -> Result<BtreeStats> {
-    if let Some(root) = root {
-        multimap_stats_helper(root, mem, fixed_key_size, fixed_value_size, hint)
-    } else {
-        Ok(BtreeStats {
-            tree_height: 0,
-            leaf_pages: 0,
-            branch_pages: 0,
-            stored_leaf_bytes: 0,
-            metadata_bytes: 0,
-            fragmented_bytes: 0,
-        })
-    }
-}
-
-fn multimap_stats_helper(
-    page_number: PageNumber,
-    mem: &TransactionalMemory,
-    fixed_key_size: Option<usize>,
-    fixed_value_size: Option<usize>,
-    hint: PageHint,
-) -> Result<BtreeStats> {
-    let page = mem.get_page(page_number, hint)?;
-    let node_mem = page.memory();
-    match node_mem[0] {
-        LEAF => {
-            let accessor = LeafAccessor::new(
-                page.memory(),
-                fixed_key_size,
-                DynamicCollection::<()>::fixed_width_with(fixed_value_size),
-            );
-            let mut leaf_bytes = 0u64;
-            let mut is_branch = false;
-            for i in 0..accessor.num_pairs() {
-                let entry = accessor.entry(i).unwrap();
-                let collection: &UntypedDynamicCollection =
-                    UntypedDynamicCollection::new(entry.value());
-                match collection.collection_type() {
-                    Inline => {
-                        let inline_accessor = LeafAccessor::new(
-                            collection.as_inline(),
-                            fixed_value_size,
-                            <() as Value>::fixed_width(),
-                        );
-                        leaf_bytes +=
-                            inline_accessor.length_of_pairs(0, inline_accessor.num_pairs()) as u64;
-                    }
-                    SubtreeV2 => {
-                        is_branch = true;
-                    }
-                }
-            }
-            let mut overhead_bytes = (accessor.total_length() as u64) - leaf_bytes;
-            let mut fragmented_bytes = (page.memory().len() - accessor.total_length()) as u64;
-            let mut max_child_height = 0;
-            let (mut leaf_pages, mut branch_pages) = if is_branch { (0, 1) } else { (1, 0) };
-
-            for i in 0..accessor.num_pairs() {
-                let entry = accessor.entry(i).unwrap();
-                let collection: &UntypedDynamicCollection =
-                    UntypedDynamicCollection::new(entry.value());
-                match collection.collection_type() {
-                    Inline => {
-                        // data is inline, so it was already counted above
-                    }
-                    SubtreeV2 => {
-                        // this is a sub-tree, so traverse it
-                        let stats = btree_stats(
-                            Some(collection.as_subtree().root),
-                            mem,
-                            fixed_value_size,
-                            <() as Value>::fixed_width(),
-                            hint,
-                        )?;
-                        max_child_height = max(max_child_height, stats.tree_height);
-                        branch_pages += stats.branch_pages;
-                        leaf_pages += stats.leaf_pages;
-                        fragmented_bytes += stats.fragmented_bytes;
-                        overhead_bytes += stats.metadata_bytes;
-                        leaf_bytes += stats.stored_leaf_bytes;
-                    }
-                }
-            }
-
-            Ok(BtreeStats {
-                tree_height: max_child_height + 1,
-                leaf_pages,
-                branch_pages,
-                stored_leaf_bytes: leaf_bytes,
-                metadata_bytes: overhead_bytes,
-                fragmented_bytes,
-            })
-        }
-        BRANCH => {
-            let accessor = BranchAccessor::new(&page, fixed_key_size);
-            let mut max_child_height = 0;
-            let mut leaf_pages = 0;
-            let mut branch_pages = 1;
-            let mut stored_leaf_bytes = 0;
-            let mut metadata_bytes = accessor.total_length() as u64;
-            let mut fragmented_bytes = (page.memory().len() - accessor.total_length()) as u64;
-            for i in 0..accessor.count_children() {
-                if let Some(child) = accessor.child_page(i) {
-                    let stats =
-                        multimap_stats_helper(child, mem, fixed_key_size, fixed_value_size, hint)?;
-                    max_child_height = max(max_child_height, stats.tree_height);
-                    leaf_pages += stats.leaf_pages;
-                    branch_pages += stats.branch_pages;
-                    stored_leaf_bytes += stats.stored_leaf_bytes;
-                    metadata_bytes += stats.metadata_bytes;
-                    fragmented_bytes += stats.fragmented_bytes;
-                }
-            }
-
-            Ok(BtreeStats {
-                tree_height: max_child_height + 1,
-                leaf_pages,
-                branch_pages,
-                stored_leaf_bytes,
-                metadata_bytes,
-                fragmented_bytes,
-            })
-        }
-        _ => unreachable!(),
-    }
-}
-
-// Verify all the checksums in the tree, including any Dynamic collection subtrees
-pub(crate) fn verify_tree_and_subtree_checksums(
-    root: Option<BtreeHeader>,
-    key_size: Option<usize>,
-    value_size: Option<usize>,
-    mem: Arc<TransactionalMemory>,
-    hint: PageHint,
-) -> Result<bool> {
-    if let Some(header) = root {
-        if !RawBtree::new(
-            Some(header),
-            key_size,
-            DynamicCollection::<()>::fixed_width_with(value_size),
-            mem.clone(),
-            hint,
-        )
-        .verify_checksum()?
-        {
-            return Ok(false);
-        }
-
-        let table_pages_iter = AllPageNumbersBtreeIter::new(
-            header.root,
-            key_size,
-            DynamicCollection::<()>::fixed_width_with(value_size),
-            mem.clone(),
-            hint,
-        )?;
-        for table_page in table_pages_iter {
-            let page = mem.get_page(table_page?, hint)?;
-            let subtree_roots = parse_subtree_roots(&page, key_size, value_size);
-            for header in subtree_roots {
-                if !RawBtree::new(
-                    Some(header),
-                    value_size,
-                    <()>::fixed_width(),
-                    mem.clone(),
-                    hint,
-                )
-                .verify_checksum()?
-                {
-                    return Ok(false);
-                }
-            }
-        }
-    }
-
-    Ok(true)
-}
-
-// Relocate all subtrees to lower index pages, if possible
-pub(crate) fn relocate_subtrees(
-    root: (PageNumber, Checksum),
-    key_size: Option<usize>,
-    value_size: Option<usize>,
-    mem: Arc<TransactionalMemory>,
-    freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-    relocation_map: &HashMap<PageNumber, PageNumber>,
-) -> Result<(PageNumber, Checksum)> {
-    let old_page = mem.get_page(root.0, PageHint::None)?;
-    let mut new_page = if let Some(new_page_number) = relocation_map.get(&root.0) {
-        mem.get_page_mut(*new_page_number)?
-    } else {
-        return Ok(root);
-    };
-    let new_page_number = new_page.get_page_number();
-    new_page.memory_mut().copy_from_slice(old_page.memory());
-
-    match old_page.memory()[0] {
-        LEAF => {
-            let mut leaf_page = LeafPageMut::new(
-                new_page,
-                key_size,
-                UntypedDynamicCollection::fixed_width_with(value_size),
-            );
-            let accessor = LeafAccessor::new(
-                old_page.memory(),
-                key_size,
-                UntypedDynamicCollection::fixed_width_with(value_size),
-            );
-            for i in 0..accessor.num_pairs() {
-                let entry = accessor.entry(i).unwrap();
-                let collection = UntypedDynamicCollection::from_bytes(entry.value());
-                if matches!(collection.collection_type(), SubtreeV2) {
-                    let sub_root = collection.as_subtree();
-                    let mut tree = UntypedBtreeMut::new(
-                        Some(sub_root),
-                        mem.clone(),
-                        freed_pages.clone(),
-                        value_size,
-                        <() as Value>::fixed_width(),
-                    );
-                    tree.relocate(relocation_map)?;
-                    if sub_root != tree.get_root().unwrap() {
-                        let new_collection =
-                            UntypedDynamicCollection::make_subtree_data(tree.get_root().unwrap());
-                        leaf_page.replace_value(i, &new_collection);
-                    }
-                }
-            }
-        }
-        BRANCH => {
-            let accessor = BranchAccessor::new(&old_page, key_size);
-            let mut mutator = BranchMutator::new(new_page.memory_mut());
-            for i in 0..accessor.count_children() {
-                if let Some(child) = accessor.child_page(i) {
-                    let child_checksum = accessor.child_checksum(i).unwrap();
-                    let (new_child, new_checksum) = relocate_subtrees(
-                        (child, child_checksum),
-                        key_size,
-                        value_size,
-                        mem.clone(),
-                        freed_pages.clone(),
-                        relocation_map,
-                    )?;
-                    mutator.write_child_page(i, new_child, new_checksum);
-                }
-            }
-        }
-        _ => unreachable!(),
-    }
-
-    let old_page_number = old_page.get_page_number();
-    drop(old_page);
-    // No need to track allocations, because this method is only called during compaction when
-    // there can't be any savepoints
-    let mut ignore = PageTrackerPolicy::Ignore;
-    if !mem.free_if_uncommitted(old_page_number, &mut ignore) {
-        freed_pages.lock().unwrap().push(old_page_number);
-    }
-    Ok((new_page_number, DEFERRED))
-}
-
-// Finalize all the checksums in the tree, including any Dynamic collection subtrees
-// Returns the root checksum
-pub(crate) fn finalize_tree_and_subtree_checksums(
-    root: Option<BtreeHeader>,
-    key_size: Option<usize>,
-    value_size: Option<usize>,
-    mem: Arc<TransactionalMemory>,
-) -> Result<Option<BtreeHeader>> {
-    let freed_pages = Arc::new(Mutex::new(vec![]));
-    let mut tree = UntypedBtreeMut::new(
-        root,
-        mem.clone(),
-        freed_pages.clone(),
-        key_size,
-        DynamicCollection::<()>::fixed_width_with(value_size),
-    );
-    tree.dirty_leaf_visitor(|mut leaf_page| {
-        let mut sub_root_updates = vec![];
-        let accessor = leaf_page.accessor();
-        for i in 0..accessor.num_pairs() {
-            let entry = accessor.entry(i).unwrap();
-            let collection = <&DynamicCollection<()>>::from_bytes(entry.value());
-            if matches!(collection.collection_type(), SubtreeV2) {
-                let sub_root = collection.as_subtree();
-                if mem.uncommitted(sub_root.root) {
-                    let mut subtree = UntypedBtreeMut::new(
-                        Some(sub_root),
-                        mem.clone(),
-                        freed_pages.clone(),
-                        value_size,
-                        <()>::fixed_width(),
-                    );
-                    let subtree_root = subtree.finalize_dirty_checksums()?.unwrap();
-                    sub_root_updates.push((i, subtree_root));
-                }
-            }
-        }
-        for (i, sub_root) in sub_root_updates {
-            let collection = DynamicCollection::<()>::make_subtree_data(sub_root);
-            leaf_page.replace_value(i, &collection);
-        }
-
-        Ok(())
-    })?;
-
-    let root = tree.finalize_dirty_checksums()?;
-    // No pages should have been freed by this operation
-    assert!(freed_pages.lock().unwrap().is_empty());
-    Ok(root)
-}
-
-fn parse_subtree_roots<T: Page>(
-    page: &T,
-    fixed_key_size: Option<usize>,
-    fixed_value_size: Option<usize>,
-) -> Vec<BtreeHeader> {
-    match page.memory()[0] {
-        BRANCH => {
-            vec![]
-        }
-        LEAF => {
-            let mut result = vec![];
-            let accessor = LeafAccessor::new(
-                page.memory(),
-                fixed_key_size,
-                DynamicCollection::<()>::fixed_width_with(fixed_value_size),
-            );
-            for i in 0..accessor.num_pairs() {
-                let entry = accessor.entry(i).unwrap();
-                let collection = <&DynamicCollection<()>>::from_bytes(entry.value());
-                if matches!(collection.collection_type(), SubtreeV2) {
-                    result.push(collection.as_subtree());
-                }
-            }
-
-            result
-        }
-        _ => unreachable!(),
-    }
-}
-
-pub(crate) struct UntypedMultiBtree {
-    mem: Arc<TransactionalMemory>,
-    root: Option<BtreeHeader>,
-    hint: PageHint,
-    key_width: Option<usize>,
-    value_width: Option<usize>,
-}
-
-impl UntypedMultiBtree {
-    pub(crate) fn new(
-        root: Option<BtreeHeader>,
-        mem: Arc<TransactionalMemory>,
-        hint: PageHint,
-        key_width: Option<usize>,
-        value_width: Option<usize>,
-    ) -> Self {
-        Self {
-            mem,
-            root,
-            hint,
-            key_width,
-            value_width,
-        }
-    }
-
-    // Applies visitor to pages in the tree
-    pub(crate) fn visit_all_pages<F>(&self, mut visitor: F) -> Result
-    where
-        F: FnMut(&PagePath) -> Result,
-    {
-        let tree = UntypedBtree::new(
-            self.root,
-            self.mem.clone(),
-            self.hint,
-            self.key_width,
-            UntypedDynamicCollection::fixed_width_with(self.value_width),
-        );
-        tree.visit_all_pages(|path| {
-            visitor(path)?;
-            let page = self.mem.get_page(path.page_number(), self.hint)?;
-            match page.memory()[0] {
-                LEAF => {
-                    for header in parse_subtree_roots(&page, self.key_width, self.value_width) {
-                        let subtree = UntypedBtree::new(
-                            Some(header),
-                            self.mem.clone(),
-                            self.hint,
-                            self.value_width,
-                            <() as Value>::fixed_width(),
-                        );
-                        subtree.visit_all_pages(|subpath| {
-                            let full_path = path.with_subpath(subpath);
-                            visitor(&full_path)
-                        })?;
-                    }
-                }
-                BRANCH => {
-                    // No-op. The tree.visit_pages() call will process this sub-tree
-                }
-                _ => unreachable!(),
-            }
-            Ok(())
-        })?;
-
-        Ok(())
-    }
-}
 
 pub(crate) struct LeafKeyIter<'a, V: Key + 'static> {
     inline_collection: AccessGuard<'a, &'static DynamicCollection<V>>,
@@ -489,265 +70,6 @@ impl<'a, V: Key> LeafKeyIter<'a, V> {
         accessor
             .entry((self.end_entry + 1).try_into().unwrap())
             .map(|e| e.key())
-    }
-}
-
-enum DynamicCollectionType {
-    Inline,
-    // Was used in file format version 1
-    // Subtree,
-    SubtreeV2,
-}
-
-impl From<u8> for DynamicCollectionType {
-    fn from(value: u8) -> Self {
-        match value {
-            LEAF => Inline,
-            // 2 => Subtree,
-            3 => SubtreeV2,
-            _ => unreachable!(),
-        }
-    }
-}
-
-#[allow(clippy::from_over_into)]
-impl Into<u8> for DynamicCollectionType {
-    fn into(self) -> u8 {
-        match self {
-            // Reuse the LEAF type id, so that we can cast this directly into the format used by
-            // LeafAccessor
-            Inline => LEAF,
-            // Subtree => 2,
-            SubtreeV2 => 3,
-        }
-    }
-}
-
-/// Layout:
-/// type (1 byte):
-/// * 1 = inline data
-/// * 2 = sub tree
-///
-/// (when type = 1) data (n bytes): inlined leaf node
-///
-/// (when type = 2) root (8 bytes): sub tree root page number
-/// (when type = 2) checksum (16 bytes): sub tree checksum
-///
-/// NOTE: Even though the [`PhantomData`] is zero-sized, the inner data DST must be placed last.
-/// See [Exotically Sized Types](https://doc.rust-lang.org/nomicon/exotic-sizes.html#dynamically-sized-types-dsts)
-/// section of the Rustonomicon for more details.
-#[repr(transparent)]
-struct DynamicCollection<V: Key> {
-    _value_type: PhantomData<V>,
-    data: [u8],
-}
-
-impl<V: Key> std::fmt::Debug for DynamicCollection<V> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DynamicCollection")
-            .field("data", &&self.data)
-            .finish()
-    }
-}
-
-impl<V: Key> Value for &DynamicCollection<V> {
-    type SelfType<'a>
-        = &'a DynamicCollection<V>
-    where
-        Self: 'a;
-    type AsBytes<'a>
-        = &'a [u8]
-    where
-        Self: 'a;
-
-    fn fixed_width() -> Option<usize> {
-        None
-    }
-
-    fn from_bytes<'a>(data: &'a [u8]) -> &'a DynamicCollection<V>
-    where
-        Self: 'a,
-    {
-        DynamicCollection::new(data)
-    }
-
-    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a [u8]
-    where
-        Self: 'b,
-    {
-        &value.data
-    }
-
-    fn type_name() -> TypeName {
-        TypeName::internal("redb::DynamicCollection")
-    }
-}
-
-impl<V: Key> DynamicCollection<V> {
-    fn new(data: &[u8]) -> &Self {
-        unsafe { &*(std::ptr::from_ref::<[u8]>(data) as *const DynamicCollection<V>) }
-    }
-
-    fn collection_type(&self) -> DynamicCollectionType {
-        DynamicCollectionType::from(self.data[0])
-    }
-
-    fn as_inline(&self) -> &[u8] {
-        debug_assert!(matches!(self.collection_type(), Inline));
-        &self.data[1..]
-    }
-
-    fn as_subtree(&self) -> BtreeHeader {
-        assert!(matches!(self.collection_type(), SubtreeV2));
-        BtreeHeader::from_le_bytes(
-            self.data[1..=BtreeHeader::serialized_size()]
-                .try_into()
-                .unwrap(),
-        )
-    }
-
-    fn get_num_values(&self) -> u64 {
-        match self.collection_type() {
-            Inline => {
-                let leaf_data = self.as_inline();
-                let accessor =
-                    LeafAccessor::new(leaf_data, V::fixed_width(), <() as Value>::fixed_width());
-                accessor.num_pairs() as u64
-            }
-            SubtreeV2 => {
-                let offset = 1 + PageNumber::serialized_size() + size_of::<Checksum>();
-                u64::from_le_bytes(
-                    self.data[offset..(offset + size_of::<u64>())]
-                        .try_into()
-                        .unwrap(),
-                )
-            }
-        }
-    }
-
-    fn make_inline_data(data: &[u8]) -> Vec<u8> {
-        let mut result = vec![Inline.into()];
-        result.extend_from_slice(data);
-
-        result
-    }
-
-    fn make_subtree_data(header: BtreeHeader) -> Vec<u8> {
-        let mut result = vec![SubtreeV2.into()];
-        result.extend_from_slice(&header.to_le_bytes());
-        result
-    }
-
-    pub(crate) fn fixed_width_with(_value_width: Option<usize>) -> Option<usize> {
-        None
-    }
-}
-
-impl<V: Key> DynamicCollection<V> {
-    fn iter<'a>(
-        collection: AccessGuard<'a, &'static DynamicCollection<V>>,
-        guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
-    ) -> Result<MultimapValue<'a, V>> {
-        Ok(match collection.value().collection_type() {
-            Inline => {
-                let leaf_iter =
-                    LeafKeyIter::new(collection, V::fixed_width(), <() as Value>::fixed_width());
-                MultimapValue::new_inline(leaf_iter, guard)
-            }
-            SubtreeV2 => {
-                let root = collection.value().as_subtree().root;
-                MultimapValue::new_subtree(
-                    BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(
-                        &(..),
-                        Some(root),
-                        mem,
-                        PageHint::None,
-                    )?,
-                    collection.value().get_num_values(),
-                    guard,
-                )
-            }
-        })
-    }
-
-    fn iter_free_on_drop<'a>(
-        collection: AccessGuard<'a, &'static DynamicCollection<V>>,
-        pages: Vec<PageNumber>,
-        freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-        allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
-        guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
-    ) -> Result<MultimapValue<'a, V>> {
-        let num_values = collection.value().get_num_values();
-        Ok(match collection.value().collection_type() {
-            Inline => {
-                let leaf_iter =
-                    LeafKeyIter::new(collection, V::fixed_width(), <() as Value>::fixed_width());
-                MultimapValue::new_inline(leaf_iter, guard)
-            }
-            SubtreeV2 => {
-                let root = collection.value().as_subtree().root;
-                let inner = BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(
-                    &(..),
-                    Some(root),
-                    mem.clone(),
-                    PageHint::None,
-                )?;
-                MultimapValue::new_subtree_free_on_drop(
-                    inner,
-                    num_values,
-                    freed_pages,
-                    allocated_pages,
-                    pages,
-                    guard,
-                    mem,
-                )
-            }
-        })
-    }
-}
-
-#[repr(transparent)]
-struct UntypedDynamicCollection {
-    data: [u8],
-}
-
-impl UntypedDynamicCollection {
-    pub(crate) fn fixed_width_with(_value_width: Option<usize>) -> Option<usize> {
-        None
-    }
-
-    fn new(data: &[u8]) -> &Self {
-        unsafe { &*(std::ptr::from_ref::<[u8]>(data) as *const UntypedDynamicCollection) }
-    }
-
-    fn make_subtree_data(header: BtreeHeader) -> Vec<u8> {
-        let mut result = vec![SubtreeV2.into()];
-        result.extend_from_slice(&header.to_le_bytes());
-        result
-    }
-
-    fn from_bytes(data: &[u8]) -> &Self {
-        Self::new(data)
-    }
-
-    fn collection_type(&self) -> DynamicCollectionType {
-        DynamicCollectionType::from(self.data[0])
-    }
-
-    fn as_inline(&self) -> &[u8] {
-        debug_assert!(matches!(self.collection_type(), Inline));
-        &self.data[1..]
-    }
-
-    fn as_subtree(&self) -> BtreeHeader {
-        assert!(matches!(self.collection_type(), SubtreeV2));
-        BtreeHeader::from_le_bytes(
-            self.data[1..=BtreeHeader::serialized_size()]
-                .try_into()
-                .unwrap(),
-        )
     }
 }
 
@@ -818,6 +140,69 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
             mem: None,
             _value_type: PhantomData,
         }
+    }
+
+    fn from_collection(
+        collection: AccessGuard<'a, &'static DynamicCollection<V>>,
+        guard: Arc<TransactionGuard>,
+        mem: Arc<TransactionalMemory>,
+    ) -> Result<Self> {
+        Ok(match collection.value().collection_type() {
+            Inline => {
+                let leaf_iter =
+                    LeafKeyIter::new(collection, V::fixed_width(), <() as Value>::fixed_width());
+                Self::new_inline(leaf_iter, guard)
+            }
+            SubtreeV2 => {
+                let root = collection.value().as_subtree().root;
+                Self::new_subtree(
+                    BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(
+                        &(..),
+                        Some(root),
+                        mem,
+                        PageHint::None,
+                    )?,
+                    collection.value().get_num_values(),
+                    guard,
+                )
+            }
+        })
+    }
+
+    fn from_collection_free_on_drop(
+        collection: AccessGuard<'a, &'static DynamicCollection<V>>,
+        pages: Vec<PageNumber>,
+        freed_pages: Arc<Mutex<Vec<PageNumber>>>,
+        allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
+        guard: Arc<TransactionGuard>,
+        mem: Arc<TransactionalMemory>,
+    ) -> Result<Self> {
+        let num_values = collection.value().get_num_values();
+        Ok(match collection.value().collection_type() {
+            Inline => {
+                let leaf_iter =
+                    LeafKeyIter::new(collection, V::fixed_width(), <() as Value>::fixed_width());
+                Self::new_inline(leaf_iter, guard)
+            }
+            SubtreeV2 => {
+                let root = collection.value().as_subtree().root;
+                let inner = BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(
+                    &(..),
+                    Some(root),
+                    mem.clone(),
+                    PageHint::None,
+                )?;
+                Self::new_subtree_free_on_drop(
+                    inner,
+                    num_values,
+                    freed_pages,
+                    allocated_pages,
+                    pages,
+                    guard,
+                    mem,
+                )
+            }
+        })
     }
 
     /// Returns the number of times this iterator will return `Some(Ok(_))`
@@ -925,7 +310,7 @@ impl<'a, K: Key + 'static, V: Key + 'static> Iterator for MultimapRange<'a, K, V
                 let (page, _, value_range) = entry.into_raw();
                 let collection = AccessGuard::with_page(page, value_range);
                 Some(
-                    DynamicCollection::iter(
+                    MultimapValue::from_collection(
                         collection,
                         self.transaction_guard.clone(),
                         self.mem.clone(),
@@ -946,7 +331,7 @@ impl<K: Key + 'static, V: Key + 'static> DoubleEndedIterator for MultimapRange<'
                 let (page, _, value_range) = entry.into_raw();
                 let collection = AccessGuard::with_page(page, value_range);
                 Some(
-                    DynamicCollection::iter(
+                    MultimapValue::from_collection(
                         collection,
                         self.transaction_guard.clone(),
                         self.mem.clone(),
@@ -1342,7 +727,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
 
             self.num_values -= collection.value().get_num_values();
 
-            DynamicCollection::iter_free_on_drop(
+            MultimapValue::from_collection_free_on_drop(
                 collection,
                 pages,
                 self.freed_pages.clone(),
@@ -1397,7 +782,7 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V> for Multima
     fn get<'a>(&self, key: impl Borrow<K::SelfType<'a>>) -> Result<MultimapValue<'_, V>> {
         let guard = self.transaction.transaction_guard();
         let iter = if let Some(collection) = self.tree.get(key.borrow())? {
-            DynamicCollection::iter(collection, guard, self.mem.clone())?
+            MultimapValue::from_collection(collection, guard, self.mem.clone())?
         } else {
             MultimapValue::new_subtree(
                 BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(
@@ -1546,7 +931,11 @@ impl<K: Key + 'static, V: Key + 'static> ReadOnlyMultimapTable<K, V> {
     /// alive until it is dropped.
     pub fn get<'a>(&self, key: impl Borrow<K::SelfType<'a>>) -> Result<MultimapValue<'static, V>> {
         let iter = if let Some(collection) = self.tree.get(key.borrow())? {
-            DynamicCollection::iter(collection, self.transaction_guard.clone(), self.mem.clone())?
+            MultimapValue::from_collection(
+                collection,
+                self.transaction_guard.clone(),
+                self.mem.clone(),
+            )?
         } else {
             MultimapValue::new_subtree(
                 BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(
@@ -1609,7 +998,11 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V>
     /// Returns an iterator over all values for the given key. Values are in ascending order.
     fn get<'a>(&self, key: impl Borrow<K::SelfType<'a>>) -> Result<MultimapValue<'_, V>> {
         let iter = if let Some(collection) = self.tree.get(key.borrow())? {
-            DynamicCollection::iter(collection, self.transaction_guard.clone(), self.mem.clone())?
+            MultimapValue::from_collection(
+                collection,
+                self.transaction_guard.clone(),
+                self.mem.clone(),
+            )?
         } else {
             MultimapValue::new_subtree(
                 BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -63,7 +63,7 @@ impl PagePath {
     }
 }
 
-pub(crate) struct UntypedBtree {
+pub(super) struct UntypedBtree {
     mem: Arc<TransactionalMemory>,
     root: Option<BtreeHeader>,
     hint: PageHint,
@@ -72,7 +72,7 @@ pub(crate) struct UntypedBtree {
 }
 
 impl UntypedBtree {
-    pub(crate) fn new(
+    pub(super) fn new(
         root: Option<BtreeHeader>,
         mem: Arc<TransactionalMemory>,
         hint: PageHint,
@@ -89,7 +89,7 @@ impl UntypedBtree {
     }
 
     // Applies visitor to pages in the tree
-    pub(crate) fn visit_all_pages<F>(&self, mut visitor: F) -> Result
+    pub(super) fn visit_all_pages<F>(&self, mut visitor: F) -> Result
     where
         F: FnMut(&PagePath) -> Result,
     {
@@ -126,7 +126,7 @@ impl UntypedBtree {
     }
 }
 
-pub(crate) struct UntypedBtreeMut {
+pub(super) struct UntypedBtreeMut {
     mem: Arc<TransactionalMemory>,
     root: Option<BtreeHeader>,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
@@ -135,7 +135,7 @@ pub(crate) struct UntypedBtreeMut {
 }
 
 impl UntypedBtreeMut {
-    pub(crate) fn new(
+    pub(super) fn new(
         root: Option<BtreeHeader>,
         mem: Arc<TransactionalMemory>,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
@@ -151,12 +151,12 @@ impl UntypedBtreeMut {
         }
     }
 
-    pub(crate) fn get_root(&self) -> Option<BtreeHeader> {
+    pub(super) fn get_root(&self) -> Option<BtreeHeader> {
         self.root
     }
 
     // Recomputes the checksum for all pages that are uncommitted
-    pub(crate) fn finalize_dirty_checksums(&mut self) -> Result<Option<BtreeHeader>> {
+    pub(super) fn finalize_dirty_checksums(&mut self) -> Result<Option<BtreeHeader>> {
         let mut root = self.root;
         if let Some(BtreeHeader {
             root: ref p,
@@ -209,7 +209,7 @@ impl UntypedBtreeMut {
     }
 
     // Applies visitor to all dirty leaf pages in the tree
-    pub(crate) fn dirty_leaf_visitor<F>(&mut self, visitor: F) -> Result
+    pub(super) fn dirty_leaf_visitor<F>(&mut self, visitor: F) -> Result
     where
         F: for<'a> Fn(LeafPageMut<'a>) -> Result,
     {
@@ -1065,7 +1065,7 @@ impl<K: Key, V: Value> Drop for Btree<K, V> {
     }
 }
 
-pub(crate) fn btree_stats(
+pub(super) fn btree_stats(
     root: Option<PageNumber>,
     mem: &TransactionalMemory,
     fixed_key_size: Option<usize>,

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -13,9 +13,9 @@ use std::thread;
 pub(crate) const LEAF: u8 = 1;
 pub(crate) const BRANCH: u8 = 2;
 
-pub(crate) type Checksum = u128;
+pub(super) type Checksum = u128;
 // Dummy value. Final value will be computed during commit
-pub(crate) const DEFERRED: Checksum = 999;
+pub(super) const DEFERRED: Checksum = 999;
 
 pub(super) fn leaf_checksum<T: Page>(
     page: &T,
@@ -1258,7 +1258,7 @@ impl<'b> LeafMutator<'b> {
 // outside this module need (read access via `accessor`, in-place value replacement via
 // `replace_value`). This keeps the `LeafMutator` construction details from leaking into
 // callers that operate on dynamic-collection leaf pages (e.g., multimap maintenance).
-pub(crate) struct LeafPageMut<'a> {
+pub(super) struct LeafPageMut<'a> {
     page: PageMut<'a>,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
@@ -1298,8 +1298,7 @@ impl<'a> LeafPageMut<'a> {
 }
 
 // Provides a simple zero-copy way to access a branch page
-// TODO: this should be pub(super) and the multimap btree stuff should be moved into this package
-pub(crate) struct BranchAccessor<'a: 'b, 'b, T: Page + 'a> {
+pub(super) struct BranchAccessor<'a: 'b, 'b, T: Page + 'a> {
     page: &'b T,
     num_keys: usize,
     fixed_key_size: Option<usize>,
@@ -1737,7 +1736,7 @@ impl Drop for RawBranchBuilder<'_> {
     }
 }
 
-pub(crate) struct BranchMutator<'b> {
+pub(super) struct BranchMutator<'b> {
     page: &'b mut [u8],
 }
 

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -1,13 +1,13 @@
 use crate::tree_store::btree_base::{
     BRANCH, BranchAccessor, BranchBuilder, BranchMutator, Checksum, DEFERRED, LEAF, LeafAccessor,
-    LeafBuilder, LeafMutator,
+    LeafBuilder, LeafMutator, RawLeafBuilder,
 };
 use crate::tree_store::btree_mutator::DeletionResult::{
     DeletedBranch, DeletedLeaf, PartialBranch, PartialLeaf, Subtree,
 };
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
-    AccessGuardMutInPlace, BtreeHeader, PageHint, PageNumber, PageTrackerPolicy, RawLeafBuilder,
+    AccessGuardMutInPlace, BtreeHeader, PageHint, PageNumber, PageTrackerPolicy,
     TransactionalMemory,
 };
 use crate::types::{Key, Value};

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -2,19 +2,17 @@ mod btree;
 mod btree_base;
 mod btree_iters;
 mod btree_mutator;
+mod multimap_btree;
 mod page_store;
 mod table_tree;
 mod table_tree_base;
 
-pub(crate) use btree::{
-    Btree, BtreeMut, BtreeStats, PagePath, RawBtree, UntypedBtree, UntypedBtreeMut, btree_stats,
-};
+pub(crate) use btree::{Btree, BtreeMut, BtreeStats, RawBtree};
+pub(crate) use btree_base::BtreeHeader;
 pub use btree_base::{AccessGuard, AccessGuardMut, AccessGuardMutInPlace};
-pub(crate) use btree_base::{
-    BRANCH, BranchAccessor, BranchMutator, BtreeHeader, Checksum, DEFERRED, LEAF, LeafAccessor,
-    LeafPageMut, RawLeafBuilder,
-};
+pub(crate) use btree_base::{BRANCH, LEAF, LeafAccessor, RawLeafBuilder};
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, BtreeExtractIf, BtreeRangeIter};
+pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multimap_btree_stats};
 pub(crate) use page_store::ReadOnlyBackend;
 pub(crate) use page_store::{
     FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page, PageHint, PageNumber,

--- a/src/tree_store/multimap_btree.rs
+++ b/src/tree_store/multimap_btree.rs
@@ -1,0 +1,625 @@
+use crate::Result;
+use crate::tree_store::btree::{PagePath, UntypedBtree, UntypedBtreeMut, btree_stats};
+use crate::tree_store::btree_base::{
+    BRANCH, BranchAccessor, BranchMutator, Checksum, DEFERRED, LEAF, LeafAccessor, LeafPageMut,
+};
+use crate::tree_store::multimap_btree::DynamicCollectionType::{Inline, SubtreeV2};
+use crate::tree_store::{
+    AllPageNumbersBtreeIter, BtreeHeader, BtreeStats, Page, PageHint, PageNumber,
+    PageTrackerPolicy, RawBtree, TransactionalMemory,
+};
+use crate::types::{Key, TypeName, Value};
+use std::cmp::max;
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::mem::size_of;
+use std::sync::{Arc, Mutex};
+
+pub(crate) fn multimap_btree_stats(
+    root: Option<PageNumber>,
+    mem: &TransactionalMemory,
+    fixed_key_size: Option<usize>,
+    fixed_value_size: Option<usize>,
+    hint: PageHint,
+) -> Result<BtreeStats> {
+    if let Some(root) = root {
+        multimap_stats_helper(root, mem, fixed_key_size, fixed_value_size, hint)
+    } else {
+        Ok(BtreeStats {
+            tree_height: 0,
+            leaf_pages: 0,
+            branch_pages: 0,
+            stored_leaf_bytes: 0,
+            metadata_bytes: 0,
+            fragmented_bytes: 0,
+        })
+    }
+}
+
+fn multimap_stats_helper(
+    page_number: PageNumber,
+    mem: &TransactionalMemory,
+    fixed_key_size: Option<usize>,
+    fixed_value_size: Option<usize>,
+    hint: PageHint,
+) -> Result<BtreeStats> {
+    let page = mem.get_page(page_number, hint)?;
+    let node_mem = page.memory();
+    match node_mem[0] {
+        LEAF => {
+            let accessor = LeafAccessor::new(
+                page.memory(),
+                fixed_key_size,
+                DynamicCollection::<()>::fixed_width_with(fixed_value_size),
+            );
+            let mut leaf_bytes = 0u64;
+            let mut is_branch = false;
+            for i in 0..accessor.num_pairs() {
+                let entry = accessor.entry(i).unwrap();
+                let collection: &UntypedDynamicCollection =
+                    UntypedDynamicCollection::new(entry.value());
+                match collection.collection_type() {
+                    Inline => {
+                        let inline_accessor = LeafAccessor::new(
+                            collection.as_inline(),
+                            fixed_value_size,
+                            <() as Value>::fixed_width(),
+                        );
+                        leaf_bytes +=
+                            inline_accessor.length_of_pairs(0, inline_accessor.num_pairs()) as u64;
+                    }
+                    SubtreeV2 => {
+                        is_branch = true;
+                    }
+                }
+            }
+            let mut overhead_bytes = (accessor.total_length() as u64) - leaf_bytes;
+            let mut fragmented_bytes = (page.memory().len() - accessor.total_length()) as u64;
+            let mut max_child_height = 0;
+            let (mut leaf_pages, mut branch_pages) = if is_branch { (0, 1) } else { (1, 0) };
+
+            for i in 0..accessor.num_pairs() {
+                let entry = accessor.entry(i).unwrap();
+                let collection: &UntypedDynamicCollection =
+                    UntypedDynamicCollection::new(entry.value());
+                match collection.collection_type() {
+                    Inline => {
+                        // data is inline, so it was already counted above
+                    }
+                    SubtreeV2 => {
+                        // this is a sub-tree, so traverse it
+                        let stats = btree_stats(
+                            Some(collection.as_subtree().root),
+                            mem,
+                            fixed_value_size,
+                            <() as Value>::fixed_width(),
+                            hint,
+                        )?;
+                        max_child_height = max(max_child_height, stats.tree_height);
+                        branch_pages += stats.branch_pages;
+                        leaf_pages += stats.leaf_pages;
+                        fragmented_bytes += stats.fragmented_bytes;
+                        overhead_bytes += stats.metadata_bytes;
+                        leaf_bytes += stats.stored_leaf_bytes;
+                    }
+                }
+            }
+
+            Ok(BtreeStats {
+                tree_height: max_child_height + 1,
+                leaf_pages,
+                branch_pages,
+                stored_leaf_bytes: leaf_bytes,
+                metadata_bytes: overhead_bytes,
+                fragmented_bytes,
+            })
+        }
+        BRANCH => {
+            let accessor = BranchAccessor::new(&page, fixed_key_size);
+            let mut max_child_height = 0;
+            let mut leaf_pages = 0;
+            let mut branch_pages = 1;
+            let mut stored_leaf_bytes = 0;
+            let mut metadata_bytes = accessor.total_length() as u64;
+            let mut fragmented_bytes = (page.memory().len() - accessor.total_length()) as u64;
+            for i in 0..accessor.count_children() {
+                if let Some(child) = accessor.child_page(i) {
+                    let stats =
+                        multimap_stats_helper(child, mem, fixed_key_size, fixed_value_size, hint)?;
+                    max_child_height = max(max_child_height, stats.tree_height);
+                    leaf_pages += stats.leaf_pages;
+                    branch_pages += stats.branch_pages;
+                    stored_leaf_bytes += stats.stored_leaf_bytes;
+                    metadata_bytes += stats.metadata_bytes;
+                    fragmented_bytes += stats.fragmented_bytes;
+                }
+            }
+
+            Ok(BtreeStats {
+                tree_height: max_child_height + 1,
+                leaf_pages,
+                branch_pages,
+                stored_leaf_bytes,
+                metadata_bytes,
+                fragmented_bytes,
+            })
+        }
+        _ => unreachable!(),
+    }
+}
+
+// Verify all the checksums in the tree, including any Dynamic collection subtrees
+pub(super) fn verify_tree_and_subtree_checksums(
+    root: Option<BtreeHeader>,
+    key_size: Option<usize>,
+    value_size: Option<usize>,
+    mem: Arc<TransactionalMemory>,
+    hint: PageHint,
+) -> Result<bool> {
+    if let Some(header) = root {
+        if !RawBtree::new(
+            Some(header),
+            key_size,
+            DynamicCollection::<()>::fixed_width_with(value_size),
+            mem.clone(),
+            hint,
+        )
+        .verify_checksum()?
+        {
+            return Ok(false);
+        }
+
+        let table_pages_iter = AllPageNumbersBtreeIter::new(
+            header.root,
+            key_size,
+            DynamicCollection::<()>::fixed_width_with(value_size),
+            mem.clone(),
+            hint,
+        )?;
+        for table_page in table_pages_iter {
+            let page = mem.get_page(table_page?, hint)?;
+            let subtree_roots = parse_subtree_roots(&page, key_size, value_size);
+            for header in subtree_roots {
+                if !RawBtree::new(
+                    Some(header),
+                    value_size,
+                    <()>::fixed_width(),
+                    mem.clone(),
+                    hint,
+                )
+                .verify_checksum()?
+                {
+                    return Ok(false);
+                }
+            }
+        }
+    }
+
+    Ok(true)
+}
+
+// Relocate all subtrees to lower index pages, if possible
+pub(super) fn relocate_subtrees(
+    root: (PageNumber, Checksum),
+    key_size: Option<usize>,
+    value_size: Option<usize>,
+    mem: Arc<TransactionalMemory>,
+    freed_pages: Arc<Mutex<Vec<PageNumber>>>,
+    relocation_map: &HashMap<PageNumber, PageNumber>,
+) -> Result<(PageNumber, Checksum)> {
+    let old_page = mem.get_page(root.0, PageHint::None)?;
+    let mut new_page = if let Some(new_page_number) = relocation_map.get(&root.0) {
+        mem.get_page_mut(*new_page_number)?
+    } else {
+        return Ok(root);
+    };
+    let new_page_number = new_page.get_page_number();
+    new_page.memory_mut().copy_from_slice(old_page.memory());
+
+    match old_page.memory()[0] {
+        LEAF => {
+            let mut leaf_page = LeafPageMut::new(
+                new_page,
+                key_size,
+                UntypedDynamicCollection::fixed_width_with(value_size),
+            );
+            let accessor = LeafAccessor::new(
+                old_page.memory(),
+                key_size,
+                UntypedDynamicCollection::fixed_width_with(value_size),
+            );
+            for i in 0..accessor.num_pairs() {
+                let entry = accessor.entry(i).unwrap();
+                let collection = UntypedDynamicCollection::from_bytes(entry.value());
+                if matches!(collection.collection_type(), SubtreeV2) {
+                    let sub_root = collection.as_subtree();
+                    let mut tree = UntypedBtreeMut::new(
+                        Some(sub_root),
+                        mem.clone(),
+                        freed_pages.clone(),
+                        value_size,
+                        <() as Value>::fixed_width(),
+                    );
+                    tree.relocate(relocation_map)?;
+                    if sub_root != tree.get_root().unwrap() {
+                        let new_collection =
+                            UntypedDynamicCollection::make_subtree_data(tree.get_root().unwrap());
+                        leaf_page.replace_value(i, &new_collection);
+                    }
+                }
+            }
+        }
+        BRANCH => {
+            let accessor = BranchAccessor::new(&old_page, key_size);
+            let mut mutator = BranchMutator::new(new_page.memory_mut());
+            for i in 0..accessor.count_children() {
+                if let Some(child) = accessor.child_page(i) {
+                    let child_checksum = accessor.child_checksum(i).unwrap();
+                    let (new_child, new_checksum) = relocate_subtrees(
+                        (child, child_checksum),
+                        key_size,
+                        value_size,
+                        mem.clone(),
+                        freed_pages.clone(),
+                        relocation_map,
+                    )?;
+                    mutator.write_child_page(i, new_child, new_checksum);
+                }
+            }
+        }
+        _ => unreachable!(),
+    }
+
+    let old_page_number = old_page.get_page_number();
+    drop(old_page);
+    // No need to track allocations, because this method is only called during compaction when
+    // there can't be any savepoints
+    let mut ignore = PageTrackerPolicy::Ignore;
+    if !mem.free_if_uncommitted(old_page_number, &mut ignore) {
+        freed_pages.lock().unwrap().push(old_page_number);
+    }
+    Ok((new_page_number, DEFERRED))
+}
+
+// Finalize all the checksums in the tree, including any Dynamic collection subtrees
+// Returns the root checksum
+pub(super) fn finalize_tree_and_subtree_checksums(
+    root: Option<BtreeHeader>,
+    key_size: Option<usize>,
+    value_size: Option<usize>,
+    mem: Arc<TransactionalMemory>,
+) -> Result<Option<BtreeHeader>> {
+    let freed_pages = Arc::new(Mutex::new(vec![]));
+    let mut tree = UntypedBtreeMut::new(
+        root,
+        mem.clone(),
+        freed_pages.clone(),
+        key_size,
+        DynamicCollection::<()>::fixed_width_with(value_size),
+    );
+    tree.dirty_leaf_visitor(|mut leaf_page| {
+        let mut sub_root_updates = vec![];
+        let accessor = leaf_page.accessor();
+        for i in 0..accessor.num_pairs() {
+            let entry = accessor.entry(i).unwrap();
+            let collection = <&DynamicCollection<()>>::from_bytes(entry.value());
+            if matches!(collection.collection_type(), SubtreeV2) {
+                let sub_root = collection.as_subtree();
+                if mem.uncommitted(sub_root.root) {
+                    let mut subtree = UntypedBtreeMut::new(
+                        Some(sub_root),
+                        mem.clone(),
+                        freed_pages.clone(),
+                        value_size,
+                        <()>::fixed_width(),
+                    );
+                    let subtree_root = subtree.finalize_dirty_checksums()?.unwrap();
+                    sub_root_updates.push((i, subtree_root));
+                }
+            }
+        }
+        for (i, sub_root) in sub_root_updates {
+            let collection = DynamicCollection::<()>::make_subtree_data(sub_root);
+            leaf_page.replace_value(i, &collection);
+        }
+
+        Ok(())
+    })?;
+
+    let root = tree.finalize_dirty_checksums()?;
+    // No pages should have been freed by this operation
+    assert!(freed_pages.lock().unwrap().is_empty());
+    Ok(root)
+}
+
+fn parse_subtree_roots<T: Page>(
+    page: &T,
+    fixed_key_size: Option<usize>,
+    fixed_value_size: Option<usize>,
+) -> Vec<BtreeHeader> {
+    match page.memory()[0] {
+        BRANCH => {
+            vec![]
+        }
+        LEAF => {
+            let mut result = vec![];
+            let accessor = LeafAccessor::new(
+                page.memory(),
+                fixed_key_size,
+                DynamicCollection::<()>::fixed_width_with(fixed_value_size),
+            );
+            for i in 0..accessor.num_pairs() {
+                let entry = accessor.entry(i).unwrap();
+                let collection = <&DynamicCollection<()>>::from_bytes(entry.value());
+                if matches!(collection.collection_type(), SubtreeV2) {
+                    result.push(collection.as_subtree());
+                }
+            }
+
+            result
+        }
+        _ => unreachable!(),
+    }
+}
+
+pub(super) struct UntypedMultiBtree {
+    mem: Arc<TransactionalMemory>,
+    root: Option<BtreeHeader>,
+    hint: PageHint,
+    key_width: Option<usize>,
+    value_width: Option<usize>,
+}
+
+impl UntypedMultiBtree {
+    pub(super) fn new(
+        root: Option<BtreeHeader>,
+        mem: Arc<TransactionalMemory>,
+        hint: PageHint,
+        key_width: Option<usize>,
+        value_width: Option<usize>,
+    ) -> Self {
+        Self {
+            mem,
+            root,
+            hint,
+            key_width,
+            value_width,
+        }
+    }
+
+    // Applies visitor to pages in the tree
+    pub(super) fn visit_all_pages<F>(&self, mut visitor: F) -> Result
+    where
+        F: FnMut(&PagePath) -> Result,
+    {
+        let tree = UntypedBtree::new(
+            self.root,
+            self.mem.clone(),
+            self.hint,
+            self.key_width,
+            UntypedDynamicCollection::fixed_width_with(self.value_width),
+        );
+        tree.visit_all_pages(|path| {
+            visitor(path)?;
+            let page = self.mem.get_page(path.page_number(), self.hint)?;
+            match page.memory()[0] {
+                LEAF => {
+                    for header in parse_subtree_roots(&page, self.key_width, self.value_width) {
+                        let subtree = UntypedBtree::new(
+                            Some(header),
+                            self.mem.clone(),
+                            self.hint,
+                            self.value_width,
+                            <() as Value>::fixed_width(),
+                        );
+                        subtree.visit_all_pages(|subpath| {
+                            let full_path = path.with_subpath(subpath);
+                            visitor(&full_path)
+                        })?;
+                    }
+                }
+                BRANCH => {
+                    // No-op. The tree.visit_pages() call will process this sub-tree
+                }
+                _ => unreachable!(),
+            }
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}
+
+pub(crate) enum DynamicCollectionType {
+    Inline,
+    // Was used in file format version 1
+    // Subtree,
+    SubtreeV2,
+}
+
+impl From<u8> for DynamicCollectionType {
+    fn from(value: u8) -> Self {
+        match value {
+            LEAF => Inline,
+            // 2 => Subtree,
+            3 => SubtreeV2,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<u8> for DynamicCollectionType {
+    fn into(self) -> u8 {
+        match self {
+            // Reuse the LEAF type id, so that we can cast this directly into the format used by
+            // LeafAccessor
+            Inline => LEAF,
+            // Subtree => 2,
+            SubtreeV2 => 3,
+        }
+    }
+}
+
+/// Layout:
+/// type (1 byte):
+/// * 1 = inline data
+/// * 2 = sub tree
+///
+/// (when type = 1) data (n bytes): inlined leaf node
+///
+/// (when type = 2) root (8 bytes): sub tree root page number
+/// (when type = 2) checksum (16 bytes): sub tree checksum
+///
+/// NOTE: Even though the [`PhantomData`] is zero-sized, the inner data DST must be placed last.
+/// See [Exotically Sized Types](https://doc.rust-lang.org/nomicon/exotic-sizes.html#dynamically-sized-types-dsts)
+/// section of the Rustonomicon for more details.
+#[repr(transparent)]
+pub(crate) struct DynamicCollection<V: Key> {
+    _value_type: PhantomData<V>,
+    data: [u8],
+}
+
+impl<V: Key> std::fmt::Debug for DynamicCollection<V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DynamicCollection")
+            .field("data", &&self.data)
+            .finish()
+    }
+}
+
+impl<V: Key> Value for &DynamicCollection<V> {
+    type SelfType<'a>
+        = &'a DynamicCollection<V>
+    where
+        Self: 'a;
+    type AsBytes<'a>
+        = &'a [u8]
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> &'a DynamicCollection<V>
+    where
+        Self: 'a,
+    {
+        DynamicCollection::new(data)
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a [u8]
+    where
+        Self: 'b,
+    {
+        &value.data
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::internal("redb::DynamicCollection")
+    }
+}
+
+impl<V: Key> DynamicCollection<V> {
+    pub(crate) fn new(data: &[u8]) -> &Self {
+        unsafe { &*(std::ptr::from_ref::<[u8]>(data) as *const DynamicCollection<V>) }
+    }
+
+    pub(crate) fn collection_type(&self) -> DynamicCollectionType {
+        DynamicCollectionType::from(self.data[0])
+    }
+
+    pub(crate) fn as_inline(&self) -> &[u8] {
+        debug_assert!(matches!(self.collection_type(), Inline));
+        &self.data[1..]
+    }
+
+    pub(crate) fn as_subtree(&self) -> BtreeHeader {
+        assert!(matches!(self.collection_type(), SubtreeV2));
+        BtreeHeader::from_le_bytes(
+            self.data[1..=BtreeHeader::serialized_size()]
+                .try_into()
+                .unwrap(),
+        )
+    }
+
+    pub(crate) fn get_num_values(&self) -> u64 {
+        match self.collection_type() {
+            Inline => {
+                let leaf_data = self.as_inline();
+                let accessor =
+                    LeafAccessor::new(leaf_data, V::fixed_width(), <() as Value>::fixed_width());
+                accessor.num_pairs() as u64
+            }
+            SubtreeV2 => {
+                let offset = 1 + PageNumber::serialized_size() + size_of::<Checksum>();
+                u64::from_le_bytes(
+                    self.data[offset..(offset + size_of::<u64>())]
+                        .try_into()
+                        .unwrap(),
+                )
+            }
+        }
+    }
+
+    pub(crate) fn make_inline_data(data: &[u8]) -> Vec<u8> {
+        let mut result = vec![Inline.into()];
+        result.extend_from_slice(data);
+
+        result
+    }
+
+    pub(crate) fn make_subtree_data(header: BtreeHeader) -> Vec<u8> {
+        let mut result = vec![SubtreeV2.into()];
+        result.extend_from_slice(&header.to_le_bytes());
+        result
+    }
+
+    pub(crate) fn fixed_width_with(_value_width: Option<usize>) -> Option<usize> {
+        None
+    }
+}
+
+#[repr(transparent)]
+struct UntypedDynamicCollection {
+    data: [u8],
+}
+
+impl UntypedDynamicCollection {
+    pub(crate) fn fixed_width_with(_value_width: Option<usize>) -> Option<usize> {
+        None
+    }
+
+    fn new(data: &[u8]) -> &Self {
+        unsafe { &*(std::ptr::from_ref::<[u8]>(data) as *const UntypedDynamicCollection) }
+    }
+
+    fn make_subtree_data(header: BtreeHeader) -> Vec<u8> {
+        let mut result = vec![SubtreeV2.into()];
+        result.extend_from_slice(&header.to_le_bytes());
+        result
+    }
+
+    fn from_bytes(data: &[u8]) -> &Self {
+        Self::new(data)
+    }
+
+    fn collection_type(&self) -> DynamicCollectionType {
+        DynamicCollectionType::from(self.data[0])
+    }
+
+    fn as_inline(&self) -> &[u8] {
+        debug_assert!(matches!(self.collection_type(), Inline));
+        &self.data[1..]
+    }
+
+    fn as_subtree(&self) -> BtreeHeader {
+        assert!(matches!(self.collection_type(), SubtreeV2));
+        BtreeHeader::from_le_bytes(
+            self.data[1..=BtreeHeader::serialized_size()]
+                .try_into()
+                .unwrap(),
+        )
+    }
+}

--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -4,7 +4,7 @@ use std::mem::size_of;
 const HEIGHT_OFFSET: usize = 0;
 const END_OFFSETS: usize = HEIGHT_OFFSET + size_of::<u32>();
 
-pub(crate) struct BtreeBitmap {
+pub(super) struct BtreeBitmap {
     heights: Vec<U64GroupedBitmap>,
 }
 

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -1,6 +1,5 @@
 use crate::transaction_tracker::TransactionId;
-use crate::tree_store::Checksum;
-use crate::tree_store::btree_base::BtreeHeader;
+use crate::tree_store::btree_base::{BtreeHeader, Checksum};
 use crate::tree_store::page_store::layout::{DatabaseLayout, RegionLayout};
 use crate::tree_store::page_store::page_manager::{
     FILE_FORMAT_VERSION1, FILE_FORMAT_VERSION2, FILE_FORMAT_VERSION3, xxh3_checksum,

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -1,13 +1,13 @@
 use crate::db::TransactionGuard;
 use crate::error::TableError;
-use crate::multimap_table::{
-    finalize_tree_and_subtree_checksums, multimap_btree_stats, verify_tree_and_subtree_checksums,
-};
-use crate::tree_store::btree::{UntypedBtreeMut, btree_stats};
+use crate::tree_store::btree::{PagePath, UntypedBtreeMut, btree_stats};
 use crate::tree_store::btree_base::BtreeHeader;
+use crate::tree_store::multimap_btree::{
+    finalize_tree_and_subtree_checksums, verify_tree_and_subtree_checksums,
+};
 use crate::tree_store::{
-    Btree, BtreeMut, BtreeRangeIter, InternalTableDefinition, PageHint, PageNumber, PagePath,
-    PageTrackerPolicy, RawBtree, TableType, TransactionalMemory,
+    Btree, BtreeMut, BtreeRangeIter, InternalTableDefinition, PageHint, PageNumber,
+    PageTrackerPolicy, RawBtree, TableType, TransactionalMemory, multimap_btree_stats,
 };
 use crate::types::{Key, Value};
 use crate::{DatabaseStats, Result};

--- a/src/tree_store/table_tree_base.rs
+++ b/src/tree_store/table_tree_base.rs
@@ -1,7 +1,6 @@
-use crate::multimap_table::{UntypedMultiBtree, relocate_subtrees};
-use crate::tree_store::{
-    BtreeHeader, PageHint, PageNumber, PagePath, TransactionalMemory, UntypedBtree, UntypedBtreeMut,
-};
+use crate::tree_store::btree::{PagePath, UntypedBtree, UntypedBtreeMut};
+use crate::tree_store::multimap_btree::{UntypedMultiBtree, relocate_subtrees};
+use crate::tree_store::{BtreeHeader, PageHint, PageNumber, TransactionalMemory};
 use crate::{Key, Result, TableError, TypeName, Value};
 use std::collections::HashMap;
 use std::mem::size_of;


### PR DESCRIPTION
## Summary
This PR extracts multimap-specific btree functionality from `src/multimap_table.rs` into a new dedicated module `src/tree_store/multimap_btree.rs`, improving code organization and separation of concerns.

## Key Changes
- **New module**: Created `src/tree_store/multimap_btree.rs` containing:
  - `multimap_btree_stats()` and related statistics functions
  - `verify_tree_and_subtree_checksums()` for checksum verification
  - `relocate_subtrees()` for page relocation during compaction
  - `finalize_tree_and_subtree_checksums()` for finalizing checksums
  - `UntypedMultiBtree` struct for untyped multimap btree operations
  - `DynamicCollection<V>` and `UntypedDynamicCollection` types
  - `DynamicCollectionType` enum

- **Updated imports**: 
  - `src/multimap_table.rs` now imports multimap-specific functions from the new module
  - `src/tree_store/mod.rs` exports the new multimap_btree module
  - `src/tree_store/table_tree.rs` updated to import from the new module location

- **Visibility adjustments**:
  - Changed `UntypedBtree` and related types from `pub(crate)` to `pub(super)` in `btree.rs`
  - Changed `Checksum` and `DEFERRED` from `pub(crate)` to `pub(super)` in `btree_base.rs`
  - Adjusted visibility of `BtreeBitmap` in `page_store/bitmap.rs`
  - Updated `DynamicCollection` methods to be `pub(crate)` for cross-module access

- **Refactored methods**: Moved `iter()` and `iter_free_on_drop()` methods from `DynamicCollection` into `MultimapValue` as `from_collection()` and `from_collection_free_on_drop()` methods

## Implementation Details
- The new module maintains the same functionality while providing better encapsulation of multimap-specific btree operations
- Visibility changes use `pub(super)` to restrict access to the tree_store module hierarchy
- All multimap btree statistics, verification, and relocation logic is now co-located in a single module

https://claude.ai/code/session_018EgRFnYYCaXtwQGeiUSjma