### PR TITLE
Use mutable btree cursor for pop

### DIFF
--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -3,6 +3,7 @@ use crate::tree_store::btree_base::{
     AccessGuardMut, BRANCH, BranchAccessor, BranchMutator, BtreeHeader, Checksum, DEFERRED, LEAF,
     LeafAccessor, LeafPageMut, branch_checksum, leaf_checksum,
 };
+use crate::tree_store::btree_cursor::{CursorMut, CursorMutPosition};
 use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
@@ -495,25 +496,27 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
     // Removes and returns the leftmost entry in the tree, if any, in a single tree descent.
     pub(crate) fn pop_first(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
         let mut freed_pages = self.freed_pages.lock().unwrap();
-        let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new(
+        let mut cursor: CursorMut<'_, '_, K, V> = CursorMut::new(
             &mut self.root,
-            self.page_allocator.clone(),
+            &self.page_allocator,
             freed_pages.as_mut(),
-            self.allocated_pages.clone(),
+            &self.allocated_pages,
         );
-        operation.pop_first()
+        cursor.seek_to(CursorMutPosition::Start)?;
+        cursor.remove_next()
     }
 
     // Removes and returns the rightmost entry in the tree, if any, in a single tree descent.
     pub(crate) fn pop_last(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
         let mut freed_pages = self.freed_pages.lock().unwrap();
-        let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new(
+        let mut cursor: CursorMut<'_, '_, K, V> = CursorMut::new(
             &mut self.root,
-            self.page_allocator.clone(),
+            &self.page_allocator,
             freed_pages.as_mut(),
-            self.allocated_pages.clone(),
+            &self.allocated_pages,
         );
-        operation.pop_last()
+        cursor.seek_to(CursorMutPosition::End)?;
+        cursor.remove_prev()
     }
 
     #[allow(dead_code)]

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -1,17 +1,64 @@
+use crate::AccessGuard;
 use crate::Result;
 use crate::tree_store::btree_base::{BRANCH, BranchAccessor, LEAF, LeafAccessor};
 use crate::tree_store::btree_iters::{EntryGuard, child_to_visit, lower_bound_entry};
+use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageHint, PageImpl};
-use crate::tree_store::{PageNumber, PageResolver};
+use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageResolver, PageTrackerPolicy};
 use crate::types::{Key, Value};
 use std::cmp::Ordering;
 use std::collections::Bound;
 use std::marker::PhantomData;
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone)]
 struct Branch {
     page: PageImpl,
     child_index: usize,
+}
+
+impl Branch {
+    fn new(page: PageImpl, child_index: usize) -> Self {
+        Self { page, child_index }
+    }
+
+    fn into_parts(self) -> (PageImpl, usize) {
+        (self.page, self.child_index)
+    }
+}
+
+fn descend_edge<K: Key + 'static, V: Value + 'static, F>(
+    page: PageImpl,
+    high_edge: bool,
+    path: &mut Vec<Branch>,
+    get_page: &mut F,
+) -> Result<(PageImpl, usize)>
+where
+    // TODO: introduce a trait for this that PageResolver can implement too.
+    F: FnMut(PageNumber) -> Result<PageImpl>,
+{
+    match page.memory()[0] {
+        LEAF => {
+            let len = {
+                let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
+                accessor.num_pairs()
+            };
+            Ok((page, len))
+        }
+        BRANCH => {
+            let accessor = BranchAccessor::new(&page, K::fixed_width());
+            let child_index = if high_edge {
+                accessor.count_children() - 1
+            } else {
+                0
+            };
+            let child_page = accessor.child_page(child_index).unwrap();
+            path.push(Branch::new(page, child_index));
+            let child = get_page(child_page)?;
+            descend_edge::<K, V, F>(child, high_edge, path, get_page)
+        }
+        _ => unreachable!(),
+    }
 }
 
 #[derive(Clone)]
@@ -79,7 +126,7 @@ impl<K: Key + 'static, V: Value + 'static> Cursor<K, V> {
                     let child_index = child_to_visit::<K>(&accessor, bound, false);
                     (child_index, accessor.child_page(child_index).unwrap())
                 };
-                self.path.push(Branch { page, child_index });
+                self.path.push(Branch::new(page, child_index));
                 let page = self.manager.get_page(child_page, self.hint)?;
                 self.descend_to_bound(page, bound)
             }
