### PR TITLE
Enforce primary-slot selection before using a loaded DatabaseHeader

### DIFF
--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -84,11 +84,11 @@ fn get_u64(data: &[u8]) -> u64 {
     u64::from_le_bytes(data[..size_of::<u64>()].try_into().unwrap())
 }
 
-#[derive(Copy, Clone)]
-pub(super) struct HeaderRepairInfo {
-    pub(super) invalid_magic_number: bool,
-    pub(super) primary_corrupted: bool,
-    pub(super) secondary_corrupted: bool,
+// A header parsed from disk that has not yet committed to a primary slot.
+pub(super) struct UnrepairedDatabaseHeader {
+    inner: DatabaseHeader,
+    primary_corrupted: bool,
+    secondary_corrupted: bool,
 }
 
 #[derive(Clone)]
@@ -102,6 +102,107 @@ pub(super) struct DatabaseHeader {
     full_regions: u32,
     trailing_partial_region_pages: u32,
     transaction_slots: [TransactionHeader; 2],
+}
+
+impl UnrepairedDatabaseHeader {
+    pub(super) fn from_bytes(data: &[u8]) -> Result<Self, DatabaseError> {
+        if data[..MAGICNUMBER.len()] != MAGICNUMBER {
+            return Err(StorageError::Corrupted("Invalid magic number".to_string()).into());
+        }
+
+        let primary_slot = usize::from(data[GOD_BYTE_OFFSET] & PRIMARY_BIT != 0);
+        let recovery_required = (data[GOD_BYTE_OFFSET] & RECOVERY_REQUIRED) != 0;
+        let two_phase_commit = (data[GOD_BYTE_OFFSET] & TWO_PHASE_COMMIT) != 0;
+        let page_size = get_u32(&data[PAGE_SIZE_OFFSET..]);
+        let region_header_pages = get_u32(&data[REGION_HEADER_PAGES_OFFSET..]);
+        let region_max_data_pages = get_u32(&data[REGION_MAX_DATA_PAGES_OFFSET..]);
+        let full_regions = get_u32(&data[NUM_FULL_REGIONS_OFFSET..]);
+        let trailing_data_pages = get_u32(&data[TRAILING_REGION_DATA_PAGES_OFFSET..]);
+        let (slot0, slot0_corrupted) = TransactionHeader::from_bytes(
+            &data[TRANSACTION_0_OFFSET..(TRANSACTION_0_OFFSET + TRANSACTION_SIZE)],
+        )?;
+        let (slot1, slot1_corrupted) = TransactionHeader::from_bytes(
+            &data[TRANSACTION_1_OFFSET..(TRANSACTION_1_OFFSET + TRANSACTION_SIZE)],
+        )?;
+        let (primary_corrupted, secondary_corrupted) = if primary_slot == 0 {
+            (slot0_corrupted, slot1_corrupted)
+        } else {
+            (slot1_corrupted, slot0_corrupted)
+        };
+
+        Ok(Self {
+            inner: DatabaseHeader {
+                primary_slot,
+                recovery_required,
+                two_phase_commit,
+                page_size,
+                region_header_pages,
+                region_max_data_pages,
+                full_regions,
+                trailing_partial_region_pages: trailing_data_pages,
+                transaction_slots: [slot0, slot1],
+            },
+            primary_corrupted,
+            secondary_corrupted,
+        })
+    }
+
+    pub(super) fn page_size(&self) -> u32 {
+        self.inner.page_size
+    }
+
+    pub(super) fn layout(&self) -> DatabaseLayout {
+        self.inner.layout()
+    }
+
+    pub(super) fn recovery_required(&self) -> bool {
+        self.inner.recovery_required
+    }
+
+    pub(super) fn set_layout(&mut self, layout: DatabaseLayout) {
+        self.inner.set_layout(layout);
+    }
+
+    // Consume self, select a primary slot (repairing if necessary), and return the
+    // usable DatabaseHeader.
+    // The bool is true if the original primary was kept, or false if it was swapped with the
+    // secondary.
+    pub(super) fn finalize(mut self) -> Result<(DatabaseHeader, bool)> {
+        // If the primary was written using 2-phase commit, it's guaranteed to be valid. Don't look
+        // at the secondary; even if it happens to have a valid checksum, Durability::Paranoid means
+        // we can't trust it
+        if self.inner.two_phase_commit {
+            if self.primary_corrupted {
+                return Err(StorageError::Corrupted(
+                    "Primary is corrupted despite 2-phase commit".to_string(),
+                ));
+            }
+            return Ok((self.inner, true));
+        }
+
+        // Pick whichever slot is newer, assuming it has a valid checksum. This handles an edge case
+        // where we crash during fsync(), and the only data that got written to disk was the god byte
+        // update swapping the primary -- in that case, the primary contains a valid but out-of-date
+        // transaction, so we need to load from the secondary instead
+        if self.primary_corrupted {
+            if self.secondary_corrupted {
+                return Err(StorageError::Corrupted(
+                    "Both commit slots are corrupted".to_string(),
+                ));
+            }
+            self.inner.swap_primary_slot();
+            return Ok((self.inner, false));
+        }
+
+        let secondary_newer =
+            self.inner.secondary_slot().transaction_id > self.inner.primary_slot().transaction_id;
+        if secondary_newer && !self.secondary_corrupted {
+            self.inner.swap_primary_slot();
+            return Ok((self.inner, false));
+        }
+
+        Ok((self.inner, true))
+    }
 }
 
 impl DatabaseHeader {
@@ -179,93 +280,6 @@ impl DatabaseHeader {
 
     pub(super) fn swap_primary_slot(&mut self) {
         self.primary_slot ^= 1;
-    }
-
-    // Figure out which slot to use as the primary when starting a repair. The repair process might
-    // still switch to the other slot later, if the tree checksums turn out to be invalid.
-    //
-    // Returns true if we picked the original primary, or false if we swapped
-    pub(super) fn pick_primary_for_repair(
-        &mut self,
-        repair_info: HeaderRepairInfo,
-    ) -> Result<bool> {
-        // If the primary was written using 2-phase commit, it's guaranteed to be valid. Don't look
-        // at the secondary; even if it happens to have a valid checksum, Durability::Paranoid means
-        // we can't trust it
-        if self.two_phase_commit {
-            if repair_info.primary_corrupted {
-                return Err(StorageError::Corrupted(
-                    "Primary is corrupted despite 2-phase commit".to_string(),
-                ));
-            }
-            return Ok(true);
-        }
-
-        // Pick whichever slot is newer, assuming it has a valid checksum. This handles an edge case
-        // where we crash during fsync(), and the only data that got written to disk was the god byte
-        // update swapping the primary -- in that case, the primary contains a valid but out-of-date
-        // transaction, so we need to load from the secondary instead
-        if repair_info.primary_corrupted {
-            if repair_info.secondary_corrupted {
-                return Err(StorageError::Corrupted(
-                    "Both commit slots are corrupted".to_string(),
-                ));
-            }
-            self.swap_primary_slot();
-            return Ok(false);
-        }
-
-        let secondary_newer =
-            self.secondary_slot().transaction_id > self.primary_slot().transaction_id;
-        if secondary_newer && !repair_info.secondary_corrupted {
-            self.swap_primary_slot();
-            return Ok(false);
-        }
-
-        Ok(true)
-    }
-
-    // TODO: consider returning an Err with the repair info
-    pub(super) fn from_bytes(data: &[u8]) -> Result<(Self, HeaderRepairInfo), DatabaseError> {
-        let invalid_magic_number = data[..MAGICNUMBER.len()] != MAGICNUMBER;
-
-        let primary_slot = usize::from(data[GOD_BYTE_OFFSET] & PRIMARY_BIT != 0);
-        let recovery_required = (data[GOD_BYTE_OFFSET] & RECOVERY_REQUIRED) != 0;
-        let two_phase_commit = (data[GOD_BYTE_OFFSET] & TWO_PHASE_COMMIT) != 0;
-        let page_size = get_u32(&data[PAGE_SIZE_OFFSET..]);
-        let region_header_pages = get_u32(&data[REGION_HEADER_PAGES_OFFSET..]);
-        let region_max_data_pages = get_u32(&data[REGION_MAX_DATA_PAGES_OFFSET..]);
-        let full_regions = get_u32(&data[NUM_FULL_REGIONS_OFFSET..]);
-        let trailing_data_pages = get_u32(&data[TRAILING_REGION_DATA_PAGES_OFFSET..]);
-        let (slot0, slot0_corrupted) = TransactionHeader::from_bytes(
-            &data[TRANSACTION_0_OFFSET..(TRANSACTION_0_OFFSET + TRANSACTION_SIZE)],
-        )?;
-        let (slot1, slot1_corrupted) = TransactionHeader::from_bytes(
-            &data[TRANSACTION_1_OFFSET..(TRANSACTION_1_OFFSET + TRANSACTION_SIZE)],
-        )?;
-        let (primary_corrupted, secondary_corrupted) = if primary_slot == 0 {
-            (slot0_corrupted, slot1_corrupted)
-        } else {
-            (slot1_corrupted, slot0_corrupted)
-        };
-
-        let result = Self {
-            primary_slot,
-            recovery_required,
-            two_phase_commit,
-            page_size,
-            region_header_pages,
-            region_max_data_pages,
-            full_regions,
-            trailing_partial_region_pages: trailing_data_pages,
-            transaction_slots: [slot0, slot1],
-        };
-        let repair = HeaderRepairInfo {
-            invalid_magic_number,
-            primary_corrupted,
-            secondary_corrupted,
-        };
-        Ok((result, repair))
     }
 
     pub(super) fn to_bytes(&self, include_magic_number: bool) -> [u8; DB_HEADER_SIZE] {

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -5,7 +5,9 @@ use crate::tree_store::page_store::base::{MAX_PAGE_INDEX, PageHint};
 use crate::tree_store::page_store::buddy_allocator::BuddyAllocator;
 use crate::tree_store::page_store::cached_file::PagedCachedFile;
 use crate::tree_store::page_store::fast_hash::PageNumberHashSet;
-use crate::tree_store::page_store::header::{DB_HEADER_SIZE, DatabaseHeader, MAGICNUMBER};
+use crate::tree_store::page_store::header::{
+    DB_HEADER_SIZE, DatabaseHeader, MAGICNUMBER, UnrepairedDatabaseHeader,
+};
 use crate::tree_store::page_store::layout::DatabaseLayout;
 use crate::tree_store::page_store::region::{Allocators, RegionTracker};
 use crate::tree_store::page_store::{PageImpl, PageMut, hash128_with_seed};
@@ -225,27 +227,28 @@ impl TransactionalMemory {
             storage.flush()?;
         }
         let header_bytes = storage.read_direct(0, DB_HEADER_SIZE)?;
-        let (mut header, repair_info) = DatabaseHeader::from_bytes(&header_bytes)?;
+        let mut unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes)?;
 
-        assert_eq!(header.page_size() as usize, page_size);
-        assert!(storage.raw_file_len()? >= header.layout().len());
-        let needs_recovery =
-            header.recovery_required || header.layout().len() != storage.raw_file_len()?;
+        assert_eq!(unrepaired.page_size() as usize, page_size);
+        assert!(storage.raw_file_len()? >= unrepaired.layout().len());
+        let needs_recovery = unrepaired.recovery_required()
+            || unrepaired.layout().len() != storage.raw_file_len()?;
         if needs_recovery {
             if read_only {
                 return Err(DatabaseError::RepairAborted);
             }
-            let layout = header.layout();
+            let layout = unrepaired.layout();
             let region_max_pages = layout.full_region_layout().num_pages();
             let region_header_pages = layout.full_region_layout().get_header_pages();
-            header.set_layout(DatabaseLayout::recalculate(
+            unrepaired.set_layout(DatabaseLayout::recalculate(
                 storage.raw_file_len()?,
                 region_header_pages,
                 region_max_pages,
                 page_size.try_into().unwrap(),
             ));
-            header.pick_primary_for_repair(repair_info)?;
-            assert!(!repair_info.invalid_magic_number);
+        }
+        let (header, _) = unrepaired.finalize()?;
+        if needs_recovery {
             storage
                 .write(0, DB_HEADER_SIZE, true)?
                 .mem_mut()
@@ -326,16 +329,15 @@ impl TransactionalMemory {
         self.storage.invalidate_cache_all();
 
         let header_bytes = self.storage.read_direct(0, DB_HEADER_SIZE)?;
-        let (mut header, repair_info) = DatabaseHeader::from_bytes(&header_bytes)?;
+        let unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes)?;
         // TODO: This ends up always being true because this is called from check_integrity() once the db is already open
         // TODO: Also we should recheck the layout
+        let was_recovery_required = unrepaired.recovery_required();
+        let (header, kept_primary) = unrepaired.finalize()?;
         let mut was_clean = true;
-        if header.recovery_required {
-            if !header.pick_primary_for_repair(repair_info)? {
+        if was_recovery_required {
+            if !kept_primary {
                 was_clean = false;
-            }
-            if repair_info.invalid_magic_number {
-                return Err(StorageError::Corrupted("Invalid magic number".to_string()).into());
             }
             self.storage
                 .write(0, DB_HEADER_SIZE, true)?


### PR DESCRIPTION
Previously DatabaseHeader::from_bytes returned a (header, HeaderRepairInfo) tuple, and pick_primary_for_repair took the repair info as a separate argument. Callers could destructure the result, then either forget to pass the info back in or skip pick_primary_for_repair entirely and use the header with a possibly-stale primary slot. One call site also silently constructed a header from non-redb bytes when the magic number was invalid, relying on an assert in one caller and a flag check in the other.

Split the parse and use stages using typestate.
UnrepairedDatabaseHeader is what from_bytes returns; it exposes only the operations that do not depend on which slot is primary (page_size, layout, recovery_required, set_layout). The single way to reach a usable DatabaseHeader is finalize, which consumes self, runs the primary-slot selection (including any necessary repair), and returns the header along with whether the original primary was kept. Invalid magic is rejected up-front as a Corrupted error rather than surfaced through a flag.

There is now no path from disk bytes to a usable DatabaseHeader that skips primary-slot selection -- the type system enforces it.