### PR TITLE
Add CI check to ban AI-authored commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,28 @@ on:
       - master
 
 jobs:
+  commit-authors:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Ban AI-authored commits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git fetch --no-tags --no-recurse-submodules origin "$BASE_SHA"
+          offenders=$(git log --no-merges --pretty=format:'%H %an <%ae> committed by %cn <%ce>' "$BASE_SHA".."$HEAD_SHA" \
+            | grep -iE '(claude|codex)' || true)
+          if [ -n "$offenders" ]; then
+            echo "Commits authored or committed by Claude or Codex are not allowed:"
+            echo "$offenders"
+            exit 1
+          fi
+
   ci:
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
This PR adds a new CI workflow job that prevents pull requests containing commits authored or committed by AI tools (Claude or Codex) from being merged.

## Key Changes
- Added a new `commit-authors` job to the CI workflow that runs on pull requests
- The job checks all commits in a PR against a blocklist of AI tool names (Claude, Codex)
- If any commits are found with these authors/committers, the CI check fails with a clear error message listing the offending commits
- Uses git log to inspect commit metadata across the PR's commit range (base SHA to head SHA)

## Implementation Details
- The check runs only on pull request events (`if: github.event_name == 'pull_request'`)
- Fetches full commit history (`fetch-depth: 0`) to ensure all commits are available for inspection
- Uses case-insensitive grep matching to catch variations of AI tool names
- Provides clear feedback by echoing the offending commits before failing the build
- Excludes merge commits from the check to focus on actual authored work

https://claude.ai/code/session_014T9rXPo8QhuoJ9tsuJLjFU