### PR TITLE
Fix clippy::manual_is_multiple_of in round_up_to_multiple_of

### DIFF
--- a/src/tree_store/page_store/layout.rs
+++ b/src/tree_store/page_store/layout.rs
@@ -1,7 +1,7 @@
 use std::ops::Range;
 
 fn round_up_to_multiple_of(value: u64, multiple: u64) -> u64 {
-    if value % multiple == 0 {
+    if value.is_multiple_of(multiple) {
         value
     } else {
         value + multiple - value % multiple


### PR DESCRIPTION
Clippy 1.94 emits `manual_is_multiple_of` for `value % multiple == 0`. Switch to the standard-library `u64::is_multiple_of` helper to keep `cargo clippy --all-targets --all-features` clean.

Assisted-by: Claude <claude-opus-4-7>