### PR TITLE
Introduce PageAllocator to encapsulate allocation policy

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -3,10 +3,10 @@ use crate::multimap_table::DynamicCollectionType::{Inline, SubtreeV2};
 use crate::sealed::Sealed;
 use crate::table::{ReadableTableMetadata, TableStats};
 use crate::tree_store::{
-    AllPageNumbersBtreeIter, AllocationPolicy, BRANCH, Btree, BtreeHeader, BtreeMut,
-    BtreeRangeIter, DynamicCollection, DynamicCollectionType, LEAF, LeafAccessor, MAX_PAIR_LENGTH,
-    MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTrackerPolicy, RawBtree, RawLeafBuilder,
-    TransactionalMemory, multimap_btree_stats,
+    AllPageNumbersBtreeIter, BRANCH, Btree, BtreeHeader, BtreeMut, BtreeRangeIter,
+    DynamicCollection, DynamicCollectionType, LEAF, LeafAccessor, MAX_PAIR_LENGTH,
+    MAX_VALUE_LENGTH, Page, PageAllocator, PageHint, PageNumber, PageTrackerPolicy, RawBtree,
+    RawLeafBuilder, TransactionalMemory, multimap_btree_stats,
 };
 use crate::types::{Key, Value};
 use crate::{AccessGuard, MultimapTableHandle, Result, StorageError, WriteTransaction};
@@ -108,7 +108,7 @@ pub struct MultimapValue<'a, V: Key + 'static> {
     allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
     free_on_drop: Vec<PageNumber>,
     _transaction_guard: Arc<TransactionGuard>,
-    mem: Option<Arc<TransactionalMemory>>,
+    page_allocator: Option<PageAllocator>,
     _value_type: PhantomData<V>,
 }
 
@@ -125,7 +125,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
             allocated_pages: Arc::new(Mutex::new(PageTrackerPolicy::Closed)),
             free_on_drop: vec![],
             _transaction_guard: guard,
-            mem: None,
+            page_allocator: None,
             _value_type: PhantomData,
         }
     }
@@ -137,7 +137,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
         allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
         pages: Vec<PageNumber>,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
     ) -> Self {
         Self {
             inner: Some(ValueIterState::Subtree(inner)),
@@ -146,7 +146,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
             free_on_drop: pages,
             allocated_pages,
             _transaction_guard: guard,
-            mem: Some(mem),
+            page_allocator: Some(page_allocator),
             _value_type: PhantomData,
         }
     }
@@ -160,7 +160,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
             allocated_pages: Arc::new(Mutex::new(PageTrackerPolicy::Closed)),
             free_on_drop: vec![],
             _transaction_guard: guard,
-            mem: None,
+            page_allocator: None,
             _value_type: PhantomData,
         }
     }
@@ -198,7 +198,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
         allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
     ) -> Result<Self> {
         let num_values = collection.value().get_num_values();
         Ok(match collection.value().collection_type() {
@@ -212,7 +212,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
                 let inner = BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(
                     &(..),
                     Some(root),
-                    mem.clone(),
+                    page_allocator.mem().clone(),
                     PageHint::None,
                 )?;
                 Self::new_subtree_free_on_drop(
@@ -222,7 +222,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
                     allocated_pages,
                     pages,
                     guard,
-                    mem,
+                    page_allocator,
                 )
             }
         })
@@ -303,7 +303,7 @@ impl<V: Key + 'static> Drop for MultimapValue<'_, V> {
             let mut allocated_pages = self.allocated_pages.lock().unwrap();
             for page in &self.free_on_drop {
                 if !self
-                    .mem
+                    .page_allocator
                     .as_ref()
                     .unwrap()
                     .free_if_uncommitted(*page, &mut allocated_pages)
@@ -395,8 +395,7 @@ pub struct MultimapTable<'txn, K: Key + 'static, V: Key + 'static> {
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
     allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
     tree: BtreeMut<'txn, K, &'static DynamicCollection<V>>,
-    mem: Arc<TransactionalMemory>,
-    allocation_policy: AllocationPolicy,
+    page_allocator: PageAllocator,
     _value_type: PhantomData<V>,
 }
 
@@ -414,9 +413,8 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
         num_values: u64,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
         allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
         transaction: &'txn WriteTransaction,
-        allocation_policy: AllocationPolicy,
     ) -> MultimapTable<'txn, K, V> {
         MultimapTable {
             name: name.to_string(),
@@ -427,13 +425,11 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
             tree: BtreeMut::new(
                 table_root,
                 transaction.transaction_guard(),
-                mem.clone(),
+                page_allocator.clone(),
                 freed_pages,
                 allocated_pages,
-                allocation_policy,
             ),
-            mem,
-            allocation_policy,
+            page_allocator,
             _value_type: PhantomData,
         }
     }
@@ -494,7 +490,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                         <() as Value>::fixed_width(),
                     );
 
-                    if required_inline_bytes < self.mem.get_page_size() / 2 {
+                    if required_inline_bytes < self.page_allocator.get_page_size() / 2 {
                         let mut data = vec![0; required_inline_bytes];
                         let mut builder = RawLeafBuilder::new(
                             &mut data,
@@ -522,11 +518,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                     } else {
                         // convert into a subtree
                         let mut allocated = self.allocated_pages.lock().unwrap();
-                        let mut page = self.allocation_policy.allocate(
-                            &self.mem,
-                            leaf_data.len(),
-                            &mut allocated,
-                        )?;
+                        let mut page = self
+                            .page_allocator
+                            .allocate(leaf_data.len(), &mut allocated)?;
                         drop(allocated);
                         page.memory_mut()[..leaf_data.len()].copy_from_slice(leaf_data);
                         let page_number = page.get_page_number();
@@ -537,10 +531,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                         let mut subtree: BtreeMut<'_, V, ()> = BtreeMut::new(
                             Some(BtreeHeader::new(page_number, 0, num_pairs as u64)),
                             self.transaction.transaction_guard(),
-                            self.mem.clone(),
+                            self.page_allocator.clone(),
                             self.freed_pages.clone(),
                             self.allocated_pages.clone(),
-                            self.allocation_policy,
                         );
                         let existed = subtree.insert(value.borrow(), &())?.is_some();
                         assert_eq!(existed, found);
@@ -556,10 +549,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                     let mut subtree: BtreeMut<'_, V, ()> = BtreeMut::new(
                         Some(guard.value().as_subtree()),
                         self.transaction.transaction_guard(),
-                        self.mem.clone(),
+                        self.page_allocator.clone(),
                         self.freed_pages.clone(),
                         self.allocated_pages.clone(),
-                        self.allocation_policy,
                     );
                     drop(guard);
                     let existed = subtree.insert(value.borrow(), &())?.is_some();
@@ -579,7 +571,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                 V::fixed_width(),
                 <() as Value>::fixed_width(),
             );
