### PR TITLE
Add retain regression coverage

### DIFF
--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1899,6 +1899,162 @@ fn retain_in_empty() {
     write_txn.commit().unwrap();
 }
 
+#[test]
+fn retain_collapses_to_single_entry() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u64, [u8; 200]> = TableDefinition::new("x");
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0u64..10_000 {
+            table.insert(i, &[0u8; 200]).unwrap();
+        }
+
+        table.retain(|key, _| key == 7777).unwrap();
+        assert_eq!(table.len().unwrap(), 1);
+        assert!(table.get(&7776).unwrap().is_none());
+        assert!(table.get(&7777).unwrap().is_some());
+        assert!(table.get(&7778).unwrap().is_none());
+
+        let mut iter = table.iter().unwrap();
+        let (key, _) = iter.next().unwrap().unwrap();
+        assert_eq!(key.value(), 7777);
+        assert!(iter.next().is_none());
+    }
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        assert_eq!(table.len().unwrap(), 1);
+        for i in 0u64..1000 {
+            table.insert(i, &[1u8; 200]).unwrap();
+        }
+        assert_eq!(table.len().unwrap(), 1001);
+        for i in 0u64..1000 {
+            assert!(table.remove(i).unwrap().is_some());
+        }
+        assert_eq!(table.len().unwrap(), 1);
+    }
+    write_txn.commit().unwrap();
+}
+
+#[test]
+fn retain_collapses_to_sparse_entries() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u64, [u8; 200]> = TableDefinition::new("x");
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0u64..20_000 {
+            table.insert(i, &[0u8; 200]).unwrap();
+        }
+
+        table.retain(|key, _| key == 1234 || key == 17_777).unwrap();
+        assert_eq!(table.len().unwrap(), 2);
+        assert!(table.get(&1233).unwrap().is_none());
+        assert!(table.get(&1234).unwrap().is_some());
+        assert!(table.get(&17_777).unwrap().is_some());
+        assert!(table.get(&17_778).unwrap().is_none());
+
+        let keys: Vec<_> = table
+            .iter()
+            .unwrap()
+            .map(|entry| entry.unwrap().0.value())
+            .collect();
+        assert_eq!(keys, [1234, 17_777]);
+    }
+    write_txn.commit().unwrap();
+}
+
+#[test]
+fn retain_rebuilds_changed_separators() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u64, [u8; 200]> = TableDefinition::new("x");
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0u64..30_000 {
+            table.insert(i, &[0u8; 200]).unwrap();
+        }
+
+        table
+            .retain(|key, _| key < 10_000 || key == 15_000 || key >= 20_000)
+            .unwrap();
+        assert_eq!(table.len().unwrap(), 20_001);
+        assert!(table.get(&9999).unwrap().is_some());
+        assert!(table.get(&10_000).unwrap().is_none());
+        assert!(table.get(&14_999).unwrap().is_none());
+        assert!(table.get(&15_000).unwrap().is_some());
+        assert!(table.get(&15_001).unwrap().is_none());
+        assert!(table.get(&20_000).unwrap().is_some());
+    }
+    write_txn.commit().unwrap();
+}
+
+#[test]
+fn retain_in_rebuilds_range_boundaries() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u64, [u8; 200]> = TableDefinition::new("x");
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0u64..30_000 {
+            table.insert(i, &[0u8; 200]).unwrap();
+        }
+
+        table
+            .retain_in(10_000..20_000, |key, _| key == 15_000)
+            .unwrap();
+        assert_eq!(table.len().unwrap(), 20_001);
+        assert!(table.get(&9999).unwrap().is_some());
+        assert!(table.get(&10_000).unwrap().is_none());
+        assert!(table.get(&14_999).unwrap().is_none());
+        assert!(table.get(&15_000).unwrap().is_some());
+        assert!(table.get(&15_001).unwrap().is_none());
+        assert!(table.get(&19_999).unwrap().is_none());
+        assert!(table.get(&20_000).unwrap().is_some());
+    }
+    write_txn.commit().unwrap();
+}
+
+#[test]
+fn retain_coalesces_sparse_survivors() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u64, [u8; 200]> = TableDefinition::new("x");
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0u64..20_000 {
+            table.insert(i, &[0u8; 200]).unwrap();
+        }
+
+        table.retain(|key, _| key % 100 == 0).unwrap();
+        assert_eq!(table.len().unwrap(), 200);
+        assert!(table.stats().unwrap().leaf_pages() < 50);
+        for i in 0u64..20_000 {
+            let value = table.get(&i).unwrap();
+            assert_eq!(value.is_some(), i % 100 == 0);
+        }
+    }
+    write_txn.commit().unwrap();
+}
+
 #[cfg(not(target_os = "wasi"))]
 #[test]
 fn retain_predicate_panic_poisons_transaction() {


### PR DESCRIPTION
Add retain and retain_in tests for tree collapse, sparse survivors, changed separators, bounded ranges, and sparse survivor leaf coalescing.

These tests document behavior that the optimized retain implementation must preserve without including the implementation change itself.

Assisted-by: Codex