@@ -88,33 +135,13 @@ impl<K: Key + 'static, V: Value + 'static> Cursor<K, V> {
     }
 
     fn descend_edge(&mut self, page: PageImpl, high_edge: bool) -> Result {
-        match page.memory()[0] {
-            LEAF => {
-                let (position, len) = {
-                    let accessor =
-                        LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
-                    let len = accessor.num_pairs();
-                    (if high_edge { len } else { 0 }, len)
-                };
-                self.set_leaf(page, position, len);
-                Ok(())
-            }
-            BRANCH => {
-                let (child_index, child_page) = {
-                    let accessor = BranchAccessor::new(&page, K::fixed_width());
-                    let child_index = if high_edge {
-                        accessor.count_children() - 1
-                    } else {
-                        0
-                    };
-                    (child_index, accessor.child_page(child_index).unwrap())
-                };
-                self.path.push(Branch { page, child_index });
-                let page = self.manager.get_page(child_page, self.hint)?;
-                self.descend_edge(page, high_edge)
-            }
-            _ => unreachable!(),
-        }
+        let manager = &self.manager;
+        let hint = self.hint;
+        let mut get_page = |page| manager.get_page(page, hint);
+        let (page, len) = descend_edge::<K, V, _>(page, high_edge, &mut self.path, &mut get_page)?;
+        let position = if high_edge { len } else { 0 };
+        self.set_leaf(page, position, len);
+        Ok(())
     }
 
     fn set_leaf(&mut self, page: PageImpl, position: usize, len: usize) {
@@ -242,5 +269,110 @@ impl<K: Key + 'static, V: Value + 'static> Cursor<K, V> {
                 .entry_ranges(entry)
                 .expect("cursor entry must exist");
         EntryGuard::new(leaf.page.clone(), key, value)
+    }
+}
+
+#[derive(Copy, Clone)]
+pub(super) enum CursorMutPosition {
+    Start,
+    End,
+}
+
+pub(super) struct CursorMut<'a, 'b, K: Key + 'static, V: Value + 'static> {
+    root: &'b mut Option<BtreeHeader>,
+    page_allocator: &'b PageAllocator,
+    freed: &'b mut Vec<PageNumber>,
+    allocated: &'b Arc<Mutex<PageTrackerPolicy>>,
+    path: Vec<Branch>,
+    leaf: Option<Leaf>,
+    _key_type: PhantomData<K>,
+    _value_type: PhantomData<V>,
+    _lifetime: PhantomData<&'a ()>,
+}
+
+impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
+    pub(super) fn new(
+        root: &'b mut Option<BtreeHeader>,
+        page_allocator: &'b PageAllocator,
+        freed: &'b mut Vec<PageNumber>,
+        allocated: &'b Arc<Mutex<PageTrackerPolicy>>,
+    ) -> Self {
+        Self {
+            root,
+            page_allocator,
+            freed,
+            allocated,
+            path: vec![],
+            leaf: None,
+            _key_type: PhantomData,
+            _value_type: PhantomData,
+            _lifetime: PhantomData,
+        }
+    }
+
+    pub(super) fn seek_to(&mut self, position: CursorMutPosition) -> Result {
+        self.path.clear();
+        self.leaf = None;
+        let Some(header) = *self.root else {
+            return Ok(());
+        };
+        let root = self.page_allocator.get_page(header.root, PageHint::None)?;
+        let high_edge = matches!(position, CursorMutPosition::End);
+        let page_allocator = self.page_allocator;
+        let mut get_page = |page| page_allocator.get_page(page, PageHint::None);
+        let (page, len) = descend_edge::<K, V, _>(root, high_edge, &mut self.path, &mut get_page)?;
+        let position = if high_edge { len } else { 0 };
+        self.leaf = Some(Leaf {
+            page,
+            position,
+            len,
+        });
+        Ok(())
+    }
+
+    pub(super) fn remove_next(
+        &mut self,
+    ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        let Some(leaf) = self.leaf.take() else {
+            self.path.clear();
+            return Ok(None);
+        };
+        if leaf.position == leaf.len {
+            self.path.clear();
+            return Ok(None);
+        }
+        self.remove_leaf_entry(leaf.page, leaf.position)
+    }
+
+    pub(super) fn remove_prev(
+        &mut self,
+    ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        let Some(leaf) = self.leaf.take() else {
+            self.path.clear();
+            return Ok(None);
+        };
+        let Some(position) = leaf.position.checked_sub(1) else {
+            self.path.clear();
+            return Ok(None);
+        };
+        self.remove_leaf_entry(leaf.page, position)
+    }
+
+    fn remove_leaf_entry(
+        &mut self,
+        leaf: PageImpl,
+        position: usize,
+    ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        let path = std::mem::take(&mut self.path)
+            .into_iter()
+            .map(Branch::into_parts)
+            .collect();
+        let mut helper = MutateHelper::new(
+            &mut *self.root,
+            (*self.page_allocator).clone(),
+            &mut *self.freed,
+            Arc::clone(self.allocated),
+        );
+        Ok(Some(helper.pop_leaf_entry(leaf, path, position)?))
     }
 }

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -19,17 +19,6 @@ use std::marker::PhantomData;
 use std::ops::RangeBounds;
 use std::sync::{Arc, Mutex};
 
