### PR TITLE
Add test for DoubleEndedIterator::next_back() on multimap subtrees

### DIFF
--- a/tests/multimap_tests.rs
+++ b/tests/multimap_tests.rs
@@ -445,3 +445,31 @@ fn multimap_signature_lifetimes() {
     }
     write_txn.commit().unwrap();
 }
+
+// Exercises DoubleEndedIterator::next_back() on MultimapValue when the values for a key
+// are stored in a subtree (rather than inline).
+#[test]
+fn multimap_value_next_back_subtree() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_TABLE).unwrap();
+        // Enough distinct values to promote the collection from inline to a subtree.
+        for v in 0..1000u64 {
+            table.insert(&0u64, &v).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_multimap_table(U64_TABLE).unwrap();
+    let mut iter = table.get(&0u64).unwrap();
+    assert_eq!(iter.len(), 1000);
+    for expected in (0..1000u64).rev() {
+        let guard = iter.next_back().unwrap().unwrap();
+        assert_eq!(guard.value(), expected);
+    }
+    assert!(iter.next_back().is_none());
+    assert!(iter.is_empty());
+}


### PR DESCRIPTION
## Summary
This PR adds a test case to verify that the `DoubleEndedIterator::next_back()` method works correctly on `MultimapValue` iterators when the values for a key are stored in a subtree rather than inline.

## Changes
- Added `multimap_value_next_back_subtree()` test that:
  - Inserts 1000 distinct values for a single key to force promotion from inline storage to a subtree structure
  - Verifies that `next_back()` correctly iterates through values in reverse order
  - Confirms the iterator properly reports as empty after exhaustion
  - Validates the iterator length and final state

## Details
This test exercises an important edge case in the multimap implementation where large value collections are stored in subtrees. It ensures that reverse iteration works correctly in this scenario, complementing existing tests that may only cover inline storage or forward iteration.

https://claude.ai/code/session_01AyGpdRisw7iRbMPdaEhoDA