### PR TITLE
Add test for opening multimap table as regular table

### DIFF
--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -2701,6 +2701,34 @@ fn char_type() {
     assert!(iter.next().is_none());
 }
 
+// Opening a multimap table via open_table() returns TableIsMultimap for both
+// write and read transactions.
+#[test]
+fn open_multimap_table_as_regular() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let mm_def: MultimapTableDefinition<u32, u32> = MultimapTableDefinition::new("mm");
+    let regular_def: TableDefinition<u32, u32> = TableDefinition::new("mm");
+
+    let write_txn = db.begin_write().unwrap();
+    write_txn.open_multimap_table(mm_def).unwrap();
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    assert!(matches!(
+        write_txn.open_table(regular_def),
+        Err(TableError::TableIsMultimap(_))
+    ));
+    write_txn.abort().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    assert!(matches!(
+        read_txn.open_table(regular_def),
+        Err(TableError::TableIsMultimap(_))
+    ));
+}
+
 // Test that &[u8; N] and [u8; N] are effectively the same
 #[test]
 fn u8_array_serialization() {


### PR DESCRIPTION
## Summary
Added a test case to verify that attempting to open a multimap table using the regular `open_table()` method returns a `TableIsMultimap` error for both write and read transactions.

## Changes
- Added `open_multimap_table_as_regular()` test function that:
  - Creates a database and defines both a multimap table and a regular table with the same name
  - Opens the table as a multimap table in a write transaction
  - Verifies that subsequent attempts to open it as a regular table (in both write and read transactions) return `TableError::TableIsMultimap`

## Details
This test ensures proper error handling when there's a mismatch between the table type definition used to open a table and the actual table type stored in the database. It validates that the database correctly prevents treating a multimap table as a regular table.

https://claude.ai/code/session_01H1UZjc3JsGNxZPQTmtX3D9