### PR TITLE
Implement extract_if with mutable cursors

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -672,13 +672,7 @@ impl<
     type Item = Result<(AccessGuard<'a, K>, AccessGuard<'a, V>)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let entry = self.inner.next()?;
-        Some(entry.map(|entry| {
-            let (page, key_range, value_range) = entry.into_raw();
-            let key = AccessGuard::with_page(page.clone(), key_range);
-            let value = AccessGuard::with_page(page, value_range);
-            (key, value)
-        }))
+        self.inner.next()
     }
 }
 
@@ -689,13 +683,7 @@ impl<
 > DoubleEndedIterator for ExtractIf<'_, K, V, F>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let entry = self.inner.next_back()?;
-        Some(entry.map(|entry| {
-            let (page, key_range, value_range) = entry.into_raw();
-            let key = AccessGuard::with_page(page.clone(), key_range);
-            let value = AccessGuard::with_page(page, value_range);
-            (key, value)
-        }))
+        self.inner.next_back()
     }
 }
 

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -690,11 +690,17 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
     where
         K: 'a0,
     {
-        let iter = self.range(range)?;
+        let lower_bound = range
+            .start_bound()
+            .map(|key| K::as_bytes(key.borrow()).as_ref().to_vec());
+        let upper_bound = range
+            .end_bound()
+            .map(|key| K::as_bytes(key.borrow()).as_ref().to_vec());
 
         let result = BtreeExtractIf::new(
             &mut self.root,
-            iter,
+            lower_bound,
+            upper_bound,
             predicate,
             self.freed_pages.clone(),
             self.allocated_pages.clone(),

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -492,6 +492,14 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         Ok(Some(entry_ref(leaf, leaf.position)))
     }
 
+    pub(super) fn peek_prev(&mut self) -> Result<Option<EntryRef<'_, K, V>>> {
+        if !self.prepare_prev()? {
+            return Ok(None);
+        }
+        let leaf = self.leaf.as_ref().expect("cursor must be positioned");
+        Ok(Some(entry_ref(leaf, leaf.position - 1)))
+    }
+
     pub(super) fn next(&mut self) -> Result<bool> {
         if !self.prepare_next()? {
             return Ok(false);
@@ -503,6 +511,20 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         Ok(true)
     }
 
+    pub(super) fn prev(&mut self) -> Result<bool> {
+        if !self.prepare_prev()? {
+            return Ok(false);
+        }
+        self.leaf
+            .as_mut()
+            .expect("cursor must be positioned")
+            .position -= 1;
+        Ok(true)
+    }
+
+    /// Removes and returns the next entry.
+    ///
+    /// The returned guards must be dropped before mutating the tree again.
     pub(super) fn remove_next(
         &mut self,
     ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
@@ -512,6 +534,20 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         let leaf = self.leaf.take().expect("cursor must be positioned");
         let position = leaf.position;
         self.remove_leaf_entry(leaf.page, position)
+    }
+
+    /// Removes and returns the next entry.
+    ///
+    /// The caller may continue mutating the tree while the returned guards are live.
+    pub(super) fn remove_next_detached(
+        &mut self,
+    ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        if !self.prepare_next()? {
+            return Ok(None);
+        }
+        let leaf = self.leaf.take().expect("cursor must be positioned");
+        let position = leaf.position;
+        self.remove_leaf_entry_detached(leaf.page, position)
     }
 
     pub(super) fn remove_next_discard(&mut self) -> Result<bool> {
@@ -527,6 +563,9 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         Ok(true)
     }
 
+    /// Removes and returns the previous entry.
+    ///
+    /// The returned guards must be dropped before mutating the tree again.
     pub(super) fn remove_prev(
         &mut self,
     ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
@@ -538,10 +577,41 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         self.remove_leaf_entry(leaf.page, position)
     }
 
+    /// Removes and returns the previous entry.
+    ///
+    /// The caller may continue mutating the tree while the returned guards are live.
+    pub(super) fn remove_prev_detached(
+        &mut self,
+    ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        if !self.prepare_prev()? {
+            return Ok(None);
+        }
+        let leaf = self.leaf.take().expect("cursor must be positioned");
+        let position = leaf.position - 1;
+        self.remove_leaf_entry_detached(leaf.page, position)
+    }
+
     fn remove_leaf_entry(
         &mut self,
         leaf: PageImpl,
         position: usize,
+    ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        self.remove_leaf_entry_inner(leaf, position, true)
+    }
+
+    fn remove_leaf_entry_detached(
+        &mut self,
+        leaf: PageImpl,
+        position: usize,
+    ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        self.remove_leaf_entry_inner(leaf, position, false)
+    }
+
+    fn remove_leaf_entry_inner(
+        &mut self,
+        leaf: PageImpl,
+        position: usize,
+        allow_in_place: bool,
     ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
         let path = std::mem::take(&mut self.path)
             .into_iter()
@@ -553,7 +623,12 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
             &mut *self.freed,
             Arc::clone(self.allocated),
         );
-        Ok(Some(helper.pop_leaf_entry(leaf, path, position)?))
+        let entry = if allow_in_place {
+            helper.pop_leaf_entry(leaf, path, position)?
+        } else {
+            helper.pop_leaf_entry_detached(leaf, path, position)?
+        };
+        Ok(Some(entry))
     }
 }
 

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -55,7 +55,6 @@ struct InsertionResult<'a, V: Value + 'static> {
 
 pub(crate) struct MutateHelper<'a, 'b, K: Key, V: Value> {
     root: &'b mut Option<BtreeHeader>,
-    modify_uncommitted: bool,
     page_allocator: PageAllocator,
     freed: &'b mut Vec<PageNumber>,
     allocated: Arc<Mutex<PageTrackerPolicy>>,
@@ -73,27 +72,6 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     ) -> Self {
         Self {
             root,
-            modify_uncommitted: true,
-            page_allocator,
-            freed,
-            allocated,
-            _key_type: PhantomData,
-            _value_type: PhantomData,
-            _lifetime: PhantomData,
-        }
-    }
-
-    // Creates a new mutator which will not modify any existing uncommitted pages, or free any existing pages.
-    // It will still queue pages for future freeing in the freed vec
-    pub(crate) fn new_do_not_modify(
-        root: &'b mut Option<BtreeHeader>,
-        page_allocator: PageAllocator,
-        freed: &'b mut Vec<PageNumber>,
-        allocated: Arc<Mutex<PageTrackerPolicy>>,
-    ) -> Self {
-        Self {
-            root,
-            modify_uncommitted: false,
             page_allocator,
             freed,
             allocated,
@@ -104,15 +82,11 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     }
 
     fn conditional_free(&mut self, page_number: PageNumber) {
-        if self.modify_uncommitted {
-            let mut allocated = self.allocated.lock().unwrap();
-            if !self
-                .page_allocator
-                .free_if_uncommitted(page_number, &mut allocated)
-            {
-                self.freed.push(page_number);
-            }
-        } else {
+        let mut allocated = self.allocated.lock().unwrap();
+        if !self
+            .page_allocator
+            .free_if_uncommitted(page_number, &mut allocated)
+        {
             self.freed.push(page_number);
         }
     }
@@ -196,8 +170,30 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         path: Vec<(PageImpl, usize)>,
         position: usize,
     ) -> Result<(AccessGuard<'a, K>, AccessGuard<'a, V>)> {
+        self.pop_leaf_entry_inner(leaf, path, position, true)
+    }
+
+    pub(super) fn pop_leaf_entry_detached(
+        &mut self,
+        leaf: PageImpl,
+        path: Vec<(PageImpl, usize)>,
+        position: usize,
+    ) -> Result<(AccessGuard<'a, K>, AccessGuard<'a, V>)> {
+        self.pop_leaf_entry_inner(leaf, path, position, false)
+    }
+
+    fn pop_leaf_entry_inner(
+        &mut self,
+        leaf: PageImpl,
+        path: Vec<(PageImpl, usize)>,
+        position: usize,
+        allow_in_place: bool,
+    ) -> Result<(AccessGuard<'a, K>, AccessGuard<'a, V>)> {
+        // If `allow_in_place` is true, callers must drop the returned guards before mutating the
+        // tree again.
         let length = self.root.expect("pop requires a root").length;
-        let (mut result, key, value) = self.delete_leaf_at_position(leaf, position, true)?;
+        let (mut result, key, value) =
+            self.delete_leaf_at_position(leaf, position, true, allow_in_place)?;
         for (page, child_index) in path.into_iter().rev() {
             result = self.apply_child_deletion_result(page, child_index, result)?;
         }
@@ -347,10 +343,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         )
                     }
                 };
