### PR TITLE
Use read-only btree cursor for table ranges

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -1,7 +1,7 @@
 use crate::db::TransactionGuard;
 use crate::sealed::Sealed;
 use crate::tree_store::{
-    AccessGuardMutInPlace, Btree, BtreeExtractIf, BtreeHeader, BtreeMut, BtreeRangeIter,
+    AccessGuardMutInPlace, Btree, BtreeCursorRange, BtreeExtractIf, BtreeHeader, BtreeMut,
     MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PageAllocator, PageHint, PageNumber, PageResolver,
     PageTrackerPolicy, RawBtree,
 };
@@ -327,7 +327,7 @@ impl<K: Key + 'static, V: Value + 'static> ReadableTable<K, V> for Table<'_, K, 
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
         self.tree
-            .range(&range)
+            .cursor_range(&range)
             .map(|x| Range::new(x, self.transaction.transaction_guard()))
     }
 
@@ -554,7 +554,7 @@ impl<K: Key + 'static, V: Value + 'static> ReadOnlyTable<K, V> {
         KR: Borrow<K::SelfType<'a>>,
     {
         self.tree
-            .range(&range)
+            .cursor_range(&range)
             .map(|x| Range::new(x, self.transaction_guard.clone()))
     }
 }
@@ -588,7 +588,7 @@ impl<K: Key + 'static, V: Value + 'static> ReadableTable<K, V> for ReadOnlyTable
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
         self.tree
-            .range(&range)
+            .cursor_range(&range)
             .map(|x| Range::new(x, self.transaction_guard.clone()))
     }
 
@@ -701,14 +701,14 @@ impl<
 
 #[derive(Clone)]
 pub struct Range<'a, K: Key + 'static, V: Value + 'static> {
-    inner: BtreeRangeIter<K, V>,
+    inner: BtreeCursorRange<K, V>,
     _transaction_guard: Arc<TransactionGuard>,
     // This lifetime is here so that `&` can be held on `Table` preventing concurrent mutation
     _lifetime: PhantomData<&'a ()>,
 }
 
 impl<K: Key + 'static, V: Value + 'static> Range<'_, K, V> {
