### PR TITLE
Add write transaction support to redb Python bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Cargo.lock
 
 **/__pycache__
 **/*.pyc
+.venv/
 
 # Profiling
 perf.data*

--- a/crates/redb-python/src/database.rs
+++ b/crates/redb-python/src/database.rs
@@ -1,10 +1,11 @@
-use crate::error::map_database_error;
+use crate::error::{map_database_error, map_transaction_error};
+use crate::transaction::PyWriteTransaction;
 use pyo3::prelude::*;
 use std::path::PathBuf;
 
 #[pyclass(module = "redb", name = "Database", frozen)]
 pub(crate) struct PyDatabase {
-    _inner: ::redb::Database,
+    inner: ::redb::Database,
 }
 
 #[pymethods]
@@ -16,7 +17,14 @@ impl PyDatabase {
     #[classmethod]
     fn create(_cls: &Bound<'_, pyo3::types::PyType>, path: PathBuf) -> PyResult<Self> {
         let db = ::redb::Database::create(&path).map_err(map_database_error)?;
-        Ok(Self { _inner: db })
+        Ok(Self { inner: db })
+    }
+
+    fn begin_write(slf: Py<Self>, py: Python<'_>) -> PyResult<PyWriteTransaction> {
+        let txn = py
+            .detach(|| slf.get().inner.begin_write())
+            .map_err(map_transaction_error)?;
+        Ok(PyWriteTransaction::new(slf, txn))
     }
 }
 

--- a/crates/redb-python/src/error.rs
+++ b/crates/redb-python/src/error.rs
@@ -5,6 +5,8 @@ use pyo3::prelude::*;
 create_exception!(redb, Error, PyException);
 create_exception!(redb, DatabaseError, Error);
 create_exception!(redb, StorageError, Error);
+create_exception!(redb, TransactionError, Error);
+create_exception!(redb, CommitError, Error);
 
 create_exception!(redb, DatabaseAlreadyOpen, DatabaseError);
 create_exception!(redb, RepairAborted, DatabaseError);
@@ -17,6 +19,9 @@ create_exception!(redb, Io, StorageError);
 create_exception!(redb, PreviousIo, StorageError);
 create_exception!(redb, DatabaseClosed, StorageError);
 create_exception!(redb, LockPoisoned, StorageError);
+
+create_exception!(redb, ReadTransactionStillInUse, TransactionError);
+create_exception!(redb, TransactionCompleted, TransactionError);
 
 pub(crate) fn map_database_error(err: ::redb::DatabaseError) -> PyErr {
     let msg = format!("{err}");
@@ -46,10 +51,34 @@ pub(crate) fn map_storage_error(err: ::redb::StorageError) -> PyErr {
     }
 }
 
+pub(crate) fn map_transaction_error(err: ::redb::TransactionError) -> PyErr {
+    let msg = format!("{err}");
+    match err {
+        ::redb::TransactionError::Storage(storage) => map_storage_error(storage),
+        ::redb::TransactionError::ReadTransactionStillInUse(_) => {
+            ReadTransactionStillInUse::new_err(msg)
+        }
+        // redb::TransactionError is #[non_exhaustive]; fall back to the
+        // abstract parent class for unknown future variants.
+        _ => TransactionError::new_err(msg),
+    }
+}
+
+pub(crate) fn map_commit_error(err: ::redb::CommitError) -> PyErr {
+    let msg = format!("{err}");
+    match err {
+        ::redb::CommitError::Storage(storage) => map_storage_error(storage),
+        // redb::CommitError is #[non_exhaustive]; see comment above.
+        _ => CommitError::new_err(msg),
+    }
+}
+
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("Error", m.py().get_type::<Error>())?;
     m.add("DatabaseError", m.py().get_type::<DatabaseError>())?;
     m.add("StorageError", m.py().get_type::<StorageError>())?;
+    m.add("TransactionError", m.py().get_type::<TransactionError>())?;
+    m.add("CommitError", m.py().get_type::<CommitError>())?;
     m.add(
         "DatabaseAlreadyOpen",
         m.py().get_type::<DatabaseAlreadyOpen>(),
@@ -66,5 +95,13 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("PreviousIo", m.py().get_type::<PreviousIo>())?;
     m.add("DatabaseClosed", m.py().get_type::<DatabaseClosed>())?;
     m.add("LockPoisoned", m.py().get_type::<LockPoisoned>())?;
+    m.add(
+        "ReadTransactionStillInUse",
+        m.py().get_type::<ReadTransactionStillInUse>(),
+    )?;
+    m.add(
+        "TransactionCompleted",
+        m.py().get_type::<TransactionCompleted>(),
+    )?;
     Ok(())
 }

--- a/crates/redb-python/src/lib.rs
+++ b/crates/redb-python/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod database;
 mod error;
+mod transaction;
 
 use pyo3::prelude::*;
 
@@ -23,5 +24,6 @@ use pyo3::prelude::*;
 pub fn redb(m: &Bound<'_, PyModule>) -> PyResult<()> {
     database::register(m)?;
     error::register(m)?;
+    transaction::register(m)?;
     Ok(())
 }

--- a/crates/redb-python/src/transaction.rs
+++ b/crates/redb-python/src/transaction.rs
@@ -1,0 +1,53 @@
+use crate::database::PyDatabase;
+use crate::error::{TransactionCompleted, map_commit_error, map_storage_error};
+use pyo3::prelude::*;
+use std::sync::Mutex;
+
+// Field order is load-bearing: `txn` MUST be dropped before `db`. If the
+// `WriteTransaction` is the last holder of the database reference and the
+// user drops the transaction without committing or aborting, `Database::drop`
+// runs a finalizing `begin_write()` that blocks on any active writer.
+// Dropping `db` first while `txn` still holds the writer slot would
+// self-deadlock; struct fields drop in declaration order, so listing `txn`
+// first keeps it correct.
+struct ActiveWrite {
+    txn: ::redb::WriteTransaction,
+    db: Py<PyDatabase>,
+}
+
+#[pyclass(module = "redb", name = "WriteTransaction")]
+pub(crate) struct PyWriteTransaction {
+    inner: Mutex<Option<ActiveWrite>>,
+}
+
+impl PyWriteTransaction {
+    pub(crate) fn new(db: Py<PyDatabase>, txn: ::redb::WriteTransaction) -> Self {
+        Self {
+            inner: Mutex::new(Some(ActiveWrite { txn, db })),
+        }
+    }
+
+    fn take(&self) -> PyResult<ActiveWrite> {
+        self.inner.lock().unwrap().take().ok_or_else(|| {
+            TransactionCompleted::new_err("transaction already committed or aborted")
+        })
+    }
+}
+
+#[pymethods]
+impl PyWriteTransaction {
+    fn commit(&self, py: Python<'_>) -> PyResult<()> {
+        let ActiveWrite { txn, db: _db } = self.take()?;
+        py.detach(|| txn.commit()).map_err(map_commit_error)
+    }
+
+    fn abort(&self, py: Python<'_>) -> PyResult<()> {
+        let ActiveWrite { txn, db: _db } = self.take()?;
+        py.detach(|| txn.abort()).map_err(map_storage_error)
+    }
+}
+
+pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyWriteTransaction>()?;
+    Ok(())
+}

--- a/crates/redb-python/test/test_transactions.py
+++ b/crates/redb-python/test/test_transactions.py
@@ -1,0 +1,78 @@
+"""Tests for redb write transactions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+import redb
+
+
+def test_begin_write_commit(tmp_db_path: Path) -> None:
+    db = redb.Database.create(str(tmp_db_path))
+    txn = db.begin_write()
+    txn.commit()
+
+
+def test_begin_write_abort(tmp_db_path: Path) -> None:
+    db = redb.Database.create(str(tmp_db_path))
+    txn = db.begin_write()
+    txn.abort()
+
+
+def test_completed_transaction_releases_database(tmp_db_path: Path) -> None:
+    # After commit(), the transaction must drop its reference to the
+    # Database so the underlying file lock is released. Otherwise reopening
+    # the same path while a finalized transaction is still alive would fail
+    # with DatabaseAlreadyOpen.
+    db = redb.Database.create(str(tmp_db_path))
+    txn = db.begin_write()
+    txn.commit()
+    del db
+    redb.Database.create(str(tmp_db_path))
+    assert txn is not None  # keep the finalized txn alive past the reopen
+
+
+def test_drop_unfinalized_transaction_does_not_deadlock(tmp_db_path: Path) -> None:
+    # If an unfinalized transaction is the last owner of the Database,
+    # dropping the transaction must release its writer slot before the
+    # Database is finalized. Otherwise Database::drop's own begin_write()
+    # would self-deadlock waiting for this writer.
+    txn = redb.Database.create(str(tmp_db_path)).begin_write()
+    del txn
+
+
+def test_transaction_outlives_anonymous_database(tmp_db_path: Path) -> None:
+    # The originating Database has no Python reference, only the
+    # transaction does. The transaction must keep the Database alive,
+    # otherwise Database.__del__ would block forever waiting for this
+    # writer to finish.
+    txn = redb.Database.create(str(tmp_db_path)).begin_write()
+    txn.commit()
+
+
+def test_double_commit_raises(tmp_db_path: Path) -> None:
+    db = redb.Database.create(str(tmp_db_path))
+    txn = db.begin_write()
+    txn.commit()
+    with pytest.raises(redb.TransactionCompleted) as excinfo:
+        txn.commit()
+    # TransactionCompleted < TransactionError < Error in the hierarchy.
+    assert isinstance(excinfo.value, redb.TransactionError)
+    assert isinstance(excinfo.value, redb.Error)
+
+
+@given(commits=st.lists(st.booleans(), min_size=1, max_size=20))
+@settings(max_examples=25, deadline=None)
+def test_sequential_transactions(tmp_path_factory, commits: list) -> None:
+    path = tmp_path_factory.mktemp("redb") / "txn.redb"
+    db = redb.Database.create(str(path))
+    for commit in commits:
+        txn = db.begin_write()
+        if commit:
+            txn.commit()
+        else:
+            txn.abort()


### PR DESCRIPTION
## Summary
This PR adds support for write transactions to the redb Python bindings, allowing users to begin, commit, and abort write transactions on a database.

## Key Changes
- **New `WriteTransaction` class**: Added `PyWriteTransaction` wrapper that exposes `commit()` and `abort()` methods to Python
- **Database transaction API**: Added `begin_write()` method to the `Database` class to initiate write transactions
- **Transaction error handling**: Introduced new exception types (`TransactionError`, `CommitError`, `TransactionCompleted`, `ReadTransactionStillInUse`) with proper error mapping from the underlying redb library
- **Comprehensive tests**: Added test suite covering basic transaction lifecycle (commit/abort), error cases (double commit), and property-based testing of sequential transactions

## Implementation Details
- The `PyWriteTransaction` uses a `Mutex<Option<T>>` pattern to ensure transactions can only be finalized once (either committed or aborted), raising `TransactionCompleted` on subsequent attempts
- Error mapping functions (`map_transaction_error`, `map_commit_error`) properly delegate to existing storage error handling and create appropriate Python exception types
- The exception hierarchy follows the pattern: `TransactionCompleted` < `TransactionError` < `Error`, allowing flexible exception handling in Python code
- Added `.venv/` to `.gitignore` for Python virtual environment directories

https://claude.ai/code/session_011MsNhiXo8YugqGKjYoQjdu