### PR TITLE
Remove a TODO comment

### DIFF
--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -528,7 +528,6 @@ impl PagedCachedFile {
         assert_eq!(0, offset % self.page_size);
         let mut lock = self.write_buffer.lock().unwrap();
 
-        // TODO: allow hint that page is known to be dirty and will not be in the read cache
         let cache_slot: usize = (offset % Self::lock_stripes()).try_into().unwrap();
         let existing = {
             let mut lock = self.read_cache[cache_slot].write().unwrap();


### PR DESCRIPTION
It's very hard to guarantee that a page is not in the read cache, since it could have been evicted and re-read since it was written. Instead this optimization should be done by moving the write cache into the transaction / table objects