### PR TITLE
Add force_uncommitted() method to ensure CoW path allocation

### DIFF
--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -458,6 +458,26 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         Ok(())
     }
 
+    // Reserves `key` (inserting `placeholder` if absent, preserving its value otherwise)
+    // and CoWs the path to it, so a subsequent insert_inplace() with a value of
+    // equal-or-smaller serialized size won't allocate or free pages. Returns the
+    // serialized bytes currently stored at `key`.
+    pub(crate) fn force_uncommitted(
+        &mut self,
+        key: &K::SelfType<'_>,
+        placeholder: &V::SelfType<'_>,
+    ) -> Result<Vec<u8>> {
+        let existing_bytes = self
+            .get(key)?
+            .map(|guard| V::as_bytes(&guard.value()).as_ref().to_vec());
+        let bytes = existing_bytes.unwrap_or_else(|| V::as_bytes(placeholder).as_ref().to_vec());
+        {
+            let value = V::from_bytes(&bytes);
+            self.insert(key, &value)?;
+        }
+        Ok(bytes)
+    }
+
     pub(crate) fn remove(&mut self, key: &K::SelfType<'_>) -> Result<Option<AccessGuard<'_, V>>> {
         #[cfg(feature = "logging")]
         trace!("Btree(root={:?}): Deleting {:?}", &self.root, key);

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -386,20 +386,15 @@ impl TableTreeMut<'_> {
     ) -> Result {
         assert!(self.pending_table_updates.is_empty());
 
-        // Reserve space in the table tree
-        // TODO: maybe we should have a more explicit method, like "force_uncommitted()"
-        let existing = self
-            .tree
-            .insert(
-                &name,
-                &InternalTableDefinition::new::<K, V>(TableType::Normal, None, 0),
-            )?
-            .map(|x| x.value());
-        if let Some(existing) = existing {
-            self.tree.insert(&name, &existing)?;
-        }
+        // Reserve space in the table tree, and make sure the path to the entry is
+        // uncommitted, so that the final insert_inplace() below won't allocate or
+        // free any pages.
+        let bytes = self.tree.force_uncommitted(
+            &name,
+            &InternalTableDefinition::new::<K, V>(TableType::Normal, None, 0),
+        )?;
 
-        let table_root = match self.tree.get(&name)?.unwrap().value() {
+        let table_root = match InternalTableDefinition::from_bytes(&bytes) {
             InternalTableDefinition::Normal { table_root, .. } => table_root,
             InternalTableDefinition::Multimap { .. } => {
                 unreachable!()


### PR DESCRIPTION
## Summary
This PR introduces a new `force_uncommitted()` method to the B-tree implementation that ensures a key's path is fully committed to the current transaction before performing in-place updates. This enables subsequent `insert_inplace()` calls to operate without allocating or freeing pages.

## Key Changes
- **New `force_uncommitted()` method in `BtreeMut`**: Ensures a key exists in the tree with all pages on its path being uncommitted (allocated in the current transaction). If the key already exists, its value is preserved; otherwise, a placeholder value is inserted. Returns the serialized bytes of the value now stored at the key.

- **Simplified `create_table()` logic in `TableTreeMut`**: Replaced the previous two-step insert approach (insert placeholder, then re-insert existing value if present) with a single call to `force_uncommitted()`. This is cleaner and more explicit about the intent to reserve space while preserving existing definitions.

- **Improved code clarity**: The new method makes the purpose of the operation explicit through its name and documentation, replacing a TODO comment about needing a more explicit method.

## Implementation Details
- `force_uncommitted()` retrieves the existing value if present, otherwise uses the provided placeholder
- The method serializes the value (either existing or placeholder) and re-inserts it to ensure all pages on the path are CoW'd into the current transaction
- The returned bytes can be used directly without re-fetching from the tree, improving efficiency in `create_table()`

https://claude.ai/code/session_01LxzJCXgKdV5P99kE32hS2a