### PR TITLE
Add explicit ExtractIf close method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * `Table::retain()`, `Table::retain_in()`, `Table::extract_if()`, and `Table::extract_from_if()`
   now poison the write transaction if their predicate panics, causing `WriteTransaction::commit()`
   to return `CommitError::TransactionPoisoned`.
+* Add `ExtractIf::close()` to explicitly finalize an extract iterator without removing unread
+  entries.
 * Optimize `Table::pop_first()` and `Table::pop_last()` to be about 2x faster.
 * Enable file space reclamation during non-durable transactions performed while a savepoint exists.
 * Reuse pages freed by a durable write transaction in the next write transaction when no

--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -511,15 +511,7 @@ fn handle_table_op(
             } else {
                 Box::new(reference.iter().take(take.value))
             };
-            let mut iter: Box<
-                dyn Iterator<
-                    Item = Result<(AccessGuard<u64>, AccessGuard<&[u8]>), redb::StorageError>,
-                >,
-            > = if *reversed {
-                Box::new(table.extract_if(|x, _| x % modulus == 0)?.rev())
-            } else {
-                Box::new(table.extract_if(|x, _| x % modulus == 0)?)
-            };
+            let mut iter = table.extract_if(|x, _| x % modulus == 0)?;
             let mut remaining = take.value;
             let mut remove_from_reference = vec![];
             while let Some((ref_key, ref_value_len)) = reference_iter.next() {
@@ -530,11 +522,17 @@ fn handle_table_op(
                     break;
                 }
                 remaining -= 1;
-                let (key, value) = iter.next().unwrap()?;
+                let next = if *reversed {
+                    iter.next_back()
+                } else {
+                    iter.next()
+                };
+                let (key, value) = next.unwrap()?;
                 remove_from_reference.push(*ref_key);
                 assert_eq!(*ref_key, key.value());
                 assert_eq!(*ref_value_len, value.value().len());
             }
+            iter.close()?;
             drop(reference_iter);
             for x in remove_from_reference {
                 reference.remove(&x);
@@ -555,19 +553,7 @@ fn handle_table_op(
             } else {
                 Box::new(reference.range(start..end).take(take.value))
             };
-            let mut iter: Box<
-                dyn Iterator<
-                    Item = Result<(AccessGuard<u64>, AccessGuard<&[u8]>), redb::StorageError>,
-                >,
-            > = if *reversed {
-                Box::new(
-                    table
-                        .extract_from_if(start..end, |x, _| x % modulus == 0)?
-                        .rev(),
-                )
-            } else {
-                Box::new(table.extract_from_if(start..end, |x, _| x % modulus == 0)?)
-            };
+            let mut iter = table.extract_from_if(start..end, |x, _| x % modulus == 0)?;
             let mut remaining = take.value;
             let mut remove_from_reference = vec![];
             while let Some((ref_key, ref_value_len)) = reference_iter.next() {
@@ -578,11 +564,17 @@ fn handle_table_op(
                     break;
                 }
                 remaining -= 1;
-                let (key, value) = iter.next().unwrap()?;
+                let next = if *reversed {
+                    iter.next_back()
+                } else {
+                    iter.next()
+                };
+                let (key, value) = next.unwrap()?;
                 remove_from_reference.push(*ref_key);
                 assert_eq!(*ref_key, key.value());
                 assert_eq!(*ref_value_len, value.value().len());
             }
+            iter.close()?;
             drop(reference_iter);
             for x in remove_from_reference {
                 reference.remove(&x);

--- a/src/table.rs
+++ b/src/table.rs
@@ -635,6 +635,16 @@ impl<
             poison_target,
         }
     }
+
+    /// Closes the iterator.
+    ///
+    /// Entries already returned by the iterator remain removed, and unread
+    /// entries are not tested by the predicate or removed. Dropping the iterator
+    /// also closes it, but this method returns any error encountered while
+    /// finalizing the iterator.
+    pub fn close(mut self) -> Result {
+        self.inner.close()
+    }
 }
 
 impl<

--- a/src/tree_store/extract_if.rs
+++ b/src/tree_store/extract_if.rs
@@ -55,6 +55,25 @@ impl<'a, K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) ->
         self.predicate_running = false;
         result
     }
+
+    pub(crate) fn close(&mut self) -> Result {
+        self.inner.close();
+        self.free_pending_pages();
+        Ok(())
+    }
+
+    fn free_pending_pages(&mut self) {
+        let mut master_free_list = self.master_free_list.lock().unwrap();
+        let mut allocated = self.allocated.lock().unwrap();
+        for page in self.free_on_drop.drain(..) {
+            if !self
+                .page_allocator
+                .free_if_uncommitted(page, &mut allocated)
+            {
+                master_free_list.push(page);
+            }
+        }
+    }
 }
 
 impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool> Iterator
@@ -121,16 +140,6 @@ impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> boo
     for BtreeExtractIf<'_, K, V, F>
 {
     fn drop(&mut self) {
-        self.inner.close();
-        let mut master_free_list = self.master_free_list.lock().unwrap();
-        let mut allocated = self.allocated.lock().unwrap();
-        for page in self.free_on_drop.drain(..) {
-            if !self
-                .page_allocator
-                .free_if_uncommitted(page, &mut allocated)
-            {
-                master_free_list.push(page);
-            }
-        }
+        let _ = self.close();
     }
 }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -203,7 +203,7 @@ fn extract_if() {
         // Test retain uncommitted data
         let mut extracted = table.extract_if(|k, _| k >= 5).unwrap();
         assert_eq!(extracted.next().unwrap().unwrap().0.value(), 5);
-        drop(extracted);
+        extracted.close().unwrap();
         assert_eq!(table.len().unwrap(), 9);
 
         let mut extracted = table.extract_from_if(5.., |k, _| k < 8).unwrap();


### PR DESCRIPTION
Add a public close() method for ExtractIf so callers can explicitly finalize an extract iterator while preserving lazy removal semantics for unread entries.

Update the fuzz harness to close extract iterators directly instead of relying on Drop, and document the new API in the changelog.

Assisted-by: Codex