### PR TITLE
Make MultimapValue iteration zero-copy

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -13,11 +13,16 @@ use crate::{AccessGuard, MultimapTableHandle, Result, StorageError, WriteTransac
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 use std::mem;
-use std::ops::{RangeBounds, RangeFull};
+use std::ops::{Range, RangeBounds, RangeFull};
 use std::sync::{Arc, Mutex};
 
 pub(crate) struct LeafKeyIter<'a, V: Key + 'static> {
-    inline_collection: AccessGuard<'a, &'static DynamicCollection<V>>,
+    // Kept alive so any Drop side-effects on `data` (e.g. `remove_on_drop`) still run.
+    _inline_collection: AccessGuard<'a, &'static DynamicCollection<V>>,
+    // Arc-backed view of the page holding the inline collection.
+    page_data: Arc<[u8]>,
+    // Byte range in `page_data` holding the inline leaf data for the collection.
+    inline_range: Range<usize>,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
     start_entry: isize, // inclusive
@@ -30,11 +35,18 @@ impl<'a, V: Key> LeafKeyIter<'a, V> {
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
     ) -> Self {
-        let accessor =
-            LeafAccessor::new(data.value().as_inline(), fixed_key_size, fixed_value_size);
+        let (page_data, value_range) = data.arc_view();
+        let inline_range = DynamicCollection::<V>::inline_range_within(value_range);
+        let accessor = LeafAccessor::new(
+            &page_data[inline_range.clone()],
+            fixed_key_size,
+            fixed_value_size,
+        );
         let end_entry = isize::try_from(accessor.num_pairs()).unwrap() - 1;
         Self {
-            inline_collection: data,
+            _inline_collection: data,
+            page_data,
+            inline_range,
             fixed_key_size,
             fixed_value_size,
             start_entry: 0,
@@ -42,34 +54,45 @@ impl<'a, V: Key> LeafKeyIter<'a, V> {
         }
     }
 
-    fn next_key(&mut self) -> Option<&[u8]> {
-        if self.end_entry < self.start_entry {
-            return None;
-        }
-        let accessor = LeafAccessor::new(
-            self.inline_collection.value().as_inline(),
-            self.fixed_key_size,
-            self.fixed_value_size,
-        );
-        self.start_entry += 1;
-        accessor
-            .entry((self.start_entry - 1).try_into().unwrap())
-            .map(|e| e.key())
+    fn inline_bytes(&self) -> &[u8] {
+        &self.page_data[self.inline_range.clone()]
     }
 
-    fn next_key_back(&mut self) -> Option<&[u8]> {
-        if self.end_entry < self.start_entry {
-            return None;
-        }
+    fn num_values(&self) -> u64 {
         let accessor = LeafAccessor::new(
-            self.inline_collection.value().as_inline(),
+            self.inline_bytes(),
             self.fixed_key_size,
             self.fixed_value_size,
         );
+        accessor.num_pairs() as u64
+    }
+
+    fn key_at(&self, n: usize) -> Option<AccessGuard<'static, V>> {
+        let accessor = LeafAccessor::new(
+            self.inline_bytes(),
+            self.fixed_key_size,
+            self.fixed_value_size,
+        );
+        let (key_range, _) = accessor.entry_ranges(n)?;
+        let absolute =
+            (self.inline_range.start + key_range.start)..(self.inline_range.start + key_range.end);
+        Some(AccessGuard::with_arc_page(self.page_data.clone(), absolute))
+    }
+
+    fn next_key(&mut self) -> Option<AccessGuard<'static, V>> {
+        if self.end_entry < self.start_entry {
+            return None;
+        }
+        self.start_entry += 1;
+        self.key_at((self.start_entry - 1).try_into().unwrap())
+    }
+
+    fn next_key_back(&mut self) -> Option<AccessGuard<'static, V>> {
+        if self.end_entry < self.start_entry {
+            return None;
+        }
         self.end_entry -= 1;
-        accessor
-            .entry((self.end_entry + 1).try_into().unwrap())
-            .map(|e| e.key())
+        self.key_at((self.end_entry + 1).try_into().unwrap())
     }
 }
 
@@ -129,7 +152,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
     }
 
     fn new_inline(inner: LeafKeyIter<'a, V>, guard: Arc<TransactionGuard>) -> Self {
-        let remaining = inner.inline_collection.value().get_num_values();
+        let remaining = inner.num_values();
         Self {
             inner: Some(ValueIterState::InlineLeaf(inner)),
             remaining,
@@ -221,35 +244,53 @@ impl<'a, V: Key + 'static> Iterator for MultimapValue<'a, V> {
     type Item = Result<AccessGuard<'a, V>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO: optimize out this copy
-        let bytes = match self.inner.as_mut().unwrap() {
+        // If `free_on_drop` is non-empty, the subtree pages backing the iteration will be
+        // freed when this `MultimapValue` is dropped (the `remove_all` path). Yielded
+        // guards may outlive the iterator (e.g. via `collect`), so in that case we must
+        // return owned copies rather than references into soon-to-be-freed pages.
+        let copy_values = !self.free_on_drop.is_empty();
+        let guard = match self.inner.as_mut().unwrap() {
             ValueIterState::Subtree(iter) => match iter.next()? {
-                Ok(e) => e.key_data(),
+                Ok(e) => {
+                    if copy_values {
+                        AccessGuard::with_owned_value(e.key_data())
+                    } else {
+                        let (page, key_range, _) = e.into_raw();
+                        AccessGuard::with_page(page, key_range)
+                    }
+                }
                 Err(err) => {
                     return Some(Err(err));
                 }
             },
-            ValueIterState::InlineLeaf(iter) => iter.next_key()?.to_vec(),
+            ValueIterState::InlineLeaf(iter) => iter.next_key()?,
         };
         self.remaining -= 1;
-        Some(Ok(AccessGuard::with_owned_value(bytes)))
+        Some(Ok(guard))
     }
 }
 
 impl<V: Key + 'static> DoubleEndedIterator for MultimapValue<'_, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        // TODO: optimize out this copy
-        let bytes = match self.inner.as_mut().unwrap() {
+        let copy_values = !self.free_on_drop.is_empty();
+        let guard = match self.inner.as_mut().unwrap() {
             ValueIterState::Subtree(iter) => match iter.next_back()? {
-                Ok(e) => e.key_data(),
+                Ok(e) => {
+                    if copy_values {
+                        AccessGuard::with_owned_value(e.key_data())
+                    } else {
+                        let (page, key_range, _) = e.into_raw();
+                        AccessGuard::with_page(page, key_range)
+                    }
+                }
                 Err(err) => {
                     return Some(Err(err));
                 }
             },
-            ValueIterState::InlineLeaf(iter) => iter.next_key_back()?.to_vec(),
+            ValueIterState::InlineLeaf(iter) => iter.next_key_back()?,
         };
         self.remaining -= 1;
-        Some(Ok(AccessGuard::with_owned_value(bytes)))
+        Some(Ok(guard))
     }
 }
 

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -226,6 +226,21 @@ impl<'a, V: Value + 'static> AccessGuard<'a, V> {
     pub fn value(&self) -> V::SelfType<'_> {
         V::from_bytes(&self.page.memory()[self.offset..(self.offset + self.len)])
     }
