### PR TITLE
Move extract_if iterator into its own module

### DIFF
--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -3,12 +3,11 @@ use crate::tree_store::btree_base::{
     AccessGuardMut, BRANCH, BranchAccessor, BranchMutator, BtreeHeader, Checksum, DEFERRED, LEAF,
     LeafAccessor, LeafPageMut, branch_checksum, leaf_checksum,
 };
-use crate::tree_store::btree_iters::BtreeExtractIf;
 use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
-    AccessGuardMutInPlace, AllPageNumbersBtreeIter, BtreeRangeIter, PageAllocator, PageHint,
-    PageNumber, PageResolver, PageTrackerPolicy,
+    AccessGuardMutInPlace, AllPageNumbersBtreeIter, BtreeExtractIf, BtreeRangeIter, PageAllocator,
+    PageHint, PageNumber, PageResolver, PageTrackerPolicy,
 };
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, Result};

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -2,16 +2,14 @@ use crate::Result;
 use crate::tree_store::btree_base::{BRANCH, LEAF};
 use crate::tree_store::btree_base::{BranchAccessor, LeafAccessor};
 use crate::tree_store::btree_iters::RangeIterState::{Internal, Leaf};
-use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageHint, PageImpl};
-use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageResolver, PageTrackerPolicy};
+use crate::tree_store::{PageNumber, PageResolver};
 use crate::types::{Key, Value};
 use Bound::{Excluded, Included, Unbounded};
 use std::borrow::Borrow;
 use std::collections::Bound;
 use std::marker::PhantomData;
 use std::ops::{Range, RangeBounds};
-use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone)]
 pub enum RangeIterState {
@@ -252,136 +250,6 @@ impl Iterator for AllPageNumbersBtreeIter {
     }
 }
 
-pub(crate) struct BtreeExtractIf<
-    'a,
-    K: Key + 'static,
-    V: Value + 'static,
-    F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
-> {
-    root: &'a mut Option<BtreeHeader>,
-    inner: BtreeRangeIter<K, V>,
-    predicate: F,
-    predicate_running: bool,
-    free_on_drop: Vec<PageNumber>,
-    master_free_list: Arc<Mutex<Vec<PageNumber>>>,
-    allocated: Arc<Mutex<PageTrackerPolicy>>,
-    page_allocator: PageAllocator,
-}
-
-impl<'a, K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>
-    BtreeExtractIf<'a, K, V, F>
-{
-    pub(crate) fn new(
-        root: &'a mut Option<BtreeHeader>,
-        inner: BtreeRangeIter<K, V>,
-        predicate: F,
-        master_free_list: Arc<Mutex<Vec<PageNumber>>>,
-        allocated: Arc<Mutex<PageTrackerPolicy>>,
-        page_allocator: PageAllocator,
-    ) -> Self {
-        Self {
-            root,
-            inner,
-            predicate,
-            predicate_running: false,
-            free_on_drop: vec![],
-            master_free_list,
-            allocated,
-            page_allocator,
-        }
-    }
-
-    pub(crate) fn predicate_panicked(&self) -> bool {
-        self.predicate_running
-    }
-
-    fn predicate_matches(&mut self, entry: &EntryGuard<K, V>) -> bool {
-        assert!(!self.predicate_running);
-        self.predicate_running = true;
-        let result = (self.predicate)(entry.key(), entry.value());
-        self.predicate_running = false;
-        result
-    }
-}
-
-impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool> Iterator
-    for BtreeExtractIf<'_, K, V, F>
-{
-    type Item = Result<EntryGuard<K, V>>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut item = self.inner.next();
-        while let Some(Ok(ref entry)) = item {
-            if self.predicate_matches(entry) {
-                let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new_do_not_modify(
-                    self.root,
-                    self.page_allocator.clone(),
-                    &mut self.free_on_drop,
-                    self.allocated.clone(),
-                );
-                match operation.delete(&entry.key()) {
-                    Ok(x) => {
-                        assert!(x.is_some());
-                    }
-                    Err(x) => {
-                        return Some(Err(x));
-                    }
-                }
-                break;
-            }
-            item = self.inner.next();
-        }
-        item
-    }
-}
-
-impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>
-    DoubleEndedIterator for BtreeExtractIf<'_, K, V, F>
-{
-    fn next_back(&mut self) -> Option<Self::Item> {
-        let mut item = self.inner.next_back();
-        while let Some(Ok(ref entry)) = item {
-            if self.predicate_matches(entry) {
-                let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new_do_not_modify(
-                    self.root,
-                    self.page_allocator.clone(),
-                    &mut self.free_on_drop,
-                    self.allocated.clone(),
-                );
-                match operation.delete(&entry.key()) {
-                    Ok(x) => {
-                        assert!(x.is_some());
-                    }
-                    Err(x) => {
-                        return Some(Err(x));
-                    }
-                }
-                break;
-            }
-            item = self.inner.next_back();
-        }
-        item
-    }
-}
-
-impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool> Drop
-    for BtreeExtractIf<'_, K, V, F>
-{
-    fn drop(&mut self) {
-        self.inner.close();
-        let mut master_free_list = self.master_free_list.lock().unwrap();
-        let mut allocated = self.allocated.lock().unwrap();
-        for page in self.free_on_drop.drain(..) {
-            if !self
-                .page_allocator
-                .free_if_uncommitted(page, &mut allocated)
-            {
-                master_free_list.push(page);
-            }
-        }
-    }
-}
-
 #[derive(Clone)]
 pub(crate) struct BtreeRangeIter<K: Key + 'static, V: Value + 'static> {
     left: Option<RangeIterState>, // Exclusive. The previous element returned
@@ -522,7 +390,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
         }
     }
 
