### PR TITLE
Replace hardcoded MAX_MAX_PAGE_ORDER with computed value

### DIFF
--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -36,8 +36,11 @@ const NO_HEADER: u32 = 0;
 // Regions have a maximum size of 4GiB. A `4GiB - overhead` value is the largest that can be represented,
 // because the leaf node format uses 32bit offsets
 const MAX_USABLE_REGION_SPACE: u64 = 4 * 1024 * 1024 * 1024;
-// TODO: remove this constant?
-pub(crate) const MAX_MAX_PAGE_ORDER: u8 = 20;
+// A region holds at most `MAX_PAGE_INDEX + 1` pages (the page index within a region is 20 bits),
+// so the largest buddy-allocator order any region can have is log2(MAX_PAGE_INDEX + 1).
+// `u32::ilog2` is always <= 31, so the cast to u8 is lossless.
+#[allow(clippy::cast_possible_truncation)]
+pub(crate) const MAX_MAX_PAGE_ORDER: u8 = (MAX_PAGE_INDEX + 1).ilog2() as u8;
 pub(super) const MIN_USABLE_PAGES: u32 = 10;
 const MIN_DESIRED_USABLE_BYTES: u64 = 1024 * 1024;
 


### PR DESCRIPTION
## Summary
Replaced the hardcoded constant `MAX_MAX_PAGE_ORDER = 20` with a computed value derived from `MAX_PAGE_INDEX`, making the code more maintainable and self-documenting.

## Key Changes
- Changed `MAX_MAX_PAGE_ORDER` from a magic number (20) to a calculated value: `(MAX_PAGE_INDEX + 1).ilog2() as u8`
- Added comprehensive documentation explaining the relationship between the page index bit width (20 bits) and the maximum buddy-allocator order
- Added `#[allow(clippy::cast_possible_truncation)]` to suppress the lint warning, with justification that `u32::ilog2()` always returns a value ≤ 31, making the cast to u8 lossless

## Implementation Details
The change ensures that `MAX_MAX_PAGE_ORDER` is always correctly derived from `MAX_PAGE_INDEX` rather than being independently maintained. Since a region can hold at most `MAX_PAGE_INDEX + 1` pages, the maximum buddy-allocator order is mathematically `log2(MAX_PAGE_INDEX + 1)`, which is now computed directly rather than hardcoded.

https://claude.ai/code/session_01WZhNyDcjAzyQVAb7qGKTE8