### PR TITLE
Avoid duplicate range entry decoding

### DIFF
--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -78,6 +78,10 @@ impl RangeIterState {
         }
     }
 
+    fn is_leaf(&self) -> bool {
+        matches!(self, Leaf { .. })
+    }
+
     fn next(
         self,
         reverse: bool,
@@ -515,8 +519,9 @@ impl<K: Key, V: Value> Iterator for BtreeRangeIter<K, V> {
             }
 
             self.include_left = false;
-            if self.left.as_ref().unwrap().get_entry::<K, V>().is_some() {
-                return self.left.as_ref().map(|s| s.get_entry().unwrap()).map(Ok);
+            let state = self.left.as_ref().unwrap();
+            if state.is_leaf() {
+                return Some(Ok(state.get_entry().unwrap()));
             }
         }
     }
@@ -596,8 +601,9 @@ impl<K: Key, V: Value> DoubleEndedIterator for BtreeRangeIter<K, V> {
             }
 
             self.include_right = false;
-            if self.right.as_ref().unwrap().get_entry::<K, V>().is_some() {
-                return self.right.as_ref().map(|s| s.get_entry().unwrap()).map(Ok);
+            let state = self.right.as_ref().unwrap();
+            if state.is_leaf() {
+                return Some(Ok(state.get_entry().unwrap()));
             }
         }
     }


### PR DESCRIPTION
Use the range iterator state variant to detect yieldable leaf entries instead of constructing an EntryGuard as a probe before constructing the returned guard.

Improves range() benchmark by around 3%

Assisted-by: Codex