### PR TITLE
Poison transaction on retain predicate panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # redb - Changelog
 
 ## Unreleased
+* `Table::retain()` and `Table::retain_in()` now poison the write transaction if their
+  predicate panics, causing `WriteTransaction::commit()` to return
+  `CommitError::TransactionPoisoned`.
 * Add `Table::entry()` and the associated `Entry`, `OccupiedEntry`, and `VacantEntry`
   types, mirroring `std::collections::BTreeMap::entry`. Supports `or_insert`,
   `or_insert_with`, `or_insert_with_key`, `and_modify`, and the usual `OccupiedEntry`

--- a/src/error.rs
+++ b/src/error.rs
@@ -468,12 +468,15 @@ impl std::error::Error for TransactionError {}
 pub enum CommitError {
     /// Error from underlying storage
     Storage(StorageError),
+    /// The transaction was poisoned by a panic and can no longer be committed
+    TransactionPoisoned,
 }
 
 impl CommitError {
     pub(crate) fn into_storage_error(self) -> StorageError {
         match self {
             CommitError::Storage(storage) => storage,
+            CommitError::TransactionPoisoned => unreachable!(),
         }
     }
 }
@@ -482,6 +485,7 @@ impl From<CommitError> for Error {
     fn from(err: CommitError) -> Error {
         match err {
             CommitError::Storage(storage) => storage.into(),
+            CommitError::TransactionPoisoned => Error::TransactionPoisoned,
         }
     }
 }
@@ -496,6 +500,9 @@ impl Display for CommitError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             CommitError::Storage(storage) => storage.fmt(f),
+            CommitError::TransactionPoisoned => {
+                write!(f, "Transaction was poisoned by a panic")
+            }
         }
     }
 }
@@ -525,6 +532,8 @@ pub enum Error {
     EphemeralSavepointExists,
     /// A transaction is still in-progress
     TransactionInProgress,
+    /// The transaction was poisoned by a panic and can no longer be committed
+    TransactionPoisoned,
     /// The Database is corrupted
     Corrupted(String),
     /// The database file is in an old file format and must be manually upgraded
@@ -673,6 +682,9 @@ impl Display for Error {
                     f,
                     "A transaction is still in progress. Operation cannot be performed."
                 )
+            }
+            Error::TransactionPoisoned => {
+                write!(f, "Transaction was poisoned by a panic")
             }
             Error::InvalidSavepoint => {
                 write!(f, "Savepoint is invalid or cannot be created.")

--- a/src/table.rs
+++ b/src/table.rs
@@ -13,6 +13,7 @@ use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
 use std::ops::RangeBounds;
 use std::sync::{Arc, Mutex};
+use std::thread;
 
 /// Informational storage stats about a table
 #[derive(Debug)]
@@ -68,6 +69,32 @@ pub struct Table<'txn, K: Key + 'static, V: Value + 'static> {
 impl<K: Key + 'static, V: Value + 'static> TableHandle for Table<'_, K, V> {
     fn name(&self) -> &str {
         &self.name
+    }
+}
+
+struct RetainPanicGuard<'txn> {
+    transaction: &'txn WriteTransaction,
+    disarmed: bool,
+}
+
+impl<'txn> RetainPanicGuard<'txn> {
+    fn new(transaction: &'txn WriteTransaction) -> Self {
+        Self {
+            transaction,
+            disarmed: false,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.disarmed = true;
+    }
+}
+
+impl Drop for RetainPanicGuard<'_> {
+    fn drop(&mut self) {
+        if !self.disarmed && thread::panicking() {
+            self.transaction.poison();
+        }
     }
 }
 
@@ -147,15 +174,26 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     /// Applies `predicate` to all key-value pairs. All entries for which
     /// `predicate` evaluates to `false` are removed.
     ///
+    /// The predicate must not panic. If it panics, the write transaction is
+    /// poisoned and [`crate::WriteTransaction::commit`] will return
+    /// [`crate::CommitError::TransactionPoisoned`].
+    ///
     pub fn retain<F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
         &mut self,
         predicate: F,
     ) -> Result {
-        self.tree.retain_in::<K::SelfType<'_>, F>(predicate, ..)
+        let mut panic_guard = RetainPanicGuard::new(self.transaction);
+        let result = self.tree.retain_in::<K::SelfType<'_>, F>(predicate, ..);
+        panic_guard.disarm();
+        result
     }
 
     /// Applies `predicate` to all key-value pairs in the range `start..end`. All entries for which
     /// `predicate` evaluates to `false` are removed.
+    ///
+    /// The predicate must not panic. If it panics, the write transaction is
+    /// poisoned and [`crate::WriteTransaction::commit`] will return
+    /// [`crate::CommitError::TransactionPoisoned`].
     ///
     pub fn retain_in<'a, KR, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
         &mut self,
