### PR TITLE
Add test for Vec elements with multi-byte varint encoding

### DIFF
--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -2020,6 +2020,29 @@ fn vec_vec_type() {
 }
 
 #[test]
+fn vec_long_string_element() {
+    // Vec elements with serialized length >= 254 bytes use the multi-byte varint path
+    // in complex_types.rs to encode and decode the element length.
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u8, Vec<&str>> = TableDefinition::new("x");
+    let long_str = "a".repeat(254);
+    let value = vec![long_str.as_str(), "short"];
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        table.insert(0, &value).unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(definition).unwrap();
+    assert_eq!(value, table.get(0).unwrap().unwrap().value());
+}
+
+#[test]
 fn range_lifetime() {
     let tmpfile = create_tempfile();
     let db = Database::create(tmpfile.path()).unwrap();


### PR DESCRIPTION
## Summary
This PR adds a test case to verify that Vec elements with serialized lengths >= 254 bytes are correctly encoded and decoded using the multi-byte varint path in the serialization logic.

## Key Changes
- Added `vec_long_string_element()` test that validates the handling of Vec elements with large serialized sizes
- Test creates a vector containing a 254-character string and a short string, then verifies round-trip serialization/deserialization through the database
- This ensures the multi-byte varint encoding path in `complex_types.rs` works correctly for element length encoding

## Implementation Details
The test specifically targets the edge case where element serialized length >= 254 bytes, which triggers the multi-byte varint encoding path rather than single-byte encoding. This is an important boundary condition to verify for correctness of the serialization format.

https://claude.ai/code/session_01XxqVev38dMDnenhnL69ET9