### PR TITLE
Expand Entry API with additional methods and accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 * Add `Table::entry()` and the associated `Entry`, `OccupiedEntry`, and `VacantEntry`
-  types, mirroring `std::collections::BTreeMap::entry`. Currently supports `or_insert`;
-  additional methods will follow.
+  types, mirroring `std::collections::BTreeMap::entry`. Supports `or_insert`,
+  `or_insert_with`, `or_insert_with_key`, `and_modify`, and the usual `OccupiedEntry`
+  / `VacantEntry` accessors.
 * Optimize `Table::pop_first()` and `Table::pop_last()` to be about 2x faster.
 * Enable file space reclamation during non-durable transactions performed while a savepoint exists.
 * Fix a bug where calling `compact()` on a database could cause the file to grow

--- a/src/table.rs
+++ b/src/table.rs
@@ -701,6 +701,59 @@ impl<'a, K: Key + 'static, V: Value + 'static> Entry<'a, K, V> {
             Entry::Vacant(entry) => entry.insert(default),
         }
     }
+
+    /// Ensures a value is in the entry by inserting the result of `default` if empty,
+    /// and returns a mutable accessor to the value in the entry.
+    ///
+    /// Unlike [`or_insert`](Self::or_insert), the default value is only computed if the
+    /// entry is vacant.
+    pub fn or_insert_with<'v, F, B>(self, default: F) -> Result<AccessGuardMut<'a, V>>
+    where
+        F: FnOnce() -> B,
+        B: Borrow<V::SelfType<'v>>,
+    {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(default()),
+        }
+    }
+
+    /// Ensures a value is in the entry by inserting, if empty, the result of the `default`
+    /// function, which is given a view of the key.
+    pub fn or_insert_with_key<'v, F, B>(self, default: F) -> Result<AccessGuardMut<'a, V>>
+    where
+        F: FnOnce(&K::SelfType<'a>) -> B,
+        B: Borrow<V::SelfType<'v>>,
+    {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let value = default(&entry.key);
+                entry.insert(value)
+            }
+        }
+    }
+
+    /// Provides in-place mutable access to an occupied entry before any potential inserts
+    /// into the table.
+    ///
+    /// The closure receives an [`AccessGuardMut`] and may replace the stored value via
+    /// [`AccessGuardMut::insert`]. Any errors returned by the closure are propagated.
+    pub fn and_modify<F>(self, f: F) -> Result<Self>
+    where
+        F: FnOnce(&mut AccessGuardMut<'_, V>) -> Result<()>,
+    {
+        match self {
+            Entry::Occupied(mut entry) => {
+                {
+                    let mut guard = entry.get_mut()?;
+                    f(&mut guard)?;
+                }
+                Ok(Entry::Occupied(entry))
+            }
+            Entry::Vacant(entry) => Ok(Entry::Vacant(entry)),
+        }
+    }
 }
 
 /// A view into an occupied entry in a [`Table`]. It is part of the [`Entry`] enum.
@@ -715,6 +768,24 @@ impl<'a, K: Key + 'static, V: Value + 'static> OccupiedEntry<'a, K, V> {
         &self.key
     }
 
+    /// Returns a view of this entry's value.
+    pub fn get(&self) -> Result<AccessGuard<'_, V>> {
+        self.tree.get(&self.key)?.ok_or_else(|| {
+            StorageError::Corrupted(
+                "entry for key disappeared while OccupiedEntry was live".to_string(),
+            )
+        })
+    }
+
+    /// Returns a mutable accessor to the value in the entry.
+    pub fn get_mut(&mut self) -> Result<AccessGuardMut<'_, V>> {
+        self.tree.get_mut(&self.key)?.ok_or_else(|| {
+            StorageError::Corrupted(
+                "entry for key disappeared while OccupiedEntry was live".to_string(),
+            )
+        })
+    }
+
     /// Converts the entry into a mutable accessor to the value in the entry with a lifetime
     /// bound to the table itself.
     pub fn into_mut(self) -> Result<AccessGuardMut<'a, V>> {
