### PR TITLE
Optimize U64GroupedBitmap::resize to process bits word-at-a-time

### DIFF
--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -217,6 +217,15 @@ impl BtreeBitmap {
     }
 }
 
+// Returns a u64 with bits `lo..hi` set, where `0 <= lo < hi <= 64`.
+fn bits_in_range(lo: u32, hi: u32) -> u64 {
+    debug_assert!(lo < hi && hi <= 64);
+    // Both shifts are well-defined: `lo < 64` and `64 - hi < 64`.
+    let bits_at_or_above_lo = u64::MAX << lo;
+    let bits_below_hi = u64::MAX >> (64 - hi);
+    bits_at_or_above_lo & bits_below_hi
+}
+
 // A bitmap which groups consecutive groups of 64bits together
 pub(crate) struct U64GroupedBitmap {
     len: u32,
@@ -329,14 +338,24 @@ impl U64GroupedBitmap {
         }
         let old_len = self.len;
         self.len = new_len;
-        if old_len < new_len {
-            // TODO: optimize this loop to set whole words at a time
-            for i in old_len..new_len {
-                if full {
-                    self.set(i);
-                } else {
-                    self.clear(i);
-                }
+        if old_len >= new_len {
+            return;
+        }
+        // Apply `full` to bits [old_len, new_len) one word at a time. For each
+        // word, build a mask of just the bits in that range that fall within
+        // the word, then OR it in (full=true) or AND its complement (full=false).
+        let start_word = old_len / 64;
+        let end_word = (new_len - 1) / 64;
+        for word in start_word..=end_word {
+            let word_first_bit = word * 64;
+            let lo = old_len.saturating_sub(word_first_bit);
+            let hi = (new_len - word_first_bit).min(64);
+            let mask = bits_in_range(lo, hi);
+            let slot = &mut self.data[word as usize];
+            if full {
+                *slot |= mask;
+            } else {
+                *slot &= !mask;
             }
         }
     }


### PR DESCRIPTION
## Summary
Optimized the `U64GroupedBitmap::resize` method to set/clear bits in bulk by processing entire 64-bit words at a time, rather than setting individual bits one by one.

## Key Changes
- Added `bits_in_range(lo: u32, hi: u32) -> u64` helper function that generates a u64 bitmask with bits set in the range `[lo, hi)`
- Refactored `U64GroupedBitmap::resize` to:
  - Early return if shrinking (no bits need to be modified)
  - Process the range of bits to be set/cleared word-by-word
  - For each affected word, compute a mask of only the relevant bits in that word
  - Apply the mask via bitwise OR (for `full=true`) or AND with complement (for `full=false`)

## Implementation Details
- The helper function includes debug assertions to ensure valid input ranges
- The resize logic correctly handles partial words at the boundaries (start and end of the resize range)
- This approach reduces the number of individual bit operations from O(n) to O(n/64), providing significant performance improvement for large resize operations

https://claude.ai/code/session_01QC8pbs2SPicfigLf9BGKzm