-    fn close(&mut self) {
+    pub(super) fn close(&mut self) {
         self.left = None;
         self.right = None;
         self.uninit_right_root = None;

--- a/src/tree_store/extract_if.rs
+++ b/src/tree_store/extract_if.rs
@@ -1,0 +1,136 @@
+use crate::Result;
+use crate::tree_store::btree_iters::{BtreeRangeIter, EntryGuard};
+use crate::tree_store::btree_mutator::MutateHelper;
+use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageTrackerPolicy};
+use crate::types::{Key, Value};
+use std::sync::{Arc, Mutex};
+
+pub(crate) struct BtreeExtractIf<
+    'a,
+    K: Key + 'static,
+    V: Value + 'static,
+    F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+> {
+    root: &'a mut Option<BtreeHeader>,
+    inner: BtreeRangeIter<K, V>,
+    predicate: F,
+    predicate_running: bool,
+    free_on_drop: Vec<PageNumber>,
+    master_free_list: Arc<Mutex<Vec<PageNumber>>>,
+    allocated: Arc<Mutex<PageTrackerPolicy>>,
+    page_allocator: PageAllocator,
+}
+
+impl<'a, K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>
+    BtreeExtractIf<'a, K, V, F>
+{
+    pub(crate) fn new(
+        root: &'a mut Option<BtreeHeader>,
+        inner: BtreeRangeIter<K, V>,
+        predicate: F,
+        master_free_list: Arc<Mutex<Vec<PageNumber>>>,
+        allocated: Arc<Mutex<PageTrackerPolicy>>,
+        page_allocator: PageAllocator,
+    ) -> Self {
+        Self {
+            root,
+            inner,
+            predicate,
+            predicate_running: false,
+            free_on_drop: vec![],
+            master_free_list,
+            allocated,
+            page_allocator,
+        }
+    }
+
+    pub(crate) fn predicate_panicked(&self) -> bool {
+        self.predicate_running
+    }
+
+    fn predicate_matches(&mut self, entry: &EntryGuard<K, V>) -> bool {
+        assert!(!self.predicate_running);
+        self.predicate_running = true;
+        let result = (self.predicate)(entry.key(), entry.value());
+        self.predicate_running = false;
+        result
+    }
+}
+
+impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool> Iterator
+    for BtreeExtractIf<'_, K, V, F>
+{
+    type Item = Result<EntryGuard<K, V>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut item = self.inner.next();
+        while let Some(Ok(ref entry)) = item {
+            if self.predicate_matches(entry) {
+                let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new_do_not_modify(
+                    self.root,
+                    self.page_allocator.clone(),
+                    &mut self.free_on_drop,
+                    self.allocated.clone(),
+                );
+                match operation.delete(&entry.key()) {
+                    Ok(x) => {
+                        assert!(x.is_some());
+                    }
+                    Err(x) => {
+                        return Some(Err(x));
+                    }
+                }
+                break;
+            }
+            item = self.inner.next();
+        }
+        item
+    }
+}
+
+impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>
+    DoubleEndedIterator for BtreeExtractIf<'_, K, V, F>
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let mut item = self.inner.next_back();
+        while let Some(Ok(ref entry)) = item {
+            if self.predicate_matches(entry) {
+                let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new_do_not_modify(
+                    self.root,
+                    self.page_allocator.clone(),
+                    &mut self.free_on_drop,
+                    self.allocated.clone(),
+                );
+                match operation.delete(&entry.key()) {
+                    Ok(x) => {
+                        assert!(x.is_some());
+                    }
+                    Err(x) => {
+                        return Some(Err(x));
+                    }
+                }
+                break;
+            }
+            item = self.inner.next_back();
+        }
+        item
+    }
+}
+
+impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool> Drop
+    for BtreeExtractIf<'_, K, V, F>
+{
+    fn drop(&mut self) {
+        self.inner.close();
+        let mut master_free_list = self.master_free_list.lock().unwrap();
+        let mut allocated = self.allocated.lock().unwrap();
+        for page in self.free_on_drop.drain(..) {
+            if !self
+                .page_allocator
+                .free_if_uncommitted(page, &mut allocated)
+            {
+                master_free_list.push(page);
+            }
+        }
+    }
+}

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -2,6 +2,7 @@ mod btree;
 mod btree_base;
 mod btree_iters;
 mod btree_mutator;
+mod extract_if;
 mod multimap_btree;
 mod page_store;
 mod retain;
@@ -12,7 +13,8 @@ pub(crate) use btree::{Btree, BtreeMut, BtreeStats, RawBtree};
 pub(crate) use btree_base::BtreeHeader;
 pub use btree_base::{AccessGuard, AccessGuardMut, AccessGuardMutInPlace};
 pub(crate) use btree_base::{BRANCH, LEAF, LeafAccessor, RawLeafBuilder};
-pub(crate) use btree_iters::{AllPageNumbersBtreeIter, BtreeExtractIf, BtreeRangeIter};
+pub(crate) use btree_iters::{AllPageNumbersBtreeIter, BtreeRangeIter};
+pub(crate) use extract_if::BtreeExtractIf;
 pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multimap_btree_stats};
 pub(crate) use page_store::ReadOnlyBackend;
 pub(crate) use page_store::{


### PR DESCRIPTION
Move BtreeExtractIf out of btree_iters.rs and into tree_store/extract_if.rs without changing behavior. Keep btree_iters focused on range iteration and re-export BtreeExtractIf from tree_store.

Assisted-by: Codex