### PR TITLE
Print database size metrics from redb benchmark

### DIFF
--- a/crates/redb-bench/benches/redb_benchmark.rs
+++ b/crates/redb-bench/benches/redb_benchmark.rs
@@ -24,7 +24,13 @@ fn main() {
         .create(tmpfile.path())
         .unwrap();
     let table = RedbBenchDatabase::new(&mut db);
-    benchmark(table, tmpfile.path());
+    let results = benchmark(table, tmpfile.path());
+
+    for (name, result) in &results {
+        if name.ends_with("size") {
+            println!("{name}: {result}");
+        }
+    }
 
     fs::remove_dir_all(&tmpdir).unwrap();
 }


### PR DESCRIPTION
## Summary
Modified the redb benchmark to capture and display database size metrics from benchmark results.

## Changes
- Updated `benchmark()` call to capture returned results instead of discarding them
- Added filtering and printing logic to display metrics ending with "size"
- Results are printed to stdout for easy inspection of database size information

## Implementation Details
The benchmark function now returns results that are iterated over, filtering for metrics with names ending in "size" and printing them in a simple `{name}: {result}` format. This allows users to easily see database size metrics without modifying the benchmark function itself.

https://claude.ai/code/session_01RaXbbJoHobRM9ArtFiSZRJ