-                if self.page_allocator.uncommitted(page.get_page_number())
-                    && self.modify_uncommitted
-                    && has_inplace_space()
-                {
+                if self.page_allocator.uncommitted(page.get_page_number()) && has_inplace_space() {
                     let page_number = page.get_page_number();
                     let existing_value = if found {
                         let copied_value = accessor.entry(position).unwrap().value().to_vec();
@@ -405,7 +398,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     let page_number = page.get_page_number();
                     let existing_value = if found {
                         let (start, end) = accessor.value_range(position).unwrap();
-                        if self.modify_uncommitted && self.page_allocator.uncommitted(page_number) {
+                        if self.page_allocator.uncommitted(page_number) {
                             let arc = page.to_arc();
                             drop(page);
                             let mut allocated = self.allocated.lock().unwrap();
@@ -440,7 +433,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     let page_number = page.get_page_number();
                     let existing_value = if found {
                         let (start, end) = accessor.value_range(position).unwrap();
-                        if self.modify_uncommitted && self.page_allocator.uncommitted(page_number) {
+                        if self.page_allocator.uncommitted(page_number) {
                             let arc = page.to_arc();
                             drop(page);
                             let mut allocated = self.allocated.lock().unwrap();
@@ -517,7 +510,6 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 }
 
                 if sub_result.additional_sibling.is_none()
-                    && self.modify_uncommitted
                     && self.page_allocator.uncommitted(page.get_page_number())
                 {
                     let page_number = page.get_page_number();
@@ -620,7 +612,6 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         key: &K::SelfType<'_>,
         value: &V::SelfType<'_>,
     ) -> Result<()> {
-        assert!(self.modify_uncommitted);
         let header = self.root.expect("Key not found (tree is empty)");
         self.insert_inplace_helper(
             self.page_allocator.get_page_mut(header.root)?,
@@ -668,6 +659,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         page: PageImpl,
         position: usize,
         want_key: bool,
+        allow_in_place: bool,
     ) -> Result<(
         DeletionResult,
         Option<AccessGuard<'a, K>>,
@@ -688,8 +680,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         // Fast-path for dirty pages: perform in-place removal without allocating a new page.
         // The threshold matches the merge threshold (page_size/3) so that we use in-place
         // removal for all cases where the page won't need merging with a sibling.
-        if uncommitted
-            && self.modify_uncommitted
+        if allow_in_place
+            && uncommitted
             && new_required_bytes >= self.page_allocator.get_page_size() / 3
             && accessor.num_pairs() > 1
         {
@@ -745,7 +737,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             Subtree(new_page.get_page_number())
         };
         let (key_range, value_range) = accessor.entry_ranges(position).unwrap();
-        let (key_guard, value_guard) = if uncommitted && self.modify_uncommitted {
+        let (key_guard, value_guard) = if uncommitted {
             let page_number = page.get_page_number();
             let arc = page.to_arc();
             drop(page);
@@ -777,7 +769,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             return Ok((Subtree(page.get_page_number()), None));
         }
         let (result, key_guard, value_guard) =
-            self.delete_leaf_at_position(page, position, false)?;
+            self.delete_leaf_at_position(page, position, false, true)?;
         assert!(key_guard.is_none());
         Ok((result, Some(value_guard)))
     }
@@ -843,9 +835,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 return Ok(Subtree(original_page_number));
             }
 
-            let result_page = if self.page_allocator.uncommitted(original_page_number)
-                && self.modify_uncommitted
-            {
+            let result_page = if self.page_allocator.uncommitted(original_page_number) {
                 drop(page);
                 let mut mutpage = self.page_allocator.get_page_mut(original_page_number)?;
                 let mut mutator = BranchMutator::new(mutpage.memory_mut());

--- a/src/tree_store/extract_if.rs
+++ b/src/tree_store/extract_if.rs
@@ -1,9 +1,113 @@
-use crate::Result;
-use crate::tree_store::btree_iters::{BtreeRangeIter, EntryGuard};
-use crate::tree_store::btree_mutator::MutateHelper;
+use crate::tree_store::btree_cursor::{CursorMut, CursorMutPosition, EntryRef};
 use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageTrackerPolicy};
 use crate::types::{Key, Value};
+use crate::{AccessGuard, Result};
+use std::collections::Bound;
+use std::collections::Bound::{Excluded, Included, Unbounded};
+use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
+
+type ExtractItem<'a, K, V> = (AccessGuard<'a, K>, AccessGuard<'a, V>);
+
+struct ExtractScan<'s, K, V, F>
+where
+    K: Key + 'static,
+    V: Value + 'static,
+    F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+{
+    front_bound: &'s mut Bound<Vec<u8>>,
+    back_bound: &'s mut Bound<Vec<u8>>,
+    predicate: &'s mut F,
+    predicate_running: &'s mut bool,
+    _type: PhantomData<(K, V)>,
+}
+
+impl<K, V, F> ExtractScan<'_, K, V, F>
+where
+    K: Key + 'static,
+    V: Value + 'static,
+    F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+{
+    fn next<'a>(
+        &mut self,
+        cursor: &mut CursorMut<'a, '_, K, V>,
+    ) -> Result<Option<ExtractItem<'a, K, V>>> {
+        if matches!(self.front_bound, Unbounded) {
+            cursor.seek_to(CursorMutPosition::Start)?;
+        } else {
+            cursor.seek_to_bound(bound_as_ref(self.front_bound))?;
+        }
+        while let Some(entry) = cursor.peek_next()? {
+            if !self.before_back_bound(entry.key_bytes()) {
+                return Ok(None);
+            }
+
+            let key = entry.key_bytes().to_vec();
+            if self.predicate_matches(&entry) {
+                let result = cursor
+                    .remove_next_detached()?
+                    .expect("peeked cursor entry must be removable");
+                *self.front_bound = Excluded(key);
+                return Ok(Some(result));
+            }
+            cursor.next()?;
+            *self.front_bound = Excluded(key);
+        }
+        Ok(None)
+    }
+
+    fn next_back<'a>(
+        &mut self,
+        cursor: &mut CursorMut<'a, '_, K, V>,
+    ) -> Result<Option<ExtractItem<'a, K, V>>> {
+        if matches!(self.back_bound, Unbounded) {
+            cursor.seek_to(CursorMutPosition::End)?;
+        } else {
+            cursor.seek_to_bound(back_seek_bound(self.back_bound))?;
+        }
+        while let Some(entry) = cursor.peek_prev()? {
+            if !self.after_front_bound(entry.key_bytes()) {
+                return Ok(None);
+            }
+
+            let key = entry.key_bytes().to_vec();
+            if self.predicate_matches(&entry) {
+                let result = cursor
+                    .remove_prev_detached()?
+                    .expect("peeked cursor entry must be removable");
+                *self.back_bound = Excluded(key);
+                return Ok(Some(result));
+            }
+            cursor.prev()?;
+            *self.back_bound = Excluded(key);
+        }
+        Ok(None)
+    }
+
+    fn predicate_matches(&mut self, entry: &EntryRef<'_, K, V>) -> bool {
+        assert!(!*self.predicate_running);
+        *self.predicate_running = true;
+        let result = (self.predicate)(entry.key(), entry.value());
+        *self.predicate_running = false;
+        result
+    }
+
+    fn before_back_bound(&self, key: &[u8]) -> bool {
+        match bound_as_ref(self.back_bound) {
+            Included(bound) => K::compare(key, bound).is_le(),
+            Excluded(bound) => K::compare(key, bound).is_lt(),
+            Unbounded => true,
+        }
+    }
+
+    fn after_front_bound(&self, key: &[u8]) -> bool {
+        match bound_as_ref(self.front_bound) {
+            Included(bound) => K::compare(key, bound).is_ge(),
+            Excluded(bound) => K::compare(key, bound).is_gt(),
+            Unbounded => true,
+        }
+    }
+}
 
 pub(crate) struct BtreeExtractIf<
     'a,
@@ -12,21 +116,26 @@ pub(crate) struct BtreeExtractIf<
     F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
 > {
     root: &'a mut Option<BtreeHeader>,
-    inner: BtreeRangeIter<K, V>,
+    front_bound: Bound<Vec<u8>>,
+    back_bound: Bound<Vec<u8>>,
+    done: bool,
     predicate: F,
     predicate_running: bool,
     free_on_drop: Vec<PageNumber>,
     master_free_list: Arc<Mutex<Vec<PageNumber>>>,
     allocated: Arc<Mutex<PageTrackerPolicy>>,
     page_allocator: PageAllocator,
+    _type: PhantomData<(&'a K, &'a V)>,
 }
 
-impl<'a, K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>
-    BtreeExtractIf<'a, K, V, F>
+impl<'a, K: Key + 'static, V: Value + 'static, F> BtreeExtractIf<'a, K, V, F>
+where
+    F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
 {
     pub(crate) fn new(
         root: &'a mut Option<BtreeHeader>,
-        inner: BtreeRangeIter<K, V>,
+        front_bound: Bound<Vec<u8>>,
+        back_bound: Bound<Vec<u8>>,
         predicate: F,
         master_free_list: Arc<Mutex<Vec<PageNumber>>>,
         allocated: Arc<Mutex<PageTrackerPolicy>>,
@@ -34,13 +143,16 @@ impl<'a, K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) ->
     ) -> Self {
         Self {
             root,
-            inner,
+            front_bound,
+            back_bound,
+            done: false,
             predicate,
             predicate_running: false,
             free_on_drop: vec![],
             master_free_list,
             allocated,
             page_allocator,
+            _type: PhantomData,
         }
     }
 
@@ -48,18 +160,82 @@ impl<'a, K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) ->
         self.predicate_running
     }
 
-    fn predicate_matches(&mut self, entry: &EntryGuard<K, V>) -> bool {
-        assert!(!self.predicate_running);
-        self.predicate_running = true;
-        let result = (self.predicate)(entry.key(), entry.value());
-        self.predicate_running = false;
+    pub(crate) fn close(&mut self) -> Result {
+        self.done = true;
+        self.free_pending_pages();
+        Ok(())
+    }
+
+    fn next_inner(&mut self) -> Result<Option<ExtractItem<'a, K, V>>> {
+        // TODO: keep the front cursor live across calls and only reload it when
+        // the back cursor mutates the tree.
+        let mut front_bound = self.front_bound.clone();
+        let mut back_bound = self.back_bound.clone();
+        let result = {
+            let Self {
+                root,
+                predicate,
+                predicate_running,
+                free_on_drop,
+                allocated,
+                page_allocator,
+                ..
+            } = self;
+            let mut cursor: CursorMut<'a, '_, K, V> =
+                CursorMut::new(root, page_allocator, free_on_drop, allocated);
+            let mut scan = ExtractScan {
+                front_bound: &mut front_bound,
+                back_bound: &mut back_bound,
+                predicate,
+                predicate_running,
+                _type: PhantomData,
+            };
+            scan.next(&mut cursor)
+        };
+
+        self.front_bound = front_bound;
+        self.back_bound = back_bound;
+        self.free_pending_pages();
+        if matches!(result, Ok(None)) {
+            self.done = true;
+        }
         result
     }
 
-    pub(crate) fn close(&mut self) -> Result {
-        self.inner.close();
+    fn next_back_inner(&mut self) -> Result<Option<ExtractItem<'a, K, V>>> {
+        // TODO: keep the back cursor live across calls and only reload it when
+        // the front cursor mutates the tree.
+        let mut front_bound = self.front_bound.clone();
+        let mut back_bound = self.back_bound.clone();
+        let result = {
+            let Self {
+                root,
+                predicate,
+                predicate_running,
+                free_on_drop,
+                allocated,
+                page_allocator,
+                ..
+            } = self;
+            let mut cursor: CursorMut<'a, '_, K, V> =
+                CursorMut::new(root, page_allocator, free_on_drop, allocated);
+            let mut scan = ExtractScan {
+                front_bound: &mut front_bound,
+                back_bound: &mut back_bound,
+                predicate,
+                predicate_running,
+                _type: PhantomData,
+            };
+            scan.next_back(&mut cursor)
+        };
+
+        self.front_bound = front_bound;
+        self.back_bound = back_bound;
         self.free_pending_pages();
-        Ok(())
+        if matches!(result, Ok(None)) {
+            self.done = true;
+        }
+        result
     }
 
     fn free_pending_pages(&mut self) {
@@ -76,68 +252,47 @@ impl<'a, K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) ->
     }
 }
 
-impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool> Iterator
-    for BtreeExtractIf<'_, K, V, F>
+fn bound_as_ref(bound: &Bound<Vec<u8>>) -> Bound<&[u8]> {
+    bound.as_ref().map(Vec::as_slice)
+}
+
+fn back_seek_bound(bound: &Bound<Vec<u8>>) -> Bound<&[u8]> {
+    match bound {
+        Included(bound) => Excluded(bound.as_slice()),
+        Excluded(bound) => Included(bound.as_slice()),
+        Unbounded => Unbounded,
+    }
+}
+
+impl<'a, K: Key + 'static, V: Value + 'static, F> Iterator for BtreeExtractIf<'a, K, V, F>
+where
+    F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
 {
-    type Item = Result<EntryGuard<K, V>>;
+    type Item = Result<ExtractItem<'a, K, V>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut item = self.inner.next();
-        while let Some(Ok(ref entry)) = item {
-            if self.predicate_matches(entry) {
-                let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new_do_not_modify(
-                    self.root,
-                    self.page_allocator.clone(),
-                    &mut self.free_on_drop,
-                    self.allocated.clone(),
-                );
-                match operation.delete(&entry.key()) {
-                    Ok(x) => {
-                        assert!(x.is_some());
-                    }
-                    Err(x) => {
-                        return Some(Err(x));
-                    }
-                }
-                break;
-            }
-            item = self.inner.next();
+        if self.done {
+            return None;
         }
-        item
+        self.next_inner().transpose()
     }
 }
 
-impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>
-    DoubleEndedIterator for BtreeExtractIf<'_, K, V, F>
+impl<K: Key + 'static, V: Value + 'static, F> DoubleEndedIterator for BtreeExtractIf<'_, K, V, F>
+where
+    F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let mut item = self.inner.next_back();
-        while let Some(Ok(ref entry)) = item {
-            if self.predicate_matches(entry) {
-                let mut operation: MutateHelper<'_, '_, K, V> = MutateHelper::new_do_not_modify(
-                    self.root,
-                    self.page_allocator.clone(),
-                    &mut self.free_on_drop,
-                    self.allocated.clone(),
-                );
-                match operation.delete(&entry.key()) {
-                    Ok(x) => {
-                        assert!(x.is_some());
-                    }
-                    Err(x) => {
-                        return Some(Err(x));
-                    }
-                }
-                break;
-            }
-            item = self.inner.next_back();
+        if self.done {
+            return None;
         }
-        item
+        self.next_back_inner().transpose()
     }
 }
 
-impl<K: Key, V: Value, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool> Drop
-    for BtreeExtractIf<'_, K, V, F>
+impl<K: Key + 'static, V: Value + 'static, F> Drop for BtreeExtractIf<'_, K, V, F>
+where
+    F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
 {
     fn drop(&mut self) {
         let _ = self.close();


### PR DESCRIPTION
Replace the range-iterator plus delete-by-key extract_if path with cursor-driven front and back scans. Each side stores a key bound and reloads from the current root, so mutations on one side invalidate the other side without keeping stale cursor paths alive.

Use detached cursor removals for extract_if results so dirty pages are rewritten before returned guards escape, while leaving pop() free to use the in-place removal fast path.

Assisted-by: Codex <codex@openai.com>