@@ -723,6 +794,46 @@ impl<'a, K: Key + 'static, V: Value + 'static> OccupiedEntry<'a, K, V> {
                 "entry for key disappeared while OccupiedEntry was live".to_string(),
             )
         })
+    }
+
+    /// Replaces the value of the entry with the supplied value, and returns the old value.
+    pub fn insert<'v>(
+        &mut self,
+        value: impl Borrow<V::SelfType<'v>>,
+    ) -> Result<AccessGuard<'_, V>> {
+        let value_len = V::as_bytes(value.borrow()).as_ref().len();
+        if value_len > MAX_VALUE_LENGTH {
+            return Err(StorageError::ValueTooLarge(value_len));
+        }
+        let key_len = K::as_bytes(&self.key).as_ref().len();
+        if value_len + key_len > MAX_PAIR_LENGTH {
+            return Err(StorageError::ValueTooLarge(value_len + key_len));
+        }
+        self.tree.insert(&self.key, value.borrow())?.ok_or_else(|| {
+            StorageError::Corrupted(
+                "entry for key disappeared while OccupiedEntry was live".to_string(),
+            )
+        })
+    }
+
+    /// Takes the value out of the entry, and returns it.
+    pub fn remove(self) -> Result<AccessGuard<'a, V>> {
+        self.tree.remove(&self.key)?.ok_or_else(|| {
+            StorageError::Corrupted(
+                "entry for key disappeared while OccupiedEntry was live".to_string(),
+            )
+        })
+    }
+
+    /// Takes the entry out of the table, returning the key and the value.
+    pub fn remove_entry(self) -> Result<(K::SelfType<'a>, AccessGuard<'a, V>)> {
+        let OccupiedEntry { tree, key } = self;
+        let value = tree.remove(&key)?.ok_or_else(|| {
+            StorageError::Corrupted(
+                "entry for key disappeared while OccupiedEntry was live".to_string(),
+            )
+        })?;
+        Ok((key, value))
     }
 }
 
@@ -736,6 +847,11 @@ impl<'a, K: Key + 'static, V: Value + 'static> VacantEntry<'a, K, V> {
     /// Returns a view of this entry's key.
     pub fn key(&self) -> &K::SelfType<'a> {
         &self.key
+    }
+
+    /// Consumes the entry and returns the key that was used to construct it.
+    pub fn into_key(self) -> K::SelfType<'a> {
+        self.key
     }
 
     /// Inserts `value` with the entry's key and returns a mutable accessor to it.

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1120,6 +1120,188 @@ fn entry_borrowed_key_in_loop() {
 }
 
 #[test]
