### PR TITLE
Prepare freed-page cleanup helpers

### DIFF
--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -873,13 +873,19 @@ fn exec_table_crash_support<T: Clone + Debug>(
 
     // Clear out the freed table
     let mut allocated_pages = db.begin_write().unwrap().stats().unwrap().allocated_pages();
+    // One cleanup commit can make another batch eligible without changing the allocation count.
+    let mut stable_commits = 0;
     loop {
         db.begin_write().unwrap().commit().unwrap();
         let new_allocated_pages = db.begin_write().unwrap().stats().unwrap().allocated_pages();
         if new_allocated_pages == allocated_pages {
-            break;
+            stable_commits += 1;
+            if stable_commits == 2 {
+                break;
+            }
         } else {
             allocated_pages = new_allocated_pages;
+            stable_commits = 0;
         }
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -614,35 +614,22 @@ impl Database {
     ///
     /// Returns `true` if compaction was performed, and `false` if no futher compaction was possible
     pub fn compact(&mut self) -> Result<bool, CompactionError> {
-        if self
-            .transaction_tracker
-            .oldest_live_read_transaction()
-            .is_some()
-        {
+        if self.transaction_tracker.any_user_read_reference_exists() {
             return Err(CompactionError::TransactionInProgress);
         }
         // Commit to free up any pending free pages
         // Use 2-phase commit to avoid any possible security issues. Plus this compaction is going to be so slow that it doesn't matter.
         // Once https://github.com/cberner/redb/issues/829 is fixed, we should upgrade this to use quick-repair -- that way the user
         // can cancel the compaction without requiring a full repair afterwards
-        let mut txn = self.begin_write().map_err(|e| e.into_storage_error())?;
+        let txn = self.begin_write().map_err(|e| e.into_storage_error())?;
         if txn.list_persistent_savepoints()?.next().is_some() {
             return Err(CompactionError::PersistentSavepointExists);
         }
         if self.transaction_tracker.any_savepoint_exists() {
             return Err(CompactionError::EphemeralSavepointExists);
         }
-        txn.set_two_phase_commit(true);
-        txn.commit().map_err(|e| e.into_storage_error())?;
-        // Repeat to make pages freed by the first empty commit reusable before compaction.
-        let mut txn = self.begin_write().map_err(|e| e.into_storage_error())?;
-        txn.set_two_phase_commit(true);
-        txn.commit().map_err(|e| e.into_storage_error())?;
-        // There can't be any outstanding transactions because we have a `&mut self`, so all pending free pages
-        // should have been cleared out by the above commit()
-        let txn = self.begin_write().map_err(|e| e.into_storage_error())?;
-        assert!(!txn.pending_free_pages()?);
         txn.abort()?;
+        self.drain_pending_free_pages(ShrinkPolicy::Maximum)?;
 
         let mut compacted = false;
         // Iteratively compact until no progress is made
@@ -657,16 +644,7 @@ impl Database {
                 txn.abort()?;
             }
 
-            // Second commit is needed to drain the data freed table: the first commit records
-            // the pages relocated by compact_pages() as pending frees, and this one processes
-            // them so the space becomes reusable and the file can be shrunk.
-            let mut txn = self.begin_write().map_err(|e| e.into_storage_error())?;
-            txn.set_two_phase_commit(true);
-            txn.set_shrink_policy(ShrinkPolicy::Maximum);
-            txn.commit().map_err(|e| e.into_storage_error())?;
-            let txn = self.begin_write().map_err(|e| e.into_storage_error())?;
-            assert!(!txn.pending_free_pages()?);
-            txn.abort()?;
+            self.drain_pending_free_pages(ShrinkPolicy::Maximum)?;
 
             if !progress {
                 break;
@@ -676,6 +654,23 @@ impl Database {
         }
 
         Ok(compacted)
+    }
+
+    fn drain_pending_free_pages(&self, shrink_policy: ShrinkPolicy) -> Result {
+        // Preserve compact()'s empty durable commit, which also publishes pending
+        // non-durable roots before checking for pending frees.
+        let mut force_commit = true;
+        loop {
+            let mut txn = self.begin_write().map_err(|e| e.into_storage_error())?;
+            if !force_commit && !txn.pending_free_pages()? {
+                txn.abort()?;
+                return Ok(());
+            }
+            force_commit = false;
+            txn.set_two_phase_commit(true);
+            txn.set_shrink_policy(shrink_policy);
+            txn.commit().map_err(|e| e.into_storage_error())?;
+        }
     }
 
     #[cfg_attr(not(debug_assertions), expect(dead_code))]

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -230,6 +230,23 @@ impl TransactionTracker {
         !self.state.lock().unwrap().valid_savepoints.is_empty()
     }
 
+    // Excludes internal read refs that only pin durable ancestors of pending
+    // non-durable commits.
+    pub(crate) fn any_user_read_reference_exists(&self) -> bool {
+        let state = self.state.lock().unwrap();
+        for (id, count) in &state.live_read_transactions {
+            let pending_count = state
+                .pending_non_durable_commits
+                .values()
+                .filter(|ancestor| *ancestor == id)
+                .count() as u64;
+            if *count > pending_count {
+                return true;
+            }
+        }
+        false
+    }
+
     pub(crate) fn allocate_savepoint(&self, transaction_id: TransactionId) -> SavepointId {
         let mut state = self.state.lock().unwrap();
         let id = state.next_savepoint_id.next();

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1980,6 +1980,10 @@ impl WriteTransaction {
         free_until: TransactionId,
         mut process_page: impl FnMut(PageNumber),
     ) -> Result {
+        if system_tables.get_system_table_root(definition)?.is_none() {
+            return Ok(());
+        }
+
         let mut freed = system_tables.open_system_table(self, definition)?;
         let key = TransactionIdWithPagination {
             transaction_id: free_until.raw_id(),
@@ -1987,8 +1991,9 @@ impl WriteTransaction {
         };
         for entry in freed.extract_from_if(..key, |_, _| true)? {
             let (_, page_list) = entry?;
-            for i in 0..page_list.value().len() {
-                process_page(page_list.value().get(i));
+            let page_list = page_list.value();
+            for i in 0..page_list.len() {
+                process_page(page_list.get(i));
             }
         }
 
@@ -2102,6 +2107,9 @@ impl WriteTransaction {
         pagination_counter: &mut u64,
     ) -> Result {
         assert_eq!(PageNumber::serialized_size(), 8); // We assume below that PageNumber is length 8
+        if system_freed_pages.lock().unwrap().is_empty() {
+            return Ok(());
+        }
 
         system_tree.open_table_and_flush_table_root(
             SYSTEM_FREED_TABLE.name(),

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -496,7 +496,16 @@ impl TransactionalMemory {
             self.storage.flush()?;
         }
 
-        self.state.lock().unwrap().header = header;
+        {
+            let mut state = self.state.lock().unwrap();
+            state.header = header;
+            state.read_from_secondary = false;
+        }
+        // Reloading from disk discards in-memory roots, so drop volatile allocation state
+        // that belonged only to those roots.
+        self.unpersisted.lock().unwrap().clear();
+        self.unpersisted_allocations.lock().unwrap().clear();
+        self.unpersisted_allocation_txn.lock().unwrap().clear();
 
         Ok(was_clean)
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2038,6 +2038,24 @@ fn compaction() {
     assert!(file_size2 < file_size);
 }
 
+#[test]
+fn compact_after_non_durable_commit() {
+    let tmpfile = create_tempfile();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+    let definition: TableDefinition<u32, &[u8]> = TableDefinition::new("x");
+
+    let mut txn = db.begin_write().unwrap();
+    txn.set_durability(Durability::None).unwrap();
+    {
+        let mut table = txn.open_table(definition).unwrap();
+        table.insert(&0, [0; 1024].as_slice()).unwrap();
+    }
+    txn.commit().unwrap();
+
+    // The pending non-durable root pins its durable ancestor internally.
+    db.compact().unwrap();
+}
+
 // Regression test for https://github.com/cberner/redb/issues/1165: a packed
 // database used to grow rather than shrink after compact().
 #[test]


### PR DESCRIPTION
Factor compact's pending-free drain into a reusable helper, distinguish user read references from internal non-durable root pins, and avoid creating freed-page system tables when there is nothing to process. Also clear volatile allocation state when reloading from disk and make the fuzzer cleanup loop wait for a stable allocation count.

Assisted-by: Codex