### PR TITLE
Reclaim unpersisted pages across savepoints in non-durable commits

### DIFF
--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1228,6 +1228,16 @@ impl WriteTransaction {
                     data_freed_pages.push(value.value().get(i));
                 }
             }
+            // Also queue unpersisted allocations from non-durable commits after the savepoint.
+            // These are tracked in memory rather than in DATA_ALLOCATED_TABLE. We don't remove
+            // them from the map here: if this transaction aborts, the in-memory map must still
+            // reflect the full history. durable_commit() will empty the map.
+            for page in self
+                .mem
+                .unpersisted_allocations_after(savepoint.get_transaction_id())
+            {
+                data_freed_pages.push(page);
+            }
         }
 
         // 3) Mark all savepoints newer than the restored one as invalidated for this
@@ -1539,7 +1549,11 @@ impl WriteTransaction {
         Ok(())
     }
 
-    fn store_allocated_pages(&self, data_allocated_pages: Vec<PageNumber>) -> Result {
+    // Flushes this transaction's data-tree allocations to DATA_ALLOCATED_TABLE, along with any
+    // previously unpersisted allocations that are now becoming durable. Must be called AFTER
+    // `process_freed_pages` so that pages reclaimed during this commit are already dropped from
+    // the in-memory `unpersisted_allocations` map and not written to disk as stale records.
+    fn flush_data_allocated_pages(&self, data_allocated_pages: Vec<PageNumber>) -> Result {
         // Catch scenarios like a page getting allocated and then deallocated within the same
         // transaction, but errantly left in the allocated pages list.
         #[cfg(debug_assertions)]
@@ -1551,8 +1565,16 @@ impl WriteTransaction {
             debug_assert!(self.mem.uncommitted(*page), "Page is committed: {page:?}");
         }
 
+        let unpersisted = self.mem.take_unpersisted_allocations();
         let mut system_tables = self.system_tables.lock().unwrap();
         let mut allocated_table = system_tables.open_system_table(self, DATA_ALLOCATED_TABLE)?;
+        for (txn_id, pages) in unpersisted {
+            Self::write_allocated_pages_entry(
+                &mut allocated_table,
+                txn_id,
+                pages.into_iter().collect(),
+            )?;
+        }
         Self::write_allocated_pages_entry(
             &mut allocated_table,
             self.transaction_id,
@@ -1637,13 +1659,15 @@ impl WriteTransaction {
         user_root: Option<BtreeHeader>,
         allocated_pages: Vec<PageNumber>,
     ) -> Result {
-        self.store_allocated_pages(allocated_pages)?;
-
         let free_until_transaction = self
             .transaction_tracker
             .oldest_live_read_transaction()
             .map_or(self.transaction_id, |x| x.next());
         self.process_freed_pages(free_until_transaction)?;
+        // Flush allocated pages (including previously unpersisted allocations that are now
+        // becoming durable) AFTER process_freed_pages, so that any pages reclaimed here have
+        // already been dropped from the in-memory `unpersisted_allocations` map.
+        self.flush_data_allocated_pages(allocated_pages)?;
 
         let mut system_tables = self.system_tables.lock().unwrap();
         let system_freed_pages = system_tables.system_freed_pages();
@@ -1719,22 +1743,10 @@ impl WriteTransaction {
         user_root: Option<BtreeHeader>,
         allocated_pages: Vec<PageNumber>,
     ) -> Result {
-        self.store_allocated_pages(allocated_pages)?;
-
-        let mut free_until_transaction = self
+        let free_until_transaction = self
             .transaction_tracker
             .oldest_live_read_nondurable_transaction()
             .map_or(self.transaction_id, |x| x.next());
-        // TODO: refactor the non-durable free'ed processing to remove this
-        // The reason it is needed is that non-durable commits edit previous non-durable commits,
-        // but they only edit the freed tree of unpersisted pages.
-        // The allocated tree, which savepoints rely, is not edited for performance reasons
-        // Therefore, we must not edit anything after a savepoint
-        // It would be better for non-durable transaction's unpersisted pages to be kept in-memory
-        // in a data structure where the allocated list can be efficiently edited
-        if let Some((_, oldest_savepoint)) = self.transaction_tracker.oldest_savepoint() {
-            free_until_transaction = TransactionId::min(free_until_transaction, oldest_savepoint);
-        }
         self.process_freed_pages_nondurable(free_until_transaction)?;
 
         let mut post_commit_frees = vec![];
@@ -1767,6 +1779,9 @@ impl WriteTransaction {
 
         self.mem
             .non_durable_commit(user_root, system_root, self.transaction_id)?;
+        // Record the data-tree pages allocated in this transaction in the in-memory map.
+        self.mem
+            .record_unpersisted_allocations(self.transaction_id, allocated_pages);
         // Register this as a non-durable transaction to ensure that the freed pages we just pushed
         // are only processed after this has been persisted
         self.transaction_tracker.register_non_durable_commit(

--- a/src/tree_store/page_store/fast_hash.rs
+++ b/src/tree_store/page_store/fast_hash.rs
@@ -6,6 +6,7 @@ use std::hash::{BuildHasherDefault, Hasher};
 const K: u64 = 0xf135_7aea_2e62_a9c5;
 
 pub(crate) type FastHashMapU64<V> = HashMap<u64, V, BuildHasherDefault<FastHasher64>>;
+pub(crate) type PageNumberHashMap<V> = HashMap<PageNumber, V, BuildHasherDefault<FastHasher64>>;
 pub(crate) type PageNumberHashSet = HashSet<PageNumber, BuildHasherDefault<FastHasher64>>;
 
 #[derive(Copy, Clone, Default, Eq, PartialEq)]

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -4,7 +4,7 @@ use crate::tree_store::btree_base::{BtreeHeader, Checksum};
 use crate::tree_store::page_store::base::{MAX_PAGE_INDEX, PageHint};
 use crate::tree_store::page_store::buddy_allocator::BuddyAllocator;
 use crate::tree_store::page_store::cached_file::PagedCachedFile;
-use crate::tree_store::page_store::fast_hash::PageNumberHashSet;
+use crate::tree_store::page_store::fast_hash::{PageNumberHashMap, PageNumberHashSet};
 use crate::tree_store::page_store::header::{
     DB_HEADER_SIZE, DatabaseHeader, MAGICNUMBER, UnrepairedDatabaseHeader,
 };
@@ -15,6 +15,7 @@ use crate::tree_store::{Page, PageNumber, PageTrackerPolicy};
 use crate::{CacheStats, StorageBackend};
 use crate::{DatabaseError, Result, StorageError};
 use std::cmp::{max, min};
+use std::collections::BTreeMap;
 #[cfg(debug_assertions)]
 use std::collections::HashMap;
 #[cfg(debug_assertions)]
@@ -106,7 +107,21 @@ pub(crate) struct TransactionalMemory {
     // Pages allocated since the last commit
     // TODO: maybe this should be moved to WriteTransaction?
     allocated_since_commit: Mutex<PageNumberHashSet>,
+    // TODO: Maybe we should move all this unpersisted stuff to another transaction layer.
+    // There are durable commits which support persistent and ephemeral savepoints.
+    // And then non-durable commits which support only ephemeral savepoints, and basically
+    // accumulate in unpersisted memory/file space until a durable commit is made.
+    // Maybe the non-durable commit layer should be separate, and build on top of the durable commit layer.
     unpersisted: Mutex<PageNumberHashSet>,
+    // Data-tree pages allocated by non-durable commits that have not yet been durably persisted.
+    // This is the in-memory replacement for entries
+    // in DATA_ALLOCATED_TABLE for non-durable transactions: by keeping the list in-memory we can
+    // efficiently remove entries when `free_if_unpersisted` reclaims pages.
+    // Flushed to DATA_ALLOCATED_TABLE during durable_commit, and cleared (along with
+    // `unpersisted`) once the commit succeeds.
+    unpersisted_allocations: Mutex<BTreeMap<TransactionId, PageNumberHashSet>>,
+    // Reverse index into `unpersisted_allocations`
+    unpersisted_allocation_txn: Mutex<PageNumberHashMap<TransactionId>>,
     // True if the allocator state was corrupted when the file was opened
     // TODO: maybe we can remove this flag now that CheckedBackend exists?
     needs_recovery: AtomicBool,
@@ -267,6 +282,8 @@ impl TransactionalMemory {
         Ok(Self {
             allocated_since_commit: Mutex::new(PageNumberHashSet::default()),
             unpersisted: Mutex::new(PageNumberHashSet::default()),
+            unpersisted_allocations: Mutex::new(BTreeMap::new()),
+            unpersisted_allocation_txn: Mutex::new(PageNumberHashMap::default()),
             needs_recovery: AtomicBool::new(needs_recovery),
             storage,
             state: Mutex::new(state),
@@ -652,6 +669,10 @@ impl TransactionalMemory {
         let mut unpersisted = self.unpersisted.lock().unwrap();
         unpersisted.clear();
         unpersisted.shrink_to_fit();
+        // Any remaining unpersisted allocations are now durable. Their records have already been
+        // flushed to DATA_ALLOCATED_TABLE (see WriteTransaction::durable_commit).
+        self.unpersisted_allocations.lock().unwrap().clear();
+        self.unpersisted_allocation_txn.lock().unwrap().clear();
 
         let mut state = self.state.lock().unwrap();
         assert_eq!(
@@ -863,6 +884,29 @@ impl TransactionalMemory {
         self.free_helper(page, allocated);
     }
 
+    fn remove_unpersisted_allocation(&self, page: PageNumber) {
+        let Some(txn) = self
+            .unpersisted_allocation_txn
+            .lock()
+            .unwrap()
+            .remove(&page)
+        else {
+            return;
+        };
+        let mut allocations = self.unpersisted_allocations.lock().unwrap();
+        let empty = {
+            let pages = allocations
+                .get_mut(&txn)
+                .expect("unpersisted_allocation_txn points to a missing entry");
+            let removed = pages.remove(&page);
+            debug_assert!(removed);
+            pages.is_empty()
+        };
+        if empty {
+            allocations.remove(&txn);
+        }
+    }
+
     fn free_helper(&self, page: PageNumber, allocated: &mut PageTrackerPolicy) {
         #[cfg(debug_assertions)]
         {
@@ -908,11 +952,56 @@ impl TransactionalMemory {
         allocated: &mut PageTrackerPolicy,
     ) -> bool {
         if self.unpersisted.lock().unwrap().remove(&page) {
+            self.remove_unpersisted_allocation(page);
             self.free_helper(page, allocated);
             true
         } else {
             false
         }
+    }
+
+    // Record pages allocated in the data tree by a non-durable transaction. These are tracked in
+    // memory instead of being written to DATA_ALLOCATED_TABLE so that `free_if_unpersisted` can
+    // efficiently update the allocation list when it reclaims pages.
+    pub(crate) fn record_unpersisted_allocations(
+        &self,
+        transaction_id: TransactionId,
+        pages: impl IntoIterator<Item = PageNumber>,
+    ) {
+        let mut iter = pages.into_iter().peekable();
+        if iter.peek().is_none() {
+            return;
+        }
+        let mut allocations = self.unpersisted_allocations.lock().unwrap();
+        let mut reverse = self.unpersisted_allocation_txn.lock().unwrap();
+        let entry = allocations.entry(transaction_id).or_default();
+        for page in iter {
+            if entry.insert(page) {
+                let prev = reverse.insert(page, transaction_id);
+                debug_assert!(prev.is_none(), "page {page:?} already tracked");
+            }
+        }
+    }
+
+    pub(crate) fn take_unpersisted_allocations(
+        &self,
+    ) -> BTreeMap<TransactionId, PageNumberHashSet> {
+        self.unpersisted_allocation_txn.lock().unwrap().clear();
+        std::mem::take(&mut *self.unpersisted_allocations.lock().unwrap())
+    }
+
+    // Returns all unpersisted data-tree pages allocated strictly after `transaction_id`. Used
+    // during savepoint restore to queue pages that need to be freed.
+    pub(crate) fn unpersisted_allocations_after(
+        &self,
+        transaction_id: TransactionId,
+    ) -> Vec<PageNumber> {
+        let allocations = self.unpersisted_allocations.lock().unwrap();
+        let mut result = vec![];
+        for pages in allocations.range(transaction_id.next()..).map(|(_, v)| v) {
+            result.extend(pages.iter().copied());
+        }
+        result
     }
 
     // Frees the page if it was allocated since the last commit. Returns true, if the page was freed


### PR DESCRIPTION
Non-durable commits previously clamped free_until_transaction to the oldest savepoint in process_freed_pages_nondurable(). The clamp existed because DATA_FREED_TABLE edits made by the non-durable path were not mirrored into DATA_ALLOCATED_TABLE, so freeing an unpersisted page across a savepoint would leave a stale allocation record that savepoint restore would later re-queue, causing a double-free.

Track the allocation records for unpersisted data-tree pages in memory (TransactionalMemory::unpersisted_allocations) instead of writing them to DATA_ALLOCATED_TABLE. free_if_unpersisted() and free() now remove the reclaimed page from that map, so the record stays consistent with the allocator. Durable commits flush the map to DATA_ALLOCATED_TABLE (after process_freed_pages, so pages reclaimed during the commit are excluded) and savepoint restore iterates both DATA_ALLOCATED_TABLE and the in-memory map. With these invariants the clamp is unnecessary and unpersisted pages can be reclaimed immediately even when a savepoint exists, dramatically reducing the work that restore_savepoint() and subsequent non-durable commits have to do.