### PR TITLE
Drop unused phantom lifetime parameter from `BtreeMut`

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -394,7 +394,7 @@ pub struct MultimapTable<'txn, K: Key + 'static, V: Key + 'static> {
     transaction: &'txn WriteTransaction,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
     allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
-    tree: BtreeMut<'txn, K, &'static DynamicCollection<V>>,
+    tree: BtreeMut<K, &'static DynamicCollection<V>>,
     page_allocator: PageAllocator,
     _value_type: PhantomData<V>,
 }
@@ -528,7 +528,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                         drop(guard);
 
                         // Don't bother computing the checksum, since we're about to modify the tree
-                        let mut subtree: BtreeMut<'_, V, ()> = BtreeMut::new(
+                        let mut subtree: BtreeMut<V, ()> = BtreeMut::new(
                             Some(BtreeHeader::new(page_number, 0, num_pairs as u64)),
                             self.transaction.transaction_guard(),
                             self.page_allocator.clone(),
@@ -546,7 +546,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                     found
                 }
                 SubtreeV2 => {
-                    let mut subtree: BtreeMut<'_, V, ()> = BtreeMut::new(
+                    let mut subtree: BtreeMut<V, ()> = BtreeMut::new(
                         Some(guard.value().as_subtree()),
                         self.transaction.transaction_guard(),
                         self.page_allocator.clone(),
@@ -586,7 +586,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                 self.tree
                     .insert(key.borrow(), &DynamicCollection::new(&inline_data))?;
             } else {
-                let mut subtree: BtreeMut<'_, V, ()> = BtreeMut::new(
+                let mut subtree: BtreeMut<V, ()> = BtreeMut::new(
                     None,
                     self.transaction.transaction_guard(),
                     self.page_allocator.clone(),

--- a/src/table.rs
+++ b/src/table.rs
@@ -62,7 +62,7 @@ impl TableStats {
 pub struct Table<'txn, K: Key + 'static, V: Value + 'static> {
     name: String,
     transaction: &'txn WriteTransaction,
-    tree: BtreeMut<'txn, K, V>,
+    tree: BtreeMut<K, V>,
 }
 
 impl<K: Key + 'static, V: Value + 'static> TableHandle for Table<'_, K, V> {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -53,8 +53,8 @@ pub(crate) const SYSTEM_FREED_TABLE: SystemTableDefinition<TransactionIdWithPagi
 // raw btree operations rather than open_system_table(), so there's no SystemTableDefinition
 pub(crate) const ALLOCATOR_STATE_TABLE_NAME: &str = "allocator_state";
 pub(crate) type AllocatorStateTree = Btree<AllocatorStateKey, &'static [u8]>;
-pub(crate) type AllocatorStateTreeMut<'a> = BtreeMut<'a, AllocatorStateKey, &'static [u8]>;
-pub(crate) type SystemFreedTree<'a> = BtreeMut<'a, TransactionIdWithPagination, PageList<'static>>;
+pub(crate) type AllocatorStateTreeMut = BtreeMut<AllocatorStateKey, &'static [u8]>;
+pub(crate) type SystemFreedTree = BtreeMut<TransactionIdWithPagination, PageList<'static>>;
 
 // Format:
 // 2 bytes: length
@@ -377,22 +377,22 @@ enum InternalDurability {
 }
 
 // Like a Table but only one may be open at a time to avoid possible races
-pub struct SystemTable<'db, 's, K: Key + 'static, V: Value + 'static> {
+pub struct SystemTable<'s, K: Key + 'static, V: Value + 'static> {
     name: String,
-    namespace: &'s mut SystemNamespace<'db>,
-    tree: BtreeMut<'s, K, V>,
+    namespace: &'s mut SystemNamespace,
+    tree: BtreeMut<K, V>,
     transaction_guard: Arc<TransactionGuard>,
 }
 
-impl<'db, 's, K: Key + 'static, V: Value + 'static> SystemTable<'db, 's, K, V> {
+impl<'s, K: Key + 'static, V: Value + 'static> SystemTable<'s, K, V> {
     fn new(
         name: &str,
         table_root: Option<BtreeHeader>,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
         guard: Arc<TransactionGuard>,
         page_allocator: PageAllocator,
-        namespace: &'s mut SystemNamespace<'db>,
-    ) -> SystemTable<'db, 's, K, V> {
+        namespace: &'s mut SystemNamespace,
+    ) -> SystemTable<'s, K, V> {
         // No need to track allocations in the system tree. Savepoint restoration only relies on
         // freeing in the data tree
         let ignore = Arc::new(Mutex::new(PageTrackerPolicy::Ignore));
@@ -470,7 +470,7 @@ impl<'db, 's, K: Key + 'static, V: Value + 'static> SystemTable<'db, 's, K, V> {
     }
 }
 
-impl<K: Key + 'static, V: MutInPlaceValue + 'static> SystemTable<'_, '_, K, V> {
+impl<K: Key + 'static, V: MutInPlaceValue + 'static> SystemTable<'_, K, V> {
     pub fn insert_reserve<'a>(
         &mut self,
         key: impl Borrow<K::SelfType<'a>>,
@@ -490,7 +490,7 @@ impl<K: Key + 'static, V: MutInPlaceValue + 'static> SystemTable<'_, '_, K, V> {
     }
 }
 
-impl<K: Key + 'static, V: Value + 'static> Drop for SystemTable<'_, '_, K, V> {
+impl<K: Key + 'static, V: Value + 'static> Drop for SystemTable<'_, K, V> {
     fn drop(&mut self) {
         self.namespace.close_table(
             &self.name,
@@ -500,13 +500,13 @@ impl<K: Key + 'static, V: Value + 'static> Drop for SystemTable<'_, '_, K, V> {
     }
 }
 
-struct SystemNamespace<'db> {
-    table_tree: TableTreeMut<'db>,
+struct SystemNamespace {
+    table_tree: TableTreeMut,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
     transaction_guard: Arc<TransactionGuard>,
 }
 
-impl<'db> SystemNamespace<'db> {
+impl SystemNamespace {
     fn new(
         root_page: Option<BtreeHeader>,
         guard: Arc<TransactionGuard>,
@@ -533,11 +533,11 @@ impl<'db> SystemNamespace<'db> {
         self.freed_pages.clone()
     }
 
-    fn open_system_table<'txn, 's, K: Key + 'static, V: Value + 'static>(
+    fn open_system_table<'s, K: Key + 'static, V: Value + 'static>(
         &'s mut self,
-        transaction: &'txn WriteTransaction,
+        transaction: &WriteTransaction,
         definition: SystemTableDefinition<K, V>,
-    ) -> Result<SystemTable<'db, 's, K, V>> {
+    ) -> Result<SystemTable<'s, K, V>> {
         let (root, _) = self
             .table_tree
             .get_or_create_table::<K, V>(definition.name(), TableType::Normal)
@@ -568,14 +568,14 @@ impl<'db> SystemNamespace<'db> {
     }
 }
 
-struct TableNamespace<'db> {
+struct TableNamespace {
     open_tables: HashMap<String, &'static panic::Location<'static>>,
     allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-    table_tree: TableTreeMut<'db>,
+    table_tree: TableTreeMut,
 }
 
-impl TableNamespace<'_> {
+impl TableNamespace {
     fn new(
         root_page: Option<BtreeHeader>,
         guard: Arc<TransactionGuard>,
@@ -831,8 +831,8 @@ pub struct WriteTransaction {
     mem: Arc<TransactionalMemory>,
     transaction_guard: Arc<TransactionGuard>,
     transaction_id: TransactionId,
-    tables: Mutex<TableNamespace<'static>>,
-    system_tables: Mutex<SystemNamespace<'static>>,
+    tables: Mutex<TableNamespace>,
+    system_tables: Mutex<SystemNamespace>,
     completed: bool,
     dirty: AtomicBool,
     durability: InternalDurability,
@@ -1632,7 +1632,7 @@ impl WriteTransaction {
     }
 
     fn write_allocated_pages_entry(
-        allocated_table: &mut SystemTable<'_, '_, TransactionIdWithPagination, PageList<'static>>,
+        allocated_table: &mut SystemTable<'_, TransactionIdWithPagination, PageList<'static>>,
         transaction_id: TransactionId,
         mut pages: Vec<PageNumber>,
     ) -> Result {

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -324,7 +324,7 @@ impl UntypedBtreeMut {
     }
 }
 
-pub(crate) struct BtreeMut<'a, K: Key + 'static, V: Value + 'static> {
+pub(crate) struct BtreeMut<K: Key + 'static, V: Value + 'static> {
     page_allocator: PageAllocator,
     transaction_guard: Arc<TransactionGuard>,
     root: Option<BtreeHeader>,
@@ -332,10 +332,9 @@ pub(crate) struct BtreeMut<'a, K: Key + 'static, V: Value + 'static> {
     allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
     _key_type: PhantomData<K>,
     _value_type: PhantomData<V>,
-    _lifetime: PhantomData<&'a ()>,
 }
 
-impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
+impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
     pub(crate) fn new(
         root: Option<BtreeHeader>,
         guard: Arc<TransactionGuard>,
@@ -351,7 +350,6 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
             allocated_pages,
             _key_type: PhantomData,
             _value_type: PhantomData,
-            _lifetime: PhantomData,
         }
     }
 
@@ -734,7 +732,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
     }
 }
 
-impl<'a, K: Key + 'a, V: MutInPlaceValue + 'a> BtreeMut<'a, K, V> {
+impl<K: Key + 'static, V: MutInPlaceValue + 'static> BtreeMut<K, V> {
     /// Reserve space to insert a key-value pair
     /// The returned reference will have length equal to `value_length`
     // Return type has the same lifetime as &self, because the tree must not be modified until the mutable guard is dropped

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -210,8 +210,8 @@ impl TableTree {
     }
 }
 
-pub(crate) struct TableTreeMut<'txn> {
-    tree: BtreeMut<'txn, &'static str, InternalTableDefinition>,
+pub(crate) struct TableTreeMut {
+    tree: BtreeMut<&'static str, InternalTableDefinition>,
     guard: Arc<TransactionGuard>,
     page_allocator: PageAllocator,
     // Cached updates from tables that have been closed. These must be flushed to the btree.
@@ -221,7 +221,7 @@ pub(crate) struct TableTreeMut<'txn> {
     allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
 }
 
-impl TableTreeMut<'_> {
+impl TableTreeMut {
     pub(crate) fn new(
         master_root: Option<BtreeHeader>,
         guard: Arc<TransactionGuard>,
@@ -771,7 +771,7 @@ impl TableTreeMut<'_> {
     }
 }
 
-impl Drop for TableTreeMut<'_> {
+impl Drop for TableTreeMut {
     fn drop(&mut self) {
         if thread::panicking() {
             return;


### PR DESCRIPTION
`BtreeMut<'a, K, V>` carried `_lifetime: PhantomData<&'a ()>` but did not use the lifetime for anything: every field is owned (`PageAllocator`, `Arc<TransactionGuard>`, `Option<BtreeHeader>`, `Arc<Mutex<Vec<PageNumber>>>`, `Arc<Mutex<PageTrackerPolicy>>`), and the transaction-tied lifetime is already enforced by the holding struct's `&'txn WriteTransaction` (e.g. `Table`, `MultimapTable`, `SystemTable`). The phantom parameter was never preventing a misuse that the holding struct didn't already prevent.

Removing it cascades into removing equally-vestigial lifetime parameters from `TableTreeMut`, `SystemNamespace`, `TableNamespace`, and `SystemTable` (its `'db` parameter was already unused). No observable behavior change; all existing tests pass.

This is a prerequisite for follow-on work that wants to hold a `&mut BtreeMut<K, V>` with a single lifetime (mutable references are invariant in their type parameter, so the phantom lifetime previously forced two-lifetime APIs).

Assisted-by: Claude <noreply@anthropic.com>