### PR TITLE
Stop generating docs for transitive dependencies in build_all

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ build: pre
 
 build_all: pre_all
     cargo build --all --all-targets --all-features
-    cargo doc --all
+    cargo doc --all --no-deps
 
 pre:
     cargo deny --workspace --all-features check licenses


### PR DESCRIPTION
cargo doc --all without --no-deps walks the entire transitive
dependency tree (chrono, pyo3, all of redb-bench's rocksdb / sled /
heed / fjall / bundled sqlite, etc.) and emits HTML for each, even
though docs.rs already publishes those publicly. Adding --no-deps
keeps the workspace-member doc generation that catches local doc
comment issues but skips the wasted dependency rendering, speeding up
every just test_all (and therefore every CI Run tests step) without
changing what's tested.

Assisted-by: Claude