### PR TITLE
Optimize retain_in with range iterator events

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -97,7 +97,7 @@ impl<'a, V: Key> LeafKeyIter<'a, V> {
 }
 
 enum ValueIterState<'a, V: Key + 'static> {
-    Subtree(BtreeRangeIter<V, ()>),
+    Subtree(Box<BtreeRangeIter<V, ()>>),
     InlineLeaf(LeafKeyIter<'a, V>),
 }
 
@@ -119,7 +119,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
         guard: Arc<TransactionGuard>,
     ) -> Self {
         Self {
-            inner: Some(ValueIterState::Subtree(inner)),
+            inner: Some(ValueIterState::Subtree(Box::new(inner))),
             remaining: num_values,
             freed_pages: None,
             allocated_pages: Arc::new(Mutex::new(PageTrackerPolicy::Closed)),
@@ -140,7 +140,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
         page_allocator: PageAllocator,
     ) -> Self {
         Self {
-            inner: Some(ValueIterState::Subtree(inner)),
+            inner: Some(ValueIterState::Subtree(Box::new(inner))),
             remaining: num_values,
             freed_pages: Some(freed_pages),
             free_on_drop: pages,

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -1,7 +1,7 @@
 use crate::Result;
-use crate::tree_store::btree_base::{BRANCH, LEAF};
+use crate::tree_store::btree_base::{BRANCH, BtreeHeader, Checksum, EntryAccessor, LEAF};
 use crate::tree_store::btree_base::{BranchAccessor, LeafAccessor};
-use crate::tree_store::btree_iters::RangeIterState::{BranchChild, Enter, Leaf};
+use crate::tree_store::btree_iters::RangeIterState::{BranchChild, Enter, Exit, Leaf};
 use crate::tree_store::page_store::{Page, PageHint, PageImpl};
 use crate::tree_store::{PageNumber, PageResolver};
 use crate::types::{Key, Value};
@@ -17,6 +17,7 @@ enum RangeIterState {
         page: PageImpl,
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
+        subtree: Option<RangeSubtree>,
         parent: Option<Box<RangeIterState>>,
     },
     Leaf {
@@ -26,6 +27,7 @@ enum RangeIterState {
         entry: usize,
         start: usize,
         end: usize,
+        subtree: Option<RangeSubtree>,
         parent: Option<Box<RangeIterState>>,
     },
     BranchChild {
@@ -33,6 +35,13 @@ enum RangeIterState {
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
         child: usize,
+        first_range_child: usize,
+        last_range_child: usize,
+        subtree: Option<RangeSubtree>,
+        parent: Option<Box<RangeIterState>>,
+    },
+    Exit {
+        subtree: RangeSubtree,
         parent: Option<Box<RangeIterState>>,
     },
 }
@@ -90,12 +99,103 @@ fn leaf_entries<K: Key>(
     start..end
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum RangeVisit<'a> {
+    BranchEnter { branch: &'a RangeSubtree },
+    // A whole subtree outside the requested entry range, emitted in traversal order.
+    SkippedSubtree { subtree: &'a RangeSubtree },
+    LeafEntry { entry: RangeLeafEntry<'a> },
+    LeafExit { subtree: &'a RangeSubtree },
+    BranchExit { branch: &'a RangeSubtree },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RangeSubtree {
+    page: PageNumber,
+    checksum: Checksum,
+    upper_key: Option<Vec<u8>>,
+    root_distance: u32,
+}
+
+impl RangeSubtree {
+    pub(crate) fn root(header: BtreeHeader) -> Self {
+        Self {
+            page: header.root,
+            checksum: header.checksum,
+            upper_key: None,
+            root_distance: 0,
+        }
+    }
+
+    pub(super) fn child(&self, accessor: &BranchAccessor<'_, '_, PageImpl>, index: usize) -> Self {
+        let upper_key = if index + 1 < accessor.count_children() {
+            Some(accessor.key(index).unwrap().to_vec())
+        } else {
+            self.upper_key.clone()
+        };
+        Self {
+            page: accessor.child_page(index).unwrap(),
+            checksum: accessor.child_checksum(index).unwrap(),
+            upper_key,
+            root_distance: self.root_distance + 1,
+        }
+    }
+
+    pub(crate) fn page_number(&self) -> PageNumber {
+        self.page
+    }
+
+    pub(crate) fn root_distance(&self) -> u32 {
+        self.root_distance
+    }
+
+    pub(crate) fn into_parts(self) -> (PageNumber, Checksum, Option<Vec<u8>>, u32) {
+        (self.page, self.checksum, self.upper_key, self.root_distance)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RangeLeafEntry<'a> {
+    page: &'a PageImpl,
+    subtree: &'a RangeSubtree,
+    entry_index: usize,
+}
+
+impl RangeLeafEntry<'_> {
+    pub(crate) fn page_number(&self) -> PageNumber {
+        self.subtree.page_number()
+    }
+
+    pub(crate) fn page(&self) -> &PageImpl {
+        self.page
+    }
+
+    pub(crate) fn subtree(&self) -> &RangeSubtree {
+        self.subtree
+    }
+
+    pub(crate) fn entry_index(&self) -> usize {
+        self.entry_index
+    }
+
+    pub(crate) fn entry<K: Key, V: Value>(&self) -> EntryAccessor<'_> {
+        LeafAccessor::new(self.page.memory(), K::fixed_width(), V::fixed_width())
+            .entry(self.entry_index)
+            .expect("range iterator entry must exist")
+    }
+}
+
+fn ignore_range_event(_event: RangeVisit<'_>) -> Result {
+    Ok(())
+}
+
 impl RangeIterState {
     fn page_number(&self) -> PageNumber {
         match self {
             Enter { page, .. } | Leaf { page, .. } | BranchChild { page, .. } => {
                 page.get_page_number()
             }
+            Exit { subtree, .. } => subtree.page_number(),
         }
     }
 
@@ -110,12 +210,14 @@ impl RangeIterState {
         reverse: bool,
         manager: &PageResolver,
         hint: PageHint,
+        visitor: &mut impl for<'a> FnMut(RangeVisit<'a>) -> Result,
     ) -> Result<Option<RangeIterState>> {
         match self {
             Enter {
                 page,
                 fixed_key_size,
                 fixed_value_size,
+                subtree,
                 parent,
             } => match page.memory()[0] {
                 LEAF => {
@@ -138,6 +240,7 @@ impl RangeIterState {
                             entry,
                             start: entries.start,
                             end: entries.end,
+                            subtree,
                             parent,
                         })
                     } else if (!reverse && !matches!(right_bound, Unbounded) && entries.end == 0)
@@ -145,19 +248,46 @@ impl RangeIterState {
                             && !matches!(left_bound, Unbounded)
                             && entries.start == entry_count)
                     {
-                        None
+                        if let Some(subtree) = subtree.as_ref() {
+                            visitor(RangeVisit::SkippedSubtree { subtree })?;
+                            parent.map(|x| *x)
+                        } else {
+                            None
+                        }
                     } else {
+                        if let Some(subtree) = subtree.as_ref() {
+                            visitor(RangeVisit::SkippedSubtree { subtree })?;
+                        }
                         parent.map(|x| *x)
                     })
                 }
                 BRANCH => {
                     let accessor = BranchAccessor::new(&page, fixed_key_size);
+                    if let Some(subtree) = subtree.as_ref() {
+                        visitor(RangeVisit::BranchEnter { branch: subtree })?;
+                    }
                     let seek_bound = if reverse { right_bound } else { left_bound };
+                    let child_count = accessor.count_children();
+                    let (child, first_range_child, last_range_child) = if subtree.is_some() {
+                        let first_range_child = child_to_visit::<K>(&accessor, left_bound, false);
+                        let last_range_child = child_to_visit::<K>(&accessor, right_bound, true);
+                        let child = if reverse { child_count - 1 } else { 0 };
+                        (child, first_range_child, last_range_child)
+                    } else {
+                        (
+                            child_to_visit::<K>(&accessor, seek_bound, reverse),
+                            0,
+                            child_count - 1,
+                        )
+                    };
                     Ok(Some(BranchChild {
-                        child: child_to_visit::<K>(&accessor, seek_bound, reverse),
+                        child,
+                        first_range_child,
+                        last_range_child,
                         page,
                         fixed_key_size,
                         fixed_value_size,
+                        subtree,
                         parent,
                     }))
                 }
@@ -170,6 +300,7 @@ impl RangeIterState {
                 entry,
                 start,
                 end,
+                subtree,
                 parent,
             } => {
                 let next_entry = if reverse {
@@ -186,9 +317,16 @@ impl RangeIterState {
                         entry,
                         start,
                         end,
+                        subtree,
                         parent,
                     }))
                 } else {
+                    if let Some(subtree) = subtree {
+                        let page_number = page.get_page_number();
+                        drop(page);
+                        debug_assert_eq!(page_number, subtree.page_number());
+                        visitor(RangeVisit::LeafExit { subtree: &subtree })?;
+                    }
                     Ok(parent.map(|x| *x))
                 }
             }
@@ -197,38 +335,133 @@ impl RangeIterState {
                 fixed_key_size,
                 fixed_value_size,
                 child,
+                first_range_child,
+                last_range_child,
+                subtree,
                 mut parent,
             } => {
-                let (child_page, child_count) = {
+                let (child_page, child_subtree, child_count) = {
                     let accessor = BranchAccessor::new(&page, fixed_key_size);
-                    (
-                        manager.get_page(accessor.child_page(child).unwrap(), hint)?,
-                        accessor.count_children(),
-                    )
+                    let child_count = accessor.count_children();
+                    let child_subtree = subtree
+                        .as_ref()
+                        .map(|subtree| subtree.child(&accessor, child));
+                    if let Some(child_subtree) = child_subtree.as_ref()
+                        && (child < first_range_child || child > last_range_child)
+                    {
+                        visitor(RangeVisit::SkippedSubtree {
+                            subtree: child_subtree,
+                        })?;
+                        return Ok(Self::next_branch_child(
+                            BranchChild {
+                                page,
+                                fixed_key_size,
+                                fixed_value_size,
+                                child,
+                                first_range_child,
+                                last_range_child,
+                                subtree,
+                                parent,
+                            },
+                            child_count,
+                            reverse,
+                        )
+                        .map(|state| *state));
+                    }
+                    let child_page = manager.get_page(accessor.child_page(child).unwrap(), hint)?;
+                    (child_page, child_subtree, child_count)
                 };
-                let next_child = if reverse {
-                    child.checked_sub(1)
-                } else {
-                    let next_child = child + 1;
-                    (next_child < child_count).then_some(next_child)
-                };
-                if let Some(child) = next_child {
-                    parent = Some(Box::new(BranchChild {
+                parent = Self::next_branch_child(
+                    BranchChild {
                         page,
                         fixed_key_size,
                         fixed_value_size,
                         child,
+                        first_range_child,
+                        last_range_child,
+                        subtree,
                         parent,
-                    }));
-                }
+                    },
+                    child_count,
+                    reverse,
+                );
                 Ok(Some(Enter {
                     page: child_page,
                     fixed_key_size,
                     fixed_value_size,
+                    subtree: child_subtree,
                     parent,
                 }))
             }
+            Exit { subtree, parent } => {
+                visitor(RangeVisit::BranchExit { branch: &subtree })?;
+                Ok(parent.map(|x| *x))
+            }
         }
+    }
+
+    fn next_branch_child(
+        state: RangeIterState,
+        child_count: usize,
+        reverse: bool,
+    ) -> Option<Box<RangeIterState>> {
+        let BranchChild {
+            page,
+            fixed_key_size,
+            fixed_value_size,
+            child,
+            first_range_child,
+            last_range_child,
+            subtree,
+            parent,
+        } = state
+        else {
+            unreachable!("next branch child requires a branch child state");
+        };
+        let next_child = if reverse {
+            child.checked_sub(1)
+        } else {
+            let next_child = child + 1;
+            (next_child < child_count).then_some(next_child)
+        };
+        if let Some(child) = next_child {
+            Some(Box::new(BranchChild {
+                page,
+                fixed_key_size,
+                fixed_value_size,
+                child,
+                first_range_child,
+                last_range_child,
+                subtree,
+                parent,
+            }))
+        } else if let Some(subtree) = subtree {
+            Some(Box::new(Exit { subtree, parent }))
+        } else {
+            parent
+        }
+    }
+
+    fn visit_leaf_entry(
+        &self,
+        visitor: &mut impl for<'a> FnMut(RangeVisit<'a>) -> Result,
+    ) -> Result {
+        if let Leaf {
+            page,
+            entry,
+            subtree: Some(subtree),
+            ..
+        } = self
+        {
+            visitor(RangeVisit::LeafEntry {
+                entry: RangeLeafEntry {
+                    page,
+                    subtree,
+                    entry_index: *entry,
+                },
+            })?;
+        }
+        Ok(())
     }
 
     fn get_entry<K: Key, V: Value>(&self) -> Option<EntryGuard<K, V>> {
@@ -245,7 +478,7 @@ impl RangeIterState {
                         .entry_ranges(*entry)?;
                 Some(EntryGuard::new(page.clone(), key, value))
             }
-            Enter { .. } | BranchChild { .. } => None,
+            Enter { .. } | BranchChild { .. } | Exit { .. } => None,
         }
     }
 }
@@ -305,6 +538,7 @@ impl AllPageNumbersBtreeIter {
             page: root_page,
             fixed_key_size,
             fixed_value_size,
+            subtree: None,
             parent: None,
         };
         Ok(Self {
@@ -339,9 +573,17 @@ impl Iterator for AllPageNumbersBtreeIter {
                     _ => unreachable!(),
                 },
                 Leaf { entry, .. } => *entry == 0,
-                BranchChild { .. } => false,
+                BranchChild { .. } | Exit { .. } => false,
             };
-            match state.next::<()>(Unbounded, Unbounded, false, &self.manager, self.hint) {
+            let mut ignore_events = ignore_range_event;
+            match state.next::<()>(
+                Unbounded,
+                Unbounded,
+                false,
+                &self.manager,
+                self.hint,
+                &mut ignore_events,
+            ) {
                 Ok(next) => {
                     self.next = next;
                 }
@@ -401,6 +643,34 @@ impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
         manager: PageResolver,
         hint: PageHint,
     ) -> Result<Self> {
+        Self::new_inner(
+            query_range,
+            table_root.map(|root| (root, None)),
+            manager,
+            hint,
+        )
+    }
+
+    pub(crate) fn new_with_subtree_metadata<'a, T: RangeBounds<KR>, KR: Borrow<K::SelfType<'a>>>(
+        query_range: &'_ T,
+        table_root: Option<BtreeHeader>,
+        manager: PageResolver,
+        hint: PageHint,
+    ) -> Result<Self> {
+        Self::new_inner(
+            query_range,
+            table_root.map(|header| (header.root, Some(RangeSubtree::root(header)))),
+            manager,
+            hint,
+        )
+    }
+
+    fn new_inner<'a, T: RangeBounds<KR>, KR: Borrow<K::SelfType<'a>>>(
+        query_range: &'_ T,
+        table_root: Option<(PageNumber, Option<RangeSubtree>)>,
+        manager: PageResolver,
+        hint: PageHint,
+    ) -> Result<Self> {
         if range_is_empty::<K, KR, T>(query_range) {
             return Ok(Self {
                 left: None,
@@ -415,7 +685,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
                 _value_type: PhantomData,
             });
         }
-        if let Some(root) = table_root {
+        if let Some((root, root_subtree)) = table_root {
             let root_page = manager.get_page(root, hint)?;
             let left_bound = query_range
                 .start_bound()
@@ -427,12 +697,14 @@ impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
                 page: root_page.clone(),
                 fixed_key_size: K::fixed_width(),
                 fixed_value_size: V::fixed_width(),
+                subtree: root_subtree.clone(),
                 parent: None,
             });
             let right = Some(Enter {
                 page: root_page,
                 fixed_key_size: K::fixed_width(),
                 fixed_value_size: V::fixed_width(),
+                subtree: root_subtree,
                 parent: None,
             });
             Ok(Self {
@@ -463,18 +735,33 @@ impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
         }
     }
 
-    pub(super) fn close(&mut self) {
+    pub(crate) fn close(&mut self) {
         self.left = None;
         self.right = None;
     }
 
-    fn advance(&self, current: RangeIterState, reverse: bool) -> Result<Option<RangeIterState>> {
+    pub(crate) fn next_with_visitor(
+        &mut self,
+        mut visitor: impl for<'a> FnMut(RangeVisit<'a>) -> Result,
+    ) -> Option<Result> {
+        self.right = None;
+        self.include_right = false;
+        self.next_state(&mut visitor)
+    }
+
+    fn advance(
+        &self,
+        current: RangeIterState,
+        reverse: bool,
+        visitor: &mut impl for<'a> FnMut(RangeVisit<'a>) -> Result,
+    ) -> Result<Option<RangeIterState>> {
         current.next::<K>(
             self.left_bound.as_ref().map(Vec::as_slice),
             self.right_bound.as_ref().map(Vec::as_slice),
             reverse,
             &self.manager,
             self.hint,
+            visitor,
         )
     }
 
@@ -529,17 +816,18 @@ impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
     }
 }
 
-impl<K: Key, V: Value> Iterator for BtreeRangeIter<K, V> {
-    type Item = Result<EntryGuard<K, V>>;
-
-    fn next(&mut self) -> Option<Self::Item> {
+impl<K: Key + 'static, V: Value + 'static> BtreeRangeIter<K, V> {
+    fn next_state(
+        &mut self,
+        visitor: &mut impl for<'a> FnMut(RangeVisit<'a>) -> Result,
+    ) -> Option<Result> {
         loop {
             if !self.include_left || self.left.as_ref().is_some_and(|state| !state.is_leaf()) {
                 let Some(current) = self.left.take() else {
                     self.close();
                     return None;
                 };
-                match self.advance(current, false) {
+                match self.advance(current, false, visitor) {
                     Ok(left) => {
                         self.left = left;
                     }
@@ -567,21 +855,25 @@ impl<K: Key, V: Value> Iterator for BtreeRangeIter<K, V> {
                     return None;
                 }
                 self.include_left = false;
-                return Some(Ok(state.get_entry().unwrap()));
+                if let Err(err) = state.visit_leaf_entry(visitor) {
+                    return Some(Err(err));
+                }
+                return Some(Ok(()));
             }
         }
     }
-}
 
-impl<K: Key, V: Value> DoubleEndedIterator for BtreeRangeIter<K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
+    fn next_back_state(
+        &mut self,
+        visitor: &mut impl for<'a> FnMut(RangeVisit<'a>) -> Result,
+    ) -> Option<Result> {
         loop {
             if !self.include_right || self.right.as_ref().is_some_and(|state| !state.is_leaf()) {
                 let Some(current) = self.right.take() else {
                     self.close();
                     return None;
                 };
-                match self.advance(current, true) {
+                match self.advance(current, true, visitor) {
                     Ok(right) => {
                         self.right = right;
                     }
@@ -609,8 +901,29 @@ impl<K: Key, V: Value> DoubleEndedIterator for BtreeRangeIter<K, V> {
                     return None;
                 }
                 self.include_right = false;
-                return Some(Ok(state.get_entry().unwrap()));
+                if let Err(err) = state.visit_leaf_entry(visitor) {
+                    return Some(Err(err));
+                }
+                return Some(Ok(()));
             }
         }
+    }
+}
+
+impl<K: Key, V: Value> Iterator for BtreeRangeIter<K, V> {
+    type Item = Result<EntryGuard<K, V>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut ignore_events = ignore_range_event;
+        self.next_state(&mut ignore_events)
+            .map(|result| result.map(|()| self.left.as_ref().unwrap().get_entry().unwrap()))
+    }
+}
+
+impl<K: Key, V: Value> DoubleEndedIterator for BtreeRangeIter<K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let mut ignore_events = ignore_range_event;
+        self.next_back_state(&mut ignore_events)
+            .map(|result| result.map(|()| self.right.as_ref().unwrap().get_entry().unwrap()))
     }
 }

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -6,15 +6,14 @@ use crate::tree_store::btree_mutator::DeletionResult::{
     DeletedBranch, DeletedLeaf, PartialBranch, PartialLeaf, Subtree,
 };
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
-use crate::tree_store::retain::{RetainBuilderContext, RetainSubtree, RetainSubtreeBuilder};
+use crate::tree_store::retain::{Retain, RetainBuilderContext};
 use crate::tree_store::{
     AccessGuardMutInPlace, BtreeHeader, PageAllocator, PageHint, PageNumber, PageTrackerPolicy,
 };
 use crate::types::{Key, Value};
 use crate::{AccessGuard, Result};
 use std::borrow::Borrow;
-use std::cmp::{Ordering, max, min};
-use std::collections::Bound;
+use std::cmp::{max, min};
 use std::marker::PhantomData;
 use std::ops::RangeBounds;
 use std::sync::{Arc, Mutex};
@@ -53,70 +52,6 @@ enum DeletionResult {
     // Indicates that the branch node was deleted, and includes the only remaining child.
     // Checksum is retained for the same reason as `PartialBranch`.
     DeletedBranch(PageNumber, Checksum),
-}
-
-enum RetainWalkResult {
-    Unchanged(RetainSubtree),
-    Changed,
-}
-
-struct RetainWalkContext {
-    checksum: Checksum,
-    upper_key: Option<Vec<u8>>,
-    root_distance: u32,
-}
-
-struct KeyRange<'a, K: Key + ?Sized> {
-    start: Bound<&'a [u8]>,
-    end: Bound<&'a [u8]>,
-    _key: PhantomData<K>,
-}
-
-impl<K: Key + ?Sized> Copy for KeyRange<'_, K> {}
-
-impl<K: Key + ?Sized> Clone for KeyRange<'_, K> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<'a, K: Key + ?Sized> KeyRange<'a, K> {
-    fn new(start: Bound<&'a [u8]>, end: Bound<&'a [u8]>) -> Self {
-        Self {
-            start,
-            end,
-            _key: PhantomData,
-        }
-    }
-
-    fn contains(&self, key: &[u8]) -> bool {
-        !self.less_than_start(key) && !self.greater_than_end(key)
-    }
-
-    fn less_than_start(&self, key: &[u8]) -> bool {
-        match self.start {
-            Bound::Included(start) => K::compare(key, start) == Ordering::Less,
-            Bound::Excluded(start) => K::compare(key, start) != Ordering::Greater,
-            Bound::Unbounded => false,
-        }
-    }
-
-    fn greater_than_end(&self, key: &[u8]) -> bool {
-        match self.end {
-            Bound::Included(end) => K::compare(key, end) == Ordering::Greater,
-            Bound::Excluded(end) => K::compare(key, end) != Ordering::Less,
-            Bound::Unbounded => false,
-        }
-    }
-
-    fn child_lower_bound_is_past_end(&self, lower_bound: &[u8]) -> bool {
-        match self.end {
-            Bound::Included(end) | Bound::Excluded(end) => {
-                K::compare(lower_bound, end) != Ordering::Less
-            }
-            Bound::Unbounded => false,
-        }
-    }
 }
 
 struct InsertionResult<'a, V: Value + 'static> {
@@ -229,253 +164,24 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             return Ok(());
         };
 
-        let start_tmp = match range.start_bound() {
-            Bound::Included(key) | Bound::Excluded(key) => Some(K::as_bytes(key.borrow())),
-            Bound::Unbounded => None,
-        };
-        let end_tmp = match range.end_bound() {
-            Bound::Included(key) | Bound::Excluded(key) => Some(K::as_bytes(key.borrow())),
-            Bound::Unbounded => None,
-        };
-        let start_bound = match (range.start_bound(), start_tmp.as_ref()) {
-            (Bound::Included(_), Some(bytes)) => Bound::Included(bytes.as_ref()),
-            (Bound::Excluded(_), Some(bytes)) => Bound::Excluded(bytes.as_ref()),
-            _ => Bound::Unbounded,
-        };
-        let end_bound = match (range.end_bound(), end_tmp.as_ref()) {
-            (Bound::Included(_), Some(bytes)) => Bound::Included(bytes.as_ref()),
-            (Bound::Excluded(_), Some(bytes)) => Bound::Excluded(bytes.as_ref()),
-            _ => Bound::Unbounded,
-        };
-        let bounds = KeyRange::<K>::new(start_bound, end_bound);
-
-        let mut removed = 0;
-        let new_root = {
-            let mut retain_context = RetainBuilderContext::<K, V>::new(
-                &self.page_allocator,
-                &self.allocated,
-                self.freed,
-                self.modify_uncommitted,
-            );
-            let mut builder = RetainSubtreeBuilder::left_to_right();
-            let root_page = retain_context.get_page(header.root)?;
-            let retain_result = Self::retain_walk(
-                &mut retain_context,
-                root_page,
-                RetainWalkContext {
-                    checksum: header.checksum,
-                    upper_key: None,
-                    root_distance: 0,
-                },
-                bounds,
-                &mut predicate,
-                &mut removed,
-                &mut builder,
-            )?;
-
-            match retain_result {
-                RetainWalkResult::Unchanged(_) => Some(header),
-                RetainWalkResult::Changed => {
-                    if let Some((root, checksum)) = builder.finish_root(&mut retain_context)? {
-                        Some(BtreeHeader::new(root, checksum, header.length - removed))
-                    } else {
-                        None
-                    }
-                }
-            }
-        };
+        let mut retain_context = RetainBuilderContext::<K, V>::new(
+            &self.page_allocator,
+            &self.allocated,
+            self.freed,
+            self.modify_uncommitted,
+        );
+        let mut retain = Retain::new();
+        retain.execute(
+            &mut retain_context,
+            header,
+            range,
+            self.page_allocator.resolver(),
+            &mut predicate,
+        )?;
+        let new_root = retain.finish(&mut retain_context, header)?;
         *self.root = new_root;
 
         Ok(())
-    }
-
-    fn retain_walk<F>(
-        retain_context: &mut RetainBuilderContext<'_, K, V>,
-        page: PageImpl,
-        context: RetainWalkContext,
-        bounds: KeyRange<'_, K>,
-        predicate: &mut F,
-        removed: &mut u64,
-        builder: &mut RetainSubtreeBuilder,
-    ) -> Result<RetainWalkResult>
-    where
-        F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
-    {
-        match page.memory()[0] {
-            LEAF => Self::retain_walk_leaf(
-                retain_context,
-                page,
-                context,
-                bounds,
-                predicate,
-                removed,
-                builder,
-            ),
-            BRANCH => Self::retain_walk_branch(
-                retain_context,
-                page,
-                context,
-                bounds,
-                predicate,
-                removed,
-                builder,
-            ),
-            _ => unreachable!(),
-        }
-    }
-
-    fn retain_walk_leaf<F>(
-        retain_context: &mut RetainBuilderContext<'_, K, V>,
-        page: PageImpl,
-        context: RetainWalkContext,
-        bounds: KeyRange<'_, K>,
-        predicate: &mut F,
-        removed: &mut u64,
-        builder: &mut RetainSubtreeBuilder,
-    ) -> Result<RetainWalkResult>
-    where
-        F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
-    {
-        let page_number = page.get_page_number();
-        let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
-        let num_pairs = accessor.num_pairs();
-        let mut keep = Vec::with_capacity(num_pairs);
-        let mut kept_count = 0;
-        for i in 0..num_pairs {
-            let entry = accessor.entry(i).unwrap();
-            let keep_entry = if bounds.contains(entry.key()) {
-                predicate(K::from_bytes(entry.key()), V::from_bytes(entry.value()))
-            } else {
-                true
-            };
-            keep.push(keep_entry);
-            if keep_entry {
-                kept_count += 1;
-            } else {
-                *removed += 1;
-            }
-        }
-
-        if kept_count == num_pairs {
-            return Ok(RetainWalkResult::Unchanged(RetainSubtree::new(
-                page_number,
-                context.checksum,
-                context.upper_key,
-                context.root_distance,
-            )));
-        }
-
-        if kept_count == 0 {
-            drop(page);
-            retain_context.conditional_free(page_number);
-            return Ok(RetainWalkResult::Changed);
-        }
-
-        for (i, kept) in keep.into_iter().enumerate() {
-            if kept {
-                let entry = accessor.entry(i).unwrap();
-                builder.push_leaf_entry(
-                    retain_context,
-                    entry.key(),
-                    entry.value(),
-                    context.root_distance,
-                )?;
-            }
-        }
-        drop(page);
-        retain_context.conditional_free(page_number);
-        Ok(RetainWalkResult::Changed)
-    }
-
-    fn retain_walk_branch<F>(
-        retain_context: &mut RetainBuilderContext<'_, K, V>,
-        page: PageImpl,
-        context: RetainWalkContext,
-        bounds: KeyRange<'_, K>,
-        predicate: &mut F,
-        removed: &mut u64,
-        builder: &mut RetainSubtreeBuilder,
-    ) -> Result<RetainWalkResult>
-    where
-        F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
-    {
-        let page_number = page.get_page_number();
-        let accessor = BranchAccessor::new(&page, K::fixed_width());
-        let child_count = accessor.count_children();
-        let mut pending_unchanged = Vec::new();
-        let child_root_distance = context.root_distance + 1;
-        let mut changed = false;
-
-        for i in 0..child_count {
-            let child_upper_key = if i + 1 < child_count {
-                Some(accessor.key(i).unwrap().to_vec())
-            } else {
-                context.upper_key.clone()
-            };
-            let below_start =
-                i + 1 < child_count && bounds.less_than_start(accessor.key(i).unwrap());
-            let above_end =
-                i > 0 && bounds.child_lower_bound_is_past_end(accessor.key(i - 1).unwrap());
-            if below_start || above_end {
-                pending_unchanged.push(RetainSubtree::branch_child(
-                    &accessor,
-                    context.upper_key.as_deref(),
-                    child_root_distance,
-                    i,
-                ));
-                continue;
-            }
-
-            let child_page_number = accessor.child_page(i).unwrap();
-            let child_checksum = accessor.child_checksum(i).unwrap();
-            let child_page = retain_context.get_page(child_page_number)?;
-            let mut child_builder = RetainSubtreeBuilder::left_to_right();
-            let child = Self::retain_walk(
-                retain_context,
-                child_page,
-                RetainWalkContext {
-                    checksum: child_checksum,
-                    upper_key: child_upper_key,
-                    root_distance: child_root_distance,
-                },
-                bounds,
-                predicate,
-                removed,
-                &mut child_builder,
-            )?;
-            match child {
-                RetainWalkResult::Unchanged(node) => {
-                    debug_assert!(child_builder.is_empty());
-                    debug_assert_eq!(node.root_distance(), child_root_distance);
-                    pending_unchanged.push(node);
-                }
-                RetainWalkResult::Changed => {
-                    changed = true;
-                    for subtree in pending_unchanged.drain(..) {
-                        builder.push_subtree(retain_context, subtree)?;
-                    }
-                    builder.append(retain_context, child_builder)?;
-                }
-            }
-        }
-
-        if !changed {
-            return Ok(RetainWalkResult::Unchanged(RetainSubtree::new(
-                page_number,
-                context.checksum,
-                context.upper_key,
-                context.root_distance,
-            )));
-        }
-
-        for subtree in pending_unchanged {
-            builder.push_subtree(retain_context, subtree)?;
-        }
-
-        drop(page);
-        retain_context.conditional_free(page_number);
-
-        Ok(RetainWalkResult::Changed)
     }
 
     fn delete_target(
@@ -1234,10 +940,10 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             } => {
                 let partial_child_accessor =
                     LeafAccessor::new(&partial_child_page, K::fixed_width(), V::fixed_width());
-                debug_assert!(partial_child_accessor.num_pairs() > 1);
+                assert!(partial_child_accessor.num_pairs() > 1);
 
                 let merge_with = if child_index == 0 { 1 } else { child_index - 1 };
-                debug_assert!(merge_with < accessor.count_children());
+                assert!(merge_with < accessor.count_children());
                 let merge_with_page = self
                     .page_allocator
                     .get_page(accessor.child_page(merge_with).unwrap(), PageHint::None)?;
@@ -1336,7 +1042,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     .page_allocator
                     .get_page(accessor.child_page(merge_with).unwrap(), PageHint::None)?;
                 let merge_with_accessor = BranchAccessor::new(&merge_with_page, K::fixed_width());
-                debug_assert!(merge_with < accessor.count_children());
+                assert!(merge_with < accessor.count_children());
                 for i in 0..accessor.count_children() {
                     if i == child_index {
                         continue;
@@ -1399,7 +1105,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     .page_allocator
                     .get_page(accessor.child_page(merge_with).unwrap(), PageHint::None)?;
                 let merge_with_accessor = BranchAccessor::new(&merge_with_page, K::fixed_width());
-                debug_assert!(merge_with < accessor.count_children());
+                assert!(merge_with < accessor.count_children());
                 for i in 0..accessor.count_children() {
                     if i == child_index {
                         continue;

--- a/src/tree_store/retain.rs
+++ b/src/tree_store/retain.rs
@@ -3,13 +3,17 @@ use crate::tree_store::btree_base::{
     BRANCH, BranchAccessor, BranchBuilder, Checksum, DEFERRED, LEAF, LeafAccessor, LeafBuilder,
     RawBranchBuilder, RawLeafBuilder,
 };
+use crate::tree_store::btree_iters::{BtreeRangeIter, RangeLeafEntry, RangeSubtree, RangeVisit};
 use crate::tree_store::page_store::{Page, PageImpl};
-use crate::tree_store::{PageAllocator, PageHint, PageNumber, PageTrackerPolicy};
+use crate::tree_store::{
+    BtreeHeader, PageAllocator, PageHint, PageNumber, PageResolver, PageTrackerPolicy,
+};
 use crate::types::{Key, Value};
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::marker::PhantomData;
-use std::ops::Range;
+use std::ops::{Range, RangeBounds};
 use std::sync::Mutex;
 
 type RetainLeafEntry = (Vec<u8>, Vec<u8>);
@@ -124,6 +128,249 @@ impl<'a, K: Key, V: Value> RetainBuilderContext<'a, K, V> {
     }
 }
 
+pub(super) struct Retain {
+    builder: RetainSubtreeBuilder,
+    in_progress: InProgressSubtree,
+    current_leaf: Option<CurrentRetainLeaf>,
+    removed: u64,
+}
+
+struct CurrentRetainLeaf {
+    page: PageImpl,
+    subtree: RangeSubtree,
+    removed_indexes: Vec<usize>,
+}
+
+impl Retain {
+    pub(super) fn new() -> Self {
+        Self {
+            builder: RetainSubtreeBuilder::left_to_right(),
+            in_progress: InProgressSubtree::new(),
+            current_leaf: None,
+            removed: 0,
+        }
+    }
+
+    pub(super) fn execute<'r, K, V, KR, F>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        header: BtreeHeader,
+        range: &'_ impl RangeBounds<KR>,
+        resolver: PageResolver,
+        predicate: &mut F,
+    ) -> Result
+    where
+        K: Key + 'static,
+        V: Value + 'static,
+        KR: Borrow<K::SelfType<'r>> + 'r,
+        F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+    {
+        let mut iter = BtreeRangeIter::<K, V>::new_with_subtree_metadata(
+            range,
+            Some(header),
+            resolver,
+            PageHint::None,
+        )?;
+        while let Some(result) =
+            iter.next_with_visitor(|event| self.visit(context, event, predicate))
+        {
+            result?;
+        }
+        Ok(())
+    }
+
+    fn visit<K: Key, V: Value, F>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        event: RangeVisit<'_>,
+        predicate: &mut F,
+    ) -> Result
+    where
+        F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+    {
+        match event {
+            RangeVisit::BranchEnter { branch } => {
+                self.in_progress.enter_branch(branch.clone());
+                Ok(())
+            }
+            RangeVisit::SkippedSubtree { subtree } => {
+                self.in_progress
+                    .push_subtree(RetainSubtree::from_range(subtree.clone()));
+                Ok(())
+            }
+            RangeVisit::LeafEntry { entry } => self.visit_leaf_entry(context, entry, predicate),
+            RangeVisit::LeafExit { subtree } => {
+                let page_number = subtree.page_number();
+                if self.current_leaf_page() == Some(page_number) {
+                    self.complete_current_leaf(context)?;
+                }
+                Ok(())
+            }
+            RangeVisit::BranchExit { branch } => {
+                if let Some(replaced_page) =
+                    self.in_progress
+                        .exit_branch_into(context, &mut self.builder, branch)?
+                {
+                    context.conditional_free(replaced_page);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    pub(super) fn finish<K: Key, V: Value>(
+        mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        header: BtreeHeader,
+    ) -> Result<Option<BtreeHeader>> {
+        self.complete_current_leaf(context)?;
+        if self.removed == 0 {
+            return Ok(Some(header));
+        }
+
+        let replaced_pages = self.in_progress.finish_into(context, &mut self.builder)?;
+        for page in replaced_pages {
+            context.conditional_free(page);
+        }
+
+        if let Some((root, checksum)) = self.builder.finish_root(context)? {
+            Ok(Some(BtreeHeader::new(
+                root,
+                checksum,
+                header.length - self.removed,
+            )))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn visit_leaf_entry<K: Key, V: Value, F>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        entry: RangeLeafEntry<'_>,
+        predicate: &mut F,
+    ) -> Result
+    where
+        F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+    {
+        assert!(
+            self.current_leaf_page()
+                .is_none_or(|page| page == entry.page_number())
+        );
+        let new_leaf = self.current_leaf.is_none();
+        if new_leaf {
+            self.current_leaf = Some(CurrentRetainLeaf::new(entry));
+        }
+
+        let entry_accessor = entry.entry::<K, V>();
+        let key = entry_accessor.key();
+
+        if !predicate(K::from_bytes(key), V::from_bytes(entry_accessor.value())) {
+            self.mark_removed::<K, V>(context, entry.entry_index())?;
+        }
+        Ok(())
+    }
+
+    fn mark_removed<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        entry_index: usize,
+    ) -> Result {
+        let leaf = self
+            .current_leaf
+            .as_mut()
+            .expect("range visitor must set current leaf before predicate");
+        let first_removed_in_leaf = leaf.mark_removed(entry_index);
+        if first_removed_in_leaf {
+            self.in_progress.mark_changed();
+            self.in_progress.flush_into(context, &mut self.builder)?;
+        }
+        self.removed += 1;
+        Ok(())
+    }
+
+    fn complete_current_leaf<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+    ) -> Result {
+        if let Some(leaf) = self.current_leaf.take() {
+            leaf.complete_into(context, &mut self.in_progress, &mut self.builder)?;
+        }
+        Ok(())
+    }
+
+    fn current_leaf_page(&self) -> Option<PageNumber> {
+        self.current_leaf
+            .as_ref()
+            .map(CurrentRetainLeaf::page_number)
+    }
+}
+
+impl CurrentRetainLeaf {
+    fn new(entry: RangeLeafEntry<'_>) -> Self {
+        Self {
+            page: entry.page().clone(),
+            subtree: entry.subtree().clone(),
+            removed_indexes: vec![],
+        }
+    }
+
+    fn page_number(&self) -> PageNumber {
+        self.subtree.page_number()
+    }
+
+    fn root_distance(&self) -> u32 {
+        self.subtree.root_distance()
+    }
+
+    fn page(&self) -> &PageImpl {
+        &self.page
+    }
+
+    fn mark_removed(&mut self, index: usize) -> bool {
+        let first_removed = self.removed_indexes.is_empty();
+        assert!(
+            self.removed_indexes
+                .last()
+                .is_none_or(|last_index| *last_index < index)
+        );
+        self.removed_indexes.push(index);
+        first_removed
+    }
+
+    fn complete_into<K: Key, V: Value>(
+        self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        in_progress: &mut InProgressSubtree,
+        builder: &mut RetainSubtreeBuilder,
+    ) -> Result {
+        if self.removed_indexes.is_empty() {
+            in_progress.push_subtree(self.into_subtree());
+            return Ok(());
+        }
+
+        let old_page = self.page_number();
+        let root_distance = self.root_distance();
+        {
+            let accessor =
+                LeafAccessor::new(self.page().memory(), K::fixed_width(), V::fixed_width());
+            builder.push_leaf_entries_except(
+                context,
+                &accessor,
+                root_distance,
+                &self.removed_indexes,
+            )?;
+        }
+        drop(self);
+        context.conditional_free(old_page);
+        Ok(())
+    }
+
+    fn into_subtree(self) -> RetainSubtree {
+        RetainSubtree::from_range(self.subtree)
+    }
+}
+
 // A sealed B-tree subtree, annotated with its distance from the original retain walk root.
 pub(super) struct RetainSubtree {
     page: PageNumber,
@@ -171,8 +418,9 @@ impl RetainSubtree {
         )
     }
 
-    pub(super) fn root_distance(&self) -> u32 {
-        self.root_distance
+    pub(super) fn from_range(subtree: RangeSubtree) -> Self {
+        let (page, checksum, upper_key, root_distance) = subtree.into_parts();
+        Self::new(page, checksum, upper_key, root_distance)
     }
 
     fn graft_ordered<K: Key, V: Value>(
@@ -456,6 +704,173 @@ impl RetainSubtree {
     }
 }
 
+// Tracks unchanged subtrees completed by the range traversal.
+//
+// `branch_stack` mirrors the active BranchEnter/BranchExit stack. Completed
+// unchanged subtrees are kept in their open parent BranchFrame, or in
+// `completed` when no branch is open. On BranchExit, an unchanged frame
+// collapses back to its original branch page; a changed frame flushes its
+// completed children into the replacement builder.
+pub(super) struct InProgressSubtree {
+    completed: Vec<RetainSubtree>,
+    branch_stack: Vec<BranchFrame>,
+}
+
+impl InProgressSubtree {
+    pub(super) fn new() -> Self {
+        Self {
+            completed: vec![],
+            branch_stack: vec![],
+        }
+    }
+
+    pub(super) fn enter_branch(&mut self, branch: RangeSubtree) {
+        assert!(
+            self.branch_stack
+                .last()
+                .is_none_or(|current| current.page_number() != branch.page_number()),
+            "range iterator emitted duplicate branch enter"
+        );
+        self.branch_stack.push(BranchFrame::new(branch));
+    }
+
+    // Attach a completed unchanged subtree to the nearest open parent branch.
+    // If there is no parent, it is ready to be flushed directly to the builder.
+    pub(super) fn push_subtree(&mut self, subtree: RetainSubtree) {
+        if let Some(branch) = self.branch_stack.last_mut() {
+            branch.push_child(subtree);
+        } else {
+            self.completed.push(subtree);
+        }
+    }
+
+    pub(super) fn mark_changed(&mut self) {
+        if let Some(branch) = self.branch_stack.last_mut() {
+            branch.mark_changed();
+        }
+    }
+
+    pub(super) fn exit_branch_into<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        builder: &mut RetainSubtreeBuilder,
+        branch: &RangeSubtree,
+    ) -> Result<Option<PageNumber>> {
+        let frame = self
+            .branch_stack
+            .pop()
+            .expect("range iterator emitted branch exit without matching enter");
+        assert_eq!(
+            frame.page_number(),
+            branch.page_number(),
+            "range iterator emitted branch exit out of order"
+        );
+
+        self.finish_branch_frame(context, builder, frame)
+    }
+
+    // A changed leaf makes all previously completed unchanged subtrees part of
+    // the replacement stream. Keep the branch stack open for later exit events.
+    pub(super) fn flush_into<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        builder: &mut RetainSubtreeBuilder,
+    ) -> Result<()> {
+        for subtree in self.completed.drain(..) {
+            builder.push_subtree(context, subtree)?;
+        }
+        for branch in &mut self.branch_stack {
+            branch.flush_children_into(context, builder)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn finish_into<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        builder: &mut RetainSubtreeBuilder,
+    ) -> Result<Vec<PageNumber>> {
+        let mut replaced_pages = vec![];
+        while let Some(frame) = self.branch_stack.pop() {
+            if let Some(page) = self.finish_branch_frame(context, builder, frame)? {
+                replaced_pages.push(page);
+            }
+        }
+        self.flush_into(context, builder)?;
+        Ok(replaced_pages)
+    }
+
+    fn finish_branch_frame<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        builder: &mut RetainSubtreeBuilder,
+        mut frame: BranchFrame,
+    ) -> Result<Option<PageNumber>> {
+        // Unchanged frames collapse to their original branch page. Changed
+        // frames flush their unchanged children and cause the parent to rebuild.
+        if frame.is_changed() {
+            if let Some(parent) = self.branch_stack.last_mut() {
+                parent.mark_changed();
+            }
+            let old_page = frame.page_number();
+            frame.flush_children_into(context, builder)?;
+            Ok(Some(old_page))
+        } else {
+            self.push_subtree(frame.into_retain_subtree());
+            Ok(None)
+        }
+    }
+}
+
+// One open branch in the range traversal stack. Its `unchanged_children` can
+// still collapse back into `branch` if no change is found before BranchExit.
+struct BranchFrame {
+    branch: RangeSubtree,
+    unchanged_children: Vec<RetainSubtree>,
+    changed: bool,
+}
+
+impl BranchFrame {
+    fn new(branch: RangeSubtree) -> Self {
+        Self {
+            branch,
+            unchanged_children: vec![],
+            changed: false,
+        }
+    }
+
+    fn page_number(&self) -> PageNumber {
+        self.branch.page_number()
+    }
+
+    fn is_changed(&self) -> bool {
+        self.changed
+    }
+
+    fn mark_changed(&mut self) {
+        self.changed = true;
+    }
+
+    fn push_child(&mut self, subtree: RetainSubtree) {
+        self.unchanged_children.push(subtree);
+    }
+
+    fn flush_children_into<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        builder: &mut RetainSubtreeBuilder,
+    ) -> Result<()> {
+        for subtree in self.unchanged_children.drain(..) {
+            builder.push_subtree(context, subtree)?;
+        }
+        Ok(())
+    }
+
+    fn into_retain_subtree(self) -> RetainSubtree {
+        RetainSubtree::from_range(self.branch)
+    }
+}
+
 // Retained leaf entries that have not yet been sealed into a page.
 struct InProgressLeaf {
     entries: RetainLeafEntries,
@@ -649,6 +1064,7 @@ impl RetainSubtreeBuilder {
         Self::new(BuildDirection::RightToLeft)
     }
 
+    #[allow(dead_code)]
     pub(super) fn is_empty(&self) -> bool {
         self.frontier.is_empty() && self.leaf.is_empty()
     }
@@ -668,7 +1084,7 @@ impl RetainSubtreeBuilder {
             let start = parent_range.start;
             let children: Vec<_> = self.frontier.drain(parent_range).collect();
             let child_root_distance = children[0].root_distance;
-            debug_assert!(
+            assert!(
                 children
                     .iter()
                     .all(|child| child.root_distance == child_root_distance)
@@ -871,6 +1287,49 @@ impl RetainSubtreeBuilder {
         Ok(())
     }
 
+    pub(super) fn push_leaf_entries_except<K: Key, V: Value>(
+        &mut self,
+        context: &mut RetainBuilderContext<'_, K, V>,
+        accessor: &LeafAccessor<'_>,
+        root_distance: u32,
+        removed_indexes: &[usize],
+    ) -> Result<()> {
+        match self.direction {
+            BuildDirection::LeftToRight => {
+                let mut removed_pos = 0;
+                for i in 0..accessor.num_pairs() {
+                    if removed_indexes
+                        .get(removed_pos)
+                        .is_some_and(|removed| *removed == i)
+                    {
+                        removed_pos += 1;
+                    } else {
+                        let entry = accessor.entry(i).unwrap();
+                        self.push_leaf_entry(context, entry.key(), entry.value(), root_distance)?;
+                    }
+                }
+                assert_eq!(removed_pos, removed_indexes.len());
+            }
+            BuildDirection::RightToLeft => {
+                let mut removed_pos = removed_indexes.len();
+                for i in (0..accessor.num_pairs()).rev() {
+                    if removed_pos > 0
+                        && removed_indexes
+                            .get(removed_pos - 1)
+                            .is_some_and(|removed| *removed == i)
+                    {
+                        removed_pos -= 1;
+                    } else {
+                        let entry = accessor.entry(i).unwrap();
+                        self.push_leaf_entry(context, entry.key(), entry.value(), root_distance)?;
+                    }
+                }
+                assert_eq!(removed_pos, 0);
+            }
+        }
+        Ok(())
+    }
+
     pub(super) fn push_subtree<K: Key, V: Value>(
         &mut self,
         context: &mut RetainBuilderContext<'_, K, V>,
@@ -891,6 +1350,7 @@ impl RetainSubtreeBuilder {
         self.normalize_frontier(context)
     }
 
+    #[allow(dead_code)]
     pub(super) fn append<K: Key, V: Value>(
         &mut self,
         context: &mut RetainBuilderContext<'_, K, V>,
@@ -992,7 +1452,7 @@ impl RetainSubtreeBuilder {
                 }
             }
             let child_root_distance = self.frontier[0].root_distance;
-            debug_assert!(
+            assert!(
                 self.frontier
                     .iter()
                     .all(|subtree| subtree.root_distance == child_root_distance)

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -2273,6 +2273,42 @@ fn retain_in_rebuilds_range_boundaries() {
 }
 
 #[test]
+fn retain_in_upper_boundary_does_not_duplicate_subtrees() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u64, [u8; 200]> = TableDefinition::new("x");
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0u64..30_000 {
+            table.insert(i, &[0u8; 200]).unwrap();
+        }
+
+        table.retain_in(0..1295, |_, _| false).unwrap();
+        assert_eq!(table.len().unwrap(), 30_000 - 1295);
+        assert!(table.get(&1294).unwrap().is_none());
+        assert!(table.get(&1295).unwrap().is_some());
+
+        let mut count = 0;
+        let mut previous = None;
+        for entry in table.iter().unwrap() {
+            let (key, _) = entry.unwrap();
+            let key = key.value();
+            assert!(key >= 1295);
+            if let Some(previous) = previous {
+                assert!(previous < key);
+            }
+            previous = Some(key);
+            count += 1;
+        }
+        assert_eq!(count, table.len().unwrap());
+    }
+    write_txn.commit().unwrap();
+}
+
+#[test]
 fn retain_coalesces_sparse_survivors() {
     let tmpfile = create_tempfile();
     let db = Database::create(tmpfile.path()).unwrap();


### PR DESCRIPTION
Drive retain_in from the range iterator traversal instead of a separate recursive walk. The iterator now emits skipped-subtree events in traversal order, so retain can reuse unchanged subtrees, rebuild changed leaves, and free replaced pages while keeping cursor movement owned by the range iterator.

This keeps the retain-specific reconstruction logic in retain.rs while making the traversal machinery reusable for extract_if.

Assisted-by: Codex