### PR TITLE
Add code coverage reporting with cargo-llvm-cov and Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,3 +156,22 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           RUSTFLAGS="" just test_wasi
+
+  coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cargo-llvm-cov
+        run: |
+            rustup component add llvm-tools-preview
+            cargo install --force --version 0.8.5 cargo-llvm-cov --locked
+      - name: Generate coverage report
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          use_oidc: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "diff, files"
+  require_changes: false


### PR DESCRIPTION
## Summary
This PR adds automated code coverage reporting to the CI/CD pipeline using `cargo-llvm-cov` and integrates with Codecov for tracking coverage metrics over time.

## Key Changes
- **CI Workflow**: Added a new `coverage` job to the GitHub Actions workflow that:
  - Installs `cargo-llvm-cov` (v0.8.5) and LLVM tools
  - Generates coverage reports in LCOV format for all features
  - Uploads coverage data to Codecov
  
- **Codecov Configuration**: Added `codecov.yml` to configure:
  - Project and patch coverage status checks as informational (non-blocking)
  - Comment layout to show diff and file-level coverage details
  - Coverage comments on pull requests without requiring changes

## Implementation Details
- The coverage job runs on `ubuntu-latest` to keep CI costs reasonable
- Coverage is generated with `--all-features` to ensure comprehensive testing
- Codecov status checks are set to informational mode to avoid blocking merges while still providing visibility into coverage trends

https://claude.ai/code/session_01AEgsf35zzi4FjixDUWWtxW