+
+    pub(crate) fn arc_view(&self) -> (Arc<[u8]>, Range<usize>) {
+        match &self.page {
+            EitherPage::Immutable(page) => (page.to_arc(), self.offset..(self.offset + self.len)),
+            EitherPage::ArcMemory(arc) => (arc.clone(), self.offset..(self.offset + self.len)),
+            EitherPage::OwnedMemory(vec) => {
+                let bytes = &vec[self.offset..(self.offset + self.len)];
+                (Arc::from(bytes), 0..self.len)
+            }
+            EitherPage::Mutable(page) => {
+                let bytes = &page.memory()[self.offset..(self.offset + self.len)];
+                (Arc::from(bytes), 0..self.len)
+            }
+        }
+    }
 }
 
 impl<V: Value + 'static> Drop for AccessGuard<'_, V> {

--- a/src/tree_store/multimap_btree.rs
+++ b/src/tree_store/multimap_btree.rs
@@ -13,6 +13,7 @@ use std::cmp::max;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::mem::size_of;
+use std::ops::Range;
 use std::sync::{Arc, Mutex};
 
 pub(crate) fn multimap_btree_stats(
@@ -533,6 +534,14 @@ impl<V: Key> DynamicCollection<V> {
     pub(crate) fn as_inline(&self) -> &[u8] {
         debug_assert!(matches!(self.collection_type(), Inline));
         &self.data[1..]
+    }
+
+    /// Given the byte range of a serialized inline-variant collection within a larger
+    /// buffer, returns the sub-range that holds the inline leaf data (i.e. what
+    /// `as_inline` would return if the collection were deserialized).
+    pub(crate) fn inline_range_within(collection_range: Range<usize>) -> Range<usize> {
+        // `as_inline` skips the one-byte type tag at `data[0]`.
+        (collection_range.start + 1)..collection_range.end
     }
 
     pub(crate) fn as_subtree(&self) -> BtreeHeader {

--- a/tests/multimap_tests.rs
+++ b/tests/multimap_tests.rs
@@ -293,6 +293,34 @@ fn delete() {
     assert_eq!(empty, get_vec(&table, "hello"));
 }
 
+// Regression test: remove_all on a key whose values live in an uncommitted subtree must
+// return guards that remain valid after the iterator is dropped (and therefore after the
+// subtree pages have been freed). Previously the subtree iteration handed out AccessGuards
+// that held references to the page bytes; dropping the iterator then freed those pages
+// via free_if_uncommitted while the collected guards were still outstanding, tripping
+// the read_page_ref_counts debug assertion.
+#[test]
+fn remove_all_uncommitted_subtree_collect() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_TABLE).unwrap();
+        // Enough distinct values that the collection is promoted to a subtree of
+        // uncommitted pages before we remove_all in the same transaction.
+        for v in 0..2000u64 {
+            table.insert(&0u64, &v).unwrap();
+        }
+        let iter = table.remove_all(&0u64).unwrap();
+        let values: Vec<_> = iter.collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(values.len(), 2000);
+        for (i, guard) in values.iter().enumerate() {
+            assert_eq!(guard.value(), i as u64);
+        }
+    }
+    write_txn.commit().unwrap();
+}
+
 #[test]
 fn wrong_types() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
MultimapValue's Iterator and DoubleEndedIterator impls used to copy each yielded value's bytes (via to_vec() / key_data()) into an AccessGuard::with_owned_value. That is one heap allocation plus memcpy per yielded item, on what is supposed to be the zero-copy read path.

Both paths now share page memory instead of copying:

- Subtree-backed values: use EntryGuard::into_raw() to get the PageImpl and key range directly, then wrap with AccessGuard::with_page. The PageImpl holds an Arc<[u8]> so each yielded guard is just an Arc clone of the leaf page.

- Inline-leaf values: a new AccessGuard::arc_view() returns the page's Arc<[u8]> plus the byte range of the value. For the Immutable / ArcMemory variants used by every multimap read path (MultimapTable::get/range, ReadOnlyMultimapTable::get/range) this is a pure Arc::clone -- no memcpy. LeafKeyIter stores that Arc plus the inline leaf range and yields AccessGuard::with_arc_page entries that all share the page.

For the Mutable / OwnedMemory variants (only reached through the remove_on_drop path in BtreeMut::remove -> MultimapTable::remove_all) arc_view() still copies the value bytes, because WritablePage needs unique Arc ownership for mem_mut() and OwnedMemory has no Arc to clone. In that case we copy only the collection bytes, not the whole page.

The knowledge that the inline leaf data sits after a one-byte type tag stays in multimap_btree.rs via a new DynamicCollection:: inline_range_within helper, colocated with as_inline; multimap_table.rs just asks where the inline sub-range is within a collection's byte range.

Assisted-by: Claude