### PR TITLE
Make TransactionalMemory::allocate_lowest track allocated pages

### DIFF
--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1820,7 +1820,9 @@ impl WriteTransaction {
                 continue;
             }
             let old_page = self.mem.get_page(path.page_number(), PageHint::None)?;
-            let mut new_page = self.mem.allocate_lowest(old_page.memory().len())?;
+            let mut new_page = self
+                .mem
+                .allocate_lowest(old_page.memory().len(), &mut PageTrackerPolicy::Ignore)?;
             let new_page_number = new_page.get_page_number();
             // We have to copy at least the page type into the new page.
             // Otherwise its cache priority will be calculated incorrectly
@@ -1834,7 +1836,10 @@ impl WriteTransaction {
                         continue;
                     }
                     let old_parent = self.mem.get_page(*parent, PageHint::None)?;
-                    let mut new_page = self.mem.allocate_lowest(old_parent.memory().len())?;
+                    let mut new_page = self.mem.allocate_lowest(
+                        old_parent.memory().len(),
+                        &mut PageTrackerPolicy::Ignore,
+                    )?;
                     let new_page_number = new_page.get_page_number();
                     // We have to copy at least the page type into the new page.
                     // Otherwise its cache priority will be calculated incorrectly

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1221,8 +1221,16 @@ impl TransactionalMemory {
         result
     }
 
-    pub(crate) fn allocate_lowest<'txn>(&self, allocation_size: usize) -> Result<PageMut<'txn>> {
-        self.allocate_helper(allocation_size, true, true)
+    pub(crate) fn allocate_lowest<'txn>(
+        &self,
+        allocation_size: usize,
+        allocated: &mut PageTrackerPolicy,
+    ) -> Result<PageMut<'txn>> {
+        let result = self.allocate_helper(allocation_size, true, true);
+        if let Ok(ref page) = result {
+            allocated.insert(page.get_page_number());
+        }
+        result
     }
 
     pub(crate) fn count_allocated_pages(&self) -> Result<u64> {


### PR DESCRIPTION
`allocate_lowest` now takes a `&mut PageTrackerPolicy` argument and updates it on success, matching `allocate`. Both existing callers are in `compact_pages`, which doesn't track allocations, so they pass `PageTrackerPolicy::Ignore`.

https://claude.ai/code/session_017qhqmGagMTm4eLo2MmenVC