### PR TITLE
Replace HashSet with custom PageNumberHashSet for page tracking

### DIFF
--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multim
 pub(crate) use page_store::ReadOnlyBackend;
 pub(crate) use page_store::{
     AllocationPolicy, FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page,
-    PageHint, PageNumber, PageTrackerPolicy, SerializedSavepoint, ShrinkPolicy,
+    PageHint, PageNumber, PageNumberHashSet, PageTrackerPolicy, SerializedSavepoint, ShrinkPolicy,
     TransactionalMemory,
 };
 pub use page_store::{InMemoryBackend, Savepoint, file_backend};

--- a/src/tree_store/page_store/base.rs
+++ b/src/tree_store/page_store/base.rs
@@ -1,8 +1,10 @@
 use crate::tree_store::page_store::cached_file::WritablePage;
+use crate::tree_store::page_store::fast_hash::PageNumberHashSet;
 use crate::tree_store::page_store::page_manager::MAX_MAX_PAGE_ORDER;
 use std::cmp::Ordering;
 #[cfg(debug_assertions)]
 use std::collections::HashMap;
+#[cfg(debug_assertions)]
 use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
@@ -279,13 +281,13 @@ pub(crate) enum PageHint {
 
 pub(crate) enum PageTrackerPolicy {
     Ignore,
-    Track(HashSet<PageNumber>),
+    Track(PageNumberHashSet),
     Closed,
 }
 
 impl PageTrackerPolicy {
     pub(crate) fn new_tracking() -> Self {
-        PageTrackerPolicy::Track(HashSet::new())
+        PageTrackerPolicy::Track(PageNumberHashSet::default())
     }
 
     pub(crate) fn is_empty(&self) -> bool {
@@ -319,10 +321,10 @@ impl PageTrackerPolicy {
         }
     }
 
-    pub(crate) fn close(&mut self) -> HashSet<PageNumber> {
+    pub(crate) fn close(&mut self) -> PageNumberHashSet {
         let old = mem::replace(self, PageTrackerPolicy::Closed);
         match old {
-            PageTrackerPolicy::Ignore => HashSet::new(),
+            PageTrackerPolicy::Ignore => PageNumberHashSet::default(),
             PageTrackerPolicy::Track(x) => x,
             PageTrackerPolicy::Closed => {
                 panic!("Page tracker is closed");
@@ -330,13 +332,13 @@ impl PageTrackerPolicy {
         }
     }
 
-    pub(crate) fn reset(&mut self) -> HashSet<PageNumber> {
+    pub(crate) fn reset(&mut self) -> PageNumberHashSet {
         if matches!(self, PageTrackerPolicy::Ignore) {
-            return HashSet::new();
+            return PageNumberHashSet::default();
         }
-        let old = mem::replace(self, PageTrackerPolicy::Track(HashSet::new()));
+        let old = mem::replace(self, PageTrackerPolicy::Track(PageNumberHashSet::default()));
         match old {
-            PageTrackerPolicy::Ignore => HashSet::new(),
+            PageTrackerPolicy::Ignore => PageNumberHashSet::default(),
             PageTrackerPolicy::Track(x) => x,
             PageTrackerPolicy::Closed => {
                 panic!("Page tracker is closed");

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use backends::ReadOnlyBackend;
 pub(crate) use base::{
     MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTrackerPolicy,
 };
+pub(crate) use fast_hash::PageNumberHashSet;
 pub(crate) use header::PAGE_SIZE;
 pub(crate) use page_manager::{
     AllocationPolicy, FILE_FORMAT_VERSION3, ShrinkPolicy, TransactionalMemory, xxh3_checksum,

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -7,12 +7,13 @@ use crate::tree_store::multimap_btree::{
 };
 use crate::tree_store::{
     AllocationPolicy, Btree, BtreeMut, BtreeRangeIter, InternalTableDefinition, PageHint,
-    PageNumber, PageTrackerPolicy, RawBtree, TableType, TransactionalMemory, multimap_btree_stats,
+    PageNumber, PageNumberHashSet, PageTrackerPolicy, RawBtree, TableType, TransactionalMemory,
+    multimap_btree_stats,
 };
 use crate::types::{Key, Value};
 use crate::{DatabaseStats, Result};
 use std::cmp::max;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::mem::size_of;
 use std::ops::RangeFull;
 use std::sync::{Arc, Mutex};
@@ -312,7 +313,7 @@ impl TableTreeMut<'_> {
 
     pub(crate) fn flush_and_close(
         &mut self,
-    ) -> Result<(Option<BtreeHeader>, HashSet<PageNumber>, Vec<PageNumber>)> {
+    ) -> Result<(Option<BtreeHeader>, PageNumberHashSet, Vec<PageNumber>)> {
         match self.flush_inner() {
             Ok(header) => {
                 let allocated = self.allocated_pages.lock()?.close();


### PR DESCRIPTION
## Summary
This PR introduces a custom `PageNumberHashSet` type to replace the standard library `HashSet<PageNumber>` throughout the page tracking system. This change centralizes the hash set implementation for page numbers, making it easier to optimize or customize the data structure in the future.

## Key Changes
- Added import of `PageNumberHashSet` from the `fast_hash` module in `page_store/base.rs`
- Replaced all `HashSet<PageNumber>` type annotations with `PageNumberHashSet` in:
  - `PageTrackerPolicy` enum variant
  - `PageTrackerPolicy::new_tracking()` constructor
  - `PageTrackerPolicy::close()` return type
  - `PageTrackerPolicy::reset()` return type
- Updated `TableTreeMut::flush_and_close()` return type to use `PageNumberHashSet`
- Removed direct `HashSet` import from `std::collections` in `table_tree.rs`
- Exported `PageNumberHashSet` from `tree_store/mod.rs` and `tree_store/page_store/mod.rs` for public use

## Implementation Details
- All `HashSet::new()` calls were replaced with `PageNumberHashSet::default()` to use the custom type's default constructor
- The change is purely a type abstraction with no functional modifications to the logic
- This enables future optimization of the hash set implementation without requiring changes across the codebase

https://claude.ai/code/session_01AaiTS5KbxR9LeXRRtr8pBc