### PR TITLE
Python bindings: make WriteTransaction a context manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * Fix a bug where calling `compact()` on a database could cause the file to grow
   rather than shrink in some cases.
 * Python bindings: add `redb.Database.create(path)` for creating or opening a database file.
+* Python bindings: add `Database.begin_write()`, which returns a `WriteTransaction`
+  context manager. Exiting the `with` block commits the transaction on success
+  and aborts it if an exception propagates out of the block.
 * Reuse pages freed by a durable write transaction in the next write transaction when no
   live read transaction or savepoint still needs them. Previously, pages were not reused for one
   additional transaction.

--- a/crates/redb-python/src/transaction.rs
+++ b/crates/redb-python/src/transaction.rs
@@ -1,11 +1,12 @@
 use crate::database::PyDatabase;
 use crate::error::{TransactionCompleted, map_commit_error, map_storage_error};
 use pyo3::prelude::*;
+use pyo3::types::PyAny;
 use std::sync::Mutex;
 
 // Field order is load-bearing: `txn` MUST be dropped before `db`. If the
 // `WriteTransaction` is the last holder of the database reference and the
-// user drops the transaction without committing or aborting, `Database::drop`
+// user drops the transaction without entering a `with` block, `Database::drop`
 // runs a finalizing `begin_write()` that blocks on any active writer.
 // Dropping `db` first while `txn` still holds the writer slot would
 // self-deadlock; struct fields drop in declaration order, so listing `txn`
@@ -15,35 +16,82 @@ struct ActiveWrite {
     db: Py<PyDatabase>,
 }
 