+fn entry_or_insert_with() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    // or_insert_with is lazy: closure runs only for vacant entries.
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        table.entry(1).unwrap().or_insert_with(|| 42).unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.get(1).unwrap().unwrap().value(), 42);
+    drop(read_txn);
+
+    // or_insert_with_key exposes the key to the default function.
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        let value = table
+            .entry(3)
+            .unwrap()
+            .or_insert_with_key(|k| k * 2)
+            .unwrap();
+        assert_eq!(value.value(), 6);
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.get(3).unwrap().unwrap().value(), 6);
+}
+
+#[test]
+fn entry_and_modify() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        table.insert(1, 10).unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    // and_modify updates an occupied entry; or_insert after it is a no-op.
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        table
+            .entry(1)
+            .unwrap()
+            .and_modify(|guard| guard.insert(guard.value() + 5))
+            .unwrap()
+            .or_insert(0)
+            .unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.get(1).unwrap().unwrap().value(), 15);
+    drop(read_txn);
+
+    // and_modify is a no-op on vacant entries; or_insert then provides the default.
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        let value = table
+            .entry(2)
+            .unwrap()
+            .and_modify(|guard| guard.insert(0))
+            .unwrap()
+            .or_insert(7)
+            .unwrap();
+        assert_eq!(value.value(), 7);
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.get(2).unwrap().unwrap().value(), 7);
+}
+
+#[test]
+fn entry_occupied_methods() {
+    use redb::Entry;
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        table.insert(1, 10).unwrap();
+        table.insert(2, 20).unwrap();
+        table.insert(3, 30).unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    // OccupiedEntry::get / get_mut / insert.
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        let entry = table.entry(1).unwrap();
+        match entry {
+            Entry::Occupied(mut occupied) => {
+                assert_eq!(*occupied.key(), 1);
+                assert_eq!(occupied.get().unwrap().value(), 10);
+                let mut guard = occupied.get_mut().unwrap();
+                assert_eq!(guard.value(), 10);
+                guard.insert(&11).unwrap();
+                drop(guard);
+                let old = occupied.insert(&100).unwrap();
+                assert_eq!(old.value(), 11);
+            }
+            Entry::Vacant(_) => panic!("expected Occupied"),
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.get(1).unwrap().unwrap().value(), 100);
+    drop(read_txn);
+
+    // OccupiedEntry::remove.
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        match table.entry(2).unwrap() {
+            Entry::Occupied(occupied) => {
+                let removed = occupied.remove().unwrap();
+                assert_eq!(removed.value(), 20);
+            }
+            Entry::Vacant(_) => panic!("expected Occupied"),
+        }
+    }
+    write_txn.commit().unwrap();
+
+    // OccupiedEntry::remove_entry returns key and value.
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        match table.entry(3).unwrap() {
+            Entry::Occupied(occupied) => {
+                let (key, value) = occupied.remove_entry().unwrap();
+                assert_eq!(key, 3);
+                assert_eq!(value.value(), 30);
+            }
+            Entry::Vacant(_) => panic!("expected Occupied"),
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    assert!(table.get(2).unwrap().is_none());
+    assert!(table.get(3).unwrap().is_none());
+}
+
+#[test]
+fn entry_vacant_into_key() {
+    use redb::Entry;
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        match table.entry(42).unwrap() {
+            Entry::Vacant(vacant) => {
+                let key = vacant.into_key();
+                assert_eq!(key, 42);
+            }
+            Entry::Occupied(_) => panic!("expected Vacant"),
+        }
+    }
+    write_txn.commit().unwrap();
+}
+
+#[test]
 fn delete() {
     let tmpfile = create_tempfile();
     let db = Database::create(tmpfile.path()).unwrap();


### PR DESCRIPTION
## Summary
This PR expands the `Entry` API to provide more comprehensive functionality, mirroring the standard library's `BTreeMap::entry()` interface. Several new methods have been added to `Entry`, `OccupiedEntry`, and `VacantEntry` types to support common entry manipulation patterns.

## Key Changes

- **Entry methods:**
  - `or_insert_with()`: Lazily computes and inserts a default value only for vacant entries
  - `or_insert_with_key()`: Similar to `or_insert_with()` but passes the key to the closure
  - `and_modify()`: Allows in-place modification of occupied entries before potential inserts

- **OccupiedEntry methods:**
  - `get()`: Returns a read-only view of the entry's value
  - `get_mut()`: Returns a mutable accessor to the entry's value
  - `insert()`: Replaces the value and returns the old value
  - `remove()`: Removes and returns the value
  - `remove_entry()`: Removes and returns both key and value

- **VacantEntry methods:**
  - `into_key()`: Consumes the entry and returns the key

## Implementation Details

- The `or_insert_with()` and `or_insert_with_key()` methods follow the lazy evaluation pattern where the closure is only executed for vacant entries, improving performance when entries are already occupied
- The `and_modify()` method returns a `Result<Self>` to allow chaining with `or_insert()` operations
- All new methods maintain consistency with the existing error handling patterns using `Result` types
- Comprehensive test coverage has been added covering all new functionality

## Testing
Four new test functions have been added:
- `entry_or_insert_with()`: Tests lazy evaluation of default values
- `entry_and_modify()`: Tests modification of occupied and vacant entries
- `entry_occupied_methods()`: Tests all `OccupiedEntry` accessors and mutations
- `entry_vacant_into_key()`: Tests `VacantEntry::into_key()`

Fixes: https://github.com/cberner/redb/issues/942

https://claude.ai/code/session_01BLKtvsJfYtJ4RQRgeQDacu