### PR TITLE
Refactor database header recovery to handle file length changes

### DIFF
--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -151,23 +151,48 @@ impl UnrepairedDatabaseHeader {
         self.inner.page_size
     }
 
-    pub(super) fn layout(&self) -> DatabaseLayout {
-        self.inner.layout()
+    // Returns true if the header needs to be repaired before use: either the recovery_required
+    // flag is set on disk, or the stored layout no longer matches the current file length (e.g.
+    // the file was truncated or extended externally). Callers must pass the actual file length
+    // so both conditions are always checked together.
+    pub(super) fn recovery_required(&self, file_len: u64) -> bool {
+        self.inner.recovery_required || self.inner.layout().len() != file_len
     }
 
-    pub(super) fn recovery_required(&self) -> bool {
-        self.inner.recovery_required
+    // Consume self, reconcile the layout against the actual file length, and select a primary slot
+    // (repairing if necessary). Returns the usable DatabaseHeader along with a `clean` flag that is
+    // true only when nothing had to be reconciled: the primary was kept and the stored layout
+    // already matched `file_len`.
+    pub(super) fn finalize(mut self, file_len: u64) -> Result<(DatabaseHeader, bool)> {
+        // The backing file may have been truncated or extended since the header was last written
+        // (e.g. externally, or by a prior crashed resize). Re-derive the layout from the actual
+        // file length so callers always see a layout consistent with the file. Truncation below
+        // the stored layout is always corruption -- redb shrinks the file only after writing a
+        // smaller layout -- and must be rejected before `recalculate` runs, since its arithmetic
+        // assumes at least one page of file length.
+        let stored_len = self.inner.layout().len();
+        if file_len < stored_len {
+            return Err(StorageError::Corrupted(format!(
+                "File truncated below stored layout: file_len={file_len}, layout_len={stored_len}"
+            )));
+        }
+        let layout_stale = stored_len != file_len;
+        if layout_stale {
+            let layout = self.inner.layout();
+            let region_max_pages = layout.full_region_layout().num_pages();
+            let region_header_pages = layout.full_region_layout().get_header_pages();
+            self.inner.set_layout(DatabaseLayout::recalculate(
+                file_len,
+                region_header_pages,
+                region_max_pages,
+                self.inner.page_size,
+            ));
+        }
+        let kept_primary = self.select_primary_slot()?;
+        Ok((self.inner, kept_primary && !layout_stale))
     }
 
-    pub(super) fn set_layout(&mut self, layout: DatabaseLayout) {
-        self.inner.set_layout(layout);
-    }
-
-    // Consume self, select a primary slot (repairing if necessary), and return the
-    // usable DatabaseHeader.
-    // The bool is true if the original primary was kept, or false if it was swapped with the
-    // secondary.
-    pub(super) fn finalize(mut self) -> Result<(DatabaseHeader, bool)> {
+    fn select_primary_slot(&mut self) -> Result<bool> {
         // If the primary was written using 2-phase commit, it's guaranteed to be valid. Don't look
         // at the secondary; even if it happens to have a valid checksum, Durability::Paranoid means
         // we can't trust it
@@ -177,7 +202,7 @@ impl UnrepairedDatabaseHeader {
                     "Primary is corrupted despite 2-phase commit".to_string(),
                 ));
             }
-            return Ok((self.inner, true));
+            return Ok(true);
         }
 
         // Pick whichever slot is newer, assuming it has a valid checksum. This handles an edge case
@@ -191,17 +216,17 @@ impl UnrepairedDatabaseHeader {
                 ));
             }
             self.inner.swap_primary_slot();
-            return Ok((self.inner, false));
+            return Ok(false);
         }
 
         let secondary_newer =
             self.inner.secondary_slot().transaction_id > self.inner.primary_slot().transaction_id;
         if secondary_newer && !self.secondary_corrupted {
             self.inner.swap_primary_slot();
-            return Ok((self.inner, false));
+            return Ok(false);
         }
 
-        Ok((self.inner, true))
+        Ok(true)
     }
 }
 
@@ -588,6 +613,28 @@ mod test {
                 DatabaseError::Storage(StorageError::Corrupted(_))
             ));
         }
