### PR TITLE
Remove redundant third commit in Database::compact()

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -657,18 +657,11 @@ impl Database {
                 txn.abort()?;
             }
 
-            // Double commit to free up the relocated pages for reuse
+            // Second commit is needed to drain the data freed table: the first commit records
+            // the pages relocated by compact_pages() as pending frees, and this one processes
+            // them so the space becomes reusable and the file can be shrunk.
             let mut txn = self.begin_write().map_err(|e| e.into_storage_error())?;
             txn.set_two_phase_commit(true);
-            // Also shrink the database file by the maximum amount
-            txn.set_shrink_policy(ShrinkPolicy::Maximum);
-            txn.commit().map_err(|e| e.into_storage_error())?;
-            // Triple commit to free up the relocated pages for reuse
-            // TODO: this really shouldn't be necessary, but the data freed tree is a system table
-            // and so free'ing up its pages causes more deletes from the system tree
-            let mut txn = self.begin_write().map_err(|e| e.into_storage_error())?;
-            txn.set_two_phase_commit(true);
-            // Also shrink the database file by the maximum amount
             txn.set_shrink_policy(ShrinkPolicy::Maximum);
             txn.commit().map_err(|e| e.into_storage_error())?;
             let txn = self.begin_write().map_err(|e| e.into_storage_error())?;


### PR DESCRIPTION
Each iteration of the compaction loop ran three commits: one to relocate high pages (compact_pages), one to drain DATA_FREED_TABLE and shrink, and a third that the TODO described as defensive, in case modifying a system table during the second commit left more pending frees behind.

It does not. Tracing the second commit's durable_commit() in transactions.rs:

  - process_freed_pages(free_until=T3) extracts every sub-T3 entry from DATA_FREED_TABLE. The old btree pages it sheds are system-tree pages and accumulate in the system_tables freed_pages Vec (system_freed_pages).
  - compact() calls set_two_phase_commit(true) but never set_quick_repair, so the quick-repair branch at transactions.rs:1706-1743 is skipped and store_system_freed_pages() is not called. SYSTEM_FREED_TABLE stays empty (its root is None).
  - After self.mem.commit() returns, the unconditional drain loop at transactions.rs:1758-1762 empties system_freed_pages by calling self.mem.free() on every page. Per the comment there, this is safe because those pages are only reachable from write transactions, which are serialized by the &mut self on compact().

So by the time control returns to compact():
  - DATA_FREED_TABLE's root is None (all entries extracted).
  - SYSTEM_FREED_TABLE's root is None (never written to).
  - The in-memory allocator already reflects the system-tree frees, so the next transaction's try_shrink sees them.

That matches the post-condition pending_free_pages() checks, which is why the assert!(!txn.pending_free_pages()?) holds with two commits. The third commit adds no state transitions - it just rewrites the same system root with the same shrink policy.

Verification: - just test (cargo deny, fmt, clippy, and cargo test --all-features)
    passes, including the compaction and compact_does_not_grow_file
    regression tests that assert shrinkage and non-growth.
  - 60s cargo fuzz run fuzz_redb passes. The fuzzer's run_compaction epilogue asserts allocated_pages == baseline_allocated_pages, so a page leak from the removed commit would fail the run.
  - redb_benchmark: compacted file sizes are byte-identical to the pre-change build in two scenarios (the fragmented case from the compaction test: 13,373,440 -> 1,445,888; a dense small-value case: 33,820,672 -> 20,828,160). Compact wall time drops slightly (10448ms -> 10215ms) from saving one fsync'd two-phase commit per loop iteration; all other benchmarks are within noise. 

Assisted-by: Claude