### PR TITLE
Introduce PageResolver to restrict btree read paths to safe APIs

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,7 @@
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
 use crate::tree_store::{
     AllocationPolicy, BtreeHeader, InternalTableDefinition, PAGE_SIZE, PageHint, PageNumber,
-    ReadOnlyBackend, ShrinkPolicy, TableTree, TableType, TransactionalMemory,
+    PageResolver, ReadOnlyBackend, ShrinkPolicy, TableTree, TableType, TransactionalMemory,
 };
 use crate::types::{Key, Value};
 use crate::{
@@ -543,11 +543,12 @@ impl Database {
     }
 
     pub(crate) fn verify_primary_checksums(mem: Arc<TransactionalMemory>) -> Result<bool> {
+        let resolver = PageResolver::new(mem.clone());
         let table_tree = TableTree::new(
             mem.get_data_root(),
             PageHint::None,
             Arc::new(TransactionGuard::untracked()),
-            mem.clone(),
+            resolver.clone(),
         )?;
         if !table_tree.verify_checksums()? {
             return Ok(false);
@@ -556,7 +557,7 @@ impl Database {
             mem.get_system_root(),
             PageHint::None,
             Arc::new(TransactionGuard::untracked()),
-            mem.clone(),
+            resolver,
         )?;
         if !system_table_tree.verify_checksums()? {
             return Ok(false);
@@ -680,11 +681,12 @@ impl Database {
         system_root: Option<BtreeHeader>,
         mem: Arc<TransactionalMemory>,
     ) -> Result {
+        let resolver = PageResolver::new(mem.clone());
         let table_tree = TableTree::new(
             system_root,
             PageHint::None,
             Arc::new(TransactionGuard::untracked()),
-            mem.clone(),
+            resolver.clone(),
         )?;
         if let Some(table_def) = table_tree
             .get_table::<TransactionIdWithPagination, PageList>(
@@ -701,7 +703,7 @@ impl Database {
                 table_root,
                 PageHint::None,
                 Arc::new(TransactionGuard::untracked()),
-                mem.clone(),
+                resolver,
             )?;
             for result in table.range::<TransactionIdWithPagination>(..)? {
                 let (_, pages) = result?;
@@ -724,8 +726,13 @@ impl Database {
         F: FnMut(PageNumber) -> Result,
     {
         let untracked_guard = Arc::new(TransactionGuard::untracked());
-        let system_tree =
-            TableTree::new(system_root, PageHint::None, untracked_guard, mem.clone())?;
+        let resolver = PageResolver::new(mem.clone());
+        let system_tree = TableTree::new(
+            system_root,
+            PageHint::None,
+            untracked_guard,
+            resolver.clone(),
+        )?;
         let table_name = table_def.name();
         let result = match system_tree.get_table::<K, V>(table_name, TableType::Normal) {
             Ok(result) => result,
@@ -753,7 +760,7 @@ impl Database {
                     table_root,
                     PageHint::None,
                     Arc::new(TransactionGuard::untracked()),
-                    mem.clone(),
+                    resolver,
                 )?;
             for result in table.range::<TransactionIdWithPagination>(..)? {
                 let (_, page_list) = result?;
@@ -773,7 +780,12 @@ impl Database {
         let data_root = mem.get_data_root();
         {
             let untracked = Arc::new(TransactionGuard::untracked());
-            let tables = TableTree::new(data_root, PageHint::None, untracked, mem.clone())?;
+            let tables = TableTree::new(
+                data_root,
+                PageHint::None,
+                untracked,
+                PageResolver::new(mem.clone()),
+            )?;
             tables.visit_all_pages(|path| {
                 mem.mark_debug_allocated_page(path.page_number());
                 Ok(())
@@ -783,8 +795,12 @@ impl Database {
         let system_root = mem.get_system_root();
         {
             let untracked = Arc::new(TransactionGuard::untracked());
-            let system_tables =
-                TableTree::new(system_root, PageHint::None, untracked, mem.clone())?;
+            let system_tables = TableTree::new(
+                system_root,
+                PageHint::None,
+                untracked,
+                PageResolver::new(mem.clone()),
+            )?;
             system_tables.visit_all_pages(|path| {
                 mem.mark_debug_allocated_page(path.page_number());
                 Ok(())
@@ -844,7 +860,12 @@ impl Database {
         let data_root = mem.get_data_root();
         {
             let untracked = Arc::new(TransactionGuard::untracked());
-            let tables = TableTree::new(data_root, PageHint::None, untracked, mem.clone())?;
+            let tables = TableTree::new(
+                data_root,
+                PageHint::None,
+                untracked,
+                PageResolver::new(mem.clone()),
+            )?;
             tables.visit_all_pages(|path| {
                 mem.mark_page_allocated(path.page_number());
                 Ok(())
@@ -861,8 +882,12 @@ impl Database {
         let system_root = mem.get_system_root();
         {
             let untracked = Arc::new(TransactionGuard::untracked());
-            let system_tables =
-                TableTree::new(system_root, PageHint::None, untracked, mem.clone())?;
+            let system_tables = TableTree::new(
+                system_root,
+                PageHint::None,
+                untracked,
+                PageResolver::new(mem.clone()),
+            )?;
             system_tables.visit_all_pages(|path| {
                 mem.mark_page_allocated(path.page_number());
                 Ok(())
@@ -981,11 +1006,12 @@ impl Database {
         }
 
         // See if it's present in the system table tree
+        let resolver = PageResolver::new(mem.clone());
         let system_table_tree = TableTree::new(
             mem.get_system_root(),
             PageHint::None,
             Arc::new(TransactionGuard::untracked()),
-            mem.clone(),
+            resolver.clone(),
         )?;
         let Some(allocator_state_table) = system_table_tree
             .get_table::<AllocatorStateKey, &[u8]>(ALLOCATOR_STATE_TABLE_NAME, TableType::Normal)
@@ -1002,7 +1028,7 @@ impl Database {
             table_root,
             PageHint::None,
             Arc::new(TransactionGuard::untracked()),
-            mem.clone(),
+            resolver,
         )?;
 
         // Make sure this isn't stale allocator state left over from a previous transaction

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -5,8 +5,8 @@ use crate::table::{ReadableTableMetadata, TableStats};
 use crate::tree_store::{
     AllPageNumbersBtreeIter, BRANCH, Btree, BtreeHeader, BtreeMut, BtreeRangeIter,
     DynamicCollection, DynamicCollectionType, LEAF, LeafAccessor, MAX_PAIR_LENGTH,
-    MAX_VALUE_LENGTH, Page, PageAllocator, PageHint, PageNumber, PageTrackerPolicy, RawBtree,
-    RawLeafBuilder, TransactionalMemory, multimap_btree_stats,
+    MAX_VALUE_LENGTH, Page, PageAllocator, PageHint, PageNumber, PageResolver, PageTrackerPolicy,
+    RawBtree, RawLeafBuilder, multimap_btree_stats,
 };
 use crate::types::{Key, Value};
 use crate::{AccessGuard, MultimapTableHandle, Result, StorageError, WriteTransaction};
@@ -168,7 +168,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
     fn from_collection(
         collection: AccessGuard<'a, &'static DynamicCollection<V>>,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        mem: PageResolver,
     ) -> Result<Self> {
         Ok(match collection.value().collection_type() {
             Inline => {
@@ -212,7 +212,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
                 let inner = BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(
                     &(..),
                     Some(root),
-                    page_allocator.mem().clone(),
+                    page_allocator.resolver(),
                     PageHint::None,
                 )?;
                 Self::new_subtree_free_on_drop(
@@ -317,7 +317,7 @@ impl<V: Key + 'static> Drop for MultimapValue<'_, V> {
 
 pub struct MultimapRange<'a, K: Key + 'static, V: Key + 'static> {
     inner: BtreeRangeIter<K, &'static DynamicCollection<V>>,
-    mem: Arc<TransactionalMemory>,
+    mem: PageResolver,
     transaction_guard: Arc<TransactionGuard>,
     _key_type: PhantomData<K>,
     _value_type: PhantomData<V>,
@@ -328,7 +328,7 @@ impl<K: Key + 'static, V: Key + 'static> MultimapRange<'_, K, V> {
     fn new(
         inner: BtreeRangeIter<K, &'static DynamicCollection<V>>,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        mem: PageResolver,
     ) -> Self {
         Self {
             inner,
@@ -764,7 +764,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                     root,
                     V::fixed_width(),
                     <() as Value>::fixed_width(),
-                    self.page_allocator.mem().clone(),
+                    self.page_allocator.resolver(),
                     PageHint::None,
                 )?;
                 for page in all_pages {
@@ -787,7 +787,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                 BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(
                     &(..),
                     None,
-                    self.page_allocator.mem().clone(),
+                    self.page_allocator.resolver(),
                     PageHint::None,
                 )?,
                 0,
@@ -803,7 +803,7 @@ impl<K: Key + 'static, V: Key + 'static> ReadableTableMetadata for MultimapTable
     fn stats(&self) -> Result<TableStats> {
         let tree_stats = multimap_btree_stats(
             self.tree.get_root().map(|x| x.root),
-            self.page_allocator.mem(),
+            &self.page_allocator.resolver(),
             K::fixed_width(),
             V::fixed_width(),
             PageHint::None,
@@ -829,13 +829,13 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V> for Multima
     fn get<'a>(&self, key: impl Borrow<K::SelfType<'a>>) -> Result<MultimapValue<'_, V>> {
         let guard = self.transaction.transaction_guard();
         let iter = if let Some(collection) = self.tree.get(key.borrow())? {
-            MultimapValue::from_collection(collection, guard, self.page_allocator.mem().clone())?
+            MultimapValue::from_collection(collection, guard, self.page_allocator.resolver())?
         } else {
             MultimapValue::new_subtree(
                 BtreeRangeIter::new::<RangeFull, &V::SelfType<'_>>(
                     &(..),
                     None,
-                    self.page_allocator.mem().clone(),
+                    self.page_allocator.resolver(),
                     PageHint::None,
                 )?,
                 0,
@@ -854,7 +854,7 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V> for Multima
         Ok(MultimapRange::new(
             inner,
             self.transaction.transaction_guard(),
-            self.page_allocator.mem().clone(),
+            self.page_allocator.resolver(),
         ))
     }
 }
@@ -891,7 +891,7 @@ pub struct ReadOnlyUntypedMultimapTable {
     hint: PageHint,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
-    mem: Arc<TransactionalMemory>,
+    mem: PageResolver,
 }
 
 impl Sealed for ReadOnlyUntypedMultimapTable {}
@@ -929,7 +929,7 @@ impl ReadOnlyUntypedMultimapTable {
         hint: PageHint,
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
-        mem: Arc<TransactionalMemory>,
+        mem: PageResolver,
     ) -> Self {
         Self {
             num_values,
@@ -952,7 +952,7 @@ impl ReadOnlyUntypedMultimapTable {
 pub struct ReadOnlyMultimapTable<K: Key + 'static, V: Key + 'static> {
     tree: Btree<K, &'static DynamicCollection<V>>,
     num_values: u64,
-    mem: Arc<TransactionalMemory>,
+    mem: PageResolver,
     transaction_guard: Arc<TransactionGuard>,
     _value_type: PhantomData<V>,
 }
@@ -963,7 +963,7 @@ impl<K: Key + 'static, V: Key + 'static> ReadOnlyMultimapTable<K, V> {
         num_values: u64,
         hint: PageHint,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        mem: PageResolver,
     ) -> Result<ReadOnlyMultimapTable<K, V>> {
         Ok(ReadOnlyMultimapTable {
             tree: Btree::new(root, hint, guard.clone(), mem.clone())?,

--- a/src/table.rs
+++ b/src/table.rs
@@ -2,8 +2,8 @@ use crate::db::TransactionGuard;
 use crate::sealed::Sealed;
 use crate::tree_store::{
     AccessGuardMutInPlace, Btree, BtreeExtractIf, BtreeHeader, BtreeMut, BtreeRangeIter,
-    MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PageAllocator, PageHint, PageNumber, PageTrackerPolicy,
-    RawBtree, TransactionalMemory,
+    MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PageAllocator, PageHint, PageNumber, PageResolver,
+    PageTrackerPolicy, RawBtree,
 };
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, AccessGuardMut, StorageError, WriteTransaction};
@@ -454,7 +454,7 @@ impl ReadOnlyUntypedTable {
         hint: PageHint,
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
-        mem: Arc<TransactionalMemory>,
+        mem: PageResolver,
     ) -> Self {
         Self {
             tree: RawBtree::new(root_page, fixed_key_size, fixed_value_size, mem, hint),
@@ -481,7 +481,7 @@ impl<K: Key + 'static, V: Value + 'static> ReadOnlyTable<K, V> {
         root_page: Option<BtreeHeader>,
         hint: PageHint,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        mem: PageResolver,
     ) -> Result<ReadOnlyTable<K, V>> {
         Ok(ReadOnlyTable {
             name,

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -6,8 +6,9 @@ use crate::table::ReadOnlyUntypedTable;
 use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker};
 use crate::tree_store::{
     AllocationPolicy, Btree, BtreeHeader, BtreeMut, InternalTableDefinition, MAX_PAIR_LENGTH,
-    MAX_VALUE_LENGTH, Page, PageAllocator, PageHint, PageListMut, PageNumber, PageTrackerPolicy,
-    SerializedSavepoint, ShrinkPolicy, TableTree, TableTreeMut, TableType, TransactionalMemory,
+    MAX_VALUE_LENGTH, Page, PageAllocator, PageHint, PageListMut, PageNumber, PageResolver,
+    PageTrackerPolicy, SerializedSavepoint, ShrinkPolicy, TableTree, TableTreeMut, TableType,
+    TransactionalMemory,
 };
 use crate::types::{Key, Value};
 use crate::{
@@ -931,7 +932,7 @@ impl WriteTransaction {
             Some(root),
             PageHint::None,
             self.transaction_guard.clone(),
-            self.mem.clone(),
+            PageResolver::new(self.mem.clone()),
         )?;
         read(&table).map(Some)
     }
@@ -2325,7 +2326,7 @@ impl WriteTransaction {
                 Some(page),
                 PageHint::None,
                 self.transaction_guard.clone(),
-                self.mem.clone(),
+                PageResolver::new(self.mem.clone()),
             )?;
             master_tree.print_debug(true)?;
         }
@@ -2344,7 +2345,7 @@ impl WriteTransaction {
                 Some(page),
                 PageHint::None,
                 self.transaction_guard.clone(),
-                self.mem.clone(),
+                PageResolver::new(self.mem.clone()),
             )?;
             master_tree.print_debug(true)?;
         }
@@ -2386,9 +2387,10 @@ impl ReadTransaction {
     ) -> Result<Self, TransactionError> {
         let root_page = mem.get_data_root();
         let guard = Arc::new(guard);
+        let resolver = PageResolver::new(mem.clone());
         Ok(Self {
-            mem: mem.clone(),
-            tree: TableTree::new(root_page, PageHint::Clean, guard, mem)
+            mem,
+            tree: TableTree::new(root_page, PageHint::Clean, guard, resolver)
                 .map_err(TransactionError::Storage)?,
         })
     }
@@ -2409,7 +2411,7 @@ impl ReadTransaction {
                 table_root,
                 PageHint::Clean,
                 self.tree.transaction_guard().clone(),
-                self.mem.clone(),
+                PageResolver::new(self.mem.clone()),
             )?),
             InternalTableDefinition::Multimap { .. } => unreachable!(),
         }
@@ -2436,7 +2438,7 @@ impl ReadTransaction {
                 PageHint::Clean,
                 fixed_key_size,
                 fixed_value_size,
-                self.mem.clone(),
+                PageResolver::new(self.mem.clone()),
             )),
             InternalTableDefinition::Multimap { .. } => unreachable!(),
         }
@@ -2463,7 +2465,7 @@ impl ReadTransaction {
                 table_length,
                 PageHint::Clean,
                 self.tree.transaction_guard().clone(),
-                self.mem.clone(),
+                PageResolver::new(self.mem.clone()),
             )?),
         }
     }
@@ -2492,7 +2494,7 @@ impl ReadTransaction {
                 PageHint::Clean,
                 fixed_key_size,
                 fixed_value_size,
-                self.mem.clone(),
+                PageResolver::new(self.mem.clone()),
             )),
         }
     }

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -5,10 +5,10 @@ use crate::tree_store::btree_base::{
 };
 use crate::tree_store::btree_iters::BtreeExtractIf;
 use crate::tree_store::btree_mutator::MutateHelper;
-use crate::tree_store::page_store::{Page, PageImpl, PageMut, TransactionalMemory};
+use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
     AccessGuardMutInPlace, AllPageNumbersBtreeIter, BtreeRangeIter, PageAllocator, PageHint,
-    PageNumber, PageTrackerPolicy,
+    PageNumber, PageResolver, PageTrackerPolicy,
 };
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, Result};
@@ -64,7 +64,7 @@ impl PagePath {
 }
 
 pub(super) struct UntypedBtree {
-    mem: Arc<TransactionalMemory>,
+    mem: PageResolver,
     root: Option<BtreeHeader>,
     hint: PageHint,
     key_width: Option<usize>,
@@ -74,7 +74,7 @@ pub(super) struct UntypedBtree {
 impl UntypedBtree {
     pub(super) fn new(
         root: Option<BtreeHeader>,
-        mem: Arc<TransactionalMemory>,
+        mem: PageResolver,
         hint: PageHint,
         key_width: Option<usize>,
         value_width: Option<usize>,
@@ -372,7 +372,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
                 root,
                 K::fixed_width(),
                 V::fixed_width(),
-                self.page_allocator.mem().clone(),
+                self.page_allocator.resolver(),
                 PageHint::None,
             )?))
         } else {
@@ -525,7 +525,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
     pub(crate) fn stats(&self) -> Result<BtreeStats> {
         btree_stats(
             self.get_root().map(|x| x.root),
-            self.page_allocator.mem(),
+            &self.page_allocator.resolver(),
             K::fixed_width(),
             V::fixed_width(),
             PageHint::None,
@@ -537,7 +537,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
             self.get_root(),
             PageHint::None,
             self.transaction_guard.clone(),
-            self.page_allocator.mem().clone(),
+            self.page_allocator.resolver(),
         )
     }
 
@@ -761,7 +761,7 @@ impl<K: Key + 'static, V: MutInPlaceValue + 'static> BtreeMut<K, V> {
 }
 
 pub(crate) struct RawBtree {
-    mem: Arc<TransactionalMemory>,
+    mem: PageResolver,
     root: Option<BtreeHeader>,
     hint: PageHint,
     fixed_key_size: Option<usize>,
@@ -773,7 +773,7 @@ impl RawBtree {
         root: Option<BtreeHeader>,
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
-        mem: Arc<TransactionalMemory>,
+        mem: PageResolver,
         hint: PageHint,
     ) -> Self {
         Self {
@@ -853,7 +853,7 @@ impl RawBtree {
 }
 
 pub(crate) struct Btree<K: Key + 'static, V: Value + 'static> {
-    mem: Arc<TransactionalMemory>,
+    mem: PageResolver,
     transaction_guard: Arc<TransactionGuard>,
     // Cache of the root page to avoid repeated lookups
     cached_root: Option<PageImpl>,
@@ -868,7 +868,7 @@ impl<K: Key, V: Value> Btree<K, V> {
         root: Option<BtreeHeader>,
         hint: PageHint,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        mem: PageResolver,
     ) -> Result<Self> {
         let cached_root = if let Some(header) = root {
             Some(mem.get_page(header.root, hint)?)
@@ -1092,7 +1092,7 @@ impl<K: Key, V: Value> Drop for Btree<K, V> {
 
 pub(super) fn btree_stats(
     root: Option<PageNumber>,
-    mem: &TransactionalMemory,
+    mem: &PageResolver,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
     hint: PageHint,
@@ -1113,7 +1113,7 @@ pub(super) fn btree_stats(
 
 fn stats_helper(
     page_number: PageNumber,
-    mem: &TransactionalMemory,
+    mem: &PageResolver,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
     hint: PageHint,

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -3,8 +3,8 @@ use crate::tree_store::btree_base::{BRANCH, LEAF};
 use crate::tree_store::btree_base::{BranchAccessor, LeafAccessor};
 use crate::tree_store::btree_iters::RangeIterState::{Internal, Leaf};
 use crate::tree_store::btree_mutator::MutateHelper;
-use crate::tree_store::page_store::{Page, PageHint, PageImpl, TransactionalMemory};
-use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageTrackerPolicy};
+use crate::tree_store::page_store::{Page, PageHint, PageImpl};
+use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageResolver, PageTrackerPolicy};
 use crate::types::{Key, Value};
 use Bound::{Excluded, Included, Unbounded};
 use std::borrow::Borrow;
@@ -41,7 +41,7 @@ impl RangeIterState {
     fn next(
         self,
         reverse: bool,
-        manager: &TransactionalMemory,
+        manager: &PageResolver,
         hint: PageHint,
     ) -> Result<Option<RangeIterState>> {
         match self {
@@ -186,7 +186,7 @@ impl<K: Key, V: Value> EntryGuard<K, V> {
 
 pub(crate) struct AllPageNumbersBtreeIter {
     next: Option<RangeIterState>,
-    manager: Arc<TransactionalMemory>,
+    manager: PageResolver,
     hint: PageHint,
 }
 
@@ -195,7 +195,7 @@ impl AllPageNumbersBtreeIter {
         root: PageNumber,
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
-        manager: Arc<TransactionalMemory>,
+        manager: PageResolver,
         hint: PageHint,
     ) -> Result<Self> {
         let root_page = manager.get_page(root, hint)?;
@@ -374,7 +374,7 @@ pub(crate) struct BtreeRangeIter<K: Key + 'static, V: Value + 'static> {
     right: Option<RangeIterState>, // Exclusive. The previous element returned
     include_left: bool,           // left is inclusive, instead of exclusive
     include_right: bool,          // right is inclusive, instead of exclusive
-    manager: Arc<TransactionalMemory>,
+    manager: PageResolver,
     hint: PageHint,
     // When Some, the right boundary is Unbounded and not yet computed.
     // Stores the tree root for lazy initialization on first next_back() call.
@@ -409,7 +409,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
     pub(crate) fn new<'a, T: RangeBounds<KR>, KR: Borrow<K::SelfType<'a>>>(
         query_range: &'_ T,
         table_root: Option<PageNumber>,
-        manager: Arc<TransactionalMemory>,
+        manager: PageResolver,
         hint: PageHint,
     ) -> Result<Self> {
         if range_is_empty::<K, KR, T>(query_range) {
@@ -672,7 +672,7 @@ fn find_iter_unbounded<K: Key, V: Value>(
     page: PageImpl,
     mut parent: Option<Box<RangeIterState>>,
     reverse: bool,
-    manager: &TransactionalMemory,
+    manager: &PageResolver,
     hint: PageHint,
 ) -> Result<Option<RangeIterState>> {
     let node_mem = page.memory();
@@ -720,7 +720,7 @@ fn find_iter_left<K: Key, V: Value>(
     mut parent: Option<Box<RangeIterState>>,
     query: &[u8],
     include_query: bool,
-    manager: &TransactionalMemory,
+    manager: &PageResolver,
     hint: PageHint,
 ) -> Result<(bool, Option<RangeIterState>)> {
     let node_mem = page.memory();
@@ -769,7 +769,7 @@ fn find_iter_right<K: Key, V: Value>(
     mut parent: Option<Box<RangeIterState>>,
     query: &[u8],
     include_query: bool,
-    manager: &TransactionalMemory,
+    manager: &PageResolver,
     hint: PageHint,
 ) -> Result<(bool, Option<RangeIterState>)> {
     let node_mem = page.memory();

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -513,9 +513,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 let (child_index, child_page) = accessor.child_for_key::<K>(key);
                 let child_checksum = accessor.child_checksum(child_index).unwrap();
                 let sub_result = self.insert_helper(
-                    self.page_allocator
-                        .mem()
-                        .get_page(child_page, PageHint::None)?,
+                    self.page_allocator.get_page(child_page, PageHint::None)?,
                     child_checksum,
                     key,
                     value,
@@ -876,7 +874,6 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         let child_checksum = accessor.child_checksum(child_index).unwrap();
         let (result, found) = self.delete_helper(
             self.page_allocator
-                .mem()
                 .get_page(child_page_number, PageHint::None)?,
             target,
             found_key,
@@ -898,10 +895,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 && self.modify_uncommitted
             {
                 drop(page);
-                let mut mutpage = self
-                    .page_allocator
-                    .mem()
-                    .get_page_mut(original_page_number)?;
+                let mut mutpage = self.page_allocator.get_page_mut(original_page_number)?;
                 let mut mutator = BranchMutator::new(mutpage.memory_mut());
                 mutator.write_child_page(child_index, new_child, DEFERRED);
                 original_page_number
@@ -970,7 +964,6 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 debug_assert!(merge_with < accessor.count_children());
                 let merge_with_page = self
                     .page_allocator
-                    .mem()
                     .get_page(accessor.child_page(merge_with).unwrap(), PageHint::None)?;
                 let merge_with_accessor =
                     LeafAccessor::new(merge_with_page.memory(), K::fixed_width(), V::fixed_width());
@@ -1065,7 +1058,6 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 let merge_with = if child_index == 0 { 1 } else { child_index - 1 };
                 let merge_with_page = self
                     .page_allocator
-                    .mem()
                     .get_page(accessor.child_page(merge_with).unwrap(), PageHint::None)?;
                 let merge_with_accessor = BranchAccessor::new(&merge_with_page, K::fixed_width());
                 debug_assert!(merge_with < accessor.count_children());
@@ -1116,7 +1108,6 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 let merge_with = if child_index == 0 { 1 } else { child_index - 1 };
                 let merge_with_page = self
                     .page_allocator
-                    .mem()
                     .get_page(accessor.child_page(merge_with).unwrap(), PageHint::None)?;
                 let merge_with_accessor = BranchAccessor::new(&merge_with_page, K::fixed_width());
                 debug_assert!(merge_with < accessor.count_children());

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -16,8 +16,8 @@ pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multim
 pub(crate) use page_store::ReadOnlyBackend;
 pub(crate) use page_store::{
     AllocationPolicy, FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page,
-    PageAllocator, PageHint, PageNumber, PageNumberHashSet, PageTrackerPolicy, SerializedSavepoint,
-    ShrinkPolicy, TransactionalMemory,
+    PageAllocator, PageHint, PageNumber, PageNumberHashSet, PageResolver, PageTrackerPolicy,
+    SerializedSavepoint, ShrinkPolicy, TransactionalMemory,
 };
 pub use page_store::{InMemoryBackend, Savepoint, file_backend};
 pub(crate) use table_tree::{PageListMut, TableTree, TableTreeMut};

--- a/src/tree_store/multimap_btree.rs
+++ b/src/tree_store/multimap_btree.rs
@@ -6,7 +6,7 @@ use crate::tree_store::btree_base::{
 use crate::tree_store::multimap_btree::DynamicCollectionType::{Inline, SubtreeV2};
 use crate::tree_store::{
     AllPageNumbersBtreeIter, BtreeHeader, BtreeStats, Page, PageAllocator, PageHint, PageNumber,
-    PageTrackerPolicy, RawBtree, TransactionalMemory,
+    PageResolver, PageTrackerPolicy, RawBtree,
 };
 use crate::types::{Key, TypeName, Value};
 use std::cmp::max;
@@ -18,7 +18,7 @@ use std::sync::{Arc, Mutex};
 
 pub(crate) fn multimap_btree_stats(
     root: Option<PageNumber>,
-    mem: &TransactionalMemory,
+    mem: &PageResolver,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
     hint: PageHint,
@@ -39,7 +39,7 @@ pub(crate) fn multimap_btree_stats(
 
 fn multimap_stats_helper(
     page_number: PageNumber,
-    mem: &TransactionalMemory,
+    mem: &PageResolver,
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
     hint: PageHint,
@@ -154,7 +154,7 @@ pub(super) fn verify_tree_and_subtree_checksums(
     root: Option<BtreeHeader>,
     key_size: Option<usize>,
     value_size: Option<usize>,
-    mem: Arc<TransactionalMemory>,
+    mem: PageResolver,
     hint: PageHint,
 ) -> Result<bool> {
     if let Some(header) = root {
@@ -364,7 +364,7 @@ fn parse_subtree_roots<T: Page>(
 }
 
 pub(super) struct UntypedMultiBtree {
-    mem: Arc<TransactionalMemory>,
+    mem: PageResolver,
     root: Option<BtreeHeader>,
     hint: PageHint,
     key_width: Option<usize>,
@@ -374,7 +374,7 @@ pub(super) struct UntypedMultiBtree {
 impl UntypedMultiBtree {
     pub(super) fn new(
         root: Option<BtreeHeader>,
-        mem: Arc<TransactionalMemory>,
+        mem: PageResolver,
         hint: PageHint,
         key_width: Option<usize>,
         value_width: Option<usize>,

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -22,8 +22,8 @@ pub(crate) use base::{
 pub(crate) use fast_hash::PageNumberHashSet;
 pub(crate) use header::PAGE_SIZE;
 pub(crate) use page_manager::{
-    AllocationPolicy, FILE_FORMAT_VERSION3, PageAllocator, ShrinkPolicy, TransactionalMemory,
-    xxh3_checksum,
+    AllocationPolicy, FILE_FORMAT_VERSION3, PageAllocator, PageResolver, ShrinkPolicy,
+    TransactionalMemory, xxh3_checksum,
 };
 pub use savepoint::Savepoint;
 pub(crate) use savepoint::SerializedSavepoint;

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -81,6 +81,33 @@ pub(crate) enum AllocationPolicy {
     Lowest,
 }
 
+/// Read-only view over `TransactionalMemory` exposing only the methods that
+/// btree read paths and stats helpers need. Cheap to clone -- a single
+/// `Arc<TransactionalMemory>` bump.
+///
+/// Construct one from `PageAllocator::resolver()` (write-transaction context)
+/// or `PageResolver::new(mem)` (read-transaction context). Read-only btree
+/// types accept `PageResolver` rather than `Arc<TransactionalMemory>` so that
+/// they cannot be used to bypass `PageAllocator`'s allocation tracking.
+#[derive(Clone)]
+pub(crate) struct PageResolver {
+    mem: Arc<TransactionalMemory>,
+}
+
+impl PageResolver {
+    pub(crate) fn new(mem: Arc<TransactionalMemory>) -> Self {
+        Self { mem }
+    }
+
+    pub(crate) fn get_page(&self, page_number: PageNumber, hint: PageHint) -> Result<PageImpl> {
+        self.mem.get_page(page_number, hint)
+    }
+
+    pub(crate) fn count_allocated_pages(&self) -> Result<u64> {
+        self.mem.count_allocated_pages()
+    }
+}
+
 /// Per-write-transaction handle through which btree mutation code allocates
 /// and frees pages. Bundles the shared `TransactionalMemory` with the write
 /// transaction's `AllocationPolicy`.
@@ -100,11 +127,9 @@ impl PageAllocator {
         }
     }
 
-    // TODO: migrate remaining callers off of this and make it private. Btree
-    // mutation code should interact with `TransactionalMemory` exclusively
-    // through `PageAllocator`.
-    pub(crate) fn mem(&self) -> &Arc<TransactionalMemory> {
-        &self.mem
+    /// Returns a `PageResolver` for constructing read-only views of this transaction's pages.
+    pub(crate) fn resolver(&self) -> PageResolver {
+        PageResolver::new(self.mem.clone())
     }
 
     /// Drains the set of pages allocated since the last commit, returning

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -7,8 +7,7 @@ use crate::tree_store::multimap_btree::{
 };
 use crate::tree_store::{
     Btree, BtreeMut, BtreeRangeIter, InternalTableDefinition, PageAllocator, PageHint, PageNumber,
-    PageNumberHashSet, PageTrackerPolicy, RawBtree, TableType, TransactionalMemory,
-    multimap_btree_stats,
+    PageNumberHashSet, PageResolver, PageTrackerPolicy, RawBtree, TableType, multimap_btree_stats,
 };
 use crate::types::{Key, Value};
 use crate::{DatabaseStats, Result};
@@ -67,7 +66,7 @@ impl Iterator for TableNameIter {
 
 pub(crate) struct TableTree {
     tree: Btree<&'static str, InternalTableDefinition>,
-    mem: Arc<TransactionalMemory>,
+    mem: PageResolver,
 }
 
 impl TableTree {
@@ -75,7 +74,7 @@ impl TableTree {
         master_root: Option<BtreeHeader>,
         page_hint: PageHint,
         guard: Arc<TransactionGuard>,
-        mem: Arc<TransactionalMemory>,
+        mem: PageResolver,
     ) -> Result<Self> {
         Ok(Self {
             tree: Btree::new(master_root, page_hint, guard, mem.clone())?,
@@ -269,11 +268,9 @@ impl TableTreeMut {
                 .get_table_untyped(&entry, TableType::Normal)
                 .map_err(|e| e.into_storage_error_or_corrupted("Internal corruption"))?
                 .unwrap();
-            definition.visit_all_pages(
-                self.page_allocator.mem().clone(),
-                PageHint::None,
-                |path| visitor(path),
-            )?;
+            definition.visit_all_pages(self.page_allocator.resolver(), PageHint::None, |path| {
+                visitor(path)
+            })?;
         }
 
         for entry in self.list_tables(TableType::Multimap)? {
@@ -281,11 +278,9 @@ impl TableTreeMut {
                 .get_table_untyped(&entry, TableType::Multimap)
                 .map_err(|e| e.into_storage_error_or_corrupted("Internal corruption"))?
                 .unwrap();
-            definition.visit_all_pages(
-                self.page_allocator.mem().clone(),
-                PageHint::None,
-                |path| visitor(path),
-            )?;
+            definition.visit_all_pages(self.page_allocator.resolver(), PageHint::None, |path| {
+                visitor(path)
+            })?;
         }
 
         Ok(())
@@ -487,7 +482,7 @@ impl TableTreeMut {
             self.tree.get_root(),
             PageHint::None,
             self.guard.clone(),
-            self.page_allocator.mem().clone(),
+            self.page_allocator.resolver(),
         )?;
         tree.list_tables(table_type)
     }
@@ -501,7 +496,7 @@ impl TableTreeMut {
             self.tree.get_root(),
             PageHint::None,
             self.guard.clone(),
-            self.page_allocator.mem().clone(),
+            self.page_allocator.resolver(),
         )?;
         let mut result = tree.get_table_untyped(name, table_type);
 
@@ -524,7 +519,7 @@ impl TableTreeMut {
             self.tree.get_root(),
             PageHint::None,
             self.guard.clone(),
-            self.page_allocator.mem().clone(),
+            self.page_allocator.resolver(),
         )?;
         let mut result = tree.get_table::<K, V>(name, table_type);
 
@@ -569,14 +564,10 @@ impl TableTreeMut {
             // Collect all pages first, then free them. The walk reads each page to discover
             // its children, so we must not invalidate any page before the walk completes.
             let mut pages = vec![];
-            definition.visit_all_pages(
-                self.page_allocator.mem().clone(),
-                PageHint::None,
-                |path| {
-                    pages.push(path.page_number());
-                    Ok(())
-                },
-            )?;
+            definition.visit_all_pages(self.page_allocator.resolver(), PageHint::None, |path| {
+                pages.push(path.page_number());
+                Ok(())
+            })?;
             let mut freed_pages = self.freed_pages.lock().unwrap();
             let mut allocated_pages = self.allocated_pages.lock().unwrap();
             for page in pages {
@@ -642,17 +633,13 @@ impl TableTreeMut {
                 definition.set_header(*updated_root, *updated_length);
             }
 
-            definition.visit_all_pages(
-                self.page_allocator.mem().clone(),
-                PageHint::None,
-                |path| {
-                    output.insert(path.page_number(), path.clone());
-                    while output.len() > n {
-                        output.pop_first();
-                    }
-                    Ok(())
-                },
-            )?;
+            definition.visit_all_pages(self.page_allocator.resolver(), PageHint::None, |path| {
+                output.insert(path.page_number(), path.clone());
+                while output.len() > n {
+                    output.pop_first();
+                }
+                Ok(())
+            })?;
         }
 
         self.tree.visit_all_pages(|path| {
@@ -709,6 +696,7 @@ impl TableTreeMut {
             master_tree_stats.metadata_bytes + master_tree_stats.stored_leaf_bytes;
         let mut total_fragmented = master_tree_stats.fragmented_bytes;
 
+        let resolver = self.page_allocator.resolver();
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;
             let mut definition = entry.value();
@@ -724,7 +712,7 @@ impl TableTreeMut {
                 } => {
                     let subtree_stats = btree_stats(
                         table_root.map(|x| x.root),
-                        self.page_allocator.mem(),
+                        &resolver,
                         fixed_key_size,
                         fixed_value_size,
                         PageHint::None,
@@ -744,7 +732,7 @@ impl TableTreeMut {
                 } => {
                     let subtree_stats = multimap_btree_stats(
                         table_root.map(|x| x.root),
-                        self.page_allocator.mem(),
+                        &resolver,
                         fixed_key_size,
                         fixed_value_size,
                         PageHint::None,
@@ -760,7 +748,7 @@ impl TableTreeMut {
         }
         Ok(DatabaseStats {
             tree_height: master_tree_stats.tree_height + max_subtree_height,
-            allocated_pages: self.page_allocator.mem().count_allocated_pages()?,
+            allocated_pages: resolver.count_allocated_pages()?,
             leaf_pages,
             branch_pages,
             stored_leaf_bytes: total_stored_bytes,

--- a/src/tree_store/table_tree_base.rs
+++ b/src/tree_store/table_tree_base.rs
@@ -1,6 +1,6 @@
 use crate::tree_store::btree::{PagePath, UntypedBtree, UntypedBtreeMut};
 use crate::tree_store::multimap_btree::{UntypedMultiBtree, relocate_subtrees};
-use crate::tree_store::{BtreeHeader, PageAllocator, PageHint, PageNumber, TransactionalMemory};
+use crate::tree_store::{BtreeHeader, PageAllocator, PageHint, PageNumber, PageResolver};
 use crate::{Key, Result, TableError, TypeName, Value};
 use std::collections::HashMap;
 use std::mem::size_of;
@@ -182,7 +182,7 @@ impl InternalTableDefinition {
 
     pub(crate) fn visit_all_pages<'a, F>(
         &self,
-        mem: Arc<TransactionalMemory>,
+        mem: PageResolver,
         hint: PageHint,
         visitor: F,
     ) -> Result


### PR DESCRIPTION
## Summary

This PR introduces a new `PageResolver` type that provides a read-only view over `TransactionalMemory`, exposing only the methods needed by btree read paths and statistics helpers. This prevents read-only btree code from accidentally bypassing `PageAllocator`'s allocation tracking.

## Key Changes

- **New `PageResolver` type**: A cheap-to-clone wrapper around `Arc<TransactionalMemory>` that exposes only `get_page()` and `count_allocated_pages()` methods
  - Constructable via `PageAllocator::resolver()` in write-transaction contexts
  - Constructable via `PageResolver::new(mem)` in read-transaction contexts

- **Updated btree and table APIs**: All read-only btree types (`Btree`, `RawBtree`, `BtreeRangeIter`, `AllPageNumbersBtreeIter`) now accept `PageResolver` instead of `Arc<TransactionalMemory>`
  - Includes `UntypedBtree`, `UntypedMultiBtree`, and related iterator types
  - Statistics functions (`btree_stats`, `multimap_btree_stats`) now take `&PageResolver`

- **Updated table implementations**: 
  - `ReadOnlyTable`, `ReadOnlyUntypedTable`, `MultimapTable`, `ReadOnlyUntypedMultimapTable` now use `PageResolver`
  - `TableTree` and related structures updated to use `PageResolver`

- **Simplified `PageAllocator` API**: 
  - Removed `mem()` method (was marked for migration)
  - Added `resolver()` method to create `PageResolver` instances
  - Mutation code (`btree_mutator.rs`) now calls `page_allocator.get_page()` directly instead of `page_allocator.mem().get_page()`

- **Updated transaction code**: `ReadTransaction` and `WriteTransaction` now create `PageResolver` instances when constructing read-only btree views

## Implementation Details

- `PageResolver` is a thin wrapper that maintains the same performance characteristics as before (single `Arc` bump on clone)
- The change is primarily about API boundaries and type safety—preventing accidental misuse of `TransactionalMemory` in read-only contexts
- All existing functionality is preserved; this is a refactoring for better encapsulation

https://claude.ai/code/session_01X37W88Mc9yY4cVPD1sidi7