+    }
+
+    // If the file is externally truncated below the stored layout, both open and check_integrity
+    // should report corruption rather than panicking in the layout recalculation.
+    #[test]
+    fn truncated_file_is_rejected() {
+        let tmpfile = crate::create_tempfile();
+        let mut db = Database::builder().create(tmpfile.path()).unwrap();
+        assert!(db.check_integrity().unwrap());
+        drop(db);
+
+        let file = OpenOptions::new().write(true).open(tmpfile.path()).unwrap();
+        // Truncate to just the header (no page data) -- this is less than one page on any
+        // supported page size, so recalculate() would underflow without the guard.
+        file.set_len(crate::tree_store::page_store::header::DB_HEADER_SIZE as u64)
+            .unwrap();
+
+        let err = Database::open(tmpfile.path()).unwrap_err();
+        assert!(
+            matches!(err, DatabaseError::Storage(StorageError::Corrupted(_))),
+            "expected Corrupted, got {err:?}"
+        );
     }
 
     #[test]

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -289,27 +289,15 @@ impl TransactionalMemory {
             storage.flush()?;
         }
         let header_bytes = storage.read_direct(0, DB_HEADER_SIZE)?;
-        let mut unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes)?;
+        let unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes)?;
 
         assert_eq!(unrepaired.page_size() as usize, page_size);
-        assert!(storage.raw_file_len()? >= unrepaired.layout().len());
-        let needs_recovery = unrepaired.recovery_required()
-            || unrepaired.layout().len() != storage.raw_file_len()?;
-        if needs_recovery {
-            if read_only {
-                return Err(DatabaseError::RepairAborted);
-            }
-            let layout = unrepaired.layout();
-            let region_max_pages = layout.full_region_layout().num_pages();
-            let region_header_pages = layout.full_region_layout().get_header_pages();
-            unrepaired.set_layout(DatabaseLayout::recalculate(
-                storage.raw_file_len()?,
-                region_header_pages,
-                region_max_pages,
-                page_size.try_into().unwrap(),
-            ));
+        let file_len = storage.raw_file_len()?;
+        let needs_recovery = unrepaired.recovery_required(file_len);
+        if needs_recovery && read_only {
+            return Err(DatabaseError::RepairAborted);
         }
-        let (header, _) = unrepaired.finalize()?;
+        let (header, _) = unrepaired.finalize(file_len)?;
         if needs_recovery {
             storage
                 .write(0, DB_HEADER_SIZE, true)?
@@ -392,15 +380,8 @@ impl TransactionalMemory {
 
         let header_bytes = self.storage.read_direct(0, DB_HEADER_SIZE)?;
         let unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes)?;
-        // TODO: This ends up always being true because this is called from check_integrity() once the db is already open
-        // TODO: Also we should recheck the layout
-        let was_recovery_required = unrepaired.recovery_required();
-        let (header, kept_primary) = unrepaired.finalize()?;
-        let mut was_clean = true;
-        if was_recovery_required {
-            if !kept_primary {
-                was_clean = false;
-            }
+        let (header, was_clean) = unrepaired.finalize(self.storage.raw_file_len()?)?;
+        if !was_clean {
             self.storage
                 .write(0, DB_HEADER_SIZE, true)?
                 .mem_mut()


### PR DESCRIPTION
## Summary
Refactored the database header recovery logic to properly detect and handle cases where the backing file has been truncated or extended externally. The recovery check now always considers both the on-disk recovery flag and whether the stored layout matches the actual file length.

## Key Changes
- **Enhanced `recovery_required()` method**: Now takes the actual file length as a parameter and returns true if either the recovery flag is set OR the stored layout doesn't match the file length
- **Refactored `finalize()` method**: 
  - Now takes `file_len` as a parameter to enable layout reconciliation
  - Automatically recalculates the database layout if it's stale (doesn't match actual file length)
  - Returns a `clean` flag that is true only when no reconciliation was needed (primary was kept and layout already matched)
  - Extracted slot selection logic into a separate `select_primary_slot()` helper method
- **Simplified caller logic in `page_manager.rs`**:
  - Removed manual layout recalculation code from `open()` - now handled by `finalize()`
  - Consolidated recovery detection into a single `recovery_required()` call
  - Improved `check_integrity()` to properly use the `clean` flag returned by `finalize()`
  - Eliminated redundant TODO comments and simplified the repair decision logic

## Implementation Details
- The `finalize()` method now owns the responsibility for both layout reconciliation and slot selection, ensuring these operations are always performed together
- File length is passed through the call chain to ensure consistent state checking
- The `clean` flag accurately reflects whether any repair work was performed, enabling proper write-back of the header when needed

https://claude.ai/code/session_01AozxQQYZQZ7ackWThrURfN