+enum State {
+    Pending(ActiveWrite),
+    InWith(ActiveWrite),
+    Finalized,
+}
+
 #[pyclass(module = "redb", name = "WriteTransaction")]
 pub(crate) struct PyWriteTransaction {
-    inner: Mutex<Option<ActiveWrite>>,
+    state: Mutex<State>,
 }
 
 impl PyWriteTransaction {
     pub(crate) fn new(db: Py<PyDatabase>, txn: ::redb::WriteTransaction) -> Self {
         Self {
-            inner: Mutex::new(Some(ActiveWrite { txn, db })),
+            state: Mutex::new(State::Pending(ActiveWrite { txn, db })),
         }
-    }
-
-    fn take(&self) -> PyResult<ActiveWrite> {
-        self.inner.lock().unwrap().take().ok_or_else(|| {
-            TransactionCompleted::new_err("transaction already committed or aborted")
-        })
     }
 }
 
 #[pymethods]
 impl PyWriteTransaction {
-    fn commit(&self, py: Python<'_>) -> PyResult<()> {
-        let ActiveWrite { txn, db: _db } = self.take()?;
-        py.detach(|| txn.commit()).map_err(map_commit_error)
+    fn __enter__(slf: PyRef<'_, Self>) -> PyResult<PyRef<'_, Self>> {
+        {
+            let mut state = slf.state.lock().unwrap();
+            match std::mem::replace(&mut *state, State::Finalized) {
+                State::Pending(active) => {
+                    *state = State::InWith(active);
+                }
+                State::InWith(active) => {
+                    *state = State::InWith(active);
+                    return Err(TransactionCompleted::new_err(
+                        "transaction is already in use by a `with` block",
+                    ));
+                }
+                State::Finalized => {
+                    return Err(TransactionCompleted::new_err(
+                        "transaction already committed or aborted",
+                    ));
+                }
+            }
+        }
+        Ok(slf)
     }
 
-    fn abort(&self, py: Python<'_>) -> PyResult<()> {
-        let ActiveWrite { txn, db: _db } = self.take()?;
-        py.detach(|| txn.abort()).map_err(map_storage_error)
+    // Auto-finalize on context manager exit: commit on success, abort if an
+    // exception is propagating out of the `with` block. To abort early, raise
+    // an exception inside the block.
+    #[pyo3(signature = (exc_type, exc_value, traceback))]
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        exc_type: &Bound<'_, PyAny>,
+        exc_value: &Bound<'_, PyAny>,
+        traceback: &Bound<'_, PyAny>,
+    ) -> PyResult<bool> {
+        let _ = (exc_value, traceback);
+        let active = {
+            let mut state = self.state.lock().unwrap();
+            match std::mem::replace(&mut *state, State::Finalized) {
+                State::InWith(active) => active,
+                other => {
+                    // Python guarantees __exit__ pairs with a successful
+                    // __enter__, so any other state means external tampering;
+                    // restore and no-op rather than acting on a stale handle.
+                    *state = other;
+                    return Ok(false);
+                }
+            }
+        };
+        let ActiveWrite { txn, db: _db } = active;
+        if exc_type.is_none() {
+            py.detach(|| txn.commit()).map_err(map_commit_error)?;
+        } else {
+            py.detach(|| txn.abort()).map_err(map_storage_error)?;
+        }
+        Ok(false)
     }
 }
 

--- a/crates/redb-python/test/test_transactions.py
+++ b/crates/redb-python/test/test_transactions.py
@@ -13,24 +13,25 @@ import redb
 
 def test_begin_write_commit(tmp_db_path: Path) -> None:
     db = redb.Database.create(str(tmp_db_path))
-    txn = db.begin_write()
-    txn.commit()
+    with db.begin_write():
+        pass
 
 
 def test_begin_write_abort(tmp_db_path: Path) -> None:
     db = redb.Database.create(str(tmp_db_path))
-    txn = db.begin_write()
-    txn.abort()
+    with pytest.raises(RuntimeError, match="rollback"):
+        with db.begin_write():
+            raise RuntimeError("rollback")
 
 
 def test_completed_transaction_releases_database(tmp_db_path: Path) -> None:
-    # After commit(), the transaction must drop its reference to the
-    # Database so the underlying file lock is released. Otherwise reopening
-    # the same path while a finalized transaction is still alive would fail
-    # with DatabaseAlreadyOpen.
+    # After the `with` block exits, the transaction must drop its reference
+    # to the Database so the underlying file lock is released. Otherwise
+    # reopening the same path while a finalized transaction is still alive
+    # would fail with DatabaseAlreadyOpen.
     db = redb.Database.create(str(tmp_db_path))
-    txn = db.begin_write()
-    txn.commit()
+    with db.begin_write() as txn:
+        pass
     del db
     redb.Database.create(str(tmp_db_path))
     assert txn is not None  # keep the finalized txn alive past the reopen
@@ -50,19 +51,32 @@ def test_transaction_outlives_anonymous_database(tmp_db_path: Path) -> None:
     # transaction does. The transaction must keep the Database alive,
     # otherwise Database.__del__ would block forever waiting for this
     # writer to finish.
-    txn = redb.Database.create(str(tmp_db_path)).begin_write()
-    txn.commit()
+    with redb.Database.create(str(tmp_db_path)).begin_write():
+        pass
 
 
-def test_double_commit_raises(tmp_db_path: Path) -> None:
+def test_reentering_finalized_transaction_raises(tmp_db_path: Path) -> None:
     db = redb.Database.create(str(tmp_db_path))
     txn = db.begin_write()
-    txn.commit()
+    with txn:
+        pass
     with pytest.raises(redb.TransactionCompleted) as excinfo:
-        txn.commit()
+        with txn:
+            pass
     # TransactionCompleted < TransactionError < Error in the hierarchy.
     assert isinstance(excinfo.value, redb.TransactionError)
     assert isinstance(excinfo.value, redb.Error)
+
+
+def test_nested_with_block_raises(tmp_db_path: Path) -> None:
+    # Re-entering a transaction that's already inside a `with` block must
+    # raise rather than panic across the FFI boundary.
+    db = redb.Database.create(str(tmp_db_path))
+    txn = db.begin_write()
+    with pytest.raises(redb.TransactionCompleted):
+        with txn:
+            with txn:
+                pass
 
 
 @given(commits=st.lists(st.booleans(), min_size=1, max_size=20))
@@ -71,8 +85,22 @@ def test_sequential_transactions(tmp_path_factory, commits: list) -> None:
     path = tmp_path_factory.mktemp("redb") / "txn.redb"
     db = redb.Database.create(str(path))
     for commit in commits:
-        txn = db.begin_write()
         if commit:
-            txn.commit()
+            with db.begin_write():
+                pass
         else:
-            txn.abort()
+            with pytest.raises(RuntimeError, match="rollback"):
+                with db.begin_write():
+                    raise RuntimeError("rollback")
+
+
+def test_context_manager_aborts_on_exception(tmp_db_path: Path) -> None:
+    db = redb.Database.create(str(tmp_db_path))
+    txn = db.begin_write()
+    with pytest.raises(RuntimeError, match="boom"):
+        with txn:
+            raise RuntimeError("boom")
+    # The transaction is finalized; re-entering must fail.
+    with pytest.raises(redb.TransactionCompleted):
+        with txn:
+            pass


### PR DESCRIPTION
## Summary
Convert `WriteTransaction` to a context manager that automatically commits on successful exit and aborts if an exception propagates out of the `with` block. This provides a more Pythonic API and ensures proper transaction finalization.

## Key Changes
- Implement `__enter__` and `__exit__` methods on `PyWriteTransaction` to support the context manager protocol
- `__enter__` validates that the transaction hasn't already been finalized
- `__exit__` automatically commits on success or aborts if an exception is propagating
- Remove the explicit `commit()` and `abort()` methods from the public API
- Update all test cases to use the context manager pattern instead of manual commit/abort calls
- Add new test `test_context_manager_aborts_on_exception` to verify exception handling behavior
- Rename `test_double_commit_raises` to `test_reentering_finalized_transaction_raises` to reflect the new API

## Implementation Details
- The `__exit__` method checks `exc_type.is_none()` to determine whether to commit or abort
- Transaction finalization is guaranteed by the context manager protocol, ensuring the database lock is properly released
- The implementation maintains the existing field ordering requirement where `txn` must be dropped before `db` to avoid deadlocks
- Updated comments to reflect the new `with` block semantics instead of explicit commit/abort calls

https://claude.ai/code/session_01YKBLFZqjfjF3cN3ggDi3SL