### PR TITLE
redb-python: add Database.create() binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Enable file space reclamation during non-durable transactions performed while a savepoint exists.
 * Fix a bug where calling `compact()` on a database could cause the file to grow
   rather than shrink in some cases.
+* Python bindings: add `redb.Database.create(path)` for creating or opening a database file.
 
 ## 4.1.0 - 2026-04-19
 **This release contains a large number of bug fixes discovered by AI coding agents**

--- a/crates/redb-python/src/database.rs
+++ b/crates/redb-python/src/database.rs
@@ -1,0 +1,26 @@
+use crate::error::map_database_error;
+use pyo3::prelude::*;
+use std::path::PathBuf;
+
+#[pyclass(module = "redb", name = "Database", frozen)]
+pub(crate) struct PyDatabase {
+    _inner: ::redb::Database,
+}
+
+#[pymethods]
+impl PyDatabase {
+    /// Create or open a redb database at the given filesystem path.
+    ///
+    /// If the file does not exist (or is empty) a new database is initialized.
+    /// If the file is an existing redb database it is opened.
+    #[classmethod]
+    fn create(_cls: &Bound<'_, pyo3::types::PyType>, path: PathBuf) -> PyResult<Self> {
+        let db = ::redb::Database::create(&path).map_err(map_database_error)?;
+        Ok(Self { _inner: db })
+    }
+}
+
+pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyDatabase>()?;
+    Ok(())
+}

--- a/crates/redb-python/src/error.rs
+++ b/crates/redb-python/src/error.rs
@@ -1,0 +1,70 @@
+use pyo3::create_exception;
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+
+create_exception!(redb, Error, PyException);
+create_exception!(redb, DatabaseError, Error);
+create_exception!(redb, StorageError, Error);
+
+create_exception!(redb, DatabaseAlreadyOpen, DatabaseError);
+create_exception!(redb, RepairAborted, DatabaseError);
+create_exception!(redb, UpgradeRequired, DatabaseError);
+create_exception!(redb, TransactionInProgress, DatabaseError);
+
+create_exception!(redb, Corrupted, StorageError);
+create_exception!(redb, ValueTooLarge, StorageError);
+create_exception!(redb, Io, StorageError);
+create_exception!(redb, PreviousIo, StorageError);
+create_exception!(redb, DatabaseClosed, StorageError);
+create_exception!(redb, LockPoisoned, StorageError);
+
+pub(crate) fn map_database_error(err: ::redb::DatabaseError) -> PyErr {
+    let msg = format!("{err}");
+    match err {
+        ::redb::DatabaseError::DatabaseAlreadyOpen => DatabaseAlreadyOpen::new_err(msg),
+        ::redb::DatabaseError::RepairAborted => RepairAborted::new_err(msg),
+        ::redb::DatabaseError::UpgradeRequired(_) => UpgradeRequired::new_err(msg),
+        ::redb::DatabaseError::TransactionInProgress => TransactionInProgress::new_err(msg),
+        ::redb::DatabaseError::Storage(storage) => map_storage_error(storage),
+        // redb::DatabaseError is #[non_exhaustive], so the wildcard is required.
+        // Fall back to the abstract parent class for unknown future variants.
+        _ => DatabaseError::new_err(msg),
+    }
+}
+
+pub(crate) fn map_storage_error(err: ::redb::StorageError) -> PyErr {
+    let msg = format!("{err}");
+    match err {
+        ::redb::StorageError::Corrupted(_) => Corrupted::new_err(msg),
+        ::redb::StorageError::ValueTooLarge(_) => ValueTooLarge::new_err(msg),
+        ::redb::StorageError::Io(_) => Io::new_err(msg),
+        ::redb::StorageError::PreviousIo => PreviousIo::new_err(msg),
+        ::redb::StorageError::DatabaseClosed => DatabaseClosed::new_err(msg),
+        ::redb::StorageError::LockPoisoned(_) => LockPoisoned::new_err(msg),
+        // redb::StorageError is #[non_exhaustive]; see comment above.
+        _ => StorageError::new_err(msg),
+    }
+}
+
+pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("Error", m.py().get_type::<Error>())?;
+    m.add("DatabaseError", m.py().get_type::<DatabaseError>())?;
+    m.add("StorageError", m.py().get_type::<StorageError>())?;
+    m.add(
+        "DatabaseAlreadyOpen",
+        m.py().get_type::<DatabaseAlreadyOpen>(),
+    )?;
+    m.add("RepairAborted", m.py().get_type::<RepairAborted>())?;
+    m.add("UpgradeRequired", m.py().get_type::<UpgradeRequired>())?;
+    m.add(
+        "TransactionInProgress",
+        m.py().get_type::<TransactionInProgress>(),
+    )?;
+    m.add("Corrupted", m.py().get_type::<Corrupted>())?;
+    m.add("ValueTooLarge", m.py().get_type::<ValueTooLarge>())?;
+    m.add("Io", m.py().get_type::<Io>())?;
+    m.add("PreviousIo", m.py().get_type::<PreviousIo>())?;
+    m.add("DatabaseClosed", m.py().get_type::<DatabaseClosed>())?;
+    m.add("LockPoisoned", m.py().get_type::<LockPoisoned>())?;
+    Ok(())
+}