-// Describes which entry to delete. `Key` navigates via key comparison; `First`
-// and `Last` navigate to the leftmost or rightmost entry, and also cause the
-// deleted key bytes to be captured so the caller can return them alongside the
-// value (used by pop_first / pop_last).
-#[derive(Copy, Clone)]
-enum DeleteTarget<'a> {
-    Key(&'a [u8]),
-    First,
-    Last,
-}
-
 #[derive(Debug)]
 enum DeletionResult {
     // A proper subtree
@@ -133,22 +122,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     }
 
     pub(crate) fn delete(&mut self, key: &K::SelfType<'_>) -> Result<Option<AccessGuard<'a, V>>> {
-        let mut found_key = None;
-        self.delete_target(DeleteTarget::Key(K::as_bytes(key).as_ref()), &mut found_key)
-    }
-
-    // Deletes the leftmost entry in the tree and returns (key, value), or None if empty.
-    pub(crate) fn pop_first(&mut self) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
-        let mut found_key = None;
-        let value = self.delete_target(DeleteTarget::First, &mut found_key)?;
-        Ok(value.map(|v| (found_key.take().unwrap(), v)))
-    }
-
-    // Deletes the rightmost entry in the tree and returns (key, value), or None if empty.
-    pub(crate) fn pop_last(&mut self) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
-        let mut found_key = None;
-        let value = self.delete_target(DeleteTarget::Last, &mut found_key)?;
-        Ok(value.map(|v| (found_key.take().unwrap(), v)))
+        self.delete_key(K::as_bytes(key).as_ref())
     }
 
     pub(crate) fn retain_in_range<'r, KR, F>(
@@ -185,20 +159,13 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         Ok(())
     }
 
-    fn delete_target(
-        &mut self,
-        target: DeleteTarget<'_>,
-        found_key: &mut Option<AccessGuard<'a, K>>,
-    ) -> Result<Option<AccessGuard<'a, V>>> {
+    fn delete_key(&mut self, key: &[u8]) -> Result<Option<AccessGuard<'a, V>>> {
         if let Some(BtreeHeader {
             root: p, length, ..
         }) = *self.root
         {
-            let (deletion_result, found) = self.delete_helper(
-                self.page_allocator.get_page(p, PageHint::None)?,
-                target,
-                found_key,
-            )?;
+            let (deletion_result, found) =
+                self.delete_helper(self.page_allocator.get_page(p, PageHint::None)?, key)?;
             if found.is_none() {
                 // The tree was not modified; leave *self.root untouched so that any clean
                 // root page keeps its already-valid checksum.
@@ -259,6 +226,24 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         };
         *self.root = new_root;
         Ok(())
+    }
+
+    pub(super) fn pop_leaf_entry(
+        &mut self,
+        leaf: PageImpl,
+        path: Vec<(PageImpl, usize)>,
+        position: usize,
+    ) -> Result<(AccessGuard<'a, K>, AccessGuard<'a, V>)> {
+        let length = self.root.expect("pop requires a root").length;
+        let (mut result, key, value) = self.delete_leaf_at_position(leaf, position, true)?;
+        for (page, child_index) in path.into_iter().rev() {
+            result = self.apply_child_deletion_result(page, child_index, result)?;
+        }
+        self.finish_deletion(result, length - 1)?;
+        Ok((
+            key.expect("deleted key must be returned when requested"),
+            value,
+        ))
     }
 
     #[allow(clippy::type_complexity)]