-    pub(super) fn new(inner: BtreeRangeIter<K, V>, guard: Arc<TransactionGuard>) -> Self {
+    pub(super) fn new(inner: BtreeCursorRange<K, V>, guard: Arc<TransactionGuard>) -> Self {
         Self {
             inner,
             _transaction_guard: guard,

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -430,7 +430,7 @@ impl<'s, K: Key + 'static, V: Value + 'static> SystemTable<'s, K, V> {
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
         self.tree
-            .range(&range)
+            .cursor_range(&range)
             .map(|x| Range::new(x, self.transaction_guard.clone()))
     }
 

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -6,8 +6,8 @@ use crate::tree_store::btree_base::{
 use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
-    AccessGuardMutInPlace, AllPageNumbersBtreeIter, BtreeExtractIf, BtreeRangeIter, PageAllocator,
-    PageHint, PageNumber, PageResolver, PageTrackerPolicy,
+    AccessGuardMutInPlace, AllPageNumbersBtreeIter, BtreeCursorRange, BtreeExtractIf,
+    BtreeRangeIter, PageAllocator, PageHint, PageNumber, PageResolver, PageTrackerPolicy,
 };
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, Result};
@@ -660,6 +660,16 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         self.read_tree()?.range(range)
     }
 
+    pub(crate) fn cursor_range<'a0, T: RangeBounds<KR> + 'a0, KR: Borrow<K::SelfType<'a0>> + 'a0>(
+        &self,
+        range: &'_ T,
+    ) -> Result<BtreeCursorRange<K, V>>
+    where
+        K: 'a0,
+    {
+        self.read_tree()?.cursor_range(range)
+    }
+
     pub(crate) fn extract_from_if<
         'a,
         'a0,
@@ -1008,6 +1018,18 @@ impl<K: Key, V: Value> Btree<K, V> {
         range: &'_ T,
     ) -> Result<BtreeRangeIter<K, V>> {
         BtreeRangeIter::new(
+            range,
+            self.root.map(|x| x.root),
+            self.mem.clone(),
+            self.hint,
+        )
+    }
+
+    pub(crate) fn cursor_range<'a0, T: RangeBounds<KR>, KR: Borrow<K::SelfType<'a0>>>(
+        &self,
+        range: &'_ T,
+    ) -> Result<BtreeCursorRange<K, V>> {
+        BtreeCursorRange::new(
             range,
             self.root.map(|x| x.root),
             self.mem.clone(),

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -1,0 +1,246 @@
+use crate::Result;
+use crate::tree_store::btree_base::{BRANCH, BranchAccessor, LEAF, LeafAccessor};
+use crate::tree_store::btree_iters::{EntryGuard, child_to_visit, lower_bound_entry};
+use crate::tree_store::page_store::{Page, PageHint, PageImpl};
+use crate::tree_store::{PageNumber, PageResolver};
+use crate::types::{Key, Value};
+use std::cmp::Ordering;
+use std::collections::Bound;
+use std::marker::PhantomData;
+
+#[derive(Clone)]
+struct Branch {
+    page: PageImpl,
+    child_index: usize,
+}
+
+#[derive(Clone)]
+struct Leaf {
+    page: PageImpl,
+    position: usize,
+    len: usize,
+}
+
+#[derive(Clone)]
+pub(super) struct Cursor<K: Key + 'static, V: Value + 'static> {
+    root: PageNumber,
+    path: Vec<Branch>,
+    // Gap cursor position: next() returns the entry at position, and prev()
+    // returns the entry before position.
+    leaf: Option<Leaf>,
+    manager: PageResolver,
+    hint: PageHint,
+    _key_type: PhantomData<K>,
+    _value_type: PhantomData<V>,
+}
+
+impl<K: Key + 'static, V: Value + 'static> Cursor<K, V> {
+    pub(super) fn new(root: PageNumber, manager: PageResolver, hint: PageHint) -> Self {
+        Self {
+            root,
+            path: vec![],
+            leaf: None,
+            manager,
+            hint,
+            _key_type: PhantomData,
+            _value_type: PhantomData,
+        }
+    }
+
+    pub(super) fn seek_to(&mut self, bound: Bound<&[u8]>) -> Result {
+        self.path.clear();
+        let root_page = self.manager.get_page(self.root, self.hint)?;
+        self.descend_to_bound(root_page, bound)
+    }
+
+    pub(super) fn seek_to_end(&mut self) -> Result {
+        self.path.clear();
+        let root_page = self.manager.get_page(self.root, self.hint)?;
+        self.descend_edge(root_page, true)
+    }
+
+    fn descend_to_bound(&mut self, page: PageImpl, bound: Bound<&[u8]>) -> Result {
+        match page.memory()[0] {
+            LEAF => {
+                let (position, len) = {
+                    let accessor =
+                        LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
+                    (
+                        lower_bound_entry::<K>(&accessor, bound),
+                        accessor.num_pairs(),
+                    )
+                };
+                self.set_leaf(page, position, len);
+                Ok(())
+            }
+            BRANCH => {
+                let (child_index, child_page) = {
+                    let accessor = BranchAccessor::new(&page, K::fixed_width());
+                    let child_index = child_to_visit::<K>(&accessor, bound, false);
+                    (child_index, accessor.child_page(child_index).unwrap())
+                };
+                self.path.push(Branch { page, child_index });
+                let page = self.manager.get_page(child_page, self.hint)?;
+                self.descend_to_bound(page, bound)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn descend_edge(&mut self, page: PageImpl, high_edge: bool) -> Result {
+        match page.memory()[0] {
+            LEAF => {
+                let (position, len) = {
+                    let accessor =
+                        LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
+                    let len = accessor.num_pairs();
+                    (if high_edge { len } else { 0 }, len)
+                };
+                self.set_leaf(page, position, len);
+                Ok(())
+            }
+            BRANCH => {
+                let (child_index, child_page) = {
+                    let accessor = BranchAccessor::new(&page, K::fixed_width());
+                    let child_index = if high_edge {
+                        accessor.count_children() - 1
+                    } else {
+                        0
+                    };
+                    (child_index, accessor.child_page(child_index).unwrap())
+                };
+                self.path.push(Branch { page, child_index });
+                let page = self.manager.get_page(child_page, self.hint)?;
+                self.descend_edge(page, high_edge)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn set_leaf(&mut self, page: PageImpl, position: usize, len: usize) {
+        self.leaf = Some(Leaf {
+            page,
+            position,
+            len,
+        });
+    }
+
+    fn move_to_adjacent_leaf(&mut self, forward: bool) -> Result<bool> {
+        for index in (0..self.path.len()).rev() {
+            let next_child = {
+                let frame = &self.path[index];
+                let accessor = BranchAccessor::new(&frame.page, K::fixed_width());
+                if forward {
+                    let child_index = frame.child_index + 1;
+                    (child_index < accessor.count_children())
+                        .then(|| (child_index, accessor.child_page(child_index).unwrap()))
+                } else {
+                    frame
+                        .child_index
+                        .checked_sub(1)
+                        .map(|child_index| (child_index, accessor.child_page(child_index).unwrap()))
+                }
+            };
+
+            if let Some((child_index, child_page)) = next_child {
+                self.path[index].child_index = child_index;
+                self.path.truncate(index + 1);
+                let page = self.manager.get_page(child_page, self.hint)?;
+                self.descend_edge(page, !forward)?;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    pub(super) fn normalize_forward_gap(&mut self) -> Result {
+        let Some(leaf) = self.leaf.as_ref() else {
+            return Ok(());
+        };
+        if leaf.position == leaf.len {
+            self.move_to_adjacent_leaf(true)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn next(&mut self) -> Result<Option<EntryGuard<K, V>>> {
+        loop {
+            let Some(leaf) = self.leaf.as_ref() else {
+                return Ok(None);
+            };
+            if leaf.position < leaf.len {
+                let entry = self.get_entry(leaf.position);
+                self.leaf
+                    .as_mut()
+                    .expect("cursor must be positioned")
+                    .position += 1;
+                return Ok(Some(entry));
+            }
+
+            if !self.move_to_adjacent_leaf(true)? {
+                return Ok(None);
+            }
+        }
+    }
+
+    pub(super) fn prev(&mut self) -> Result<Option<EntryGuard<K, V>>> {
+        loop {
+            let Some(leaf) = self.leaf.as_ref() else {
+                return Ok(None);
+            };
+            if leaf.position > 0 {
+                let entry = leaf.position - 1;
+                self.leaf
+                    .as_mut()
+                    .expect("cursor must be positioned")
+                    .position = entry;
+                return Ok(Some(self.get_entry(entry)));
+            }
+
+            if !self.move_to_adjacent_leaf(false)? {
+                return Ok(None);
+            }
+        }
+    }
+
+    fn page_number(&self) -> PageNumber {
+        self.leaf
+            .as_ref()
+            .expect("cursor must be positioned")
+            .page
+            .get_page_number()
+    }
+
+    fn position(&self) -> usize {
+        self.leaf
+            .as_ref()
+            .expect("cursor must be positioned")
+            .position
+    }
+
+    pub(super) fn compare_position(&self, other: &Self) -> Ordering {
+        let self_page = self.page_number();
+        let other_page = other.page_number();
+        if self_page == other_page {
+            return self.position().cmp(&other.position());
+        }
+
+        assert_eq!(self.path.len(), other.path.len());
+        for (self_frame, other_frame) in self.path.iter().zip(&other.path) {
+            match self_frame.child_index.cmp(&other_frame.child_index) {
+                Ordering::Equal => {}
+                ordering => return ordering,
+            }
+        }
+        unreachable!("distinct cursor pages must diverge in their branch path")
+    }
+
+    fn get_entry(&self, entry: usize) -> EntryGuard<K, V> {
+        let leaf = self.leaf.as_ref().expect("cursor must be positioned");
+        let (key, value) =
+            LeafAccessor::new(leaf.page.memory(), K::fixed_width(), V::fixed_width())
+                .entry_ranges(entry)
+                .expect("cursor entry must exist");
+        EntryGuard::new(leaf.page.clone(), key, value)
+    }
+}

--- a/src/tree_store/btree_cursor_range.rs
+++ b/src/tree_store/btree_cursor_range.rs
@@ -1,0 +1,240 @@
+use crate::Result;
+use crate::tree_store::btree_cursor::Cursor;
+use crate::tree_store::btree_iters::{EntryGuard, range_is_empty};
+use crate::tree_store::page_store::PageHint;
+use crate::tree_store::{PageNumber, PageResolver};
+use crate::types::{Key, Value};
+use Bound::{Excluded, Included, Unbounded};
+use std::borrow::Borrow;
+use std::cmp::Ordering;
+use std::collections::Bound;
+use std::ops::RangeBounds;
+
+#[derive(Clone)]
+enum Slot<C> {
+    Uninitialized,
+    Active(C),
+    Exhausted,
+}
+
+impl<C> Slot<C> {
+    fn active(&self) -> Option<&C> {
+        match self {
+            Slot::Active(cursor) => Some(cursor),
+            Slot::Uninitialized | Slot::Exhausted => None,
+        }
+    }
+
+    fn active_mut(&mut self) -> Option<&mut C> {
+        match self {
+            Slot::Active(cursor) => Some(cursor),
+            Slot::Uninitialized | Slot::Exhausted => None,
+        }
+    }
+
+    fn is_uninitialized(&self) -> bool {
+        matches!(self, Slot::Uninitialized)
+    }
+}
+
+#[derive(Copy, Clone)]
+enum Side {
+    Front,
+    Back,
+}
+
+#[derive(Clone)]
+pub(crate) struct BtreeCursorRange<K: Key + 'static, V: Value + 'static> {
+    root: Option<PageNumber>,
+    lower_bound: Bound<Vec<u8>>,
+    upper_bound: Bound<Vec<u8>>,
+    manager: PageResolver,
+    hint: PageHint,
+    front: Slot<Cursor<K, V>>,
+    back: Slot<Cursor<K, V>>,
+}
+
+impl<K: Key + 'static, V: Value + 'static> BtreeCursorRange<K, V> {
+    pub(crate) fn new<'a, T: RangeBounds<KR>, KR: Borrow<K::SelfType<'a>>>(
+        query_range: &'_ T,
+        table_root: Option<PageNumber>,
+        manager: PageResolver,
+        hint: PageHint,
+    ) -> Result<Self> {
+        if table_root.is_none() || range_is_empty::<K, KR, T>(query_range) {
+            return Ok(Self::empty(manager, hint));
+        }
+
+        let lower_bound = query_range
+            .start_bound()
+            .map(|key| K::as_bytes(key.borrow()).as_ref().to_vec());
+        let upper_bound = query_range
+            .end_bound()
+            .map(|key| K::as_bytes(key.borrow()).as_ref().to_vec());
+        Ok(Self {
+            root: table_root,
+            lower_bound,
+            upper_bound,
+            manager,
+            hint,
+            front: Slot::Uninitialized,
+            back: Slot::Uninitialized,
+        })
+    }
+
+    fn empty(manager: PageResolver, hint: PageHint) -> Self {
+        Self {
+            root: None,
+            lower_bound: Unbounded,
+            upper_bound: Unbounded,
+            manager,
+            hint,
+            front: Slot::Exhausted,
+            back: Slot::Exhausted,
+        }
+    }
+
+    fn close(&mut self) {
+        self.root = None;
+        self.front = Slot::Exhausted;
+        self.back = Slot::Exhausted;
+    }
+
+    fn initialize_side(&mut self, side: Side) -> Result {
+        assert!(matches!(self.slot(side), Slot::Uninitialized));
+        let root = self.root.expect("range cursor must have a root");
+        let mut cursor = Cursor::new(root, self.manager.clone(), self.hint);
+        match side {
+            Side::Front => {
+                cursor.seek_to(self.lower_bound.as_ref().map(Vec::as_slice))?;
+            }
+            Side::Back => match self.upper_bound.as_ref().map(Vec::as_slice) {
+                Included(key) => cursor.seek_to(Excluded(key))?,
+                Excluded(key) => cursor.seek_to(Included(key))?,
+                Unbounded => cursor.seek_to_end()?,
+            },
+        }
+        *self.slot_mut(side) = Slot::Active(cursor);
+        Ok(())
+    }
+
+    fn prepare(&mut self, side: Side) -> Result<bool> {
+        if matches!(self.slot(side), Slot::Uninitialized) {
+            self.initialize_side(side)?;
+        }
+        Ok(self.slot(side).active().is_some())
+    }
+
+    fn slot(&self, side: Side) -> &Slot<Cursor<K, V>> {
+        match side {
+            Side::Front => &self.front,
+            Side::Back => &self.back,
+        }
+    }
+
+    fn slot_mut(&mut self, side: Side) -> &mut Slot<Cursor<K, V>> {
+        match side {
+            Side::Front => &mut self.front,
+            Side::Back => &mut self.back,
+        }
+    }
+
+    fn opposite_slot(&self, side: Side) -> &Slot<Cursor<K, V>> {
+        match side {
+            Side::Front => &self.back,
+            Side::Back => &self.front,
+        }
+    }
+
+    fn active_cursor_mut(&mut self, side: Side) -> &mut Cursor<K, V> {
+        self.slot_mut(side)
+            .active_mut()
+            .expect("cursor must be active")
+    }
+
+    fn cursors_have_remaining(&mut self) -> Result<bool> {
+        // The gap after one leaf is the same logical position as the gap before
+        // the next leaf. Keep the front cursor canonical so path comparison can
+        // detect when alternating iteration has consumed the whole range.
+        if let (Slot::Active(front), Slot::Active(_)) = (&mut self.front, &self.back) {
+            front.normalize_forward_gap()?;
+        }
+
+        match (&self.front, &self.back) {
+            (Slot::Active(front), Slot::Active(back)) => {
+                Ok(front.compare_position(back) == Ordering::Less)
+            }
+            (Slot::Exhausted, _) | (_, Slot::Exhausted) => Ok(false),
+            (Slot::Uninitialized, _) | (_, Slot::Uninitialized) => Ok(true),
+        }
+    }
+
+    fn advance_cursor(&mut self, side: Side) -> Result<Option<EntryGuard<K, V>>> {
+        match side {
+            Side::Front => self.active_cursor_mut(side).next(),
+            Side::Back => self.active_cursor_mut(side).prev(),
+        }
+    }
+
+    fn entry_within_open_bound(&self, entry: &EntryGuard<K, V>, side: Side) -> bool {
+        let key = entry.key_bytes();
+        match side {
+            Side::Front => match self.upper_bound.as_ref().map(Vec::as_slice) {
+                Included(bound) => K::compare(key, bound).is_le(),
+                Excluded(bound) => K::compare(key, bound).is_lt(),
+                Unbounded => true,
+            },
+            Side::Back => match self.lower_bound.as_ref().map(Vec::as_slice) {
+                Included(bound) => K::compare(key, bound).is_ge(),
+                Excluded(bound) => K::compare(key, bound).is_gt(),
+                Unbounded => true,
+            },
+        }
+    }
+
+    fn next_from(&mut self, side: Side) -> Option<Result<EntryGuard<K, V>>> {
+        match self.prepare(side) {
+            Ok(true) => {}
+            Ok(false) => return None,
+            Err(err) => return Some(Err(err)),
+        }
+        match self.cursors_have_remaining() {
+            Ok(true) => {}
+            Ok(false) => {
+                self.close();
+                return None;
+            }
+            Err(err) => return Some(Err(err)),
+        }
+
+        let entry = match self.advance_cursor(side) {
+            Ok(Some(entry)) => entry,
+            Ok(None) => {
+                self.close();
+                return None;
+            }
+            Err(err) => return Some(Err(err)),
+        };
+        if self.opposite_slot(side).is_uninitialized()
+            && !self.entry_within_open_bound(&entry, side)
+        {
+            self.close();
+            return None;
+        }
+        Some(Ok(entry))
+    }
+}
+
+impl<K: Key + 'static, V: Value + 'static> Iterator for BtreeCursorRange<K, V> {
+    type Item = Result<EntryGuard<K, V>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_from(Side::Front)
+    }
+}
+
+impl<K: Key + 'static, V: Value + 'static> DoubleEndedIterator for BtreeCursorRange<K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.next_from(Side::Back)
+    }
+}

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -46,7 +46,7 @@ enum RangeIterState {
     },
 }
 
-fn lower_bound_entry<K: Key>(accessor: &LeafAccessor<'_>, bound: Bound<&[u8]>) -> usize {
+pub(super) fn lower_bound_entry<K: Key>(accessor: &LeafAccessor<'_>, bound: Bound<&[u8]>) -> usize {
     match bound {
         Included(query) | Excluded(query) => {
             let (mut position, found) = accessor.position::<K>(query);
@@ -72,7 +72,7 @@ fn upper_bound_entry<K: Key>(accessor: &LeafAccessor<'_>, bound: Bound<&[u8]>) -
     }
 }
 
-fn child_to_visit<K: Key>(
+pub(super) fn child_to_visit<K: Key>(
     accessor: &BranchAccessor<'_, '_, PageImpl>,
     bound: Bound<&[u8]>,
     reverse: bool,
@@ -492,7 +492,7 @@ pub(crate) struct EntryGuard<K: Key, V: Value> {
 }
 
 impl<K: Key, V: Value> EntryGuard<K, V> {
-    fn new(page: PageImpl, key_range: Range<usize>, value_range: Range<usize>) -> Self {
+    pub(super) fn new(page: PageImpl, key_range: Range<usize>, value_range: Range<usize>) -> Self {
         Self {
             page,
             key_range,
@@ -500,6 +500,10 @@ impl<K: Key, V: Value> EntryGuard<K, V> {
             _key_type: PhantomData,
             _value_type: PhantomData,
         }
+    }
+
+    pub(super) fn key_bytes(&self) -> &[u8] {
+        &self.page.memory()[self.key_range.clone()]
     }
 
     pub(crate) fn key_data(&self) -> Vec<u8> {
@@ -614,7 +618,12 @@ pub(crate) struct BtreeRangeIter<K: Key + 'static, V: Value + 'static> {
     _value_type: PhantomData<V>,
 }
 
-fn range_is_empty<'a, K: Key + 'static, KR: Borrow<K::SelfType<'a>>, T: RangeBounds<KR>>(
+pub(super) fn range_is_empty<
+    'a,
+    K: Key + 'static,
+    KR: Borrow<K::SelfType<'a>>,
+    T: RangeBounds<KR>,
+>(
     range: &T,
 ) -> bool {
     match (range.start_bound(), range.end_bound()) {

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -1,5 +1,7 @@
 mod btree;
 mod btree_base;
+mod btree_cursor;
+mod btree_cursor_range;
 mod btree_iters;
 mod btree_mutator;
 mod extract_if;
@@ -14,6 +16,7 @@ pub(crate) use btree::{Btree, BtreeMut, BtreeStats, RawBtree};
 pub(crate) use btree_base::BtreeHeader;
 pub use btree_base::{AccessGuard, AccessGuardMut, AccessGuardMutInPlace};
 pub(crate) use btree_base::{BRANCH, LEAF, LeafAccessor, RawLeafBuilder};
+pub(crate) use btree_cursor_range::BtreeCursorRange;
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, BtreeRangeIter};
 pub(crate) use extract_if::BtreeExtractIf;
 pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multimap_btree_stats};

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2058,6 +2058,35 @@ fn range_mixed_direction_no_duplicates_multi_page() {
 }
 
 #[test]
+fn range_alternating_direction_meets_at_leaf_boundary() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let definition: TableDefinition<u64, [u8; 200]> = TableDefinition::new("x");
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0..5_000u64 {
+            table.insert(i, &[0u8; 200]).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let definition: TableDefinition<u64, [u8; 200]> = TableDefinition::new("x");
+    let table = read_txn.open_table(definition).unwrap();
+    let mut iter = table.range(0..5_000).unwrap();
+    for i in 0..2_500u64 {
+        let (key, _) = iter.next().unwrap().unwrap();
+        assert_eq!(key.value(), i);
+
+        let (key, _) = iter.next_back().unwrap().unwrap();
+        assert_eq!(key.value(), 4_999 - i);
+    }
+    assert!(iter.next().is_none());
+    assert!(iter.next_back().is_none());
+}
+
+#[test]
 fn alias_table() {
     let tmpfile = create_tempfile();
     let db = Database::create(tmpfile.path()).unwrap();


### PR DESCRIPTION
Add an internal read-only cursor and a cursor-backed range iterator for public table range scans. The existing BtreeRangeIter remains available for internal traversal users that need range visit events.

Initialize the front and back cursors lazily so forward-only and backward-only scans do not pay to seek the opposite end of the range.

Assisted-by: Codex