### PR TITLE
Optimize retain() and retain_in()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # redb - Changelog
 
 ## 4.2.0 - 2026-XX-XX
+* Optimize `Table::retain()` and `Table::retain_in()`. Some benchmarks on large tables show a 25x speedup.
 * Add `Table::entry()` and the associated `Entry`, `OccupiedEntry`, and `VacantEntry`
   types, mirroring `std::collections::BTreeMap::entry`. Supports `or_insert`,
   `or_insert_with`, `or_insert_with_key`, `and_modify`, and the usual `OccupiedEntry`

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -691,38 +691,22 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
 
     pub(crate) fn retain_in<'a, KR, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
         &mut self,
-        mut predicate: F,
+        predicate: F,
         range: impl RangeBounds<KR> + 'a,
     ) -> Result
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
-        let iter = self.range(&range)?;
         let mut freed = vec![];
-        // Do not modify the existing tree, because we're iterating over it concurrently with the removals
-        // TODO: optimize this to iterate and remove at the same time
-        let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new_do_not_modify(
+        let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new(
             &mut self.root,
             self.page_allocator.clone(),
             &mut freed,
             self.allocated_pages.clone(),
         );
-        for entry in iter {
-            let entry = entry?;
-            if !predicate(entry.key(), entry.value()) {
-                assert!(operation.delete(&entry.key())?.is_some());
-            }
-        }
+        operation.retain_in_range(&range, predicate)?;
         let mut freed_pages = self.freed_pages.lock().unwrap();
-        let mut allocated_pages = self.allocated_pages.lock().unwrap();
-        for page in freed {
-            if !self
-                .page_allocator
-                .free_if_uncommitted(page, &mut allocated_pages)
-            {
-                freed_pages.push(page);
-            }
-        }
+        freed_pages.extend(freed);
 
         Ok(())
     }

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -6,13 +6,17 @@ use crate::tree_store::btree_mutator::DeletionResult::{
     DeletedBranch, DeletedLeaf, PartialBranch, PartialLeaf, Subtree,
 };
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
+use crate::tree_store::retain::{RetainBuilderContext, RetainSubtree, RetainSubtreeBuilder};
 use crate::tree_store::{
     AccessGuardMutInPlace, BtreeHeader, PageAllocator, PageHint, PageNumber, PageTrackerPolicy,
 };
 use crate::types::{Key, Value};
 use crate::{AccessGuard, Result};
-use std::cmp::{max, min};
+use std::borrow::Borrow;
+use std::cmp::{Ordering, max, min};
+use std::collections::Bound;
 use std::marker::PhantomData;
+use std::ops::RangeBounds;
 use std::sync::{Arc, Mutex};
 
 // Describes which entry to delete. `Key` navigates via key comparison; `First`
