### PR TITLE
Move allocated-since-commit tracking from TransactionalMemory to PageAllocator

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1027,28 +1027,41 @@ impl Database {
     /// write may be in progress at a time. If a write is in progress, this function will block
     /// until it completes.
     pub fn begin_write(&self) -> Result<WriteTransaction, TransactionError> {
+        self.begin_write_with_allocation_policy(AllocationPolicy::Default)
+    }
+
+    // The allocation policy is fixed for the lifetime of the transaction; every page allocation
+    // this transaction makes goes through it.
+    pub(crate) fn begin_write_with_allocation_policy(
+        &self,
+        allocation_policy: AllocationPolicy,
+    ) -> Result<WriteTransaction, TransactionError> {
         // Fail early if there has been an I/O error -- nothing can be committed in that case
         self.mem.check_io_errors()?;
         let guard = TransactionGuard::new_write(
             self.transaction_tracker.start_write_transaction(),
             self.transaction_tracker.clone(),
         );
-        WriteTransaction::new(guard, self.transaction_tracker.clone(), self.mem.clone())
-            .map_err(|e| e.into())
+        WriteTransaction::new(
+            guard,
+            self.transaction_tracker.clone(),
+            self.mem.clone(),
+            allocation_policy,
+        )
+        .map_err(|e| e.into())
     }
 
     fn ensure_allocator_state_table_and_trim(&self) -> Result<(), Error> {
         // Make a new quick-repair commit to update the allocator state table
         #[cfg(feature = "logging")]
         debug!("Writing allocator state table");
-        let mut tx = self.begin_write()?;
-        tx.set_quick_repair(true);
-        tx.set_shrink_policy(ShrinkPolicy::Maximum);
         // If compact() left no free pages, the default allocator lands this
         // commit's writes at high page indices (see AllocationPolicy::Lowest)
         // and try_shrink can't reclaim the growth. See
         // https://github.com/cberner/redb/issues/1165
-        tx.set_allocation_policy(AllocationPolicy::Lowest);
+        let mut tx = self.begin_write_with_allocation_policy(AllocationPolicy::Lowest)?;
+        tx.set_quick_repair(true);
+        tx.set_shrink_policy(ShrinkPolicy::Maximum);
         tx.commit()?;
 
         Ok(())

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -849,6 +849,7 @@ impl WriteTransaction {
         guard: TransactionGuard,
         transaction_tracker: Arc<TransactionTracker>,
         mem: Arc<TransactionalMemory>,
+        allocation_policy: AllocationPolicy,
     ) -> Result<Self> {
         let transaction_id = guard.id();
         let guard = Arc::new(guard);
@@ -856,7 +857,7 @@ impl WriteTransaction {
         let root_page = mem.get_data_root();
         let system_page = mem.get_system_root();
 
-        let page_allocator = PageAllocator::new(mem.clone(), AllocationPolicy::Default);
+        let page_allocator = PageAllocator::new(mem.clone(), allocation_policy);
         let tables = TableNamespace::new(root_page, guard.clone(), page_allocator.clone());
         let system_tables = SystemNamespace::new(system_page, guard.clone(), page_allocator);
 
@@ -881,17 +882,16 @@ impl WriteTransaction {
         self.shrink_policy = shrink_policy;
     }
 
-    pub(crate) fn set_allocation_policy(&mut self, policy: AllocationPolicy) {
+    // A PageAllocator for this transaction. All clones share the same
+    // allocated-since-commit set so they agree on which pages this
+    // transaction has allocated.
+    fn page_allocator(&self) -> PageAllocator {
         self.tables
             .lock()
             .unwrap()
             .table_tree
-            .set_allocation_policy(policy);
-        self.system_tables
-            .lock()
-            .unwrap()
-            .table_tree
-            .set_allocation_policy(policy);
+            .page_allocator()
+            .clone()
     }
 
     pub(crate) fn pending_free_pages(&self) -> Result<bool> {
@@ -1230,10 +1230,11 @@ impl WriteTransaction {
         // 2) queue all pages that became unreachable
         {
             let tables = self.tables.lock().unwrap();
+            let page_allocator = tables.table_tree.page_allocator();
             for page in tables.allocated_pages.lock().unwrap().reset() {
-                debug_assert!(self.mem.uncommitted(page));
+                debug_assert!(page_allocator.uncommitted(page));
                 debug_assert!(self.mem.is_allocated(page));
-                self.mem.free(page, &mut PageTrackerPolicy::Ignore);
+                page_allocator.free(page, &mut PageTrackerPolicy::Ignore);
             }
             let mut data_freed_pages = tables.freed_pages.lock().unwrap();
             data_freed_pages.clear();
@@ -1543,6 +1544,8 @@ impl WriteTransaction {
         let mut system_tables = self.system_tables.lock().unwrap();
         let mut freed_table = system_tables.open_system_table(self, DATA_FREED_TABLE)?;
         let mut pagination_counter = 0;
+        #[cfg(debug_assertions)]
+        let page_allocator = self.page_allocator();
         while !freed_pages.is_empty() {
             let chunk_size = 400;
             let buffer_size = PageList::required_bytes(chunk_size);
@@ -1560,7 +1563,11 @@ impl WriteTransaction {
                     self.mem.is_allocated(page),
                     "Page is not allocated: {page:?}"
                 );
-                debug_assert!(!self.mem.uncommitted(page), "Page is uncommitted: {page:?}");
+                #[cfg(debug_assertions)]
+                debug_assert!(
+                    !page_allocator.uncommitted(page),
+                    "Page is uncommitted: {page:?}"
+                );
                 access_guard.as_mut().push_back(page);
             }
 
@@ -1578,12 +1585,18 @@ impl WriteTransaction {
         // Catch scenarios like a page getting allocated and then deallocated within the same
         // transaction, but errantly left in the allocated pages list.
         #[cfg(debug_assertions)]
-        for page in &data_allocated_pages {
-            debug_assert!(
-                self.mem.is_allocated(*page),
-                "Page is not allocated: {page:?}"
-            );
-            debug_assert!(self.mem.uncommitted(*page), "Page is committed: {page:?}");
+        {
+            let page_allocator = self.page_allocator();
+            for page in &data_allocated_pages {
+                debug_assert!(
+                    self.mem.is_allocated(*page),
+                    "Page is not allocated: {page:?}"
+                );
+                debug_assert!(
+                    page_allocator.uncommitted(*page),
+                    "Page is committed: {page:?}"
+                );
+            }
         }
 
         let unpersisted = self.mem.take_unpersisted_allocations();
@@ -1662,14 +1675,15 @@ impl WriteTransaction {
             .table_tree
             .clear_root_updates_and_close();
         // Release all transaction-local savepoint state. The on-disk mutations
-        // (SAVEPOINT_TABLE / NEXT_SAVEPOINT_TABLE) are reverted by
-        // rollback_uncommitted_writes() below; apply_on_abort handles the
-        // in-memory TransactionTracker state that rollback cannot see.
+        // (SAVEPOINT_TABLE / NEXT_SAVEPOINT_TABLE) are reverted by the
+        // `PageAllocator::rollback_all` call below; `apply_on_abort` handles
+        // the in-memory `TransactionTracker` state that rollback cannot see.
         self.savepoint_state
             .lock()
             .unwrap()
             .apply_on_abort(&self.transaction_tracker);
-        self.mem.rollback_uncommitted_writes()?;
+        self.mem.check_io_errors()?;
+        self.page_allocator().rollback_all();
         #[cfg(feature = "logging")]
         debug!("Finished abort of transaction id={:?}", self.transaction_id);
         Ok(())
@@ -1738,6 +1752,7 @@ impl WriteTransaction {
 
         let system_root = system_tree.finalize_dirty_checksums()?;
 
+        let page_allocator = self.page_allocator();
         self.mem.commit(
             user_root,
             system_root,
@@ -1745,6 +1760,8 @@ impl WriteTransaction {
             self.two_phase_commit,
             self.shrink_policy,
         )?;
+        // All of this transaction's allocations are durable; discard the per-txn tracker.
+        let _ = page_allocator.take_allocated_since_commit();
 
         // Mark any pending non-durable commits as fully committed.
         self.transaction_tracker.clear_pending_non_durable_commits();
@@ -1752,7 +1769,7 @@ impl WriteTransaction {
         // Immediately free the pages that were freed from the system-tree. These are only
         // accessed by write transactions, so it's safe to free them as soon as the commit is done.
         for page in system_freed_pages.lock().unwrap().drain(..) {
-            self.mem.free(page, &mut PageTrackerPolicy::Ignore);
+            page_allocator.free(page, &mut PageTrackerPolicy::Ignore);
         }
 
         Ok(())
@@ -1798,8 +1815,13 @@ impl WriteTransaction {
                 .finalize_dirty_checksums()?
         };
 
-        self.mem
-            .non_durable_commit(user_root, system_root, self.transaction_id)?;
+        let newly_unpersisted = self.page_allocator().take_allocated_since_commit();
+        self.mem.non_durable_commit(
+            user_root,
+            system_root,
+            self.transaction_id,
+            newly_unpersisted,
+        )?;
         // Record the data-tree pages allocated in this transaction in the in-memory map.
         self.mem
             .record_unpersisted_allocations(self.transaction_id, allocated_pages);
@@ -1891,6 +1913,7 @@ impl WriteTransaction {
         // We assume below that PageNumber is length 8
         assert_eq!(PageNumber::serialized_size(), 8);
 
+        let page_allocator = self.page_allocator();
         // Handle the data freed tree
         let mut system_tables = self.system_tables.lock().unwrap();
         {
@@ -1909,7 +1932,7 @@ impl WriteTransaction {
                     // result, no entry whose pages are still unpersisted is eligible for
                     // processing here.
                     debug_assert!(!self.mem.unpersisted(page));
-                    self.mem.free(page, &mut PageTrackerPolicy::Ignore);
+                    page_allocator.free(page, &mut PageTrackerPolicy::Ignore);
                 }
             }
         }
@@ -1926,7 +1949,7 @@ impl WriteTransaction {
                 for i in 0..page_list.value().len() {
                     let page = page_list.value().get(i);
                     debug_assert!(!self.mem.unpersisted(page));
-                    self.mem.free(page, &mut PageTrackerPolicy::Ignore);
+                    page_allocator.free(page, &mut PageTrackerPolicy::Ignore);
                 }
             }
         }

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -7,8 +7,8 @@ use crate::tree_store::btree_iters::BtreeExtractIf;
 use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageImpl, PageMut, TransactionalMemory};
 use crate::tree_store::{
-    AccessGuardMutInPlace, AllPageNumbersBtreeIter, AllocationPolicy, BtreeRangeIter,
-    PageAllocator, PageHint, PageNumber, PageTrackerPolicy,
+    AccessGuardMutInPlace, AllPageNumbersBtreeIter, BtreeRangeIter, PageAllocator, PageHint,
+    PageNumber, PageTrackerPolicy,
 };
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, Result};
@@ -127,7 +127,7 @@ impl UntypedBtree {
 }
 
 pub(super) struct UntypedBtreeMut {
-    mem: Arc<TransactionalMemory>,
+    page_allocator: PageAllocator,
     root: Option<BtreeHeader>,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
     key_width: Option<usize>,
@@ -137,13 +137,13 @@ pub(super) struct UntypedBtreeMut {
 impl UntypedBtreeMut {
     pub(super) fn new(
         root: Option<BtreeHeader>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
         key_width: Option<usize>,
         value_width: Option<usize>,
     ) -> Self {
         Self {
-            mem,
+            page_allocator,
             root,
             freed_pages,
             key_width,
@@ -164,7 +164,7 @@ impl UntypedBtreeMut {
             length: _,
         }) = root
         {
-            if !self.mem.uncommitted(*p) {
+            if !self.page_allocator.uncommitted(*p) {
                 // root page is clean
                 return Ok(root);
             }
@@ -177,8 +177,8 @@ impl UntypedBtreeMut {
     }
 
     fn finalize_dirty_checksums_helper(&mut self, page_number: PageNumber) -> Result<Checksum> {
-        assert!(self.mem.uncommitted(page_number));
-        let mut page = self.mem.get_page_mut(page_number)?;
+        assert!(self.page_allocator.uncommitted(page_number));
+        let mut page = self.page_allocator.get_page_mut(page_number)?;
 
         match page.memory()[0] {
             LEAF => leaf_checksum(&page, self.key_width, self.value_width),
@@ -187,7 +187,7 @@ impl UntypedBtreeMut {
                 let mut new_children = vec![];
                 for i in 0..accessor.count_children() {
                     let child_page = accessor.child_page(i).unwrap();
-                    if self.mem.uncommitted(child_page) {
+                    if self.page_allocator.uncommitted(child_page) {
                         let new_checksum = self.finalize_dirty_checksums_helper(child_page)?;
                         new_children.push(Some((i, child_page, new_checksum)));
                     } else {
@@ -214,12 +214,12 @@ impl UntypedBtreeMut {
         F: for<'a> Fn(LeafPageMut<'a>) -> Result,
     {
         if let Some(page_number) = self.root.map(|x| x.root) {
-            if !self.mem.uncommitted(page_number) {
+            if !self.page_allocator.uncommitted(page_number) {
                 // root page is clean
                 return Ok(());
             }
 
-            let page = self.mem.get_page_mut(page_number)?;
+            let page = self.page_allocator.get_page_mut(page_number)?;
             match page.memory()[0] {
                 LEAF => {
                     visitor(LeafPageMut::new(page, self.key_width, self.value_width))?;
@@ -239,8 +239,8 @@ impl UntypedBtreeMut {
     where
         F: for<'a> Fn(LeafPageMut<'a>) -> Result,
     {
-        assert!(self.mem.uncommitted(page_number));
-        let page = self.mem.get_page_mut(page_number)?;
+        assert!(self.page_allocator.uncommitted(page_number));
+        let page = self.page_allocator.get_page_mut(page_number)?;
 
         match page.memory()[0] {
             LEAF => {
@@ -250,7 +250,7 @@ impl UntypedBtreeMut {
                 let accessor = BranchAccessor::new(&page, self.key_width);
                 for i in 0..accessor.count_children() {
                     let child_page = accessor.child_page(i).unwrap();
-                    if self.mem.uncommitted(child_page) {
+                    if self.page_allocator.uncommitted(child_page) {
                         self.dirty_leaf_visitor_helper(child_page, visitor)?;
                     }
                 }
@@ -281,9 +281,9 @@ impl UntypedBtreeMut {
         page_number: PageNumber,
         relocation_map: &HashMap<PageNumber, PageNumber>,
     ) -> Result<Option<(PageNumber, Checksum)>> {
-        let old_page = self.mem.get_page(page_number, PageHint::None)?;
+        let old_page = self.page_allocator.get_page(page_number, PageHint::None)?;
         let mut new_page = if let Some(new_page_number) = relocation_map.get(&page_number) {
-            self.mem.get_page_mut(*new_page_number)?
+            self.page_allocator.get_page_mut(*new_page_number)?
         } else {
             return Ok(None);
         };
@@ -313,7 +313,10 @@ impl UntypedBtreeMut {
         // No need to track allocations, because this method is only called during compaction when
         // there can't be any savepoints
         let mut ignore = PageTrackerPolicy::Ignore;
-        if !self.mem.free_if_uncommitted(page_number, &mut ignore) {
+        if !self
+            .page_allocator
+            .free_if_uncommitted(page_number, &mut ignore)
+        {
             freed_pages.push(page_number);
         }
 
@@ -352,14 +355,10 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         }
     }
 
-    pub(crate) fn set_allocation_policy(&mut self, policy: AllocationPolicy) {
-        self.page_allocator = PageAllocator::new(self.page_allocator.mem().clone(), policy);
-    }
-
     pub(crate) fn finalize_dirty_checksums(&mut self) -> Result<Option<BtreeHeader>> {
         let mut tree = UntypedBtreeMut::new(
             self.get_root(),
-            self.page_allocator.mem().clone(),
+            self.page_allocator.clone(),
             self.freed_pages.clone(),
             K::fixed_width(),
             V::fixed_width(),
@@ -404,7 +403,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
     ) -> Result<bool> {
         let mut tree = UntypedBtreeMut::new(
             self.get_root(),
-            self.page_allocator.mem().clone(),
+            self.page_allocator.clone(),
             self.freed_pages.clone(),
             K::fixed_width(),
             V::fixed_width(),
@@ -555,19 +554,18 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         if let Some(ref mut root) = self.root {
             let key_bytes = K::as_bytes(key);
             let query = key_bytes.as_ref();
-            let mem = self.page_allocator.mem();
-            let page_mut = if mem.uncommitted(root.root) {
-                mem.get_page_mut(root.root)?
+            let page_mut = if self.page_allocator.uncommitted(root.root) {
+                self.page_allocator.get_page_mut(root.root)?
             } else {
                 let mut freed_pages = self.freed_pages.lock().unwrap();
                 let mut allocated = self.allocated_pages.lock().unwrap();
                 let required: usize = root
                     .root
-                    .page_size_bytes(mem.get_page_size().try_into().unwrap())
+                    .page_size_bytes(self.page_allocator.get_page_size().try_into().unwrap())
                     .try_into()
                     .unwrap();
                 let mut new_page = self.page_allocator.allocate(required, &mut allocated)?;
-                let old_page = mem.get_page(root.root, PageHint::None)?;
+                let old_page = self.page_allocator.get_page(root.root, PageHint::None)?;
                 new_page.memory_mut().copy_from_slice(old_page.memory());
                 drop(old_page);
                 freed_pages.push(root.root);
@@ -600,7 +598,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
                         end - start,
                         entry_index,
                         parent,
-                        self.page_allocator.mem().clone(),
+                        self.page_allocator.clone(),
                         self.allocated_pages.clone(),
                         self.root.as_mut().unwrap(),
                         K::fixed_width(),
@@ -615,18 +613,18 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
                     let accessor = BranchAccessor::new(&page, K::fixed_width());
                     accessor.child_for_key::<K>(query)
                 };
-                let mem = self.page_allocator.mem();
-                let child_page_mut = if mem.uncommitted(child_page) {
-                    mem.get_page_mut(child_page)?
+                let child_page_mut = if self.page_allocator.uncommitted(child_page) {
+                    self.page_allocator.get_page_mut(child_page)?
                 } else {
                     let mut freed_pages = self.freed_pages.lock().unwrap();
                     let mut allocated = self.allocated_pages.lock().unwrap();
                     let required: usize = child_page
-                        .page_size_bytes(mem.get_page_size().try_into().unwrap())
+                        .page_size_bytes(self.page_allocator.get_page_size().try_into().unwrap())
                         .try_into()
                         .unwrap();
                     let mut new_page = self.page_allocator.allocate(required, &mut allocated)?;
-                    let old_child_page = mem.get_page(child_page, PageHint::None)?;
+                    let old_child_page =
+                        self.page_allocator.get_page(child_page, PageHint::None)?;
                     new_page
                         .memory_mut()
                         .copy_from_slice(old_child_page.memory());

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -1,5 +1,5 @@
-use crate::tree_store::page_store::{Page, PageImpl, PageMut, TransactionalMemory, xxh3_checksum};
-use crate::tree_store::{AllocationPolicy, PageAllocator, PageNumber, PageTrackerPolicy};
+use crate::tree_store::page_store::{Page, PageImpl, PageMut, xxh3_checksum};
+use crate::tree_store::{PageAllocator, PageNumber, PageTrackerPolicy};
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{Result, StorageError};
 use std::borrow::Borrow;
@@ -269,7 +269,7 @@ pub struct AccessGuardMut<'a, V: Value + 'static> {
     len: usize,
     entry_index: usize,
     parent: Option<(PageMut<'a>, usize)>,
-    mem: Arc<TransactionalMemory>,
+    page_allocator: PageAllocator,
     allocated: Arc<Mutex<PageTrackerPolicy>>,
     root_ref: &'a mut BtreeHeader,
     key_width: Option<usize>,
@@ -284,14 +284,14 @@ impl<'a, V: Value + 'static> AccessGuardMut<'a, V> {
         len: usize,
         entry_index: usize,
         parent: Option<(PageMut<'a>, usize)>,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
         allocated: Arc<Mutex<PageTrackerPolicy>>,
         root_ref: &'a mut BtreeHeader,
         key_width: Option<usize>,
     ) -> Self {
-        assert!(mem.uncommitted(page.get_page_number()));
+        assert!(page_allocator.uncommitted(page.get_page_number()));
         if let Some((ref parent_page, _)) = parent {
-            assert!(mem.uncommitted(parent_page.get_page_number()));
+            assert!(page_allocator.uncommitted(parent_page.get_page_number()));
         }
         AccessGuardMut {
             page,
@@ -299,7 +299,7 @@ impl<'a, V: Value + 'static> AccessGuardMut<'a, V> {
             len,
             entry_index,
             parent,
-            mem,
+            page_allocator,
             allocated,
             root_ref,
             key_width,
@@ -328,9 +328,8 @@ impl<'a, V: Value + 'static> AccessGuardMut<'a, V> {
             mutator.replace(self.entry_index, value_bytes.as_ref());
         } else {
             let accessor = LeafAccessor::new(self.page.memory(), self.key_width, V::fixed_width());
-            let page_allocator = PageAllocator::new(self.mem.clone(), AllocationPolicy::Default);
             let mut builder = LeafBuilder::new(
-                &page_allocator,
+                &self.page_allocator,
                 &self.allocated,
                 accessor.num_pairs(),
                 self.key_width,
@@ -361,7 +360,7 @@ impl<'a, V: Value + 'static> AccessGuardMut<'a, V> {
             self.page = new_page;
             let mut allocated = self.allocated.lock().unwrap();
             assert!(
-                self.mem
+                self.page_allocator
                     .free_if_uncommitted(old_page_number, &mut allocated)
             );
         }

--- a/src/tree_store/multimap_btree.rs
+++ b/src/tree_store/multimap_btree.rs
@@ -5,7 +5,7 @@ use crate::tree_store::btree_base::{
 };
 use crate::tree_store::multimap_btree::DynamicCollectionType::{Inline, SubtreeV2};
 use crate::tree_store::{
-    AllPageNumbersBtreeIter, BtreeHeader, BtreeStats, Page, PageHint, PageNumber,
+    AllPageNumbersBtreeIter, BtreeHeader, BtreeStats, Page, PageAllocator, PageHint, PageNumber,
     PageTrackerPolicy, RawBtree, TransactionalMemory,
 };
 use crate::types::{Key, TypeName, Value};
@@ -204,13 +204,13 @@ pub(super) fn relocate_subtrees(
     root: (PageNumber, Checksum),
     key_size: Option<usize>,
     value_size: Option<usize>,
-    mem: Arc<TransactionalMemory>,
+    page_allocator: PageAllocator,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
     relocation_map: &HashMap<PageNumber, PageNumber>,
 ) -> Result<(PageNumber, Checksum)> {
-    let old_page = mem.get_page(root.0, PageHint::None)?;
+    let old_page = page_allocator.get_page(root.0, PageHint::None)?;
     let mut new_page = if let Some(new_page_number) = relocation_map.get(&root.0) {
-        mem.get_page_mut(*new_page_number)?
+        page_allocator.get_page_mut(*new_page_number)?
     } else {
         return Ok(root);
     };
@@ -236,7 +236,7 @@ pub(super) fn relocate_subtrees(
                     let sub_root = collection.as_subtree();
                     let mut tree = UntypedBtreeMut::new(
                         Some(sub_root),
-                        mem.clone(),
+                        page_allocator.clone(),
                         freed_pages.clone(),
                         value_size,
                         <() as Value>::fixed_width(),
@@ -260,7 +260,7 @@ pub(super) fn relocate_subtrees(
                         (child, child_checksum),
                         key_size,
                         value_size,
-                        mem.clone(),
+                        page_allocator.clone(),
                         freed_pages.clone(),
                         relocation_map,
                     )?;
@@ -276,7 +276,7 @@ pub(super) fn relocate_subtrees(
     // No need to track allocations, because this method is only called during compaction when
     // there can't be any savepoints
     let mut ignore = PageTrackerPolicy::Ignore;
-    if !mem.free_if_uncommitted(old_page_number, &mut ignore) {
+    if !page_allocator.free_if_uncommitted(old_page_number, &mut ignore) {
         freed_pages.lock().unwrap().push(old_page_number);
     }
     Ok((new_page_number, DEFERRED))
@@ -288,12 +288,12 @@ pub(super) fn finalize_tree_and_subtree_checksums(
     root: Option<BtreeHeader>,
     key_size: Option<usize>,
     value_size: Option<usize>,
-    mem: Arc<TransactionalMemory>,
+    page_allocator: PageAllocator,
 ) -> Result<Option<BtreeHeader>> {
     let freed_pages = Arc::new(Mutex::new(vec![]));
     let mut tree = UntypedBtreeMut::new(
         root,
-        mem.clone(),
+        page_allocator.clone(),
         freed_pages.clone(),
         key_size,
         DynamicCollection::<()>::fixed_width_with(value_size),
@@ -306,10 +306,10 @@ pub(super) fn finalize_tree_and_subtree_checksums(
             let collection = <&DynamicCollection<()>>::from_bytes(entry.value());
             if matches!(collection.collection_type(), SubtreeV2) {
                 let sub_root = collection.as_subtree();
-                if mem.uncommitted(sub_root.root) {
+                if page_allocator.uncommitted(sub_root.root) {
                     let mut subtree = UntypedBtreeMut::new(
                         Some(sub_root),
-                        mem.clone(),
+                        page_allocator.clone(),
                         freed_pages.clone(),
                         value_size,
                         <()>::fixed_width(),

--- a/src/tree_store/page_store/base.rs
+++ b/src/tree_store/page_store/base.rs
@@ -309,6 +309,23 @@ impl PageTrackerPolicy {
         }
     }
 
+    /// Removes `page` if present. Returns whether it was in the set.
+    pub(crate) fn remove_if_present(&mut self, page: PageNumber) -> bool {
+        match self {
+            PageTrackerPolicy::Ignore => false,
+            PageTrackerPolicy::Track(x) => x.remove(&page),
+            PageTrackerPolicy::Closed => panic!("Page tracker is closed"),
+        }
+    }
+
+    pub(crate) fn contains(&self, page: PageNumber) -> bool {
+        match self {
+            PageTrackerPolicy::Ignore => false,
+            PageTrackerPolicy::Track(x) => x.contains(&page),
+            PageTrackerPolicy::Closed => panic!("Page tracker is closed"),
+        }
+    }
+
     pub(super) fn insert(&mut self, page: PageNumber) {
         match self {
             PageTrackerPolicy::Ignore => {}

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -88,11 +88,16 @@ pub(crate) enum AllocationPolicy {
 pub(crate) struct PageAllocator {
     mem: Arc<TransactionalMemory>,
     policy: AllocationPolicy,
+    allocated_since_commit: Arc<Mutex<PageTrackerPolicy>>,
 }
 
 impl PageAllocator {
     pub(crate) fn new(mem: Arc<TransactionalMemory>, policy: AllocationPolicy) -> Self {
-        Self { mem, policy }
+        Self {
+            mem,
+            policy,
+            allocated_since_commit: Arc::new(Mutex::new(PageTrackerPolicy::new_tracking())),
+        }
     }
 
     // TODO: migrate remaining callers off of this and make it private. Btree
@@ -102,15 +107,37 @@ impl PageAllocator {
         &self.mem
     }
 
+    /// Drains the set of pages allocated since the last commit, returning
+    /// them. Used by commit and non-durable commit paths to hand the set over
+    /// to `TransactionalMemory`.
+    pub(crate) fn take_allocated_since_commit(&self) -> PageNumberHashSet {
+        self.allocated_since_commit.lock().unwrap().reset()
+    }
+
+    /// Reverses every allocation made since the last commit: drains the
+    /// allocated-since-commit set and frees each page.
+    pub(crate) fn rollback_all(&self) {
+        self.mem.debug_assert_no_dirty_pages();
+        let drained = self.take_allocated_since_commit();
+        for page in &drained {
+            self.mem.free(*page, &mut PageTrackerPolicy::Ignore);
+        }
+    }
+
     pub(crate) fn allocate<'a>(
         &self,
         size: usize,
         allocated: &mut PageTrackerPolicy,
     ) -> Result<PageMut<'a>> {
-        match self.policy {
-            AllocationPolicy::Default => self.mem.allocate(size, allocated),
-            AllocationPolicy::Lowest => self.mem.allocate_lowest(size, allocated),
-        }
+        let page = match self.policy {
+            AllocationPolicy::Default => self.mem.allocate(size, allocated)?,
+            AllocationPolicy::Lowest => self.mem.allocate_lowest(size, allocated)?,
+        };
+        self.allocated_since_commit
+            .lock()
+            .unwrap()
+            .insert(page.get_page_number());
+        Ok(page)
     }
 
     // Always allocates at the lowest free page, ignoring `self.policy`. Used
@@ -121,10 +148,19 @@ impl PageAllocator {
         size: usize,
         allocated: &mut PageTrackerPolicy,
     ) -> Result<PageMut<'a>> {
-        self.mem.allocate_lowest(size, allocated)
+        let page = self.mem.allocate_lowest(size, allocated)?;
+        self.allocated_since_commit
+            .lock()
+            .unwrap()
+            .insert(page.get_page_number());
+        Ok(page)
     }
 
     pub(crate) fn free(&self, page: PageNumber, allocated: &mut PageTrackerPolicy) {
+        self.allocated_since_commit
+            .lock()
+            .unwrap()
+            .remove_if_present(page);
         self.mem.free(page, allocated);
     }
 
@@ -133,11 +169,21 @@ impl PageAllocator {
         page: PageNumber,
         allocated: &mut PageTrackerPolicy,
     ) -> bool {
-        self.mem.free_if_uncommitted(page, allocated)
+        if self
+            .allocated_since_commit
+            .lock()
+            .unwrap()
+            .remove_if_present(page)
+        {
+            self.mem.free(page, allocated);
+            true
+        } else {
+            false
+        }
     }
 
     pub(crate) fn uncommitted(&self, page: PageNumber) -> bool {
-        self.mem.uncommitted(page)
+        self.allocated_since_commit.lock().unwrap().contains(page)
     }
 
     pub(crate) fn get_page(&self, page_number: PageNumber, hint: PageHint) -> Result<PageImpl> {
@@ -209,9 +255,6 @@ impl InMemoryState {
 }
 
 pub(crate) struct TransactionalMemory {
-    // Pages allocated since the last commit
-    // TODO: maybe this should be moved to WriteTransaction?
-    allocated_since_commit: Mutex<PageNumberHashSet>,
     // TODO: Maybe we should move all this unpersisted stuff to another transaction layer.
     // There are durable commits which support persistent and ephemeral savepoints.
     // And then non-durable commits which support only ephemeral savepoints, and basically
@@ -368,7 +411,6 @@ impl TransactionalMemory {
         assert!(page_size >= DB_HEADER_SIZE);
 
         Ok(Self {
-            allocated_since_commit: Mutex::new(PageNumberHashSet::default()),
             unpersisted: Mutex::new(PageNumberHashSet::default()),
             unpersisted_allocations: Mutex::new(BTreeMap::new()),
             unpersisted_allocation_txn: Mutex::new(PageNumberHashMap::default()),
@@ -392,6 +434,20 @@ impl TransactionalMemory {
 
     pub(crate) fn check_io_errors(&self) -> Result {
         self.storage.check_io_errors()
+    }
+
+    // Panics in debug builds if any `PageMut` handed out by `get_page_mut` or
+    // `allocate*` has not yet been dropped. Intended as a precondition for
+    // commit/abort paths, which assume no mutable page references remain.
+    pub(crate) fn debug_assert_no_dirty_pages(&self) {
+        #[cfg(debug_assertions)]
+        {
+            let dirty_pages = self.open_dirty_pages.lock().unwrap();
+            debug_assert!(
+                dirty_pages.is_empty(),
+                "Dirty pages outstanding: {dirty_pages:?}"
+            );
+        }
     }
 
     #[cfg(debug_assertions)]
@@ -426,8 +482,6 @@ impl TransactionalMemory {
     }
 
     pub(crate) fn clear_cache_and_reload(&mut self) -> Result<bool, DatabaseError> {
-        assert!(self.allocated_since_commit.lock().unwrap().is_empty());
-
         self.storage.flush()?;
         self.storage.invalidate_cache_all();
 
@@ -659,7 +713,6 @@ impl TransactionalMemory {
     }
 
     // Commit all outstanding changes and make them visible as the primary
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn commit(
         &self,
         data_root: Option<BtreeHeader>,
@@ -671,8 +724,7 @@ impl TransactionalMemory {
         // All mutable pages must be dropped, this ensures that when a transaction completes
         // no more writes can happen to the pages it allocated. Thus it is safe to make them visible
         // to future read transactions
-        #[cfg(debug_assertions)]
-        debug_assert!(self.open_dirty_pages.lock().unwrap().is_empty());
+        self.debug_assert_no_dirty_pages();
         self.storage.check_io_errors()?;
 
         let mut state = self.state.lock().unwrap();
@@ -711,9 +763,6 @@ impl TransactionalMemory {
         if shrunk {
             self.storage.resize(header.layout().len())?;
         }
-        let mut allocated_since_commit = self.allocated_since_commit.lock().unwrap();
-        allocated_since_commit.clear();
-        allocated_since_commit.shrink_to_fit();
         let mut unpersisted = self.unpersisted.lock().unwrap();
         unpersisted.clear();
         unpersisted.shrink_to_fit();
@@ -734,24 +783,23 @@ impl TransactionalMemory {
         Ok(())
     }
 
-    // Make changes visible, without a durability guarantee
+    // Make changes visible, without a durability guarantee. `newly_unpersisted` is the set of
+    // pages allocated by this transaction; they become part of the unpersisted-page tracking so
+    // they can be reclaimed if a subsequent durable commit fails.
     pub(crate) fn non_durable_commit(
         &self,
         data_root: Option<BtreeHeader>,
         system_root: Option<BtreeHeader>,
         transaction_id: TransactionId,
+        newly_unpersisted: PageNumberHashSet,
     ) -> Result {
         // All mutable pages must be dropped, this ensures that when a transaction completes
         // no more writes can happen to the pages it allocated. Thus it is safe to make them visible
         // to future read transactions
-        #[cfg(debug_assertions)]
-        debug_assert!(self.open_dirty_pages.lock().unwrap().is_empty());
+        self.debug_assert_no_dirty_pages();
         self.storage.check_io_errors()?;
 
-        let mut unpersisted = self.unpersisted.lock().unwrap();
-        let mut allocated_since_commit = self.allocated_since_commit.lock().unwrap();
-        unpersisted.extend(allocated_since_commit.drain());
-        allocated_since_commit.shrink_to_fit();
+        self.unpersisted.lock().unwrap().extend(newly_unpersisted);
         self.storage.write_barrier()?;
 
         let mut state = self.state.lock().unwrap();
@@ -760,45 +808,6 @@ impl TransactionalMemory {
         secondary.user_root = data_root;
         secondary.system_root = system_root;
         state.read_from_secondary = true;
-
-        Ok(())
-    }
-
-    pub(crate) fn rollback_uncommitted_writes(&self) -> Result {
-        #[cfg(debug_assertions)]
-        {
-            let dirty_pages = self.open_dirty_pages.lock().unwrap();
-            debug_assert!(
-                dirty_pages.is_empty(),
-                "Dirty pages outstanding: {dirty_pages:?}"
-            );
-        }
-        self.storage.check_io_errors()?;
-        let mut state = self.state.lock().unwrap();
-        let mut guard = self.allocated_since_commit.lock().unwrap();
-        for page_number in guard.iter() {
-            let region_index = page_number.region;
-            state
-                .get_region_tracker_mut()
-                .mark_free(page_number.page_order, region_index);
-            state
-                .get_region_mut(region_index)
-                .free(page_number.page_index, page_number.page_order);
-            #[cfg(debug_assertions)]
-            assert!(self.allocated_pages.lock().unwrap().remove(page_number));
-
-            let address = page_number.address_range(
-                self.page_size.into(),
-                self.region_size,
-                self.region_header_with_padding_size,
-                self.page_size,
-            );
-            let len: usize = (address.end - address.start).try_into().unwrap();
-            self.storage.invalidate_cache(address.start, len);
-            self.storage.cancel_pending_write(address.start, len);
-        }
-        guard.clear();
-        guard.shrink_to_fit();
 
         Ok(())
     }
@@ -900,7 +909,6 @@ impl TransactionalMemory {
     }
 
     pub(crate) fn free(&self, page: PageNumber, allocated: &mut PageTrackerPolicy) {
-        self.allocated_since_commit.lock().unwrap().remove(&page);
         self.free_helper(page, allocated);
     }
 
@@ -1024,25 +1032,6 @@ impl TransactionalMemory {
         result
     }
 
-    // Frees the page if it was allocated since the last commit. Returns true, if the page was freed
-    pub(crate) fn free_if_uncommitted(
-        &self,
-        page: PageNumber,
-        allocated: &mut PageTrackerPolicy,
-    ) -> bool {
-        if self.allocated_since_commit.lock().unwrap().remove(&page) {
-            self.free_helper(page, allocated);
-            true
-        } else {
-            false
-        }
-    }
-
-    // Page has not been committed
-    pub(crate) fn uncommitted(&self, page: PageNumber) -> bool {
-        self.allocated_since_commit.lock().unwrap().contains(&page)
-    }
-
     pub(crate) fn unpersisted(&self, page: PageNumber) -> bool {
         self.unpersisted.lock().unwrap().contains(&page)
     }
@@ -1051,7 +1040,6 @@ impl TransactionalMemory {
         &self,
         allocation_size: usize,
         lowest: bool,
-        transactional: bool,
     ) -> Result<PageMut<'txn>> {
         let required_pages = allocation_size.div_ceil(self.get_page_size());
         let required_order = ceil_log2(required_pages);
@@ -1079,13 +1067,6 @@ impl TransactionalMemory {
                 "Allocated a page that is still referenced! {page_number:?}"
             );
             assert!(!self.open_dirty_pages.lock().unwrap().contains(&page_number));
-        }
-
-        if transactional {
-            self.allocated_since_commit
-                .lock()
-                .unwrap()
-                .insert(page_number);
         }
 
         let address_range = page_number.address_range(
@@ -1228,7 +1209,7 @@ impl TransactionalMemory {
         allocation_size: usize,
         allocated: &mut PageTrackerPolicy,
     ) -> Result<PageMut<'txn>> {
-        let result = self.allocate_helper(allocation_size, false, true);
+        let result = self.allocate_helper(allocation_size, false);
         if let Ok(ref page) = result {
             allocated.insert(page.get_page_number());
         }
@@ -1240,7 +1221,7 @@ impl TransactionalMemory {
         allocation_size: usize,
         allocated: &mut PageTrackerPolicy,
     ) -> Result<PageMut<'txn>> {
-        let result = self.allocate_helper(allocation_size, true, true);
+        let result = self.allocate_helper(allocation_size, true);
         if let Ok(ref page) = result {
             allocated.insert(page.get_page_number());
         }

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -6,9 +6,9 @@ use crate::tree_store::multimap_btree::{
     finalize_tree_and_subtree_checksums, verify_tree_and_subtree_checksums,
 };
 use crate::tree_store::{
-    AllocationPolicy, Btree, BtreeMut, BtreeRangeIter, InternalTableDefinition, PageAllocator,
-    PageHint, PageNumber, PageNumberHashSet, PageTrackerPolicy, RawBtree, TableType,
-    TransactionalMemory, multimap_btree_stats,
+    Btree, BtreeMut, BtreeRangeIter, InternalTableDefinition, PageAllocator, PageHint, PageNumber,
+    PageNumberHashSet, PageTrackerPolicy, RawBtree, TableType, TransactionalMemory,
+    multimap_btree_stats,
 };
 use crate::types::{Key, Value};
 use crate::{DatabaseStats, Result};
@@ -245,11 +245,6 @@ impl TableTreeMut<'_> {
         }
     }
 
-    pub(crate) fn set_allocation_policy(&mut self, policy: AllocationPolicy) {
-        self.page_allocator = PageAllocator::new(self.page_allocator.mem().clone(), policy);
-        self.tree.set_allocation_policy(policy);
-    }
-
     pub(crate) fn page_allocator(&self) -> &PageAllocator {
         &self.page_allocator
     }
@@ -365,7 +360,7 @@ impl TableTreeMut<'_> {
                 } => {
                     let mut tree = UntypedBtreeMut::new(
                         new_root,
-                        self.page_allocator.mem().clone(),
+                        self.page_allocator.clone(),
                         self.freed_pages.clone(),
                         fixed_key_size,
                         fixed_value_size,
@@ -384,7 +379,7 @@ impl TableTreeMut<'_> {
                         new_root,
                         fixed_key_size,
                         fixed_value_size,
-                        self.page_allocator.mem().clone(),
+                        self.page_allocator.clone(),
                     )?;
                     *table_length = new_length;
                 }
@@ -685,7 +680,7 @@ impl TableTreeMut<'_> {
             }
 
             if let Some(new_root) = definition.relocate_tree(
-                self.page_allocator.mem().clone(),
+                self.page_allocator.clone(),
                 self.freed_pages.clone(),
                 relocation_map,
             )? {

--- a/src/tree_store/table_tree_base.rs
+++ b/src/tree_store/table_tree_base.rs
@@ -1,6 +1,6 @@
 use crate::tree_store::btree::{PagePath, UntypedBtree, UntypedBtreeMut};
 use crate::tree_store::multimap_btree::{UntypedMultiBtree, relocate_subtrees};
-use crate::tree_store::{BtreeHeader, PageHint, PageNumber, TransactionalMemory};
+use crate::tree_store::{BtreeHeader, PageAllocator, PageHint, PageNumber, TransactionalMemory};
 use crate::{Key, Result, TableError, TypeName, Value};
 use std::collections::HashMap;
 use std::mem::size_of;
@@ -222,7 +222,7 @@ impl InternalTableDefinition {
 
     pub(crate) fn relocate_tree(
         &mut self,
-        mem: Arc<TransactionalMemory>,
+        page_allocator: PageAllocator,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
         relocation_map: &HashMap<PageNumber, PageNumber>,
     ) -> Result<Option<BtreeHeader>> {
@@ -240,7 +240,7 @@ impl InternalTableDefinition {
                         (header.root, header.checksum),
                         *fixed_key_size,
                         *fixed_value_size,
-                        mem.clone(),
+                        page_allocator.clone(),
                         freed_pages.clone(),
                         relocation_map,
                     )?;
@@ -252,7 +252,7 @@ impl InternalTableDefinition {
         };
         let mut tree = UntypedBtreeMut::new(
             relocated_root,
-            mem,
+            page_allocator,
             freed_pages,
             self.private_get_fixed_key_size(),
             self.private_get_fixed_value_size(),


### PR DESCRIPTION
## Summary
This refactoring moves the responsibility for tracking pages allocated since the last commit from `TransactionalMemory` to `PageAllocator`. This improves the separation of concerns by having the allocator track its own allocations, making the code more modular and easier to reason about.

## Key Changes

- **Moved `allocated_since_commit` tracking**: Relocated from `TransactionalMemory` to `PageAllocator` as an `Arc<Mutex<PageTrackerPolicy>>`, allowing each allocator instance to independently track its allocations.

- **New `PageAllocator` methods**:
  - `take_allocated_since_commit()`: Drains and returns the set of allocated pages since last commit
  - `rollback_all()`: Reverses all allocations made since last commit by freeing each page
  - Updated `allocate()`, `allocate_lowest()`, `free()`, `free_if_uncommitted()`, and `uncommitted()` to maintain the per-allocator tracking

- **Removed from `TransactionalMemory`**:
  - `allocated_since_commit` field and related cleanup logic
  - `rollback_uncommitted_writes()` method (replaced by `PageAllocator::rollback_all()`)
  - `free_if_uncommitted()` and `uncommitted()` methods (moved to `PageAllocator`)
  - Removed `transactional` parameter from `allocate_helper()`

- **Updated `WriteTransaction`**:
  - Added `allocation_policy` parameter to `new()` to set the policy at transaction creation time
  - Replaced `set_allocation_policy()` with `page_allocator()` getter method
  - Updated abort/commit paths to use `PageAllocator::rollback_all()` and `take_allocated_since_commit()`
  - Updated all page freeing operations to use the transaction's `PageAllocator`

- **Updated `Database`**:
  - Added `begin_write_with_allocation_policy()` to allow specifying allocation policy at transaction start
  - Refactored `ensure_allocator_state_table_and_trim()` to use the new method

- **Updated `PageTrackerPolicy`**:
  - Added `remove_if_present()` method to conditionally remove a page
  - Added `contains()` method to check page membership

- **Updated btree and table tree code**: Changed to use `PageAllocator` instead of `TransactionalMemory` for allocation-related operations, improving type safety and clarity.

## Implementation Details

The allocation policy is now fixed for the lifetime of a transaction and is passed at transaction creation time, rather than being changeable mid-transaction. This simplifies the design and makes the allocator's behavior more predictable. The per-allocator tracking ensures that all clones of a `PageAllocator` share the same allocated-since-commit set, maintaining consistency across the transaction.

https://claude.ai/code/session_01AaiTS5KbxR9LeXRRtr8pBc