@@ -819,27 +804,19 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     fn delete_leaf_helper(
         &mut self,
         page: PageImpl,
-        target: DeleteTarget<'_>,
-        found_key: &mut Option<AccessGuard<'a, K>>,
+        key: &[u8],
     ) -> Result<(DeletionResult, Option<AccessGuard<'a, V>>)> {
         let (position, found) = {
             let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
-            match target {
-                DeleteTarget::Key(key) => accessor.position::<K>(key),
-                DeleteTarget::First => (0, true),
-                DeleteTarget::Last => (accessor.num_pairs() - 1, true),
-            }
+            accessor.position::<K>(key)
         };
         if !found {
             // Leaf is unchanged; caller short-circuits via `found.is_none()`.
             return Ok((Subtree(page.get_page_number()), None));
         }
-        let want_key = matches!(target, DeleteTarget::First | DeleteTarget::Last);
         let (result, key_guard, value_guard) =
-            self.delete_leaf_at_position(page, position, want_key)?;
-        if want_key {
-            *found_key = Some(key_guard.expect("deleted key must be returned when requested"));
-        }
+            self.delete_leaf_at_position(page, position, false)?;
+        assert!(key_guard.is_none());
         Ok((result, Some(value_guard)))
     }
 
@@ -865,26 +842,17 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     fn delete_branch_helper(
         &mut self,
         page: PageImpl,
-        target: DeleteTarget<'_>,
-        found_key: &mut Option<AccessGuard<'a, K>>,
+        key: &[u8],
     ) -> Result<(DeletionResult, Option<AccessGuard<'a, V>>)> {
         let original_page_number = page.get_page_number();
         let (child_index, child_page_number) = {
             let accessor = BranchAccessor::new(&page, K::fixed_width());
-            match target {
-                DeleteTarget::Key(key) => accessor.child_for_key::<K>(key),
-                DeleteTarget::First => (0, accessor.child_page(0).unwrap()),
-                DeleteTarget::Last => {
-                    let idx = accessor.count_children() - 1;
-                    (idx, accessor.child_page(idx).unwrap())
-                }
-            }
+            accessor.child_for_key::<K>(key)
         };
         let (result, found) = self.delete_helper(
             self.page_allocator
                 .get_page(child_page_number, PageHint::None)?,
-            target,
-            found_key,
+            key,
         )?;
         if found.is_none() {
             // Subtree unchanged; caller identifies this via `found.is_none()`.
@@ -1013,8 +981,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
 
                     drop(page);
                     self.conditional_free(original_page_number);
-                    // child_page_number does not need to be freed, because it's a leaf and the
-                    // MutAccessGuard will free it
+                    // The leaf helper already handled the original child page lifetime.
 
                     return Ok(result);
                 }
@@ -1071,8 +1038,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 let page_number = merge_with_page.get_page_number();
                 drop(merge_with_page);
                 self.conditional_free(page_number);
-                // child_page_number does not need to be freed, because it's a leaf and the
-                // MutAccessGuard will free it
+                // The leaf helper already handled the original child page lifetime.
 
                 result
             }
@@ -1219,18 +1185,15 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
 
     // Returns the page number of the sub-tree with this key deleted, or None if the sub-tree is empty.
     // If key is not found, guaranteed not to modify the tree.
-    // When `target` is DeleteTarget::First or DeleteTarget::Last, `found_key` is populated
-    // with an AccessGuard for the deleted key.
     fn delete_helper(
         &mut self,
         page: PageImpl,
-        target: DeleteTarget<'_>,
-        found_key: &mut Option<AccessGuard<'a, K>>,
+        key: &[u8],
     ) -> Result<(DeletionResult, Option<AccessGuard<'a, V>>)> {
         let node_mem = page.memory();
         match node_mem[0] {
-            LEAF => self.delete_leaf_helper(page, target, found_key),
-            BRANCH => self.delete_branch_helper(page, target, found_key),
+            LEAF => self.delete_leaf_helper(page, key),
+            BRANCH => self.delete_branch_helper(page, key),
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
Add a minimal internal mutable cursor for left and right edge removal, and use it to implement pop_first() and pop_last(). The cursor owns the edge descent and passes its path to the existing delete rebalance code, which removes the specialized First/Last delete targets while preserving the dirty-page fast path for repeated pops.

Assisted-by: Codex