### PR TITLE
Optimize CI cache strategy for faster builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,14 @@ jobs:
                 ~/.cargo/registry/index/
                 ~/.cargo/registry/cache/
                 ~/.cargo/git/db/
-                target/
+                target/.rustc_info.json
+                target/debug/.fingerprint/
+                target/debug/build/
+                target/debug/deps/
                 fuzz/target/
             key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.toml', '.github/workflows/*.yml', 'rust-toolchain') }}
+            restore-keys: |
+                ${{ runner.os }}-${{ runner.arch }}-
 
       - name: Non ASCII characters
         if: startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
## Summary
Improved the GitHub Actions CI cache configuration to be more granular and efficient, reducing cache size and improving hit rates for incremental builds.

## Key Changes
- **Refined cache paths**: Changed from caching the entire `target/` directory to only caching specific subdirectories that benefit from caching:
  - `target/.rustc_info.json` - Rust compiler metadata
  - `target/debug/.fingerprint/` - Build fingerprints for change detection
  - `target/debug/build/` - Build script outputs
  - `target/debug/deps/` - Compiled dependencies
  
- **Added cache restore keys**: Implemented fallback restore keys to allow partial cache hits when exact matches aren't available, improving cache effectiveness across different commits

## Benefits
- Reduces cache upload/download time by excluding large intermediate build artifacts
- Improves cache hit rates on subsequent runs through fallback restore keys
- Maintains faster incremental builds while keeping cache size manageable

https://claude.ai/code/session_0191JfXKV51YVLQ37RbJwjZN