@@ -49,6 +53,70 @@ enum DeletionResult {
     // Indicates that the branch node was deleted, and includes the only remaining child.
     // Checksum is retained for the same reason as `PartialBranch`.
     DeletedBranch(PageNumber, Checksum),
+}
+
+enum RetainWalkResult {
+    Unchanged(RetainSubtree),
+    Changed,
+}
+
+struct RetainWalkContext {
+    checksum: Checksum,
+    upper_key: Option<Vec<u8>>,
+    root_distance: u32,
+}
+
+struct KeyRange<'a, K: Key + ?Sized> {
+    start: Bound<&'a [u8]>,
+    end: Bound<&'a [u8]>,
+    _key: PhantomData<K>,
+}
+
+impl<K: Key + ?Sized> Copy for KeyRange<'_, K> {}
+
+impl<K: Key + ?Sized> Clone for KeyRange<'_, K> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, K: Key + ?Sized> KeyRange<'a, K> {
+    fn new(start: Bound<&'a [u8]>, end: Bound<&'a [u8]>) -> Self {
+        Self {
+            start,
+            end,
+            _key: PhantomData,
+        }
+    }
+
+    fn contains(&self, key: &[u8]) -> bool {
+        !self.less_than_start(key) && !self.greater_than_end(key)
+    }
+
+    fn less_than_start(&self, key: &[u8]) -> bool {
+        match self.start {
+            Bound::Included(start) => K::compare(key, start) == Ordering::Less,
+            Bound::Excluded(start) => K::compare(key, start) != Ordering::Greater,
+            Bound::Unbounded => false,
+        }
+    }
+
+    fn greater_than_end(&self, key: &[u8]) -> bool {
+        match self.end {
+            Bound::Included(end) => K::compare(key, end) == Ordering::Greater,
+            Bound::Excluded(end) => K::compare(key, end) != Ordering::Less,
+            Bound::Unbounded => false,
+        }
+    }
+
+    fn child_lower_bound_is_past_end(&self, lower_bound: &[u8]) -> bool {
+        match self.end {
+            Bound::Included(end) | Bound::Excluded(end) => {
+                K::compare(lower_bound, end) != Ordering::Less
+            }
+            Bound::Unbounded => false,
+        }
+    }
 }
 
 struct InsertionResult<'a, V: Value + 'static> {
@@ -145,6 +213,269 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         let mut found_key = None;
         let value = self.delete_target(DeleteTarget::Last, &mut found_key)?;
         Ok(value.map(|v| (found_key.take().unwrap(), v)))
+    }
+
+    pub(crate) fn retain_in_range<'r, KR, F>(
+        &mut self,
+        range: &'_ impl RangeBounds<KR>,
+        mut predicate: F,
+    ) -> Result
+    where
+        KR: Borrow<K::SelfType<'r>> + 'r,
+        F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+    {
+        assert!(self.modify_uncommitted);
+        let Some(header) = *self.root else {
+            return Ok(());
+        };
+
+        let start_tmp = match range.start_bound() {
+            Bound::Included(key) | Bound::Excluded(key) => Some(K::as_bytes(key.borrow())),
+            Bound::Unbounded => None,
+        };
+        let end_tmp = match range.end_bound() {
+            Bound::Included(key) | Bound::Excluded(key) => Some(K::as_bytes(key.borrow())),
+            Bound::Unbounded => None,
+        };
+        let start_bound = match (range.start_bound(), start_tmp.as_ref()) {
+            (Bound::Included(_), Some(bytes)) => Bound::Included(bytes.as_ref()),
+            (Bound::Excluded(_), Some(bytes)) => Bound::Excluded(bytes.as_ref()),
+            _ => Bound::Unbounded,
+        };
+        let end_bound = match (range.end_bound(), end_tmp.as_ref()) {
+            (Bound::Included(_), Some(bytes)) => Bound::Included(bytes.as_ref()),
+            (Bound::Excluded(_), Some(bytes)) => Bound::Excluded(bytes.as_ref()),
+            _ => Bound::Unbounded,
+        };
+        let bounds = KeyRange::<K>::new(start_bound, end_bound);
+
+        let mut removed = 0;
+        let new_root = {
+            let mut retain_context = RetainBuilderContext::<K, V>::new(
+                &self.page_allocator,
+                &self.allocated,
+                self.freed,
+                self.modify_uncommitted,
+            );
+            let mut builder = RetainSubtreeBuilder::new();
+            let root_page = retain_context.get_page(header.root)?;
+            let retain_result = Self::retain_walk(
+                &mut retain_context,
+                root_page,
+                RetainWalkContext {
+                    checksum: header.checksum,
+                    upper_key: None,
+                    root_distance: 0,
+                },
+                bounds,
+                &mut predicate,
+                &mut removed,
+                &mut builder,
+            )?;
+
+            match retain_result {
+                RetainWalkResult::Unchanged(_) => Some(header),
+                RetainWalkResult::Changed => {
+                    if let Some((root, checksum)) = builder.finish_root(&mut retain_context)? {
+                        Some(BtreeHeader::new(root, checksum, header.length - removed))
+                    } else {
+                        None
+                    }
+                }
+            }
+        };
+        *self.root = new_root;
+
+        Ok(())
+    }
+
+    fn retain_walk<F>(
+        retain_context: &mut RetainBuilderContext<'_, K, V>,
+        page: PageImpl,
+        context: RetainWalkContext,
+        bounds: KeyRange<'_, K>,
+        predicate: &mut F,
+        removed: &mut u64,
+        builder: &mut RetainSubtreeBuilder,
+    ) -> Result<RetainWalkResult>
+    where
+        F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+    {
+        match page.memory()[0] {
+            LEAF => Self::retain_walk_leaf(
+                retain_context,
+                page,
+                context,
+                bounds,
+                predicate,
+                removed,
+                builder,
+            ),
+            BRANCH => Self::retain_walk_branch(
+                retain_context,
+                page,
+                context,
+                bounds,
+                predicate,
+                removed,
+                builder,
+            ),
+            _ => unreachable!(),
+        }
+    }
+
+    fn retain_walk_leaf<F>(
+        retain_context: &mut RetainBuilderContext<'_, K, V>,
+        page: PageImpl,
+        context: RetainWalkContext,
+        bounds: KeyRange<'_, K>,
+        predicate: &mut F,
+        removed: &mut u64,
+        builder: &mut RetainSubtreeBuilder,
+    ) -> Result<RetainWalkResult>
+    where
+        F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+    {
+        let page_number = page.get_page_number();
+        let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
+        let num_pairs = accessor.num_pairs();
+        let mut keep = Vec::with_capacity(num_pairs);
+        let mut kept_count = 0;
+        for i in 0..num_pairs {
+            let entry = accessor.entry(i).unwrap();
+            let keep_entry = if bounds.contains(entry.key()) {
+                predicate(K::from_bytes(entry.key()), V::from_bytes(entry.value()))
+            } else {
+                true
+            };
+            keep.push(keep_entry);
+            if keep_entry {
+                kept_count += 1;
+            } else {
+                *removed += 1;
+            }
+        }
+
+        if kept_count == num_pairs {
+            return Ok(RetainWalkResult::Unchanged(RetainSubtree::new(
+                page_number,
+                context.checksum,
+                context.upper_key,
+                context.root_distance,
+            )));
+        }
+
+        if kept_count == 0 {
+            drop(page);
+            retain_context.conditional_free(page_number);
+            return Ok(RetainWalkResult::Changed);
+        }
+
+        for (i, kept) in keep.into_iter().enumerate() {
+            if kept {
+                let entry = accessor.entry(i).unwrap();
+                builder.push_leaf_entry(
+                    retain_context,
+                    entry.key(),
+                    entry.value(),
+                    context.root_distance,
+                )?;
+            }
+        }
+        drop(page);
+        retain_context.conditional_free(page_number);
+        Ok(RetainWalkResult::Changed)
+    }
+
+    fn retain_walk_branch<F>(
+        retain_context: &mut RetainBuilderContext<'_, K, V>,
+        page: PageImpl,
+        context: RetainWalkContext,
+        bounds: KeyRange<'_, K>,
+        predicate: &mut F,
+        removed: &mut u64,
+        builder: &mut RetainSubtreeBuilder,
+    ) -> Result<RetainWalkResult>
+    where
+        F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+    {
+        let page_number = page.get_page_number();
+        let accessor = BranchAccessor::new(&page, K::fixed_width());
+        let child_count = accessor.count_children();
+        let mut pending_unchanged = Vec::new();
+        let child_root_distance = context.root_distance + 1;
+        let mut changed = false;
+
+        for i in 0..child_count {
+            let child_upper_key = if i + 1 < child_count {
+                Some(accessor.key(i).unwrap().to_vec())
+            } else {
+                context.upper_key.clone()
+            };
+            let below_start =
+                i + 1 < child_count && bounds.less_than_start(accessor.key(i).unwrap());
+            let above_end =
+                i > 0 && bounds.child_lower_bound_is_past_end(accessor.key(i - 1).unwrap());
+            if below_start || above_end {
+                pending_unchanged.push(RetainSubtree::branch_child(
+                    &accessor,
+                    context.upper_key.as_deref(),
+                    child_root_distance,
+                    i,
+                ));
+                continue;
+            }
+
+            let child_page_number = accessor.child_page(i).unwrap();
+            let child_checksum = accessor.child_checksum(i).unwrap();
+            let child_page = retain_context.get_page(child_page_number)?;
+            let mut child_builder = RetainSubtreeBuilder::new();
+            let child = Self::retain_walk(
+                retain_context,
+                child_page,
+                RetainWalkContext {
+                    checksum: child_checksum,
+                    upper_key: child_upper_key,
+                    root_distance: child_root_distance,
+                },
+                bounds,
+                predicate,
+                removed,
+                &mut child_builder,
+            )?;
+            match child {
+                RetainWalkResult::Unchanged(node) => {
+                    debug_assert!(child_builder.is_empty());
+                    debug_assert_eq!(node.root_distance(), child_root_distance);
+                    pending_unchanged.push(node);
+                }
+                RetainWalkResult::Changed => {
+                    changed = true;
+                    for subtree in pending_unchanged.drain(..) {
+                        builder.push_subtree(retain_context, subtree)?;
+                    }
+                    builder.append(retain_context, child_builder)?;
+                }
+            }
+        }
+
+        if !changed {
+            return Ok(RetainWalkResult::Unchanged(RetainSubtree::new(
+                page_number,
+                context.checksum,
+                context.upper_key,
+                context.root_distance,
+            )));
+        }
+
+        for subtree in pending_unchanged {
+            builder.push_subtree(retain_context, subtree)?;
+        }
+
+        drop(page);
+        retain_context.conditional_free(page_number);
+
+        Ok(RetainWalkResult::Changed)
     }
 
     fn delete_target(

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -4,6 +4,7 @@ mod btree_iters;
 mod btree_mutator;
 mod multimap_btree;
 mod page_store;
+mod retain;
 mod table_tree;
 mod table_tree_base;
 

--- a/src/tree_store/retain.rs
+++ b/src/tree_store/retain.rs
@@ -1,0 +1,814 @@
+use crate::Result;
+use crate::tree_store::btree_base::{
+    BRANCH, BranchAccessor, BranchBuilder, Checksum, DEFERRED, LEAF, LeafAccessor, LeafBuilder,
+    RawBranchBuilder, RawLeafBuilder,
+};
+use crate::tree_store::page_store::{Page, PageImpl};
+use crate::tree_store::{PageAllocator, PageHint, PageNumber, PageTrackerPolicy};
+use crate::types::{Key, Value};
+use std::cmp::Ordering;
+use std::marker::PhantomData;
+use std::ops::Range;
+use std::sync::Mutex;
+
+type RetainLeafEntry = (Vec<u8>, Vec<u8>);
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum RetainEdge {
+    Left,
+    Right,
+}
+
+impl RetainEdge {
+    fn child_index<T: Page>(self, accessor: &BranchAccessor<'_, '_, T>) -> usize {
+        match self {
+            Self::Left => 0,
+            Self::Right => accessor.count_children() - 1,
+        }
+    }
+}
+
+pub(super) struct RetainBuilderContext<'a, K: Key, V: Value> {
+    page_allocator: &'a PageAllocator,
+    allocated: &'a Mutex<PageTrackerPolicy>,
+    freed: &'a mut Vec<PageNumber>,
+    modify_uncommitted: bool,
+    _types: PhantomData<(K, V)>,
+}
+
+impl<'a, K: Key, V: Value> RetainBuilderContext<'a, K, V> {
+    pub(super) fn new(
+        page_allocator: &'a PageAllocator,
+        allocated: &'a Mutex<PageTrackerPolicy>,
+        freed: &'a mut Vec<PageNumber>,
+        modify_uncommitted: bool,
+    ) -> Self {
+        Self {
+            page_allocator,
+            allocated,
+            freed,
+            modify_uncommitted,
+            _types: PhantomData,
+        }
+    }
+
+    pub(super) fn get_page(&self, page_number: PageNumber) -> Result<PageImpl> {
+        self.page_allocator.get_page(page_number, PageHint::None)
+    }
+
+    pub(super) fn conditional_free(&mut self, page_number: PageNumber) {
+        if self.modify_uncommitted {
+            let mut allocated = self.allocated.lock().unwrap();
+            if !self
+                .page_allocator
+                .free_if_uncommitted(page_number, &mut allocated)
+            {
+                self.freed.push(page_number);
+            }
+        } else {
+            self.freed.push(page_number);
+        }
+    }
+}
+
+// A sealed B-tree subtree, annotated with its distance from the original retain walk root.
+pub(super) struct RetainSubtree {
+    page: PageNumber,
+    checksum: Checksum,
+    // Upper bound for this subtree. Parent branch separators are rebuilt from
+    // it. Only the final subtree in an ordered list may use None; separator
+    // keys on older branch pages can be stale upper bounds, so retain must not
+    // rely on this being the exact maximum key unless the node was just rebuilt.
+    upper_key: Option<Vec<u8>>,
+    root_distance: u32,
+}
+
+impl RetainSubtree {
+    pub(super) fn new(
+        page: PageNumber,
+        checksum: Checksum,
+        upper_key: Option<Vec<u8>>,
+        root_distance: u32,
+    ) -> Self {
+        Self {
+            page,
+            checksum,
+            upper_key,
+            root_distance,
+        }
+    }
+
+    pub(super) fn branch_child(
+        accessor: &BranchAccessor<'_, '_, PageImpl>,
+        parent_upper_key: Option<&[u8]>,
+        root_distance: u32,
+        index: usize,
+    ) -> Self {
+        let upper_key = if index + 1 < accessor.count_children() {
+            Some(accessor.key(index).unwrap().to_vec())
+        } else {
+            parent_upper_key.map(<[u8]>::to_vec)
+        };
+
+        Self::new(
+            accessor.child_page(index).unwrap(),
+            accessor.child_checksum(index).unwrap(),
+            upper_key,
+            root_distance,
+        )
+    }
+
+    pub(super) fn root_distance(&self) -> u32 {
+        self.root_distance
+    }
+
+    fn graft_ordered<K: Key, V: Value>(
+        context: &mut RetainBuilderContext<'_, K, V>,
+        left: Self,
+        right: Self,
+    ) -> Result<(Self, Option<Self>)> {
+        match left.root_distance.cmp(&right.root_distance) {
+            Ordering::Equal => Ok((left, Some(right))),
+            Ordering::Greater => {
+                Self::graft_deeper_into_shallower(context, left, right, RetainEdge::Left)
+            }
+            Ordering::Less => {
+                Self::graft_deeper_into_shallower(context, right, left, RetainEdge::Right)
+            }
+        }
+    }
+
+    fn graft_deeper_into_shallower<K: Key, V: Value>(
+        context: &mut RetainBuilderContext<'_, K, V>,
+        deeper: Self,
+        shallower: Self,
+        edge: RetainEdge,
+    ) -> Result<(Self, Option<Self>)> {
+        assert!(deeper.root_distance > shallower.root_distance);
+        let old_page = shallower.page;
+        let branch_root_distance = shallower.root_distance;
+        let branch_upper_key = shallower.upper_key;
+        assert!(edge == RetainEdge::Left || branch_upper_key.is_some());
+        let page = context.get_page(old_page)?;
+        assert_eq!(page.memory()[0], BRANCH);
+        let accessor = BranchAccessor::new(&page, K::fixed_width());
+        let child_root_distance = branch_root_distance + 1;
+        let edge_index = edge.child_index(&accessor);
+        let edge_child = Self::branch_child(
+            &accessor,
+            branch_upper_key.as_deref(),
+            child_root_distance,
+            edge_index,
+        );
+        let replacement = match edge {
+            RetainEdge::Left => Self::graft_ordered(context, deeper, edge_child)?,
+            RetainEdge::Right => Self::graft_ordered(context, edge_child, deeper)?,
+        };
+
+        let rebuilt = Self::replace_branch_child(
+            context,
+            &accessor,
+            branch_root_distance,
+            branch_upper_key,
+            edge,
+            replacement,
+        )?;
+        drop(page);
+        context.conditional_free(old_page);
+        Ok(rebuilt)
+    }
+
+    fn absorb_leaf_entries<K: Key, V: Value>(
+        self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        entries: Vec<RetainLeafEntry>,
+        entry_root_distance: u32,
+        edge: RetainEdge,
+    ) -> Result<(Self, Option<Self>)> {
+        match self.root_distance.cmp(&entry_root_distance) {
+            Ordering::Equal => {
+                let page = context.get_page(self.page)?;
+                assert_eq!(page.memory()[0], LEAF);
+                let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
+                assert!(!entries.is_empty());
+                let upper_key = match edge {
+                    RetainEdge::Left => self.upper_key.clone(),
+                    RetainEdge::Right => Some(entries.last().unwrap().0.clone()),
+                };
+                let mut builder = LeafBuilder::new(
+                    context.page_allocator,
+                    context.allocated,
+                    entries.len() + accessor.num_pairs(),
+                    K::fixed_width(),
+                    V::fixed_width(),
+                );
+                match edge {
+                    RetainEdge::Left => {
+                        for (key, value) in &entries {
+                            builder.push(key, value);
+                        }
+                        builder.push_all_except(&accessor, None);
+                    }
+                    RetainEdge::Right => {
+                        builder.push_all_except(&accessor, None);
+                        for (key, value) in &entries {
+                            builder.push(key, value);
+                        }
+                    }
+                }
+                let result = if builder.should_split() {
+                    let (left, separator, right) = builder.build_split()?;
+                    let separator = separator.to_vec();
+                    (
+                        Self::new(
+                            left.get_page_number(),
+                            DEFERRED,
+                            Some(separator),
+                            entry_root_distance,
+                        ),
+                        Some(Self::new(
+                            right.get_page_number(),
+                            DEFERRED,
+                            upper_key,
+                            entry_root_distance,
+                        )),
+                    )
+                } else {
+                    let page = builder.build()?;
+                    (
+                        Self::new(
+                            page.get_page_number(),
+                            DEFERRED,
+                            upper_key,
+                            entry_root_distance,
+                        ),
+                        None,
+                    )
+                };
+                drop(page);
+                context.conditional_free(self.page);
+                Ok(result)
+            }
+            Ordering::Less => {
+                let old_page = self.page;
+                let branch_root_distance = self.root_distance;
+                let branch_upper_key = self.upper_key;
+                let page = context.get_page(old_page)?;
+                assert_eq!(page.memory()[0], BRANCH);
+                let accessor = BranchAccessor::new(&page, K::fixed_width());
+                let child_root_distance = branch_root_distance + 1;
+                let edge_index = edge.child_index(&accessor);
+                let edge_child = Self::branch_child(
+                    &accessor,
+                    branch_upper_key.as_deref(),
+                    child_root_distance,
+                    edge_index,
+                );
+                let replacement =
+                    edge_child.absorb_leaf_entries(context, entries, entry_root_distance, edge)?;
+                let rebuilt = Self::replace_branch_child(
+                    context,
+                    &accessor,
+                    branch_root_distance,
+                    branch_upper_key,
+                    edge,
+                    replacement,
+                )?;
+                drop(page);
+                context.conditional_free(old_page);
+                Ok(rebuilt)
+            }
+            Ordering::Greater => {
+                unreachable!("retain leaf entries cannot be above the subtree they are joining")
+            }
+        }
+    }
+
+    fn replace_branch_child<K: Key, V: Value>(
+        context: &mut RetainBuilderContext<'_, K, V>,
+        accessor: &BranchAccessor<'_, '_, PageImpl>,
+        branch_root_distance: u32,
+        branch_upper_key: Option<Vec<u8>>,
+        edge: RetainEdge,
+        replacement: (Self, Option<Self>),
+    ) -> Result<(Self, Option<Self>)> {
+        let child_root_distance = branch_root_distance + 1;
+        let (left, right) = replacement;
+        assert_eq!(left.root_distance, child_root_distance);
+        if let Some(ref right) = right {
+            assert_eq!(right.root_distance, child_root_distance);
+        }
+        let child_index = edge.child_index(accessor);
+
+        let replacement_upper_key = right
+            .as_ref()
+            .map_or_else(|| left.upper_key.clone(), |right| right.upper_key.clone());
+        let branch_upper_key = match edge {
+            RetainEdge::Left => {
+                assert_eq!(replacement_upper_key.as_deref(), accessor.key(child_index));
+                branch_upper_key
+            }
+            RetainEdge::Right => replacement_upper_key,
+        };
+
+        let child_capacity = accessor.count_children() + usize::from(right.is_some());
+        let mut builder = BranchBuilder::new(
+            context.page_allocator,
+            context.allocated,
+            child_capacity,
+            K::fixed_width(),
+        );
+
+        match (edge, right.as_ref()) {
+            (_, None) => {
+                builder.push_all(accessor);
+                builder.replace_child(child_index, left.page, left.checksum);
+            }
+            (RetainEdge::Left, Some(right)) => {
+                builder.push_child(left.page, left.checksum);
+                builder.push_key(
+                    left.upper_key
+                        .as_ref()
+                        .expect("non-final retain child must have an upper bound"),
+                );
+                builder.push_all(accessor);
+                builder.replace_child(1, right.page, right.checksum);
+            }
+            (RetainEdge::Right, Some(right)) => {
+                builder.push_all(accessor);
+                builder.replace_child(child_index, left.page, left.checksum);
+                builder.push_key(
+                    left.upper_key
+                        .as_ref()
+                        .expect("non-final retain child must have an upper bound"),
+                );
+                builder.push_child(right.page, right.checksum);
+            }
+        }
+
+        Self::build_branch_from_builder(builder, branch_root_distance, branch_upper_key)
+    }
+
+    fn build_parent_subtrees<K: Key, V: Value>(
+        context: &mut RetainBuilderContext<'_, K, V>,
+        children: &[Self],
+        child_root_distance: u32,
+    ) -> Result<(Self, Option<Self>)> {
+        assert!(children.len() > 1);
+        let root_distance = child_root_distance
+            .checked_sub(1)
+            .expect("retain branch children must be below their parent");
+        let mut builder = BranchBuilder::new(
+            context.page_allocator,
+            context.allocated,
+            children.len(),
+            K::fixed_width(),
+        );
+        for (i, child) in children.iter().enumerate() {
+            builder.push_child(child.page, child.checksum);
+            if i + 1 < children.len() {
+                builder.push_key(
+                    child
+                        .upper_key
+                        .as_ref()
+                        .expect("non-final retain child must have an upper bound"),
+                );
+            }
+        }
+        let upper_key = children.last().unwrap().upper_key.clone();
+        Self::build_branch_from_builder(builder, root_distance, upper_key)
+    }
+
+    fn build_branch_from_builder(
+        builder: BranchBuilder<'_, '_>,
+        root_distance: u32,
+        upper_key: Option<Vec<u8>>,
+    ) -> Result<(Self, Option<Self>)> {
+        if builder.should_split() {
+            let (left, separator, right) = builder.build_split()?;
+            let separator = separator.to_vec();
+            let left_page = left.get_page_number();
+            let right_page = right.get_page_number();
+            Ok((
+                Self::new(left_page, DEFERRED, Some(separator), root_distance),
+                Some(Self::new(right_page, DEFERRED, upper_key, root_distance)),
+            ))
+        } else {
+            let page = builder.build()?;
+            Ok((
+                Self::new(page.get_page_number(), DEFERRED, upper_key, root_distance),
+                None,
+            ))
+        }
+    }
+}
+
+// Retained leaf entries that have not yet been sealed into a page.
+struct InProgressLeaf {
+    entries: Vec<RetainLeafEntry>,
+    root_distance: Option<u32>,
+}
+
+impl InProgressLeaf {
+    fn new() -> Self {
+        Self {
+            entries: vec![],
+            root_distance: None,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty() && self.root_distance.is_none()
+    }
+
+    fn required_bytes<K: Key, V: Value>(entries: &[RetainLeafEntry]) -> usize {
+        let entries_bytes = entries
+            .iter()
+            .map(|(key, value)| key.len() + value.len())
+            .sum();
+        RawLeafBuilder::required_bytes(
+            entries.len(),
+            entries_bytes,
+            K::fixed_width(),
+            V::fixed_width(),
+        )
+    }
+
+    fn push<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        key: &[u8],
+        value: &[u8],
+        root_distance: u32,
+    ) -> Result<Option<RetainSubtree>> {
+        let mut flushed = None;
+        if let Some(leaf_root_distance) = self.root_distance {
+            assert_eq!(leaf_root_distance, root_distance);
+        } else {
+            self.root_distance = Some(root_distance);
+        }
+
+        self.entries.push((key.to_vec(), value.to_vec()));
+        if self.entries.len() > 1
+            && Self::required_bytes::<K, V>(&self.entries) > context.page_allocator.get_page_size()
+        {
+            let overflow = self.entries.pop().unwrap();
+            if self.is_full_enough(context) {
+                assert!(flushed.is_none());
+                flushed = self.seal_if_sufficient(context)?;
+                self.root_distance = Some(root_distance);
+                self.entries.push(overflow);
+            } else {
+                self.entries.push(overflow);
+                assert!(flushed.is_none());
+                flushed = self.seal_if_sufficient(context)?;
+            }
+        }
+
+        Ok(flushed)
+    }
+
+    fn is_full_enough<K: Key, V: Value>(&self, context: &RetainBuilderContext<'_, K, V>) -> bool {
+        Self::required_bytes::<K, V>(&self.entries) >= context.page_allocator.get_page_size() / 3
+    }
+
+    fn seal_if_sufficient<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+    ) -> Result<Option<RetainSubtree>> {
+        if self.entries.is_empty() {
+            self.root_distance = None;
+            return Ok(None);
+        }
+
+        if !self.is_full_enough(context) {
+            return Ok(None);
+        }
+
+        self.seal_unchecked(context)
+    }
+
+    fn seal_unchecked<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+    ) -> Result<Option<RetainSubtree>> {
+        if self.entries.is_empty() {
+            self.root_distance = None;
+            return Ok(None);
+        }
+
+        let entries = std::mem::take(&mut self.entries);
+        let root_distance = self
+            .root_distance
+            .take()
+            .expect("retain leaf entries must have a root distance");
+        let upper_key = entries.last().unwrap().0.clone();
+        let mut builder = LeafBuilder::new(
+            context.page_allocator,
+            context.allocated,
+            entries.len(),
+            K::fixed_width(),
+            V::fixed_width(),
+        );
+        for (key, value) in &entries {
+            builder.push(key, value);
+        }
+        let page = builder.build()?;
+        Ok(Some(RetainSubtree::new(
+            page.get_page_number(),
+            DEFERRED,
+            Some(upper_key),
+            root_distance,
+        )))
+    }
+
+    fn take_entries(&mut self) -> Option<(Vec<RetainLeafEntry>, u32)> {
+        if self.entries.is_empty() {
+            self.root_distance = None;
+            None
+        } else {
+            let entries = std::mem::take(&mut self.entries);
+            let root_distance = self
+                .root_distance
+                .take()
+                .expect("retain leaf entries must have a root distance");
+            Some((entries, root_distance))
+        }
+    }
+
+    fn graft_to_subtree<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        subtree: RetainSubtree,
+        edge: RetainEdge,
+    ) -> Result<(RetainSubtree, Option<RetainSubtree>)> {
+        let (entries, root_distance) = self
+            .take_entries()
+            .expect("retain leaf entries must exist before subtree grafting");
+        subtree.absorb_leaf_entries(context, entries, root_distance, edge)
+    }
+}
+
+pub(super) struct RetainSubtreeBuilder {
+    // In-progress left-to-right replacement stream. The builder keeps the
+    // right subtree in each adjacent pair at the same root distance or farther
+    // from the root, so the pending frontier is bounded by one accumulation
+    // buffer per root distance.
+    frontier: Vec<RetainSubtree>,
+    leaf: InProgressLeaf,
+}
+
+impl RetainSubtreeBuilder {
+    pub(super) fn new() -> Self {
+        Self {
+            frontier: vec![],
+            leaf: InProgressLeaf::new(),
+        }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.frontier.is_empty() && self.leaf.is_empty()
+    }
+
+    fn normalize_frontier<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+    ) -> Result<()> {
+        while let Some(index) = self.rightmost_descent() {
+            self.graft_pair_at(context, index)?;
+            assert!(
+                self.rightmost_descent()
+                    .is_none_or(|next_index| next_index < index),
+                "retain descent graft did not progress"
+            );
+        }
+
+        while let Some(parent_range) =
+            self.same_root_distance_prefix_ready_for_parent::<K, V>(context)
+        {
+            let old_len = self.frontier.len();
+            let start = parent_range.start;
+            let children: Vec<_> = self.frontier.drain(parent_range).collect();
+            let child_root_distance = children[0].root_distance;
+            debug_assert!(
+                children
+                    .iter()
+                    .all(|child| child.root_distance == child_root_distance)
+            );
+            let parents =
+                RetainSubtree::build_parent_subtrees(context, &children, child_root_distance)?;
+            let (parent, right_parent) = parents;
+            assert!(right_parent.is_none());
+            self.frontier.insert(start, parent);
+            assert!(self.frontier.len() < old_len);
+            assert!(self.rightmost_descent().is_none());
+        }
+
+        Ok(())
+    }
+
+    fn rightmost_descent(&self) -> Option<usize> {
+        self.frontier
+            .windows(2)
+            .rposition(|pair| pair[0].root_distance > pair[1].root_distance)
+    }
+
+    fn first_root_distance_change(&self) -> Option<usize> {
+        self.frontier
+            .windows(2)
+            .position(|pair| pair[0].root_distance != pair[1].root_distance)
+    }
+
+    fn same_root_distance_prefix_ready_for_parent<K: Key, V: Value>(
+        &self,
+        context: &RetainBuilderContext<'_, K, V>,
+    ) -> Option<Range<usize>> {
+        if self.frontier.len() <= 1 {
+            return None;
+        }
+
+        let root_distance = self.frontier.last().unwrap().root_distance;
+        let same_distance_start = self
+            .frontier
+            .iter()
+            .rposition(|subtree| subtree.root_distance != root_distance)
+            .map_or(0, |index| index + 1);
+        if self.frontier[same_distance_start].root_distance == 0 {
+            return None;
+        }
+
+        let page_size = context.page_allocator.get_page_size();
+        let min_size = page_size / 3;
+        for right_remainder_start in same_distance_start + 2..self.frontier.len() - 1 {
+            let left_parent_with_next = &self.frontier[same_distance_start..=right_remainder_start];
+            let right_remainder = &self.frontier[right_remainder_start..];
+            if Self::branch_group_required_bytes::<K>(left_parent_with_next) > page_size {
+                if Self::branch_group_required_bytes::<K>(right_remainder) >= min_size {
+                    return Some(same_distance_start..right_remainder_start);
+                }
+                return None;
+            }
+        }
+        None
+    }
+
+    fn graft_pair_at<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        index: usize,
+    ) -> Result<()> {
+        let right = self.frontier.remove(index + 1);
+        let left = self.frontier.remove(index);
+        let (grafted, right_grafted) = RetainSubtree::graft_ordered(context, left, right)?;
+        self.frontier.insert(index, grafted);
+        if let Some(right_grafted) = right_grafted {
+            self.frontier.insert(index + 1, right_grafted);
+        }
+        Ok(())
+    }
+
+    fn branch_group_required_bytes<K: Key>(children: &[RetainSubtree]) -> usize {
+        assert!(children.len() > 1);
+        let total_key_bytes = children
+            .iter()
+            .take(children.len() - 1)
+            .map(|child| {
+                child
+                    .upper_key
+                    .as_ref()
+                    .expect("non-final retain child must have an upper bound")
+                    .len()
+            })
+            .sum();
+        RawBranchBuilder::required_bytes(children.len() - 1, total_key_bytes, K::fixed_width())
+    }
+
+    pub(super) fn push_leaf_entry<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        key: &[u8],
+        value: &[u8],
+        root_distance: u32,
+    ) -> Result<()> {
+        if let Some(leaf) = self.leaf.push(context, key, value, root_distance)? {
+            self.frontier.push(leaf);
+            self.normalize_frontier(context)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn push_subtree<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        subtree: RetainSubtree,
+    ) -> Result<()> {
+        if let Some(leaf) = self.leaf.seal_if_sufficient(context)? {
+            self.frontier.push(leaf);
+            self.normalize_frontier(context)?;
+        }
+
+        if self.leaf.is_empty() {
+            self.frontier.push(subtree);
+        } else {
+            let (subtree, right_subtree) =
+                self.leaf
+                    .graft_to_subtree(context, subtree, RetainEdge::Left)?;
+            self.frontier.push(subtree);
+            if let Some(right_subtree) = right_subtree {
+                self.frontier.push(right_subtree);
+            }
+        }
+        self.normalize_frontier(context)
+    }
+
+    pub(super) fn append<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        child_builder: RetainSubtreeBuilder,
+    ) -> Result<()> {
+        let RetainSubtreeBuilder { frontier, mut leaf } = child_builder;
+
+        for subtree in frontier {
+            self.push_subtree(context, subtree)?;
+        }
+        if let Some((entries, root_distance)) = leaf.take_entries() {
+            for (key, value) in entries {
+                self.push_leaf_entry(context, &key, &value, root_distance)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn finish_root<K: Key, V: Value>(
+        mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+    ) -> Result<Option<(PageNumber, Checksum)>> {
+        if let Some(leaf) = self.leaf.seal_if_sufficient(context)? {
+            self.frontier.push(leaf);
+            self.normalize_frontier(context)?;
+        }
+        if !self.leaf.is_empty() {
+            if let Some(subtree) = self.frontier.pop() {
+                let (subtree, right_subtree) =
+                    self.leaf
+                        .graft_to_subtree(context, subtree, RetainEdge::Right)?;
+                self.frontier.push(subtree);
+                if let Some(right_subtree) = right_subtree {
+                    self.frontier.push(right_subtree);
+                }
+            } else if let Some(leaf) = self.leaf.seal_unchecked(context)? {
+                self.frontier.push(leaf);
+            }
+        }
+
+        self.normalize_frontier(context)?;
+        while self.frontier.len() > 1 {
+            while let Some(index) = self.first_root_distance_change() {
+                let old_len = self.frontier.len();
+                self.graft_pair_at(context, index)?;
+                assert!(
+                    self.frontier.len() < old_len
+                        || self
+                            .first_root_distance_change()
+                            .is_none_or(|next_index| next_index > index),
+                    "retain root-distance graft did not progress"
+                );
+            }
+
+            if self.frontier.len() <= 1 {
+                break;
+            }
+
+            // Multiple subtrees at root distance zero need a new root above
+            // them. Bump their relative distances before building that parent.
+            if self
+                .frontier
+                .iter()
+                .all(|subtree| subtree.root_distance == 0)
+            {
+                for subtree in &mut self.frontier {
+                    subtree.root_distance += 1;
+                }
+            }
+            let child_root_distance = self.frontier[0].root_distance;
+            debug_assert!(
+                self.frontier
+                    .iter()
+                    .all(|subtree| subtree.root_distance == child_root_distance)
+            );
+            let parents =
+                RetainSubtree::build_parent_subtrees(context, &self.frontier, child_root_distance)?;
+            let (parent, right_parent) = parents;
+            let old_len = self.frontier.len();
+            self.frontier.clear();
+            self.frontier.push(parent);
+            if let Some(right_parent) = right_parent {
+                self.frontier.push(right_parent);
+            }
+            assert!(self.frontier.len() < old_len);
+            self.normalize_frontier(context)?;
+        }
+
+        Ok(self.frontier.pop().map(|root| (root.page, root.checksum)))
+    }
+}

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1895,6 +1895,16 @@ fn retain_in_empty() {
         #[expect(clippy::reversed_empty_ranges)]
         table.retain_in(500..0, |_, _| false).unwrap();
         assert_eq!(table.len().unwrap(), 1000);
+
+        let mut called = false;
+        table
+            .retain_in(2000..3000, |_, _| {
+                called = true;
+                false
+            })
+            .unwrap();
+        assert!(!called);
+        assert_eq!(table.len().unwrap(), 1000);
     }
     write_txn.commit().unwrap();
 }
@@ -2014,11 +2024,15 @@ fn retain_in_rebuilds_range_boundaries() {
         for i in 0u64..30_000 {
             table.insert(i, &[0u8; 200]).unwrap();
         }
+        let height_before = table.stats().unwrap().tree_height();
 
         table
             .retain_in(10_000..20_000, |key, _| key == 15_000)
             .unwrap();
         assert_eq!(table.len().unwrap(), 20_001);
+        let stats = table.stats().unwrap();
+        assert!(stats.tree_height() <= height_before);
+        assert!(stats.leaf_pages() < 2_100);
         assert!(table.get(&9999).unwrap().is_some());
         assert!(table.get(&10_000).unwrap().is_none());
         assert!(table.get(&14_999).unwrap().is_none());
@@ -2050,6 +2064,32 @@ fn retain_coalesces_sparse_survivors() {
         for i in 0u64..20_000 {
             let value = table.get(&i).unwrap();
             assert_eq!(value.is_some(), i % 100 == 0);
+        }
+    }
+    write_txn.commit().unwrap();
+}
+
+#[test]
+fn retain_variable_sized_sparse_survivors_terminates() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+    let large = vec![0u8; 3_600];
+    let small = vec![1u8; 600];
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0u64..3_000 {
+            let value = if i % 3 == 0 { &large } else { &small };
+            table.insert(i, value.as_slice()).unwrap();
+        }
+
+        table.retain(|key, _| key % 3 != 1).unwrap();
+        assert_eq!(table.len().unwrap(), 2_000);
+        for i in 0u64..3_000 {
+            assert_eq!(table.get(i).unwrap().is_some(), i % 3 != 1);
         }
     }
     write_txn.commit().unwrap();


### PR DESCRIPTION
Rework retain and retain_in to rebuild changed ranges using a streaming subtree builder. The retained output is coalesced as it is produced, avoiding the sparse-retain fragmentation of the old per-leaf rebuild path while keeping unchanged boundary subtrees sealed.

Track replacement subtrees by their distance from the retain walk root so stitching does not depend on measuring or inferring leaf-distance heights for unchanged boundary trees. Underfilled rebuilt pages are merged with adjacent subtrees.

retain() benchmark is now about 25x faster

Assisted-by: Codex