### PR TITLE
Optimize cache invalidation on file resize

### DIFF
--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -390,10 +390,31 @@ impl PagedCachedFile {
 
     // Caller should invalidate all cached pages that are no longer valid
     pub(super) fn resize(&self, len: u64) -> Result {
-        // TODO: be more fine-grained about this invalidation
-        self.invalidate_cache_all();
+        // Growing leaves all existing cached pages valid. Shrinking only
+        // invalidates pages whose offset falls past the new end-of-file.
+        let old_len = self.file.len()?;
+        if len < old_len {
+            self.invalidate_read_cache_above(len);
+        }
 
         self.file.set_len(len)
+    }
+
+    // Drop cached read pages whose offset is at or beyond `threshold`.
+    fn invalidate_read_cache_above(&self, threshold: u64) {
+        for cache_slot in 0..self.read_cache.len() {
+            let mut lock = self.read_cache[cache_slot].write().unwrap();
+            let stale: Vec<u64> = lock
+                .iter()
+                .filter_map(|(k, _)| (*k >= threshold).then_some(*k))
+                .collect();
+            for k in stale {
+                if let Some(removed) = lock.remove(k) {
+                    self.read_cache_bytes
+                        .fetch_sub(removed.len(), Ordering::AcqRel);
+                }
+            }
+        }
     }
 
     pub(super) fn flush(&self) -> Result {
@@ -651,5 +672,27 @@ mod test {
         t2.join().unwrap();
         cached_file.invalidate_cache(0, 128);
         assert_eq!(cached_file.read_cache_bytes.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn resize_preserves_cached_pages() {
+        let backend = InMemoryBackend::new();
+        backend.set_len(1024).unwrap();
+        let cached_file = PagedCachedFile::new(Box::new(backend), 128, 4096).unwrap();
+
+        // Populate the read cache with two pages from opposite ends of the file.
+        cached_file.read(0, 128, PageHint::None).unwrap();
+        cached_file.read(512, 128, PageHint::None).unwrap();
+        assert_eq!(cached_file.read_cache_bytes.load(Ordering::Acquire), 256);
+
+        // Growing must keep every cached page valid.
+        cached_file.resize(2048).unwrap();
+        assert_eq!(cached_file.read_cache_bytes.load(Ordering::Acquire), 256);
+        assert_eq!(cached_file.raw_file_len().unwrap(), 2048);
+
+        // Shrinking only drops pages whose offset is at or beyond the new end.
+        cached_file.resize(256).unwrap();
+        assert_eq!(cached_file.read_cache_bytes.load(Ordering::Acquire), 128);
+        assert_eq!(cached_file.raw_file_len().unwrap(), 256);
     }
 }


### PR DESCRIPTION
## Summary
Improved the cache invalidation strategy in `PagedCachedFile::resize()` to be more granular and efficient. Previously, all cached pages were invalidated on any resize operation. Now, the implementation only invalidates pages that are actually affected by the resize.

## Key Changes
- **Refined resize logic**: Growing a file now preserves all existing cached pages (since they remain valid), while shrinking only invalidates pages whose offsets fall at or beyond the new end-of-file
- **New helper method**: Added `invalidate_read_cache_above()` to selectively drop cached read pages above a given threshold, with proper accounting of freed cache bytes
- **Added test coverage**: Implemented `resize_preserves_cached_pages()` test to verify that:
  - Growing the file preserves all cached pages
  - Shrinking the file only removes pages beyond the new end-of-file
  - Cache byte accounting remains accurate

## Implementation Details
The new `invalidate_read_cache_above()` method iterates through all read cache slots, identifies stale entries (those at or beyond the threshold), removes them, and properly updates the `read_cache_bytes` atomic counter using `fetch_sub()` with `AcqRel` ordering to maintain consistency.

https://claude.ai/code/session_01EhCpvsbx8PGBJUpBfej82n