--- a/crates/redb-python/src/lib.rs
+++ b/crates/redb-python/src/lib.rs
@@ -14,5 +14,14 @@
     clippy::unreadable_literal
 )]
 
-mod python;
-pub use crate::python::redb;
+mod database;
+mod error;
+
+use pyo3::prelude::*;
+
+#[pymodule]
+pub fn redb(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    database::register(m)?;
+    error::register(m)?;
+    Ok(())
+}

--- a/crates/redb-python/src/python.rs
+++ b/crates/redb-python/src/python.rs
@@ -1,6 +1,0 @@
-use pyo3::prelude::*;
-
-#[pymodule]
-pub fn redb(_m: &Bound<'_, PyModule>) -> PyResult<()> {
-    Ok(())
-}

--- a/crates/redb-python/test/test_database_create.py
+++ b/crates/redb-python/test/test_database_create.py
@@ -1,0 +1,66 @@
+"""Tests for redb.Database.create()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+import redb
+
+
+def test_create_new_database_creates_file(tmp_db_path: Path) -> None:
+    redb.Database.create(str(tmp_db_path))
+    assert tmp_db_path.is_file()
+    assert tmp_db_path.stat().st_size > 0
+
+
+def test_create_on_non_database_file_raises_error(tmp_db_path: Path) -> None:
+    tmp_db_path.write_bytes(b"not a redb database, just some bytes")
+    with pytest.raises(redb.Io) as excinfo:
+        redb.Database.create(str(tmp_db_path))
+    # redb.Io < redb.StorageError < redb.Error in the exception hierarchy.
+    assert isinstance(excinfo.value, redb.StorageError)
+    assert isinstance(excinfo.value, redb.Error)
+
+
+# Windows reserves these device basenames (case-insensitive, also when
+# followed by an extension), even though they contain only "safe" chars.
+_WIN_RESERVED = frozenset(
+    ["CON", "PRN", "AUX", "NUL"]
+    + [f"COM{i}" for i in range(1, 10)]
+    + [f"LPT{i}" for i in range(1, 10)]
+)
+
+
+def _is_portable_filename(s: str) -> bool:
+    if s in (".", "..") or s.startswith(".") or s.strip() != s:
+        return False
+    stem = s.split(".", 1)[0]
+    return stem.upper() not in _WIN_RESERVED
+
+
+# Filenames: stick to a portable subset that's valid on Linux, macOS, and
+# Windows. Avoid path separators, NULs, control chars, and the Windows-
+# reserved punctuation (\ : * ? " < > |). Skip dotfiles and Windows device
+# names to keep the on-disk layout boring.
+_filename = st.text(
+    alphabet=st.characters(
+        whitelist_categories=("Lu", "Ll", "Lo", "Nd"),
+        whitelist_characters="-_+= ",
+    ),
+    min_size=1,
+    max_size=32,
+).filter(_is_portable_filename)
+
+
+@given(name=_filename)
+@settings(max_examples=25, deadline=None)
+def test_create_then_reopen_arbitrary_filenames(tmp_path_factory, name: str) -> None:
+    path = tmp_path_factory.mktemp("redb") / name
+    redb.Database.create(str(path))
+    assert path.is_file()
+    # Reopening the same file must succeed.
+    redb.Database.create(str(path))


### PR DESCRIPTION
Exposes redb::Database::create as a Python classmethod so callers can
create (or open) a database file from Python. Adds a pytest sanity test
plus a hypothesis test that fuzzes the filename.

Refs: https://github.com/cberner/redb/issues/19

Assisted-by: Claude <noreply@anthropic.com>