### PR TITLE
Poison transaction on extract_if() predicate panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
   types, mirroring `std::collections::BTreeMap::entry`. Supports `or_insert`,
   `or_insert_with`, `or_insert_with_key`, `and_modify`, and the usual `OccupiedEntry`
   / `VacantEntry` accessors.
-* `Table::retain()` and `Table::retain_in()` now poison the write transaction if their
-  predicate panics, causing `WriteTransaction::commit()` to return
-  `CommitError::TransactionPoisoned`.
+* `Table::retain()`, `Table::retain_in()`, `Table::extract_if()`, and `Table::extract_from_if()`
+  now poison the write transaction if their predicate panics, causing `WriteTransaction::commit()`
+  to return `CommitError::TransactionPoisoned`.
 * Optimize `Table::pop_first()` and `Table::pop_last()` to be about 2x faster.
 * Enable file space reclamation during non-durable transactions performed while a savepoint exists.
 * Reuse pages freed by a durable write transaction in the next write transaction when no

--- a/src/table.rs
+++ b/src/table.rs
@@ -147,6 +147,10 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     /// `predicate` evaluates to `true` are returned in an iterator, and those which are read from the iterator are removed
     ///
     /// Note: values not read from the iterator will not be removed
+    ///
+    /// The predicate must not panic. If it panics, the write transaction is
+    /// poisoned and [`crate::WriteTransaction::commit`] will return
+    /// [`crate::CommitError::TransactionPoisoned`].
     pub fn extract_if<F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
         &mut self,
         predicate: F,
@@ -158,6 +162,10 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     /// `predicate` evaluates to `true` are returned in an iterator, and those which are read from the iterator are removed
     ///
     /// Note: values not read from the iterator will not be removed
+    ///
+    /// The predicate must not panic. If it panics, the write transaction is
+    /// poisoned and [`crate::WriteTransaction::commit`] will return
+    /// [`crate::CommitError::TransactionPoisoned`].
     pub fn extract_from_if<'a, KR, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
         &mut self,
         range: impl RangeBounds<KR> + 'a,
@@ -166,9 +174,8 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
-        self.tree
-            .extract_from_if(&range, predicate)
-            .map(ExtractIf::new)
+        let inner = self.tree.extract_from_if(&range, predicate)?;
+        Ok(ExtractIf::new(inner, Some(self.transaction)))
     }
 
     /// Applies `predicate` to all key-value pairs. All entries for which
@@ -609,6 +616,7 @@ pub struct ExtractIf<
     F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
 > {
     inner: BtreeExtractIf<'a, K, V, F>,
+    poison_target: Option<&'a WriteTransaction>,
 }
 
 impl<
@@ -618,8 +626,29 @@ impl<
     F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
 > ExtractIf<'a, K, V, F>
 {
-    pub(crate) fn new(inner: BtreeExtractIf<'a, K, V, F>) -> Self {
-        Self { inner }
+    pub(crate) fn new(
+        inner: BtreeExtractIf<'a, K, V, F>,
+        poison_target: Option<&'a WriteTransaction>,
+    ) -> Self {
+        Self {
+            inner,
+            poison_target,
+        }
+    }
+}
+
+impl<
+    K: Key + 'static,
+    V: Value + 'static,
+    F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+> Drop for ExtractIf<'_, K, V, F>
+{
+    fn drop(&mut self) {
+        if self.inner.predicate_panicked()
+            && let Some(transaction) = self.poison_target
+        {
+            transaction.poison();
+        }
     }
 }
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -444,7 +444,7 @@ impl<'s, K: Key + 'static, V: Value + 'static> SystemTable<'s, K, V> {
     {
         self.tree
             .extract_from_if(&range, predicate)
-            .map(ExtractIf::new)
+            .map(|inner| ExtractIf::new(inner, None))
     }
 
     pub fn insert<'k, 'v>(

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -261,6 +261,7 @@ pub(crate) struct BtreeExtractIf<
     root: &'a mut Option<BtreeHeader>,
     inner: BtreeRangeIter<K, V>,
     predicate: F,
+    predicate_running: bool,
     free_on_drop: Vec<PageNumber>,
     master_free_list: Arc<Mutex<Vec<PageNumber>>>,
     allocated: Arc<Mutex<PageTrackerPolicy>>,
@@ -282,11 +283,24 @@ impl<'a, K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) ->
             root,
             inner,
             predicate,
+            predicate_running: false,
             free_on_drop: vec![],
             master_free_list,
             allocated,
             page_allocator,
         }
+    }
+
+    pub(crate) fn predicate_panicked(&self) -> bool {
+        self.predicate_running
+    }
+
+    fn predicate_matches(&mut self, entry: &EntryGuard<K, V>) -> bool {
+        assert!(!self.predicate_running);
+        self.predicate_running = true;
+        let result = (self.predicate)(entry.key(), entry.value());
+        self.predicate_running = false;
+        result
     }
 }
 
@@ -298,7 +312,7 @@ impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> boo
     fn next(&mut self) -> Option<Self::Item> {
         let mut item = self.inner.next();
         while let Some(Ok(ref entry)) = item {
-            if (self.predicate)(entry.key(), entry.value()) {
+            if self.predicate_matches(entry) {
                 let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new_do_not_modify(
                     self.root,
                     self.page_allocator.clone(),
@@ -327,7 +341,7 @@ impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> boo
     fn next_back(&mut self) -> Option<Self::Item> {
         let mut item = self.inner.next_back();
         while let Some(Ok(ref entry)) = item {
-            if (self.predicate)(entry.key(), entry.value()) {
+            if self.predicate_matches(entry) {
                 let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new_do_not_modify(
                     self.root,
                     self.page_allocator.clone(),

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -253,6 +253,58 @@ fn extract_if() {
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
+#[test]
+fn extract_if_predicate_panic_poisons_transaction() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..10 {
+            table.insert(&i, &i).unwrap();
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut extracted = table
+                .extract_if(|key, _| {
+                    assert_ne!(key, 2);
+                    key == 0
+                })
+                .unwrap();
+            assert_eq!(extracted.next().unwrap().unwrap().0.value(), 0);
+            let _ = extracted.next();
+        }));
+        assert!(result.is_err());
+    }
+    assert!(matches!(
+        write_txn.commit(),
+        Err(CommitError::TransactionPoisoned)
+    ));
+}
+
+#[cfg(not(target_os = "wasi"))]
+#[test]
+fn extract_if_caller_panic_does_not_poison_transaction() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..10 {
+            table.insert(&i, &i).unwrap();
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut extracted = table.extract_if(|key, _| key == 0).unwrap();
+            assert_eq!(extracted.next().unwrap().unwrap().0.value(), 0);
+            panic!("caller panic");
+        }));
+        assert!(result.is_err());
+    }
+    write_txn.commit().unwrap();
+}
+
 #[test]
 fn retain() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
Match retain() behavior by poisoning write transactions when an extract_if() or extract_from_if() predicate panics.

Assisted-by: Codex