### PR TITLE
Fix silent database corruption from transient I/O errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Enable file space reclamation during non-durable transactions performed while a savepoint exists.
 * Fix a bug where calling `compact()` on a database could cause the file to grow
   rather than shrink in some cases.
+* Fix a bug where a transient I/O error during certain transaction and recovery
+  operations could silently corrupt the database: the next time it was opened,
+  recovery would not run even though it was needed.
 
 ## 4.1.0 - 2026-04-19
 **This release contains a large number of bug fixes discovered by AI coding agents**

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -403,11 +403,24 @@ impl TransactionalMemory {
     }
 
     pub(crate) fn begin_writable(&self) -> Result {
-        let mut state = self.state.lock().unwrap();
-        assert!(!state.header.recovery_required);
-        state.header.recovery_required = true;
-        self.write_header(&state.header)?;
-        self.storage.flush()
+        self.mark_recovery_on_err(|| {
+            let mut state = self.state.lock().unwrap();
+            assert!(!state.header.recovery_required);
+            state.header.recovery_required = true;
+            self.write_header(&state.header)?;
+            self.storage.flush()
+        })
+    }
+
+    // If `f` returns an error, set `needs_recovery` so that any partial on-disk
+    // state is repaired on the next open, and so that in-memory state (which may
+    // now be out of sync with disk) is not trusted by later operations.
+    fn mark_recovery_on_err<T>(&self, f: impl FnOnce() -> Result<T>) -> Result<T> {
+        let result = f();
+        if result.is_err() {
+            self.needs_recovery.store(true, Ordering::Release);
+        }
+        result
     }
 
     pub(crate) fn used_two_phase_commit(&self) -> bool {
@@ -456,13 +469,14 @@ impl TransactionalMemory {
     }
 
     pub(crate) fn end_repair(&self) -> Result<()> {
-        let mut state = self.state.lock().unwrap();
-        state.header.recovery_required = false;
-        self.write_header(&state.header)?;
-        let result = self.storage.flush();
-        self.needs_recovery.store(false, Ordering::Release);
-
-        result
+        self.mark_recovery_on_err(|| {
+            let mut state = self.state.lock().unwrap();
+            state.header.recovery_required = false;
+            self.write_header(&state.header)?;
+            self.storage.flush()?;
+            self.needs_recovery.store(false, Ordering::Release);
+            Ok(())
+        })
     }
 
     pub(crate) fn reserve_allocator_state(
@@ -624,17 +638,15 @@ impl TransactionalMemory {
         two_phase: bool,
         shrink_policy: ShrinkPolicy,
     ) -> Result {
-        let result = self.commit_inner(
-            data_root,
-            system_root,
-            transaction_id,
-            two_phase,
-            shrink_policy,
-        );
-        if result.is_err() {
-            self.needs_recovery.store(true, Ordering::Release);
-        }
-        result
+        self.mark_recovery_on_err(|| {
+            self.commit_inner(
+                data_root,
+                system_root,
+                transaction_id,
+                two_phase,
+                shrink_policy,
+            )
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -687,13 +699,7 @@ impl TransactionalMemory {
         self.storage.flush()?;
 
         if shrunk {
-            let result = self.storage.resize(header.layout().len());
-            if result.is_err() {
-                // TODO: it would be nice to have a more cohesive approach to setting this.
-                // we do it in commit() & rollback() on failure, but there are probably other places that need it
-                self.needs_recovery.store(true, Ordering::Release);
-                return result;
-            }
+            self.storage.resize(header.layout().len())?;
         }
         let mut allocated_since_commit = self.allocated_since_commit.lock().unwrap();
         allocated_since_commit.clear();
@@ -727,37 +733,35 @@ impl TransactionalMemory {
         system_root: Option<BtreeHeader>,
         transaction_id: TransactionId,
     ) -> Result {
-        // All mutable pages must be dropped, this ensures that when a transaction completes
-        // no more writes can happen to the pages it allocated. Thus it is safe to make them visible
-        // to future read transactions
-        #[cfg(debug_assertions)]
-        debug_assert!(self.open_dirty_pages.lock().unwrap().is_empty());
-        assert!(!self.needs_recovery.load(Ordering::Acquire));
+        self.mark_recovery_on_err(|| {
+            // All mutable pages must be dropped, this ensures that when a transaction completes
+            // no more writes can happen to the pages it allocated. Thus it is safe to make them visible
+            // to future read transactions
+            #[cfg(debug_assertions)]
+            debug_assert!(self.open_dirty_pages.lock().unwrap().is_empty());
+            assert!(!self.needs_recovery.load(Ordering::Acquire));
 
-        let mut unpersisted = self.unpersisted.lock().unwrap();
-        let mut allocated_since_commit = self.allocated_since_commit.lock().unwrap();
-        unpersisted.extend(allocated_since_commit.drain());
-        allocated_since_commit.shrink_to_fit();
-        self.storage.write_barrier()?;
+            let mut unpersisted = self.unpersisted.lock().unwrap();
+            let mut allocated_since_commit = self.allocated_since_commit.lock().unwrap();
+            unpersisted.extend(allocated_since_commit.drain());
+            allocated_since_commit.shrink_to_fit();
+            self.storage.write_barrier()?;
 
-        let mut state = self.state.lock().unwrap();
-        let secondary = state.header.secondary_slot_mut();
-        secondary.transaction_id = transaction_id;
-        secondary.user_root = data_root;
-        secondary.system_root = system_root;
+            let mut state = self.state.lock().unwrap();
+            let secondary = state.header.secondary_slot_mut();
+            secondary.transaction_id = transaction_id;
+            secondary.user_root = data_root;
+            secondary.system_root = system_root;
 
-        // TODO: maybe we can remove this flag and just update the in-memory DatabaseHeader state?
-        self.read_from_secondary.store(true, Ordering::Release);
+            // TODO: maybe we can remove this flag and just update the in-memory DatabaseHeader state?
+            self.read_from_secondary.store(true, Ordering::Release);
 
-        Ok(())
+            Ok(())
+        })
     }
 
     pub(crate) fn rollback_uncommitted_writes(&self) -> Result {
-        let result = self.rollback_uncommitted_writes_inner();
-        if result.is_err() {
-            self.needs_recovery.store(true, Ordering::Release);
-        }
-        result
+        self.mark_recovery_on_err(|| self.rollback_uncommitted_writes_inner())
     }
 
     fn rollback_uncommitted_writes_inner(&self) -> Result {
@@ -1228,13 +1232,7 @@ impl TransactionalMemory {
         );
         assert!(new_layout.len() >= layout.len());
 
-        let result = self.storage.resize(new_layout.len());
-        if result.is_err() {
-            // TODO: it would be nice to have a more cohesive approach to setting this.
-            // we do it in commit() & rollback() on failure, but there are probably other places that need it
-            self.needs_recovery.store(true, Ordering::Release);
-            return result;
-        }
+        self.mark_recovery_on_err(|| self.storage.resize(new_layout.len()))?;
 
         state.allocators.resize_to(new_layout);
         state.header.set_layout(new_layout);


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where transient I/O errors during transaction and recovery operations could silently corrupt the database. When such errors occurred, the recovery flag would not be properly set, causing the database to skip recovery on the next open even though it was needed.

## Key Changes
- **Introduced `mark_recovery_on_err()` helper method**: A new utility function that wraps operations and automatically sets the `needs_recovery` flag if an error occurs. This ensures consistent error handling across multiple code paths.

- **Refactored `begin_writable()`**: Now uses `mark_recovery_on_err()` to ensure recovery is flagged if the initial write barrier fails.

- **Refactored `end_repair()`**: Now uses `mark_recovery_on_err()` to ensure recovery state is properly managed even if repair operations fail.

- **Refactored `commit()`**: Simplified to use `mark_recovery_on_err()` instead of manual error checking, ensuring the recovery flag is set on any commit failure.

- **Refactored `finalize_transaction()`**: Wrapped in `mark_recovery_on_err()` to handle errors consistently.

- **Refactored `rollback_uncommitted_writes()`**: Now uses `mark_recovery_on_err()` for consistent error handling.

- **Simplified storage resize operations**: Removed redundant manual error handling in `commit_inner()` and `allocate_pages()` by leveraging the `mark_recovery_on_err()` pattern at higher levels.

## Implementation Details
The `mark_recovery_on_err()` method provides a centralized way to handle transient failures by:
1. Executing the provided closure
2. If an error occurs, setting `needs_recovery` to true with `Ordering::Release` semantics
3. Returning the result unchanged

This approach ensures that any I/O error during critical operations will trigger recovery on the next database open, preventing silent corruption while maintaining the original error information for the caller.

https://claude.ai/code/session_01BGhw7ToyaBkgPrPttEDPhC