-            if required_inline_bytes < self.mem.get_page_size() / 2 {
+            if required_inline_bytes < self.page_allocator.get_page_size() / 2 {
                 let mut data = vec![0; required_inline_bytes];
                 let mut builder = RawLeafBuilder::new(
                     &mut data,
@@ -597,10 +589,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                 let mut subtree: BtreeMut<'_, V, ()> = BtreeMut::new(
                     None,
                     self.transaction.transaction_guard(),
-                    self.mem.clone(),
+                    self.page_allocator.clone(),
                     self.freed_pages.clone(),
                     self.allocated_pages.clone(),
-                    self.allocation_policy,
                 );
                 subtree.insert(value.borrow(), &())?;
                 let subtree_data =
@@ -685,10 +676,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                 let mut subtree: BtreeMut<V, ()> = BtreeMut::new(
                     Some(v.as_subtree()),
                     self.transaction.transaction_guard(),
-                    self.mem.clone(),
+                    self.page_allocator.clone(),
                     self.freed_pages.clone(),
                     self.allocated_pages.clone(),
-                    self.allocation_policy,
                 );
                 drop(guard);
                 let existed = subtree.remove(value.borrow())?.is_some();
@@ -699,7 +689,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                     length: new_length,
                 }) = subtree.get_root()
                 {
-                    let page = self.mem.get_page(new_root, PageHint::None)?;
+                    let page = self.page_allocator.get_page(new_root, PageHint::None)?;
                     match page.memory()[0] {
                         LEAF => {
                             let accessor = LeafAccessor::new(
@@ -708,14 +698,17 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                                 <() as Value>::fixed_width(),
                             );
                             let len = accessor.total_length();
-                            if len < self.mem.get_page_size() / 2 {
+                            if len < self.page_allocator.get_page_size() / 2 {
                                 let inline_data =
                                     DynamicCollection::<V>::make_inline_data(&page.memory()[..len]);
                                 self.tree
                                     .insert(key.borrow(), &DynamicCollection::new(&inline_data))?;
                                 drop(page);
                                 let mut allocated_pages = self.allocated_pages.lock().unwrap();
-                                if !self.mem.free_if_uncommitted(new_root, &mut allocated_pages) {
+                                if !self
+                                    .page_allocator
+                                    .free_if_uncommitted(new_root, &mut allocated_pages)
+                                {
                                     (*self.freed_pages).lock().unwrap().push(new_root);
                                 }
                             } else {
@@ -771,7 +764,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                     root,
                     V::fixed_width(),
                     <() as Value>::fixed_width(),
-                    self.mem.clone(),
+                    self.page_allocator.mem().clone(),
                     PageHint::None,
                 )?;
                 for page in all_pages {
@@ -787,14 +780,14 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                 self.freed_pages.clone(),
                 self.allocated_pages.clone(),
                 self.transaction.transaction_guard(),
-                self.mem.clone(),
+                self.page_allocator.clone(),
             )?
         } else {
             MultimapValue::new_subtree(
                 BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(
                     &(..),
                     None,
-                    self.mem.clone(),
+                    self.page_allocator.mem().clone(),
                     PageHint::None,
                 )?,
                 0,
@@ -810,7 +803,7 @@ impl<K: Key + 'static, V: Key + 'static> ReadableTableMetadata for MultimapTable
     fn stats(&self) -> Result<TableStats> {
         let tree_stats = multimap_btree_stats(
             self.tree.get_root().map(|x| x.root),
-            &self.mem,
+            self.page_allocator.mem(),
             K::fixed_width(),
             V::fixed_width(),
             PageHint::None,
@@ -836,13 +829,13 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V> for Multima
     fn get<'a>(&self, key: impl Borrow<K::SelfType<'a>>) -> Result<MultimapValue<'_, V>> {
         let guard = self.transaction.transaction_guard();
         let iter = if let Some(collection) = self.tree.get(key.borrow())? {
-            MultimapValue::from_collection(collection, guard, self.mem.clone())?
+            MultimapValue::from_collection(collection, guard, self.page_allocator.mem().clone())?
         } else {
             MultimapValue::new_subtree(
                 BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(
                     &(..),
                     None,
-                    self.mem.clone(),
+                    self.page_allocator.mem().clone(),
                     PageHint::None,
                 )?,
                 0,
@@ -861,7 +854,7 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V> for Multima
         Ok(MultimapRange::new(
             inner,
             self.transaction.transaction_guard(),
-            self.mem.clone(),
+            self.page_allocator.mem().clone(),
         ))
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,8 +1,8 @@
 use crate::db::TransactionGuard;
 use crate::sealed::Sealed;
 use crate::tree_store::{
-    AccessGuardMutInPlace, AllocationPolicy, Btree, BtreeExtractIf, BtreeHeader, BtreeMut,
-    BtreeRangeIter, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PageHint, PageNumber, PageTrackerPolicy,
+    AccessGuardMutInPlace, Btree, BtreeExtractIf, BtreeHeader, BtreeMut, BtreeRangeIter,
+    MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PageAllocator, PageHint, PageNumber, PageTrackerPolicy,
     RawBtree, TransactionalMemory,
 };
 use crate::types::{Key, MutInPlaceValue, Value};
@@ -77,9 +77,8 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         table_root: Option<BtreeHeader>,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
         allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
         transaction: &'txn WriteTransaction,
-        allocation_policy: AllocationPolicy,
     ) -> Table<'txn, K, V> {
         Table {
             name: name.to_string(),
@@ -87,10 +86,9 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
             tree: BtreeMut::new(
                 table_root,
                 transaction.transaction_guard(),
-                mem,
+                page_allocator,
                 freed_pages,
                 allocated_pages,
-                allocation_policy,
             ),
         }
     }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -6,7 +6,7 @@ use crate::table::ReadOnlyUntypedTable;
 use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker};
 use crate::tree_store::{
     AllocationPolicy, Btree, BtreeHeader, BtreeMut, InternalTableDefinition, MAX_PAIR_LENGTH,
-    MAX_VALUE_LENGTH, Page, PageHint, PageListMut, PageNumber, PageTrackerPolicy,
+    MAX_VALUE_LENGTH, Page, PageAllocator, PageHint, PageListMut, PageNumber, PageTrackerPolicy,
     SerializedSavepoint, ShrinkPolicy, TableTree, TableTreeMut, TableType, TransactionalMemory,
 };
 use crate::types::{Key, Value};
@@ -390,9 +390,8 @@ impl<'db, 's, K: Key + 'static, V: Value + 'static> SystemTable<'db, 's, K, V> {
         table_root: Option<BtreeHeader>,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
         namespace: &'s mut SystemNamespace<'db>,
-        allocation_policy: AllocationPolicy,
     ) -> SystemTable<'db, 's, K, V> {
         // No need to track allocations in the system tree. Savepoint restoration only relies on
         // freeing in the data tree
@@ -403,10 +402,9 @@ impl<'db, 's, K: Key + 'static, V: Value + 'static> SystemTable<'db, 's, K, V> {
             tree: BtreeMut::new(
                 table_root,
                 guard.clone(),
-                mem,
+                page_allocator,
                 freed_pages,
                 ignore,
-                allocation_policy,
             ),
             transaction_guard: guard,
         }
@@ -512,7 +510,7 @@ impl<'db> SystemNamespace<'db> {
     fn new(
         root_page: Option<BtreeHeader>,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
     ) -> Self {
         // No need to track allocations in the system tree. Savepoint restoration only relies on
         // freeing in the data tree
@@ -522,10 +520,9 @@ impl<'db> SystemNamespace<'db> {
             table_tree: TableTreeMut::new(
                 root_page,
                 guard.clone(),
-                mem,
+                page_allocator,
                 freed_pages.clone(),
                 ignore,
-                AllocationPolicy::Default,
             ),
             freed_pages,
             transaction_guard: guard.clone(),
@@ -549,15 +546,14 @@ impl<'db> SystemNamespace<'db> {
             })?;
         transaction.dirty.store(true, Ordering::Release);
 
-        let allocation_policy = self.table_tree.allocation_policy();
+        let page_allocator = self.table_tree.page_allocator().clone();
         Ok(SystemTable::new(
             definition.name(),
             root,
             self.freed_pages.clone(),
             self.transaction_guard.clone(),
-            transaction.mem.clone(),
+            page_allocator,
             self,
-            allocation_policy,
         ))
     }
 
@@ -583,19 +579,18 @@ impl TableNamespace<'_> {
     fn new(
         root_page: Option<BtreeHeader>,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
     ) -> Self {
         let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
         let freed_pages = Arc::new(Mutex::new(vec![]));
         let table_tree = TableTreeMut::new(
             root_page,
             guard,
-            mem,
+            page_allocator,
             // Committed pages which are no longer reachable and will be queued for free'ing
             // These are separated from the system freed pages
             freed_pages.clone(),
             allocated.clone(),
-            AllocationPolicy::Default,
         );
         Self {
             open_tables: HashMap::default(),
@@ -655,9 +650,8 @@ impl TableNamespace<'_> {
             length,
             self.freed_pages.clone(),
             self.allocated_pages.clone(),
-            transaction.mem.clone(),
+            self.table_tree.page_allocator().clone(),
             transaction,
-            self.table_tree.allocation_policy(),
         ))
     }
 
@@ -677,9 +671,8 @@ impl TableNamespace<'_> {
             root,
             self.freed_pages.clone(),
             self.allocated_pages.clone(),
-            transaction.mem.clone(),
+            self.table_tree.page_allocator().clone(),
             transaction,
-            self.table_tree.allocation_policy(),
         ))
     }
 
@@ -863,8 +856,9 @@ impl WriteTransaction {
         let root_page = mem.get_data_root();
         let system_page = mem.get_system_root();
 
-        let tables = TableNamespace::new(root_page, guard.clone(), mem.clone());
-        let system_tables = SystemNamespace::new(system_page, guard.clone(), mem.clone());
+        let page_allocator = PageAllocator::new(mem.clone(), AllocationPolicy::Default);
+        let tables = TableNamespace::new(root_page, guard.clone(), page_allocator.clone());
+        let system_tables = SystemNamespace::new(system_page, guard.clone(), page_allocator);
 
         Ok(Self {
             transaction_tracker,
@@ -1840,15 +1834,16 @@ impl WriteTransaction {
         let system_table_tree = &mut system_tables.table_tree;
         system_table_tree.highest_index_pages(MAX_PAGES_PER_COMPACTION, &mut highest_pages)?;
 
+        let page_allocator = table_tree.page_allocator().clone();
+
         // Calculate how many of them can be relocated to lower pages, starting from the last page
         let mut relocation_map = HashMap::new();
         for path in highest_pages.into_values().rev() {
             if relocation_map.contains_key(&path.page_number()) {
                 continue;
             }
-            let old_page = self.mem.get_page(path.page_number(), PageHint::None)?;
-            let mut new_page = self
-                .mem
+            let old_page = page_allocator.get_page(path.page_number(), PageHint::None)?;
+            let mut new_page = page_allocator
                 .allocate_lowest(old_page.memory().len(), &mut PageTrackerPolicy::Ignore)?;
             let new_page_number = new_page.get_page_number();
             // We have to copy at least the page type into the new page.
@@ -1862,8 +1857,8 @@ impl WriteTransaction {
                     if relocation_map.contains_key(parent) {
                         continue;
                     }
-                    let old_parent = self.mem.get_page(*parent, PageHint::None)?;
-                    let mut new_page = self.mem.allocate_lowest(
+                    let old_parent = page_allocator.get_page(*parent, PageHint::None)?;
+                    let mut new_page = page_allocator.allocate_lowest(
                         old_parent.memory().len(),
                         &mut PageTrackerPolicy::Ignore,
                     )?;
@@ -1875,8 +1870,7 @@ impl WriteTransaction {
                     relocation_map.insert(*parent, new_page_number);
                 }
             } else {
-                self.mem
-                    .free(new_page_number, &mut PageTrackerPolicy::Ignore);
+                page_allocator.free(new_page_number, &mut PageTrackerPolicy::Ignore);
                 break;
             }
         }

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -7,8 +7,8 @@ use crate::tree_store::btree_iters::BtreeExtractIf;
 use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageImpl, PageMut, TransactionalMemory};
 use crate::tree_store::{
-    AccessGuardMutInPlace, AllPageNumbersBtreeIter, AllocationPolicy, BtreeRangeIter, PageHint,
-    PageNumber, PageTrackerPolicy,
+    AccessGuardMutInPlace, AllPageNumbersBtreeIter, AllocationPolicy, BtreeRangeIter,
+    PageAllocator, PageHint, PageNumber, PageTrackerPolicy,
 };
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, Result};
@@ -322,7 +322,7 @@ impl UntypedBtreeMut {
 }
 
 pub(crate) struct BtreeMut<'a, K: Key + 'static, V: Value + 'static> {
-    mem: Arc<TransactionalMemory>,
+    page_allocator: PageAllocator,
     transaction_guard: Arc<TransactionGuard>,
     root: Option<BtreeHeader>,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
@@ -330,20 +330,18 @@ pub(crate) struct BtreeMut<'a, K: Key + 'static, V: Value + 'static> {
     _key_type: PhantomData<K>,
     _value_type: PhantomData<V>,
     _lifetime: PhantomData<&'a ()>,
-    allocation_policy: AllocationPolicy,
 }
 
 impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
     pub(crate) fn new(
         root: Option<BtreeHeader>,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
         allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
-        allocation_policy: AllocationPolicy,
     ) -> Self {
         Self {
-            mem,
+            page_allocator,
             transaction_guard: guard,
             root,
             freed_pages,
@@ -351,18 +349,17 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
             _key_type: PhantomData,
             _value_type: PhantomData,
             _lifetime: PhantomData,
-            allocation_policy,
         }
     }
 
     pub(crate) fn set_allocation_policy(&mut self, policy: AllocationPolicy) {
-        self.allocation_policy = policy;
+        self.page_allocator = PageAllocator::new(self.page_allocator.mem().clone(), policy);
     }
 
     pub(crate) fn finalize_dirty_checksums(&mut self) -> Result<Option<BtreeHeader>> {
         let mut tree = UntypedBtreeMut::new(
             self.get_root(),
-            self.mem.clone(),
+            self.page_allocator.mem().clone(),
             self.freed_pages.clone(),
             K::fixed_width(),
             V::fixed_width(),
@@ -378,7 +375,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
                 root,
                 K::fixed_width(),
                 V::fixed_width(),
-                self.mem.clone(),
+                self.page_allocator.mem().clone(),
                 PageHint::None,
             )?))
         } else {
@@ -407,7 +404,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
     ) -> Result<bool> {
         let mut tree = UntypedBtreeMut::new(
             self.get_root(),
-            self.mem.clone(),
+            self.page_allocator.mem().clone(),
             self.freed_pages.clone(),
             K::fixed_width(),
             V::fixed_width(),
@@ -435,10 +432,9 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         let mut freed_pages = self.freed_pages.lock().unwrap();
         let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new(
             &mut self.root,
-            self.mem.clone(),
+            self.page_allocator.clone(),
             freed_pages.as_mut(),
             self.allocated_pages.clone(),
-            self.allocation_policy,
         );
         let (old_value, _) = operation.insert(key, value)?;
         Ok(old_value)
@@ -457,10 +453,9 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         let fake_allocated_pages = Arc::new(Mutex::new(PageTrackerPolicy::Closed));
         let mut operation = MutateHelper::<K, V>::new(
             &mut self.root,
-            self.mem.clone(),
+            self.page_allocator.clone(),
             fake_freed_pages.as_mut(),
             fake_allocated_pages,
-            self.allocation_policy,
         );
         operation.insert_inplace(key, value)?;
         assert!(fake_freed_pages.is_empty());
@@ -493,10 +488,9 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         let mut freed_pages = self.freed_pages.lock().unwrap();
         let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new(
             &mut self.root,
-            self.mem.clone(),
+            self.page_allocator.clone(),
             freed_pages.as_mut(),
             self.allocated_pages.clone(),
-            self.allocation_policy,
         );
         let result = operation.delete(key)?;
         Ok(result)
@@ -507,10 +501,9 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         let mut freed_pages = self.freed_pages.lock().unwrap();
         let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new(
             &mut self.root,
-            self.mem.clone(),
+            self.page_allocator.clone(),
             freed_pages.as_mut(),
             self.allocated_pages.clone(),
-            self.allocation_policy,
         );
         operation.pop_first()
     }
@@ -520,10 +513,9 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         let mut freed_pages = self.freed_pages.lock().unwrap();
         let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new(
             &mut self.root,
-            self.mem.clone(),
+            self.page_allocator.clone(),
             freed_pages.as_mut(),
             self.allocated_pages.clone(),
-            self.allocation_policy,
         );
         operation.pop_last()
     }
@@ -536,7 +528,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
     pub(crate) fn stats(&self) -> Result<BtreeStats> {
         btree_stats(
             self.get_root().map(|x| x.root),
-            &self.mem,
+            self.page_allocator.mem(),
             K::fixed_width(),
             V::fixed_width(),
             PageHint::None,
@@ -548,7 +540,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
             self.get_root(),
             PageHint::None,
             self.transaction_guard.clone(),
-            self.mem.clone(),
+            self.page_allocator.mem().clone(),
         )
     }
 
@@ -563,20 +555,19 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         if let Some(ref mut root) = self.root {
             let key_bytes = K::as_bytes(key);
             let query = key_bytes.as_ref();
-            let page_mut = if self.mem.uncommitted(root.root) {
-                self.mem.get_page_mut(root.root)?
+            let mem = self.page_allocator.mem();
+            let page_mut = if mem.uncommitted(root.root) {
+                mem.get_page_mut(root.root)?
             } else {
                 let mut freed_pages = self.freed_pages.lock().unwrap();
                 let mut allocated = self.allocated_pages.lock().unwrap();
                 let required: usize = root
                     .root
-                    .page_size_bytes(self.mem.get_page_size().try_into().unwrap())
+                    .page_size_bytes(mem.get_page_size().try_into().unwrap())
                     .try_into()
                     .unwrap();
-                let mut new_page =
-                    self.allocation_policy
-                        .allocate(&self.mem, required, &mut allocated)?;
-                let old_page = self.mem.get_page(root.root, PageHint::None)?;
+                let mut new_page = self.page_allocator.allocate(required, &mut allocated)?;
+                let old_page = mem.get_page(root.root, PageHint::None)?;
                 new_page.memory_mut().copy_from_slice(old_page.memory());
                 drop(old_page);
                 freed_pages.push(root.root);
@@ -609,7 +600,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
                         end - start,
                         entry_index,
                         parent,
-                        self.mem.clone(),
+                        self.page_allocator.mem().clone(),
                         self.allocated_pages.clone(),
                         self.root.as_mut().unwrap(),
                         K::fixed_width(),
@@ -624,19 +615,18 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
                     let accessor = BranchAccessor::new(&page, K::fixed_width());
                     accessor.child_for_key::<K>(query)
                 };
-                let child_page_mut = if self.mem.uncommitted(child_page) {
-                    self.mem.get_page_mut(child_page)?
+                let mem = self.page_allocator.mem();
+                let child_page_mut = if mem.uncommitted(child_page) {
+                    mem.get_page_mut(child_page)?
                 } else {
                     let mut freed_pages = self.freed_pages.lock().unwrap();
                     let mut allocated = self.allocated_pages.lock().unwrap();
                     let required: usize = child_page
-                        .page_size_bytes(self.mem.get_page_size().try_into().unwrap())
+                        .page_size_bytes(mem.get_page_size().try_into().unwrap())
                         .try_into()
                         .unwrap();
-                    let mut new_page =
-                        self.allocation_policy
-                            .allocate(&self.mem, required, &mut allocated)?;
-                    let old_child_page = self.mem.get_page(child_page, PageHint::None)?;
+                    let mut new_page = self.page_allocator.allocate(required, &mut allocated)?;
+                    let old_child_page = mem.get_page(child_page, PageHint::None)?;
                     new_page
                         .memory_mut()
                         .copy_from_slice(old_child_page.memory());
@@ -697,8 +687,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
             predicate,
             self.freed_pages.clone(),
             self.allocated_pages.clone(),
-            self.mem.clone(),
-            self.allocation_policy,
+            self.page_allocator.clone(),
         );
 
         Ok(result)
@@ -718,10 +707,9 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         // TODO: optimize this to iterate and remove at the same time
         let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new_do_not_modify(
             &mut self.root,
-            self.mem.clone(),
+            self.page_allocator.clone(),
             &mut freed,
             self.allocated_pages.clone(),
-            self.allocation_policy,
         );
         for entry in iter {
             let entry = entry?;
@@ -732,7 +720,10 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         let mut freed_pages = self.freed_pages.lock().unwrap();
         let mut allocated_pages = self.allocated_pages.lock().unwrap();
         for page in freed {
-            if !self.mem.free_if_uncommitted(page, &mut allocated_pages) {
+            if !self
+                .page_allocator
+                .free_if_uncommitted(page, &mut allocated_pages)
+            {
                 freed_pages.push(page);
             }
         }
@@ -764,10 +755,9 @@ impl<'a, K: Key + 'a, V: MutInPlaceValue + 'a> BtreeMut<'a, K, V> {
         V::initialize(&mut value);
         let mut operation = MutateHelper::<K, V>::new(
             &mut self.root,
-            self.mem.clone(),
+            self.page_allocator.clone(),
             freed_pages.as_mut(),
             self.allocated_pages.clone(),
-            self.allocation_policy,
         );
         let (_, guard) = operation.insert(key, &V::from_bytes(&value))?;
         Ok(guard)

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -1,5 +1,5 @@
 use crate::tree_store::page_store::{Page, PageImpl, PageMut, TransactionalMemory, xxh3_checksum};
-use crate::tree_store::{AllocationPolicy, PageNumber, PageTrackerPolicy};
+use crate::tree_store::{AllocationPolicy, PageAllocator, PageNumber, PageTrackerPolicy};
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{Result, StorageError};
 use std::borrow::Borrow;
@@ -328,13 +328,13 @@ impl<'a, V: Value + 'static> AccessGuardMut<'a, V> {
             mutator.replace(self.entry_index, value_bytes.as_ref());
         } else {
             let accessor = LeafAccessor::new(self.page.memory(), self.key_width, V::fixed_width());
+            let page_allocator = PageAllocator::new(self.mem.clone(), AllocationPolicy::Default);
             let mut builder = LeafBuilder::new(
-                &self.mem,
+                &page_allocator,
                 &self.allocated,
                 accessor.num_pairs(),
                 self.key_width,
                 V::fixed_width(),
-                AllocationPolicy::Default,
             );
 
             for i in 0..accessor.num_pairs() {
@@ -640,9 +640,8 @@ pub(super) struct LeafBuilder<'a, 'b> {
     fixed_value_size: Option<usize>,
     total_key_bytes: usize,
     total_value_bytes: usize,
-    mem: &'b TransactionalMemory,
+    page_allocator: &'b PageAllocator,
     allocated_pages: &'b Mutex<PageTrackerPolicy>,
-    allocation_policy: AllocationPolicy,
 }
 
 impl<'a, 'b> LeafBuilder<'a, 'b> {
@@ -656,12 +655,11 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
     }
 
     pub(super) fn new(
-        mem: &'b TransactionalMemory,
+        page_allocator: &'b PageAllocator,
         allocated_pages: &'b Mutex<PageTrackerPolicy>,
         capacity: usize,
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
-        allocation_policy: AllocationPolicy,
     ) -> Self {
         Self {
             pairs: Vec::with_capacity(capacity),
@@ -669,9 +667,8 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
             fixed_value_size,
             total_key_bytes: 0,
             total_value_bytes: 0,
-            mem,
+            page_allocator,
             allocated_pages,
-            allocation_policy,
         }
     }
 
@@ -702,7 +699,7 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
             self.pairs.len(),
             self.total_key_bytes + self.total_value_bytes,
         );
-        required_size > self.mem.get_page_size() && self.pairs.len() > 1
+        required_size > self.page_allocator.get_page_size() && self.pairs.len() > 1
     }
 
     pub(super) fn build_split<'txn>(self) -> Result<(PageMut<'txn>, &'a [u8], PageMut<'txn>)> {
@@ -722,9 +719,9 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
         let required_size =
             self.required_bytes(division, first_split_key_bytes + first_split_value_bytes);
         let mut allocated_pages = self.allocated_pages.lock().unwrap();
-        let mut page1 =
-            self.allocation_policy
-                .allocate(self.mem, required_size, &mut allocated_pages)?;
+        let mut page1 = self
+            .page_allocator
+            .allocate(required_size, &mut allocated_pages)?;
         let mut builder = RawLeafBuilder::new(
             page1.memory_mut(),
             division,
@@ -743,9 +740,9 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
                 - first_split_key_bytes
                 - first_split_value_bytes,
         );
-        let mut page2 =
-            self.allocation_policy
-                .allocate(self.mem, required_size, &mut allocated_pages)?;
+        let mut page2 = self
+            .page_allocator
+            .allocate(required_size, &mut allocated_pages)?;
         let mut builder = RawLeafBuilder::new(
             page2.memory_mut(),
             self.pairs.len() - division,
@@ -767,9 +764,9 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
             self.total_key_bytes + self.total_value_bytes,
         );
         let mut allocated_pages = self.allocated_pages.lock().unwrap();
-        let mut page =
-            self.allocation_policy
-                .allocate(self.mem, required_size, &mut allocated_pages)?;
+        let mut page = self
+            .page_allocator
+            .allocate(required_size, &mut allocated_pages)?;
         let mut builder = RawLeafBuilder::new(
             page.memory_mut(),
             self.pairs.len(),
@@ -1468,27 +1465,24 @@ pub(super) struct BranchBuilder<'a, 'b> {
     keys: Vec<&'a [u8]>,
     total_key_bytes: usize,
     fixed_key_size: Option<usize>,
-    mem: &'b TransactionalMemory,
+    page_allocator: &'b PageAllocator,
     allocated_pages: &'b Mutex<PageTrackerPolicy>,
-    allocation_policy: AllocationPolicy,
 }
 
 impl<'a, 'b> BranchBuilder<'a, 'b> {
     pub(super) fn new(
-        mem: &'b TransactionalMemory,
+        page_allocator: &'b PageAllocator,
         allocated_pages: &'b Mutex<PageTrackerPolicy>,
         child_capacity: usize,
         fixed_key_size: Option<usize>,
-        allocation_policy: AllocationPolicy,
     ) -> Self {
         Self {
             children: Vec::with_capacity(child_capacity),
             keys: Vec::with_capacity(child_capacity - 1),
             total_key_bytes: 0,
             fixed_key_size,
-            mem,
+            page_allocator,
             allocated_pages,
-            allocation_policy,
         }
     }
 
@@ -1541,9 +1535,7 @@ impl<'a, 'b> BranchBuilder<'a, 'b> {
             self.fixed_key_size,
         );
         let mut allocated_pages = self.allocated_pages.lock().unwrap();
-        let mut page = self
-            .allocation_policy
-            .allocate(self.mem, size, &mut allocated_pages)?;
+        let mut page = self.page_allocator.allocate(size, &mut allocated_pages)?;
         let mut builder =
             RawBranchBuilder::new(page.memory_mut(), self.keys.len(), self.fixed_key_size);
         builder.write_first_page(self.children[0].0, self.children[0].1);
@@ -1562,7 +1554,7 @@ impl<'a, 'b> BranchBuilder<'a, 'b> {
             self.total_key_bytes,
             self.fixed_key_size,
         );
-        size > self.mem.get_page_size() && self.keys.len() >= 3
+        size > self.page_allocator.get_page_size() && self.keys.len() >= 3
     }
 
     pub(super) fn build_split<'txn>(self) -> Result<(PageMut<'txn>, &'a [u8], PageMut<'txn>)> {
@@ -1576,9 +1568,7 @@ impl<'a, 'b> BranchBuilder<'a, 'b> {
 
         let size =
             RawBranchBuilder::required_bytes(division, first_split_key_len, self.fixed_key_size);
-        let mut page1 = self
-            .allocation_policy
-            .allocate(self.mem, size, &mut allocated_pages)?;
+        let mut page1 = self.page_allocator.allocate(size, &mut allocated_pages)?;
         let mut builder = RawBranchBuilder::new(page1.memory_mut(), division, self.fixed_key_size);
         builder.write_first_page(self.children[0].0, self.children[0].1);
         for i in 0..division {
@@ -1597,9 +1587,7 @@ impl<'a, 'b> BranchBuilder<'a, 'b> {
             second_split_key_len,
             self.fixed_key_size,
         );
-        let mut page2 = self
-            .allocation_policy
-            .allocate(self.mem, size, &mut allocated_pages)?;
+        let mut page2 = self.page_allocator.allocate(size, &mut allocated_pages)?;
         let mut builder = RawBranchBuilder::new(
             page2.memory_mut(),
             self.keys.len() - division - 1,

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -4,7 +4,7 @@ use crate::tree_store::btree_base::{BranchAccessor, LeafAccessor};
 use crate::tree_store::btree_iters::RangeIterState::{Internal, Leaf};
 use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageHint, PageImpl, TransactionalMemory};
-use crate::tree_store::{AllocationPolicy, BtreeHeader, PageNumber, PageTrackerPolicy};
+use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageTrackerPolicy};
 use crate::types::{Key, Value};
 use Bound::{Excluded, Included, Unbounded};
 use std::borrow::Borrow;
@@ -264,8 +264,7 @@ pub(crate) struct BtreeExtractIf<
     free_on_drop: Vec<PageNumber>,
     master_free_list: Arc<Mutex<Vec<PageNumber>>>,
     allocated: Arc<Mutex<PageTrackerPolicy>>,
-    mem: Arc<TransactionalMemory>,
-    allocation_policy: AllocationPolicy,
+    page_allocator: PageAllocator,
 }
 
 impl<'a, K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>
@@ -277,8 +276,7 @@ impl<'a, K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) ->
         predicate: F,
         master_free_list: Arc<Mutex<Vec<PageNumber>>>,
         allocated: Arc<Mutex<PageTrackerPolicy>>,
-        mem: Arc<TransactionalMemory>,
-        allocation_policy: AllocationPolicy,
+        page_allocator: PageAllocator,
     ) -> Self {
         Self {
             root,
@@ -287,8 +285,7 @@ impl<'a, K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) ->
             free_on_drop: vec![],
             master_free_list,
             allocated,
-            mem,
-            allocation_policy,
+            page_allocator,
         }
     }
 }
@@ -304,10 +301,9 @@ impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> boo
             if (self.predicate)(entry.key(), entry.value()) {
                 let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new_do_not_modify(
                     self.root,
-                    self.mem.clone(),
+                    self.page_allocator.clone(),
                     &mut self.free_on_drop,
                     self.allocated.clone(),
-                    self.allocation_policy,
                 );
                 match operation.delete(&entry.key()) {
                     Ok(x) => {
@@ -334,10 +330,9 @@ impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> boo
             if (self.predicate)(entry.key(), entry.value()) {
                 let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new_do_not_modify(
                     self.root,
-                    self.mem.clone(),
+                    self.page_allocator.clone(),
                     &mut self.free_on_drop,
                     self.allocated.clone(),
-                    self.allocation_policy,
                 );
                 match operation.delete(&entry.key()) {
                     Ok(x) => {
@@ -363,7 +358,10 @@ impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> boo
         let mut master_free_list = self.master_free_list.lock().unwrap();
         let mut allocated = self.allocated.lock().unwrap();
         for page in self.free_on_drop.drain(..) {
-            if !self.mem.free_if_uncommitted(page, &mut allocated) {
+            if !self
+                .page_allocator
+                .free_if_uncommitted(page, &mut allocated)
+            {
                 master_free_list.push(page);
             }
         }

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -7,8 +7,7 @@ use crate::tree_store::btree_mutator::DeletionResult::{
 };
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
-    AccessGuardMutInPlace, AllocationPolicy, BtreeHeader, PageHint, PageNumber, PageTrackerPolicy,
-    TransactionalMemory,
+    AccessGuardMutInPlace, BtreeHeader, PageAllocator, PageHint, PageNumber, PageTrackerPolicy,
 };
 use crate::types::{Key, Value};
 use crate::{AccessGuard, Result};
@@ -68,33 +67,30 @@ struct InsertionResult<'a, V: Value + 'static> {
 pub(crate) struct MutateHelper<'a, 'b, K: Key, V: Value> {
     root: &'b mut Option<BtreeHeader>,
     modify_uncommitted: bool,
-    mem: Arc<TransactionalMemory>,
+    page_allocator: PageAllocator,
     freed: &'b mut Vec<PageNumber>,
     allocated: Arc<Mutex<PageTrackerPolicy>>,
     _key_type: PhantomData<K>,
     _value_type: PhantomData<V>,
     _lifetime: PhantomData<&'a ()>,
-    allocation_policy: AllocationPolicy,
 }
 
 impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     pub(crate) fn new(
         root: &'b mut Option<BtreeHeader>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
         freed: &'b mut Vec<PageNumber>,
         allocated: Arc<Mutex<PageTrackerPolicy>>,
-        allocation_policy: AllocationPolicy,
     ) -> Self {
         Self {
             root,
             modify_uncommitted: true,
-            mem,
+            page_allocator,
             freed,
             allocated,
             _key_type: PhantomData,
             _value_type: PhantomData,
             _lifetime: PhantomData,
-            allocation_policy,
         }
     }
 
@@ -102,28 +98,29 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     // It will still queue pages for future freeing in the freed vec
     pub(crate) fn new_do_not_modify(
         root: &'b mut Option<BtreeHeader>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
         freed: &'b mut Vec<PageNumber>,
         allocated: Arc<Mutex<PageTrackerPolicy>>,
-        allocation_policy: AllocationPolicy,
     ) -> Self {
         Self {
             root,
             modify_uncommitted: false,
-            mem,
+            page_allocator,
             freed,
             allocated,
             _key_type: PhantomData,
             _value_type: PhantomData,
             _lifetime: PhantomData,
-            allocation_policy,
         }
     }
 
     fn conditional_free(&mut self, page_number: PageNumber) {
         if self.modify_uncommitted {
             let mut allocated = self.allocated.lock().unwrap();
-            if !self.mem.free_if_uncommitted(page_number, &mut allocated) {
+            if !self
+                .page_allocator
+                .free_if_uncommitted(page_number, &mut allocated)
+            {
                 self.freed.push(page_number);
             }
         } else {
@@ -159,8 +156,11 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             root: p, length, ..
         }) = *self.root
         {
-            let (deletion_result, found) =
-                self.delete_helper(self.mem.get_page(p, PageHint::None)?, target, found_key)?;
+            let (deletion_result, found) = self.delete_helper(
+                self.page_allocator.get_page(p, PageHint::None)?,
+                target,
+                found_key,
+            )?;
             if found.is_none() {
                 // The tree was not modified; leave *self.root untouched so that any clean
                 // root page keeps its already-valid checksum.
@@ -173,12 +173,11 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 PartialLeaf { page, deleted_pair } => {
                     let accessor = LeafAccessor::new(&page, K::fixed_width(), V::fixed_width());
                     let mut builder = LeafBuilder::new(
-                        &self.mem,
+                        &self.page_allocator,
                         &self.allocated,
                         accessor.num_pairs() - 1,
                         K::fixed_width(),
                         V::fixed_width(),
-                        self.allocation_policy,
                     );
                     builder.push_all_except(&accessor, Some(deleted_pair));
                     let page = builder.build()?;
@@ -191,11 +190,10 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 }
                 PartialBranch { children, keys } => {
                     let mut builder = BranchBuilder::new(
-                        &self.mem,
+                        &self.page_allocator,
                         &self.allocated,
                         children.len(),
                         K::fixed_width(),
-                        self.allocation_policy,
                     );
                     for (child, child_checksum) in children {
                         builder.push_child(child, child_checksum);
@@ -234,7 +232,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         }) = *self.root
         {
             let result = self.insert_helper(
-                self.mem.get_page(p, PageHint::None)?,
+                self.page_allocator.get_page(p, PageHint::None)?,
                 checksum,
                 K::as_bytes(key).as_ref(),
                 V::as_bytes(value).as_ref(),
@@ -247,13 +245,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             };
 
             let new_root = if let Some((key, page2, page2_checksum)) = result.additional_sibling {
-                let mut builder = BranchBuilder::new(
-                    &self.mem,
-                    &self.allocated,
-                    2,
-                    K::fixed_width(),
-                    self.allocation_policy,
-                );
+                let mut builder =
+                    BranchBuilder::new(&self.page_allocator, &self.allocated, 2, K::fixed_width());
                 builder.push_child(result.new_root, result.root_checksum);
                 builder.push_key(&key);
                 builder.push_child(page2, page2_checksum);
@@ -269,12 +262,11 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             let key_bytes = key_bytes.as_ref();
             let value_bytes = value_bytes.as_ref();
             let mut builder = LeafBuilder::new(
-                &self.mem,
+                &self.page_allocator,
                 &self.allocated,
                 1,
                 K::fixed_width(),
                 V::fixed_width(),
-                self.allocation_policy,
             );
             builder.push(key_bytes, value_bytes);
             let page = builder.build()?;
@@ -305,15 +297,14 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
 
                 // Fast-path to avoid re-building and splitting pages with a single large value
                 let single_large_value = accessor.num_pairs() == 1
-                    && accessor.total_length() >= self.mem.get_page_size();
+                    && accessor.total_length() >= self.page_allocator.get_page_size();
                 if !found && single_large_value {
                     let mut builder = LeafBuilder::new(
-                        &self.mem,
+                        &self.page_allocator,
                         &self.allocated,
                         1,
                         K::fixed_width(),
                         V::fixed_width(),
-                        self.allocation_policy,
                     );
                     builder.push(key, value);
                     let new_page = builder.build()?;
@@ -367,7 +358,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         )
                     }
                 };
-                if self.mem.uncommitted(page.get_page_number())
+                if self.page_allocator.uncommitted(page.get_page_number())
                     && self.modify_uncommitted
                     && has_inplace_space()
                 {
@@ -379,7 +370,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         None
                     };
                     drop(page);
-                    let mut page_mut = self.mem.get_page_mut(page_number)?;
+                    let mut page_mut = self.page_allocator.get_page_mut(page_number)?;
                     let mut mutator =
                         LeafMutator::new(page_mut.memory_mut(), K::fixed_width(), V::fixed_width());
                     if found {
@@ -401,12 +392,11 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 }
 
                 let mut builder = LeafBuilder::new(
-                    &self.mem,
+                    &self.page_allocator,
                     &self.allocated,
                     accessor.num_pairs() + 1,
                     K::fixed_width(),
                     V::fixed_width(),
-                    self.allocation_policy,
                 );
                 for i in 0..accessor.num_pairs() {
                     if i == position {
@@ -426,11 +416,11 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     let page_number = page.get_page_number();
                     let existing_value = if found {
                         let (start, end) = accessor.value_range(position).unwrap();
-                        if self.modify_uncommitted && self.mem.uncommitted(page_number) {
+                        if self.modify_uncommitted && self.page_allocator.uncommitted(page_number) {
                             let arc = page.to_arc();
                             drop(page);
                             let mut allocated = self.allocated.lock().unwrap();
-                            self.mem.free(page_number, &mut allocated);
+                            self.page_allocator.free(page_number, &mut allocated);
                             Some(AccessGuard::with_arc_page(arc, start..end))
                         } else {
                             self.freed.push(page_number);
@@ -461,11 +451,11 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     let page_number = page.get_page_number();
                     let existing_value = if found {
                         let (start, end) = accessor.value_range(position).unwrap();
-                        if self.modify_uncommitted && self.mem.uncommitted(page_number) {
+                        if self.modify_uncommitted && self.page_allocator.uncommitted(page_number) {
                             let arc = page.to_arc();
                             drop(page);
                             let mut allocated = self.allocated.lock().unwrap();
-                            self.mem.free(page_number, &mut allocated);
+                            self.page_allocator.free(page_number, &mut allocated);
                             Some(AccessGuard::with_arc_page(arc, start..end))
                         } else {
                             self.freed.push(page_number);
@@ -514,7 +504,9 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 let (child_index, child_page) = accessor.child_for_key::<K>(key);
                 let child_checksum = accessor.child_checksum(child_index).unwrap();
                 let sub_result = self.insert_helper(
-                    self.mem.get_page(child_page, PageHint::None)?,
+                    self.page_allocator
+                        .mem()
+                        .get_page(child_page, PageHint::None)?,
                     child_checksum,
                     key,
                     value,
@@ -539,11 +531,11 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
 
                 if sub_result.additional_sibling.is_none()
                     && self.modify_uncommitted
-                    && self.mem.uncommitted(page.get_page_number())
+                    && self.page_allocator.uncommitted(page.get_page_number())
                 {
                     let page_number = page.get_page_number();
                     drop(page);
-                    let mut mutpage = self.mem.get_page_mut(page_number)?;
+                    let mut mutpage = self.page_allocator.get_page_mut(page_number)?;
                     let mut mutator = BranchMutator::new(mutpage.memory_mut());
                     mutator.write_child_page(
                         child_index,
@@ -561,11 +553,10 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
 
                 // A child was added, or we couldn't use the fast-path above
                 let mut builder = BranchBuilder::new(
-                    &self.mem,
+                    &self.page_allocator,
                     &self.allocated,
                     accessor.count_children() + 1,
                     K::fixed_width(),
-                    self.allocation_policy,
                 );
                 if child_index == 0 {
                     builder.push_child(sub_result.new_root, sub_result.root_checksum);
@@ -645,7 +636,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         assert!(self.modify_uncommitted);
         let header = self.root.expect("Key not found (tree is empty)");
         self.insert_inplace_helper(
-            self.mem.get_page_mut(header.root)?,
+            self.page_allocator.get_page_mut(header.root)?,
             K::as_bytes(key).as_ref(),
             V::as_bytes(value).as_ref(),
         )?;
@@ -654,7 +645,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     }
 
     fn insert_inplace_helper(&mut self, mut page: PageMut, key: &[u8], value: &[u8]) -> Result<()> {
-        assert!(self.mem.uncommitted(page.get_page_number()));
+        assert!(self.page_allocator.uncommitted(page.get_page_number()));
 
         let node_mem = page.memory();
         match node_mem[0] {
@@ -671,7 +662,11 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             BRANCH => {
                 let accessor = BranchAccessor::new(&page, K::fixed_width());
                 let (child_index, child_page) = accessor.child_for_key::<K>(key);
-                self.insert_inplace_helper(self.mem.get_page_mut(child_page)?, key, value)?;
+                self.insert_inplace_helper(
+                    self.page_allocator.get_page_mut(child_page)?,
+                    key,
+                    value,
+                )?;
                 let mut mutator = BranchMutator::new(page.memory_mut());
                 mutator.write_child_page(child_index, child_page, DEFERRED);
             }
@@ -706,14 +701,14 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             K::fixed_width(),
             V::fixed_width(),
         );
-        let uncommitted = self.mem.uncommitted(page.get_page_number());
+        let uncommitted = self.page_allocator.uncommitted(page.get_page_number());
 
         // Fast-path for dirty pages: perform in-place removal without allocating a new page.
         // The threshold matches the merge threshold (page_size/3) so that we use in-place
         // removal for all cases where the page won't need merging with a sibling.
         if uncommitted
             && self.modify_uncommitted
-            && new_required_bytes >= self.mem.get_page_size() / 3
+            && new_required_bytes >= self.page_allocator.get_page_size() / 3
             && accessor.num_pairs() > 1
         {
             let (start, end) = accessor.value_range(position).unwrap();
@@ -726,7 +721,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             }
             let page_number = page.get_page_number();
             drop(page);
-            let page_mut = self.mem.get_page_mut(page_number)?;
+            let page_mut = self.page_allocator.get_page_mut(page_number)?;
 
             let guard = AccessGuard::remove_on_drop(
                 page_mut,
@@ -740,7 +735,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
 
         let result = if accessor.num_pairs() == 1 {
             DeletedLeaf
-        } else if new_required_bytes < self.mem.get_page_size() / 3 {
+        } else if new_required_bytes < self.page_allocator.get_page_size() / 3 {
             // Merge when less than 33% full. Splits occur when a page is full and produce two 50%
             // full pages, so we use 33% instead of 50% to avoid oscillating
             PartialLeaf {
@@ -749,12 +744,11 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             }
         } else {
             let mut builder = LeafBuilder::new(
-                &self.mem,
+                &self.page_allocator,
                 &self.allocated,
                 accessor.num_pairs() - 1,
                 K::fixed_width(),
                 V::fixed_width(),
-                self.allocation_policy,
             );
             for i in 0..accessor.num_pairs() {
                 if i == position {
@@ -772,7 +766,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             let arc = page.to_arc();
             drop(page);
             let mut allocated = self.allocated.lock().unwrap();
-            self.mem.free(page_number, &mut allocated);
+            self.page_allocator.free(page_number, &mut allocated);
             if want_key {
                 *found_key = Some(AccessGuard::with_arc_page(arc.clone(), key_range));
             }
@@ -826,7 +820,9 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         };
         let child_checksum = accessor.child_checksum(child_index).unwrap();
         let (result, found) = self.delete_helper(
-            self.mem.get_page(child_page_number, PageHint::None)?,
+            self.page_allocator
+                .mem()
+                .get_page(child_page_number, PageHint::None)?,
             target,
             found_key,
         )?;
@@ -843,37 +839,39 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 return Ok((Subtree(original_page_number), found));
             }
 
-            let result_page =
-                if self.mem.uncommitted(original_page_number) && self.modify_uncommitted {
-                    drop(page);
-                    let mut mutpage = self.mem.get_page_mut(original_page_number)?;
-                    let mut mutator = BranchMutator::new(mutpage.memory_mut());
-                    mutator.write_child_page(child_index, new_child, DEFERRED);
-                    original_page_number
-                } else {
-                    let mut builder = BranchBuilder::new(
-                        &self.mem,
-                        &self.allocated,
-                        accessor.count_children(),
-                        K::fixed_width(),
-                        self.allocation_policy,
-                    );
-                    builder.push_all(&accessor);
-                    builder.replace_child(child_index, new_child, DEFERRED);
-                    let new_page = builder.build()?;
-                    self.conditional_free(original_page_number);
-                    new_page.get_page_number()
-                };
+            let result_page = if self.page_allocator.uncommitted(original_page_number)
+                && self.modify_uncommitted
+            {
+                drop(page);
+                let mut mutpage = self
+                    .page_allocator
+                    .mem()
+                    .get_page_mut(original_page_number)?;
+                let mut mutator = BranchMutator::new(mutpage.memory_mut());
+                mutator.write_child_page(child_index, new_child, DEFERRED);
+                original_page_number
+            } else {
+                let mut builder = BranchBuilder::new(
+                    &self.page_allocator,
+                    &self.allocated,
+                    accessor.count_children(),
+                    K::fixed_width(),
+                );
+                builder.push_all(&accessor);
+                builder.replace_child(child_index, new_child, DEFERRED);
+                let new_page = builder.build()?;
+                self.conditional_free(original_page_number);
+                new_page.get_page_number()
+            };
             return Ok((Subtree(result_page), found));
         }
 
         // Child is requesting to be merged with a sibling
         let mut builder = BranchBuilder::new(
-            &self.mem,
+            &self.page_allocator,
             &self.allocated,
             accessor.count_children(),
             K::fixed_width(),
-            self.allocation_policy,
         );
 
         let final_result = match result {
@@ -903,7 +901,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     }
                     builder.push_key(accessor.key(i).unwrap());
                 }
-                Self::finalize_branch_builder(builder, self.mem.get_page_size())?
+                Self::finalize_branch_builder(builder, self.page_allocator.get_page_size())?
             }
             PartialLeaf {
                 page: partial_child_page,
@@ -916,29 +914,32 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 let merge_with = if child_index == 0 { 1 } else { child_index - 1 };
                 debug_assert!(merge_with < accessor.count_children());
                 let merge_with_page = self
-                    .mem
+                    .page_allocator
+                    .mem()
                     .get_page(accessor.child_page(merge_with).unwrap(), PageHint::None)?;
                 let merge_with_accessor =
                     LeafAccessor::new(merge_with_page.memory(), K::fixed_width(), V::fixed_width());
 
                 let single_large_value = merge_with_accessor.num_pairs() == 1
-                    && merge_with_accessor.total_length() >= self.mem.get_page_size();
+                    && merge_with_accessor.total_length() >= self.page_allocator.get_page_size();
                 // Don't try to merge or rebalance, if the sibling contains a single large value
                 if single_large_value {
                     let mut child_builder = LeafBuilder::new(
-                        &self.mem,
+                        &self.page_allocator,
                         &self.allocated,
                         partial_child_accessor.num_pairs() - 1,
                         K::fixed_width(),
                         V::fixed_width(),
-                        self.allocation_policy,
                     );
                     child_builder.push_all_except(&partial_child_accessor, Some(deleted_pair));
                     let new_page = child_builder.build()?;
                     builder.push_all(&accessor);
                     builder.replace_child(child_index, new_page.get_page_number(), DEFERRED);
 
-                    let result = Self::finalize_branch_builder(builder, self.mem.get_page_size())?;
+                    let result = Self::finalize_branch_builder(
+                        builder,
+                        self.page_allocator.get_page_size(),
+                    )?;
 
                     drop(page);
                     self.conditional_free(original_page_number);
@@ -956,13 +957,12 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     let page_checksum = accessor.child_checksum(i).unwrap();
                     if i == merge_with {
                         let mut child_builder = LeafBuilder::new(
-                            &self.mem,
+                            &self.page_allocator,
                             &self.allocated,
                             partial_child_accessor.num_pairs() - 1
                                 + merge_with_accessor.num_pairs(),
                             K::fixed_width(),
                             V::fixed_width(),
-                            self.allocation_policy,
                         );
                         if child_index < merge_with {
                             child_builder
@@ -995,7 +995,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     }
                 }
 
-                let result = Self::finalize_branch_builder(builder, self.mem.get_page_size())?;
+                let result =
+                    Self::finalize_branch_builder(builder, self.page_allocator.get_page_size())?;
 
                 let page_number = merge_with_page.get_page_number();
                 drop(merge_with_page);
@@ -1008,7 +1009,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             DeletedBranch(only_grandchild, grandchild_checksum) => {
                 let merge_with = if child_index == 0 { 1 } else { child_index - 1 };
                 let merge_with_page = self
-                    .mem
+                    .page_allocator
+                    .mem()
                     .get_page(accessor.child_page(merge_with).unwrap(), PageHint::None)?;
                 let merge_with_accessor = BranchAccessor::new(&merge_with_page, K::fixed_width());
                 debug_assert!(merge_with < accessor.count_children());
@@ -1020,11 +1022,10 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     let page_checksum = accessor.child_checksum(i).unwrap();
                     if i == merge_with {
                         let mut child_builder = BranchBuilder::new(
-                            &self.mem,
+                            &self.page_allocator,
                             &self.allocated,
                             merge_with_accessor.count_children() + 1,
                             K::fixed_width(),
-                            self.allocation_policy,
                         );
                         let separator_key = accessor.key(min(child_index, merge_with)).unwrap();
                         if child_index < merge_with {
@@ -1057,7 +1058,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         }
                     }
                 }
-                let result = Self::finalize_branch_builder(builder, self.mem.get_page_size())?;
+                let result =
+                    Self::finalize_branch_builder(builder, self.page_allocator.get_page_size())?;
 
                 let page_number = merge_with_page.get_page_number();
                 drop(merge_with_page);
@@ -1071,7 +1073,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             } => {
                 let merge_with = if child_index == 0 { 1 } else { child_index - 1 };
                 let merge_with_page = self
-                    .mem
+                    .page_allocator
+                    .mem()
                     .get_page(accessor.child_page(merge_with).unwrap(), PageHint::None)?;
                 let merge_with_accessor = BranchAccessor::new(&merge_with_page, K::fixed_width());
                 debug_assert!(merge_with < accessor.count_children());
@@ -1083,11 +1086,10 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     let page_checksum = accessor.child_checksum(i).unwrap();
                     if i == merge_with {
                         let mut child_builder = BranchBuilder::new(
-                            &self.mem,
+                            &self.page_allocator,
                             &self.allocated,
                             merge_with_accessor.count_children() + partial_children.len(),
                             K::fixed_width(),
-                            self.allocation_policy,
                         );
                         let separator_key = accessor.key(min(child_index, merge_with)).unwrap();
                         if child_index < merge_with {
@@ -1130,7 +1132,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         }
                     }
                 }
-                let result = Self::finalize_branch_builder(builder, self.mem.get_page_size())?;
+                let result =
+                    Self::finalize_branch_builder(builder, self.page_allocator.get_page_size())?;
 
                 let page_number = merge_with_page.get_page_number();
                 drop(merge_with_page);

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -16,8 +16,8 @@ pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multim
 pub(crate) use page_store::ReadOnlyBackend;
 pub(crate) use page_store::{
     AllocationPolicy, FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page,
-    PageHint, PageNumber, PageNumberHashSet, PageTrackerPolicy, SerializedSavepoint, ShrinkPolicy,
-    TransactionalMemory,
+    PageAllocator, PageHint, PageNumber, PageNumberHashSet, PageTrackerPolicy, SerializedSavepoint,
+    ShrinkPolicy, TransactionalMemory,
 };
 pub use page_store::{InMemoryBackend, Savepoint, file_backend};
 pub(crate) use table_tree::{PageListMut, TableTree, TableTreeMut};

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -22,7 +22,8 @@ pub(crate) use base::{
 pub(crate) use fast_hash::PageNumberHashSet;
 pub(crate) use header::PAGE_SIZE;
 pub(crate) use page_manager::{
-    AllocationPolicy, FILE_FORMAT_VERSION3, ShrinkPolicy, TransactionalMemory, xxh3_checksum,
+    AllocationPolicy, FILE_FORMAT_VERSION3, PageAllocator, ShrinkPolicy, TransactionalMemory,
+    xxh3_checksum,
 };
 pub use savepoint::Savepoint;
 pub(crate) use savepoint::SerializedSavepoint;

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -23,7 +23,6 @@ use std::collections::HashSet;
 use std::convert::TryInto;
 use std::io::ErrorKind;
 use std::marker::PhantomData;
-#[cfg(debug_assertions)]
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
@@ -82,21 +81,75 @@ pub(crate) enum AllocationPolicy {
     Lowest,
 }
 
-impl AllocationPolicy {
-    // TODO: all callers should go through this helper rather than calling
-    // `TransactionalMemory::allocate` / `allocate_lowest` directly; once
-    // that's done those methods can be file-private and only reachable via
-    // `AllocationPolicy`.
+/// Per-write-transaction handle through which btree mutation code allocates
+/// and frees pages. Bundles the shared `TransactionalMemory` with the write
+/// transaction's `AllocationPolicy`.
+#[derive(Clone)]
+pub(crate) struct PageAllocator {
+    mem: Arc<TransactionalMemory>,
+    policy: AllocationPolicy,
+}
+
+impl PageAllocator {
+    pub(crate) fn new(mem: Arc<TransactionalMemory>, policy: AllocationPolicy) -> Self {
+        Self { mem, policy }
+    }
+
+    // TODO: migrate remaining callers off of this and make it private. Btree
+    // mutation code should interact with `TransactionalMemory` exclusively
+    // through `PageAllocator`.
+    pub(crate) fn mem(&self) -> &Arc<TransactionalMemory> {
+        &self.mem
+    }
+
     pub(crate) fn allocate<'a>(
-        self,
-        mem: &TransactionalMemory,
-        allocation_size: usize,
+        &self,
+        size: usize,
         allocated: &mut PageTrackerPolicy,
     ) -> Result<PageMut<'a>> {
-        match self {
-            AllocationPolicy::Default => mem.allocate(allocation_size, allocated),
-            AllocationPolicy::Lowest => mem.allocate_lowest(allocation_size, allocated),
+        match self.policy {
+            AllocationPolicy::Default => self.mem.allocate(size, allocated),
+            AllocationPolicy::Lowest => self.mem.allocate_lowest(size, allocated),
         }
+    }
+
+    // Always allocates at the lowest free page, ignoring `self.policy`. Used
+    // by compaction's probe loop where the point is specifically to test
+    // whether a page can land below its current position.
+    pub(crate) fn allocate_lowest<'a>(
+        &self,
+        size: usize,
+        allocated: &mut PageTrackerPolicy,
+    ) -> Result<PageMut<'a>> {
+        self.mem.allocate_lowest(size, allocated)
+    }
+
+    pub(crate) fn free(&self, page: PageNumber, allocated: &mut PageTrackerPolicy) {
+        self.mem.free(page, allocated);
+    }
+
+    pub(crate) fn free_if_uncommitted(
+        &self,
+        page: PageNumber,
+        allocated: &mut PageTrackerPolicy,
+    ) -> bool {
+        self.mem.free_if_uncommitted(page, allocated)
+    }
+
+    pub(crate) fn uncommitted(&self, page: PageNumber) -> bool {
+        self.mem.uncommitted(page)
+    }
+
+    pub(crate) fn get_page(&self, page_number: PageNumber, hint: PageHint) -> Result<PageImpl> {
+        self.mem.get_page(page_number, hint)
+    }
+
+    pub(crate) fn get_page_mut<'a>(&self, page_number: PageNumber) -> Result<PageMut<'a>> {
+        self.mem.get_page_mut(page_number)
+    }
+
+    pub(crate) fn get_page_size(&self) -> usize {
+        self.mem.get_page_size()
     }
 }
 
@@ -1170,7 +1223,7 @@ impl TransactionalMemory {
         Ok(())
     }
 
-    pub(crate) fn allocate<'txn>(
+    fn allocate<'txn>(
         &self,
         allocation_size: usize,
         allocated: &mut PageTrackerPolicy,
@@ -1182,7 +1235,7 @@ impl TransactionalMemory {
         result
     }
 
-    pub(crate) fn allocate_lowest<'txn>(
+    fn allocate_lowest<'txn>(
         &self,
         allocation_size: usize,
         allocated: &mut PageTrackerPolicy,

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -6,9 +6,9 @@ use crate::tree_store::multimap_btree::{
     finalize_tree_and_subtree_checksums, verify_tree_and_subtree_checksums,
 };
 use crate::tree_store::{
-    AllocationPolicy, Btree, BtreeMut, BtreeRangeIter, InternalTableDefinition, PageHint,
-    PageNumber, PageNumberHashSet, PageTrackerPolicy, RawBtree, TableType, TransactionalMemory,
-    multimap_btree_stats,
+    AllocationPolicy, Btree, BtreeMut, BtreeRangeIter, InternalTableDefinition, PageAllocator,
+    PageHint, PageNumber, PageNumberHashSet, PageTrackerPolicy, RawBtree, TableType,
+    TransactionalMemory, multimap_btree_stats,
 };
 use crate::types::{Key, Value};
 use crate::{DatabaseStats, Result};
@@ -213,49 +213,45 @@ impl TableTree {
 pub(crate) struct TableTreeMut<'txn> {
     tree: BtreeMut<'txn, &'static str, InternalTableDefinition>,
     guard: Arc<TransactionGuard>,
-    mem: Arc<TransactionalMemory>,
+    page_allocator: PageAllocator,
     // Cached updates from tables that have been closed. These must be flushed to the btree.
     // The bool indicates whether the root has dirty (DEFERRED) checksums that need finalization.
     pending_table_updates: HashMap<String, (Option<BtreeHeader>, u64, bool)>,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
     allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
-    allocation_policy: AllocationPolicy,
 }
 
 impl TableTreeMut<'_> {
     pub(crate) fn new(
         master_root: Option<BtreeHeader>,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
         allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
-        allocation_policy: AllocationPolicy,
     ) -> Self {
         Self {
             tree: BtreeMut::new(
                 master_root,
                 guard.clone(),
-                mem.clone(),
+                page_allocator.clone(),
                 freed_pages.clone(),
                 allocated_pages.clone(),
-                allocation_policy,
             ),
             guard,
-            mem,
+            page_allocator,
             pending_table_updates: HashMap::default(),
             freed_pages,
             allocated_pages,
-            allocation_policy,
         }
     }
 
     pub(crate) fn set_allocation_policy(&mut self, policy: AllocationPolicy) {
-        self.allocation_policy = policy;
+        self.page_allocator = PageAllocator::new(self.page_allocator.mem().clone(), policy);
         self.tree.set_allocation_policy(policy);
     }
 
-    pub(crate) fn allocation_policy(&self) -> AllocationPolicy {
-        self.allocation_policy
+    pub(crate) fn page_allocator(&self) -> &PageAllocator {
+        &self.page_allocator
     }
 
     pub(crate) fn set_root(&mut self, root: Option<BtreeHeader>) {
@@ -278,7 +274,11 @@ impl TableTreeMut<'_> {
                 .get_table_untyped(&entry, TableType::Normal)
                 .map_err(|e| e.into_storage_error_or_corrupted("Internal corruption"))?
                 .unwrap();
-            definition.visit_all_pages(self.mem.clone(), PageHint::None, |path| visitor(path))?;
+            definition.visit_all_pages(
+                self.page_allocator.mem().clone(),
+                PageHint::None,
+                |path| visitor(path),
+            )?;
         }
 
         for entry in self.list_tables(TableType::Multimap)? {
@@ -286,7 +286,11 @@ impl TableTreeMut<'_> {
                 .get_table_untyped(&entry, TableType::Multimap)
                 .map_err(|e| e.into_storage_error_or_corrupted("Internal corruption"))?
                 .unwrap();
-            definition.visit_all_pages(self.mem.clone(), PageHint::None, |path| visitor(path))?;
+            definition.visit_all_pages(
+                self.page_allocator.mem().clone(),
+                PageHint::None,
+                |path| visitor(path),
+            )?;
         }
 
         Ok(())
@@ -301,7 +305,7 @@ impl TableTreeMut<'_> {
     ) {
         let dirty = table_root
             .as_ref()
-            .is_some_and(|header| self.mem.uncommitted(header.root));
+            .is_some_and(|header| self.page_allocator.uncommitted(header.root));
         self.pending_table_updates
             .insert(name.to_string(), (table_root, length, dirty));
     }
@@ -361,7 +365,7 @@ impl TableTreeMut<'_> {
                 } => {
                     let mut tree = UntypedBtreeMut::new(
                         new_root,
-                        self.mem.clone(),
+                        self.page_allocator.mem().clone(),
                         self.freed_pages.clone(),
                         fixed_key_size,
                         fixed_value_size,
@@ -380,7 +384,7 @@ impl TableTreeMut<'_> {
                         new_root,
                         fixed_key_size,
                         fixed_value_size,
-                        self.mem.clone(),
+                        self.page_allocator.mem().clone(),
                     )?;
                     *table_length = new_length;
                 }
@@ -419,10 +423,9 @@ impl TableTreeMut<'_> {
         let mut tree: BtreeMut<K, V> = BtreeMut::new(
             table_root,
             self.guard.clone(),
-            self.mem.clone(),
+            self.page_allocator.clone(),
             self.freed_pages.clone(),
             self.allocated_pages.clone(),
-            self.allocation_policy,
         );
         f(&mut tree)?;
 
@@ -460,10 +463,9 @@ impl TableTreeMut<'_> {
         let mut tree: BtreeMut<K, V> = BtreeMut::new(
             None,
             self.guard.clone(),
-            self.mem.clone(),
+            self.page_allocator.clone(),
             self.freed_pages.clone(),
             self.allocated_pages.clone(),
-            self.allocation_policy,
         );
         f(self, &mut tree)?;
 
@@ -490,7 +492,7 @@ impl TableTreeMut<'_> {
             self.tree.get_root(),
             PageHint::None,
             self.guard.clone(),
-            self.mem.clone(),
+            self.page_allocator.mem().clone(),
         )?;
         tree.list_tables(table_type)
     }
@@ -504,7 +506,7 @@ impl TableTreeMut<'_> {
             self.tree.get_root(),
             PageHint::None,
             self.guard.clone(),
-            self.mem.clone(),
+            self.page_allocator.mem().clone(),
         )?;
         let mut result = tree.get_table_untyped(name, table_type);
 
@@ -527,7 +529,7 @@ impl TableTreeMut<'_> {
             self.tree.get_root(),
             PageHint::None,
             self.guard.clone(),
-            self.mem.clone(),
+            self.page_allocator.mem().clone(),
         )?;
         let mut result = tree.get_table::<K, V>(name, table_type);
 
@@ -572,14 +574,21 @@ impl TableTreeMut<'_> {
             // Collect all pages first, then free them. The walk reads each page to discover
             // its children, so we must not invalidate any page before the walk completes.
             let mut pages = vec![];
-            definition.visit_all_pages(self.mem.clone(), PageHint::None, |path| {
-                pages.push(path.page_number());
-                Ok(())
-            })?;
+            definition.visit_all_pages(
+                self.page_allocator.mem().clone(),
+                PageHint::None,
+                |path| {
+                    pages.push(path.page_number());
+                    Ok(())
+                },
+            )?;
             let mut freed_pages = self.freed_pages.lock().unwrap();
             let mut allocated_pages = self.allocated_pages.lock().unwrap();
             for page in pages {
-                if !self.mem.free_if_uncommitted(page, &mut allocated_pages) {
+                if !self
+                    .page_allocator
+                    .free_if_uncommitted(page, &mut allocated_pages)
+                {
                     freed_pages.push(page);
                 }
             }
@@ -638,13 +647,17 @@ impl TableTreeMut<'_> {
                 definition.set_header(*updated_root, *updated_length);
             }
 
-            definition.visit_all_pages(self.mem.clone(), PageHint::None, |path| {
-                output.insert(path.page_number(), path.clone());
-                while output.len() > n {
-                    output.pop_first();
-                }
-                Ok(())
-            })?;
+            definition.visit_all_pages(
+                self.page_allocator.mem().clone(),
+                PageHint::None,
+                |path| {
+                    output.insert(path.page_number(), path.clone());
+                    while output.len() > n {
+                        output.pop_first();
+                    }
+                    Ok(())
+                },
+            )?;
         }
 
         self.tree.visit_all_pages(|path| {
@@ -672,7 +685,7 @@ impl TableTreeMut<'_> {
             }
 
             if let Some(new_root) = definition.relocate_tree(
-                self.mem.clone(),
+                self.page_allocator.mem().clone(),
                 self.freed_pages.clone(),
                 relocation_map,
             )? {
@@ -716,7 +729,7 @@ impl TableTreeMut<'_> {
                 } => {
                     let subtree_stats = btree_stats(
                         table_root.map(|x| x.root),
-                        &self.mem,
+                        self.page_allocator.mem(),
                         fixed_key_size,
                         fixed_value_size,
                         PageHint::None,
@@ -736,7 +749,7 @@ impl TableTreeMut<'_> {
                 } => {
                     let subtree_stats = multimap_btree_stats(
                         table_root.map(|x| x.root),
-                        &self.mem,
+                        self.page_allocator.mem(),
                         fixed_key_size,
                         fixed_value_size,
                         PageHint::None,
@@ -752,13 +765,13 @@ impl TableTreeMut<'_> {
         }
         Ok(DatabaseStats {
             tree_height: master_tree_stats.tree_height + max_subtree_height,
-            allocated_pages: self.mem.count_allocated_pages()?,
+            allocated_pages: self.page_allocator.mem().count_allocated_pages()?,
             leaf_pages,
             branch_pages,
             stored_leaf_bytes: total_stored_bytes,
             metadata_bytes: total_metadata_bytes,
             fragmented_bytes: total_fragmented,
-            page_size: self.mem.get_page_size(),
+            page_size: self.page_allocator.get_page_size(),
         })
     }
 }


### PR DESCRIPTION
Every btree mutation struct used to carry an Arc<TransactionalMemory>
plus an AllocationPolicy and allocate through a two-step
`policy.allocate(&mem, size, allocated)` helper. Collapse the pair into
a single PageAllocator handle that owns both, dispatches allocations
through the stored policy internally, and offers pass-through
get_page / get_page_mut / get_page_size / free / uncommitted so btree
code can interact with the storage layer through PageAllocator alone.