@@ -165,7 +203,10 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
-        self.tree.retain_in(predicate, range)
+        let mut panic_guard = RetainPanicGuard::new(self.transaction);
+        let result = self.tree.retain_in(predicate, range);
+        panic_guard.disarm();
+        result
     }
 
     /// Insert mapping of the given key to the given value

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -782,6 +782,10 @@ impl TableNamespace {
         self.table_tree
             .stage_update_table_root(name, table.get_root(), length);
     }
+
+    pub(crate) fn close_table_without_update(&mut self, name: &str) {
+        self.open_tables.remove(name).unwrap();
+    }
 }
 
 // Transaction-local savepoint lifecycle state.
@@ -858,6 +862,7 @@ pub struct WriteTransaction {
     system_tables: Mutex<SystemNamespace>,
     completed: bool,
     dirty: AtomicBool,
+    poisoned: AtomicBool,
     durability: InternalDurability,
     two_phase_commit: bool,
     shrink_policy: ShrinkPolicy,
@@ -894,6 +899,7 @@ impl WriteTransaction {
             system_tables: Mutex::new(system_tables),
             completed: false,
             dirty: AtomicBool::new(false),
+            poisoned: AtomicBool::new(false),
             durability: InternalDurability::Immediate,
             two_phase_commit: false,
             quick_repair: false,
@@ -905,6 +911,14 @@ impl WriteTransaction {
 
     pub(crate) fn set_shrink_policy(&mut self, shrink_policy: ShrinkPolicy) {
         self.shrink_policy = shrink_policy;
+    }
+
+    pub(crate) fn poison(&self) {
+        self.poisoned.store(true, Ordering::Release);
+    }
+
+    fn is_poisoned(&self) -> bool {
+        self.poisoned.load(Ordering::Acquire)
     }
 
     // A PageAllocator for this transaction. All clones share the same
@@ -1440,7 +1454,12 @@ impl WriteTransaction {
         table: &BtreeMut<K, V>,
         length: u64,
     ) {
-        self.tables.lock().unwrap().close_table(name, table, length);
+        let mut tables = self.tables.lock().unwrap();
+        if self.is_poisoned() {
+            tables.close_table_without_update(name);
+        } else {
+            tables.close_table(name, table, length);
+        }
     }
 
     /// Rename the given table
@@ -1525,9 +1544,16 @@ impl WriteTransaction {
     ///
     /// All writes performed in this transaction will be visible to future transactions, and are
     /// durable as consistent with the [`Durability`] level set by [`Self::set_durability`]
+    ///
+    /// Returns [`CommitError::TransactionPoisoned`] if a previous operation panicked and left the
+    /// transaction unable to commit.
     pub fn commit(mut self) -> Result<(), CommitError> {
         // Set completed flag first, so that we don't go through the abort() path on drop, if this fails
         self.completed = true;
+        if self.is_poisoned() {
+            self.abort_inner()?;
+            return Err(CommitError::TransactionPoisoned);
+        }
         self.commit_inner()
     }
 

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1,4 +1,6 @@
 use rand::random;
+#[cfg(not(target_os = "wasi"))]
+use redb::CommitError;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use redb::DatabaseError;
 use redb::backends::InMemoryBackend;
@@ -1895,6 +1897,53 @@ fn retain_in_empty() {
         assert_eq!(table.len().unwrap(), 1000);
     }
     write_txn.commit().unwrap();
+}
+
+#[cfg(not(target_os = "wasi"))]
+#[test]
+fn retain_predicate_panic_poisons_transaction() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0u64..4 {
+            table.insert(i, i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        table.insert(4, 4).unwrap();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            table
+                .retain(|key, _| {
+                    assert_ne!(key, 2, "retain predicate panic");
+                    key != 0
+                })
+                .unwrap();
+        }));
+        assert!(result.is_err());
+    }
+
+    assert!(matches!(
+        write_txn.commit(),
+        Err(CommitError::TransactionPoisoned)
+    ));
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(definition).unwrap();
+    assert_eq!(table.len().unwrap(), 4);
+    for i in 0u64..4 {
+        assert_eq!(table.get(i).unwrap().unwrap().value(), i);
+    }
+    assert!(table.get(4).unwrap().is_none());
 }
 
 #[test]


### PR DESCRIPTION
Add a transaction poison flag and a public CommitError::TransactionPoisoned variant so retain and retain_in predicate panics cannot be caught and followed by a commit.

Wrap retain and retain_in with an unwind guard, avoid staging table roots after poisoning, and document the predicate panic contract.

Assisted-by: Codex