### PR TITLE
Batch retain removals per leaf

### DIFF
--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -771,7 +771,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
                 cursor.remove_next_discard()?;
             }
         }
-        Ok(())
+        cursor.finish_pending_removals()
     }
 
     fn before_upper_bound(bound: Bound<&[u8]>, key: &[u8]) -> bool {

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -682,15 +682,30 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
         accessor: &'a LeafAccessor<'_>,
         except: Option<usize>,
     ) {
+        if let Some(except) = except {
+            self.push_all_except_indexes(accessor, &[except]);
+        } else {
+            self.push_all_except_indexes(accessor, &[]);
+        }
+    }
+
+    // `except` must contain valid leaf indexes in strictly ascending order.
+    pub(super) fn push_all_except_indexes(
+        &mut self,
+        accessor: &'a LeafAccessor<'_>,
+        except: &[usize],
+    ) {
+        debug_assert!(except.windows(2).all(|pair| pair[0] < pair[1]));
+        let mut next_except = 0;
         for i in 0..accessor.num_pairs() {
-            if let Some(except) = except
-                && except == i
-            {
+            if next_except < except.len() && except[next_except] == i {
+                next_except += 1;
                 continue;
             }
             let entry = accessor.entry(i).unwrap();
             self.push(entry.key(), entry.value());
         }
+        debug_assert_eq!(next_except, except.len());
     }
 
     pub(super) fn should_split(&self) -> bool {
@@ -957,6 +972,16 @@ pub(super) struct LeafMutator<'b> {
     page: &'b mut [u8],
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
+}
+
+struct RemovedLeafRanges<'a> {
+    indices: &'a [usize],
+    key_ranges: &'a [Range<usize>],
+    value_ranges: &'a [Range<usize>],
+    key_bytes: usize,
+    value_bytes: usize,
+    old_total_len: usize,
+    num_pairs: usize,
 }
 
 impl<'b> LeafMutator<'b> {
@@ -1238,6 +1263,175 @@ impl<'b> LeafMutator<'b> {
         let start = value_end;
         let end = last_value_end;
         self.page.copy_within(start..end, dest);
+    }
+
+    // `indices` must contain valid leaf indices in strictly ascending order.
+    pub(super) fn remove_indices(&mut self, indices: &[usize]) {
+        let (key_ranges, value_ranges, key_bytes, value_bytes, old_total_len, num_pairs) = {
+            let accessor = LeafAccessor::new(self.page, self.fixed_key_size, self.fixed_value_size);
+            assert!(!indices.is_empty());
+            assert!(indices.windows(2).all(|pair| pair[0] < pair[1]));
+            assert!(*indices.last().unwrap() < accessor.num_pairs());
+            assert!(indices.len() < accessor.num_pairs());
+
+            let mut key_ranges = Vec::with_capacity(indices.len());
+            let mut value_ranges = Vec::with_capacity(indices.len());
+            let mut key_bytes = 0;
+            let mut value_bytes = 0;
+            for &index in indices {
+                let (key, value) = accessor.entry_ranges(index).unwrap();
+                key_bytes += key.len();
+                value_bytes += value.len();
+                key_ranges.push(key);
+                value_ranges.push(value);
+            }
+
+            (
+                key_ranges,
+                value_ranges,
+                key_bytes,
+                value_bytes,
+                accessor.total_length(),
+                accessor.num_pairs(),
+            )
+        };
+
+        self.remove_index_ranges(RemovedLeafRanges {
+            indices,
+            key_ranges: &key_ranges,
+            value_ranges: &value_ranges,
+            key_bytes,
+            value_bytes,
+            old_total_len,
+            num_pairs,
+        });
+    }
+
+    fn remove_index_ranges(&mut self, removed_ranges: RemovedLeafRanges<'_>) {
+        let indices = removed_ranges.indices;
+        debug_assert_eq!(indices.len(), removed_ranges.key_ranges.len());
+        debug_assert_eq!(indices.len(), removed_ranges.value_ranges.len());
+        debug_assert!(indices.windows(2).all(|pair| pair[0] < pair[1]));
+        debug_assert!(*indices.last().unwrap() < removed_ranges.num_pairs);
+        debug_assert!(indices.len() < removed_ranges.num_pairs);
+
+        let key_ptr_size = if self.fixed_key_size.is_none() {
+            size_of::<u32>()
+        } else {
+            0
+        };
+        let value_ptr_size = if self.fixed_value_size.is_none() {
+            size_of::<u32>()
+        } else {
+            0
+        };
+        let new_num_pairs = removed_ranges.num_pairs - indices.len();
+        let removed_pointer_bytes = (key_ptr_size + value_ptr_size) * indices.len();
+
+        self.update_removed_indices(removed_pointer_bytes, &removed_ranges);
+
+        let mut source = 4;
+        let mut dest = 4;
+        if key_ptr_size != 0 {
+            for &index in indices {
+                let start = 4 + key_ptr_size * index;
+                Self::compact_before_hole(
+                    self.page,
+                    &mut source,
+                    &mut dest,
+                    start..start + key_ptr_size,
+                );
+            }
+        }
+        if value_ptr_size != 0 {
+            let value_pointers_start = 4 + key_ptr_size * removed_ranges.num_pairs;
+            for &index in indices {
+                let start = value_pointers_start + value_ptr_size * index;
+                Self::compact_before_hole(
+                    self.page,
+                    &mut source,
+                    &mut dest,
+                    start..start + value_ptr_size,
+                );
+            }
+        }
+        for range in removed_ranges.key_ranges {
+            Self::compact_before_hole(self.page, &mut source, &mut dest, range.clone());
+        }
+        for range in removed_ranges.value_ranges {
+            Self::compact_before_hole(self.page, &mut source, &mut dest, range.clone());
+        }
+        Self::compact_tail(
+            self.page,
+            &mut source,
+            &mut dest,
+            removed_ranges.old_total_len,
+        );
+        debug_assert_eq!(
+            dest,
+            removed_ranges.old_total_len
+                - removed_pointer_bytes
+                - removed_ranges.key_bytes
+                - removed_ranges.value_bytes
+        );
+        self.page[2..4].copy_from_slice(&u16::try_from(new_num_pairs).unwrap().to_le_bytes());
+    }
+
+    fn update_removed_indices(
+        &mut self,
+        removed_pointer_bytes: usize,
+        removed_ranges: &RemovedLeafRanges<'_>,
+    ) {
+        let mut removed = 0;
+        let mut removed_key_bytes_before = 0;
+        let mut removed_value_bytes_before = 0;
+        for i in 0..removed_ranges.num_pairs {
+            if removed < removed_ranges.indices.len() && removed_ranges.indices[removed] == i {
+                removed_key_bytes_before += removed_ranges.key_ranges[removed].len();
+                removed_value_bytes_before += removed_ranges.value_ranges[removed].len();
+                removed += 1;
+                continue;
+            }
+
+            if self.fixed_key_size.is_none() {
+                let delta =
+                    -isize::try_from(removed_pointer_bytes + removed_key_bytes_before).unwrap();
+                self.update_key_end(i, delta);
+            }
+            if self.fixed_value_size.is_none() {
+                let delta = -isize::try_from(
+                    removed_pointer_bytes + removed_ranges.key_bytes + removed_value_bytes_before,
+                )
+                .unwrap();
+                self.update_value_end(i, delta);
+            }
+        }
+        debug_assert_eq!(removed, removed_ranges.indices.len());
+    }
+
+    fn compact_before_hole(
+        page: &mut [u8],
+        source: &mut usize,
+        dest: &mut usize,
+        hole: Range<usize>,
+    ) {
+        debug_assert!(*source <= hole.start);
+        if *source < hole.start {
+            if *source != *dest {
+                page.copy_within(*source..hole.start, *dest);
+            }
+            *dest += hole.start - *source;
+        }
+        *source = hole.end;
+    }
+
+    fn compact_tail(page: &mut [u8], source: &mut usize, dest: &mut usize, end: usize) {
+        if *source < end {
+            if *source != *dest {
+                page.copy_within(*source..end, *dest);
+            }
+            *dest += end - *source;
+        }
     }
 
     fn update_key_end(&mut self, i: usize, delta: isize) {

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -410,6 +410,7 @@ pub(super) struct CursorMut<'a, 'b, K: Key + 'static, V: Value + 'static> {
     allocated: &'b Arc<Mutex<PageTrackerPolicy>>,
     path: Vec<Branch>,
     leaf: Option<Leaf>,
+    removed_indexes: Vec<usize>,
     _key_type: PhantomData<K>,
     _value_type: PhantomData<V>,
     _lifetime: PhantomData<&'a ()>,
@@ -429,6 +430,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
             allocated,
             path: vec![],
             leaf: None,
+            removed_indexes: vec![],
             _key_type: PhantomData,
             _value_type: PhantomData,
             _lifetime: PhantomData,
@@ -436,6 +438,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     }
 
     pub(super) fn seek_to(&mut self, position: CursorMutPosition) -> Result {
+        assert!(self.removed_indexes.is_empty());
         self.path.clear();
         self.leaf = None;
         let Some(header) = *self.root else {
@@ -455,6 +458,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     }
 
     pub(super) fn seek_to_bound(&mut self, bound: Bound<&[u8]>) -> Result {
+        assert!(self.removed_indexes.is_empty());
         self.path.clear();
         self.leaf = None;
         let Some(header) = *self.root else {
@@ -473,12 +477,38 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     }
 
     fn prepare_next(&mut self) -> Result<bool> {
+        loop {
+            let Some(leaf) = self.leaf.as_ref() else {
+                return Ok(false);
+            };
+            if leaf.position < leaf.len {
+                return Ok(true);
+            }
+            if self.removed_indexes.is_empty() {
+                if !self.advance_to_next_leaf()? {
+                    return Ok(false);
+                }
+            } else {
+                self.flush_removed_entries(false)?;
+            }
+        }
+    }
+
+    fn advance_to_next_leaf(&mut self) -> Result<bool> {
         let page_allocator = self.page_allocator;
         let mut get_page = |page| page_allocator.get_page(page, PageHint::None);
-        prepare_leaf::<K, V, _>(&mut self.leaf, &mut self.path, true, &mut get_page)
+        if let Some(next_leaf) =
+            move_to_adjacent_leaf::<K, V, _>(&mut self.path, true, &mut get_page)?
+        {
+            self.leaf = Some(next_leaf);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     fn prepare_prev(&mut self) -> Result<bool> {
+        assert!(self.removed_indexes.is_empty());
         let page_allocator = self.page_allocator;
         let mut get_page = |page| page_allocator.get_page(page, PageHint::None);
         prepare_leaf::<K, V, _>(&mut self.leaf, &mut self.path, false, &mut get_page)
@@ -528,6 +558,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     pub(super) fn remove_next(
         &mut self,
     ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        assert!(self.removed_indexes.is_empty());
         if !self.prepare_next()? {
             return Ok(None);
         }
@@ -542,6 +573,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     pub(super) fn remove_next_detached(
         &mut self,
     ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        assert!(self.removed_indexes.is_empty());
         if !self.prepare_next()? {
             return Ok(None);
         }
@@ -554,12 +586,9 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         if !self.prepare_next()? {
             return Ok(false);
         }
-        let leaf = self.leaf.take().expect("cursor must be positioned");
-        let position = leaf.position;
-        let key = key_data::<K, V>(&leaf, position);
-        drop(self.remove_leaf_entry(leaf.page, position)?);
-        // TODO: advance from the edited leaf instead of reseeking from the root.
-        self.seek_to_bound(Bound::Excluded(&key))?;
+        let leaf = self.leaf.as_mut().expect("cursor must be positioned");
+        self.removed_indexes.push(leaf.position);
+        leaf.position += 1;
         Ok(true)
     }
 
@@ -569,6 +598,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     pub(super) fn remove_prev(
         &mut self,
     ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        assert!(self.removed_indexes.is_empty());
         if !self.prepare_prev()? {
             return Ok(None);
         }
@@ -583,12 +613,49 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     pub(super) fn remove_prev_detached(
         &mut self,
     ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        assert!(self.removed_indexes.is_empty());
         if !self.prepare_prev()? {
             return Ok(None);
         }
         let leaf = self.leaf.take().expect("cursor must be positioned");
         let position = leaf.position - 1;
         self.remove_leaf_entry_detached(leaf.page, position)
+    }
+
+    pub(super) fn finish_pending_removals(&mut self) -> Result {
+        self.flush_removed_entries(true)
+    }
+
+    fn flush_removed_entries(&mut self, close: bool) -> Result {
+        if self.removed_indexes.is_empty() {
+            return Ok(());
+        }
+
+        let leaf = self.leaf.take().expect("cursor must be positioned");
+        // If the cursor is closing, no later operation needs a valid position.
+        // Otherwise the tree mutation invalidates the current path, so reseek
+        // to the first entry after the original leaf.
+        let next_bound = (!close).then(|| key_data::<K, V>(&leaf, leaf.len - 1));
+        let path = std::mem::take(&mut self.path)
+            .into_iter()
+            .map(Branch::into_parts)
+            .collect();
+        let mut removed_indexes = std::mem::take(&mut self.removed_indexes);
+        let mut helper: MutateHelper<'_, '_, K, V> = MutateHelper::new(
+            &mut *self.root,
+            (*self.page_allocator).clone(),
+            &mut *self.freed,
+            Arc::clone(self.allocated),
+        );
+        helper.delete_leaf_entries(leaf.page, path, &removed_indexes)?;
+        removed_indexes.clear();
+        self.removed_indexes = removed_indexes;
+
+        if let Some(next_bound) = next_bound {
+            // TODO: preserve enough cursor state to advance without reseeking from the root.
+            self.seek_to_bound(Bound::Excluded(&next_bound))?;
+        }
+        Ok(())
     }
 
     fn remove_leaf_entry(
@@ -613,6 +680,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         position: usize,
         allow_in_place: bool,
     ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        assert!(self.removed_indexes.is_empty());
         let path = std::mem::take(&mut self.path)
             .into_iter()
             .map(Branch::into_parts)

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -24,7 +24,7 @@ enum DeletionResult {
     // A leaf with fewer entries than desired
     PartialLeaf {
         page: Arc<[u8]>,
-        deleted_pair: usize,
+        deleted_pairs: DeletedPairs,
     },
     // A branch page subtree with fewer children than desired.
     // Held in unbuilt form: the caller will merge it with a sibling and build a new page,
@@ -38,6 +38,33 @@ enum DeletionResult {
     // Indicates that the branch node was deleted, and includes the only remaining child.
     // Checksum is retained for the same reason as `PartialBranch`.
     DeletedBranch(PageNumber, Checksum),
+}
+
+#[derive(Debug)]
+enum DeletedPairs {
+    One(usize),
+    Many(Vec<usize>),
+}
+
+impl DeletedPairs {
+    fn len(&self) -> usize {
+        match self {
+            Self::One(_) => 1,
+            Self::Many(indexes) => indexes.len(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum LeafDeleteDisposition {
+    Delete,
+    Merge,
+    Rebuild,
+}
+
+struct LeafDeletePlan {
+    retained_pairs: usize,
+    disposition: LeafDeleteDisposition,
 }
 
 struct InsertionResult<'a, V: Value + 'static> {
@@ -118,18 +145,24 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         let new_root = match deletion_result {
             Subtree(page) => Some(BtreeHeader::new(page, DEFERRED, new_length)),
             DeletedLeaf => None,
-            PartialLeaf { page, deleted_pair } => {
+            PartialLeaf {
+                page,
+                deleted_pairs,
+            } => {
                 let accessor = LeafAccessor::new(&page, K::fixed_width(), V::fixed_width());
                 let mut builder = LeafBuilder::new(
                     &self.page_allocator,
                     &self.allocated,
-                    accessor.num_pairs() - 1,
+                    accessor.num_pairs() - deleted_pairs.len(),
                     K::fixed_width(),
                     V::fixed_width(),
                 );
-                builder.push_all_except(&accessor, Some(deleted_pair));
+                Self::push_all_except_deleted(&mut builder, &accessor, &deleted_pairs);
                 let page = builder.build()?;
-                assert_eq!(new_length, accessor.num_pairs() as u64 - 1);
+                assert_eq!(
+                    new_length,
+                    accessor.num_pairs() as u64 - deleted_pairs.len() as u64
+                );
                 Some(BtreeHeader::new(
                     page.get_page_number(),
                     DEFERRED,
@@ -202,6 +235,23 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             key.expect("deleted key must be returned when requested"),
             value,
         ))
+    }
+
+    pub(super) fn delete_leaf_entries(
+        &mut self,
+        leaf: PageImpl,
+        path: Vec<(PageImpl, usize)>,
+        indexes: &[usize],
+    ) -> Result {
+        if indexes.is_empty() {
+            return Ok(());
+        }
+        let length = self.root.expect("delete requires a root").length;
+        let mut result = self.delete_leaf_indexes(leaf, indexes)?;
+        for (page, child_index) in path.into_iter().rev() {
+            result = self.apply_child_deletion_result(page, child_index, result)?;
+        }
+        self.finish_deletion(result, length - indexes.len() as u64)
     }
 
     #[allow(clippy::type_complexity)]
@@ -667,24 +717,14 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     )> {
         let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
         assert!(position < accessor.num_pairs());
-        let new_kv_bytes = accessor.length_of_pairs(0, accessor.num_pairs())
-            - accessor.length_of_pairs(position, position + 1);
-        let new_required_bytes = RawLeafBuilder::required_bytes(
-            accessor.num_pairs() - 1,
-            new_kv_bytes,
-            K::fixed_width(),
-            V::fixed_width(),
-        );
+        let deleted_bytes = accessor.length_of_pairs(position, position + 1);
+        let plan = self.plan_leaf_delete(&accessor, 1, deleted_bytes);
         let uncommitted = self.page_allocator.uncommitted(page.get_page_number());
 
         // Fast-path for dirty pages: perform in-place removal without allocating a new page.
         // The threshold matches the merge threshold (page_size/3) so that we use in-place
         // removal for all cases where the page won't need merging with a sibling.
-        if allow_in_place
-            && uncommitted
-            && new_required_bytes >= self.page_allocator.get_page_size() / 3
-            && accessor.num_pairs() > 1
-        {
+        if allow_in_place && uncommitted && plan.disposition == LeafDeleteDisposition::Rebuild {
             let (start, end) = accessor.value_range(position).unwrap();
             let key_guard = if want_key {
                 // The returned value guard owns the mutable page and removes the entry on drop,
@@ -709,32 +749,17 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             return Ok((Subtree(page_number), key_guard, guard));
         }
 
-        let result = if accessor.num_pairs() == 1 {
-            DeletedLeaf
-        } else if new_required_bytes < self.page_allocator.get_page_size() / 3 {
-            // Merge when less than 33% full. Splits occur when a page is full and produce two 50%
-            // full pages, so we use 33% instead of 50% to avoid oscillating
-            PartialLeaf {
+        let result = match plan.disposition {
+            LeafDeleteDisposition::Delete => DeletedLeaf,
+            LeafDeleteDisposition::Merge => PartialLeaf {
                 page: page.to_arc(),
-                deleted_pair: position,
-            }
-        } else {
-            let mut builder = LeafBuilder::new(
-                &self.page_allocator,
-                &self.allocated,
-                accessor.num_pairs() - 1,
-                K::fixed_width(),
-                V::fixed_width(),
-            );
-            for i in 0..accessor.num_pairs() {
-                if i == position {
-                    continue;
-                }
-                let entry = accessor.entry(i).unwrap();
-                builder.push(entry.key(), entry.value());
-            }
-            let new_page = builder.build()?;
-            Subtree(new_page.get_page_number())
+                deleted_pairs: DeletedPairs::One(position),
+            },
+            LeafDeleteDisposition::Rebuild => Subtree(self.build_leaf_except_indexes(
+                &accessor,
+                plan.retained_pairs,
+                &[position],
+            )?),
         };
         let (key_range, value_range) = accessor.entry_ranges(position).unwrap();
         let (key_guard, value_guard) = if uncommitted {
@@ -772,6 +797,107 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             self.delete_leaf_at_position(page, position, false, true)?;
         assert!(key_guard.is_none());
         Ok((result, Some(value_guard)))
+    }
+
+    fn delete_leaf_indexes(&mut self, page: PageImpl, indexes: &[usize]) -> Result<DeletionResult> {
+        debug_assert!(!indexes.is_empty());
+        debug_assert!(indexes.windows(2).all(|pair| pair[0] < pair[1]));
+
+        let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
+        assert!(*indexes.last().unwrap() < accessor.num_pairs());
+
+        let deleted_bytes: usize = indexes
+            .iter()
+            .map(|&index| accessor.length_of_pairs(index, index + 1))
+            .sum();
+        let plan = self.plan_leaf_delete(&accessor, indexes.len(), deleted_bytes);
+        let page_number = page.get_page_number();
+
+        if self.page_allocator.uncommitted(page_number)
+            && plan.disposition == LeafDeleteDisposition::Rebuild
+        {
+            drop(page);
+            let mut page_mut = self.page_allocator.get_page_mut(page_number)?;
+            let mut mutator =
+                LeafMutator::new(page_mut.memory_mut(), K::fixed_width(), V::fixed_width());
+            mutator.remove_indices(indexes);
+            return Ok(Subtree(page_number));
+        }
+
+        let result = match plan.disposition {
+            LeafDeleteDisposition::Delete => DeletedLeaf,
+            LeafDeleteDisposition::Merge => PartialLeaf {
+                page: page.to_arc(),
+                deleted_pairs: DeletedPairs::Many(indexes.to_vec()),
+            },
+            LeafDeleteDisposition::Rebuild => {
+                Subtree(self.build_leaf_except_indexes(&accessor, plan.retained_pairs, indexes)?)
+            }
+        };
+
+        drop(page);
+        self.conditional_free(page_number);
+        Ok(result)
+    }
+
+    fn plan_leaf_delete(
+        &self,
+        accessor: &LeafAccessor<'_>,
+        deleted_pairs: usize,
+        deleted_bytes: usize,
+    ) -> LeafDeletePlan {
+        let retained_pairs = accessor.num_pairs() - deleted_pairs;
+        let new_kv_bytes = accessor.length_of_pairs(0, accessor.num_pairs()) - deleted_bytes;
+        let new_required_bytes = RawLeafBuilder::required_bytes(
+            retained_pairs,
+            new_kv_bytes,
+            K::fixed_width(),
+            V::fixed_width(),
+        );
+
+        // Merge when less than 33% full. Splits occur when a page is full and produce two 50%
+        // full pages, so 33% avoids oscillating.
+        let disposition = if retained_pairs == 0 {
+            LeafDeleteDisposition::Delete
+        } else if new_required_bytes < self.page_allocator.get_page_size() / 3 {
+            LeafDeleteDisposition::Merge
+        } else {
+            LeafDeleteDisposition::Rebuild
+        };
+
+        LeafDeletePlan {
+            retained_pairs,
+            disposition,
+        }
+    }
+
+    fn build_leaf_except_indexes(
+        &mut self,
+        accessor: &LeafAccessor<'_>,
+        retained_pairs: usize,
+        indexes: &[usize],
+    ) -> Result<PageNumber> {
+        let mut builder = LeafBuilder::new(
+            &self.page_allocator,
+            &self.allocated,
+            retained_pairs,
+            K::fixed_width(),
+            V::fixed_width(),
+        );
+        builder.push_all_except_indexes(accessor, indexes);
+        let new_page = builder.build()?;
+        Ok(new_page.get_page_number())
+    }
+
+    fn push_all_except_deleted<'leaf>(
+        builder: &mut LeafBuilder<'leaf, '_>,
+        accessor: &'leaf LeafAccessor<'_>,
+        deleted_pairs: &DeletedPairs,
+    ) {
+        match deleted_pairs {
+            DeletedPairs::One(index) => builder.push_all_except(accessor, Some(*index)),
+            DeletedPairs::Many(indexes) => builder.push_all_except_indexes(accessor, indexes),
+        }
     }
 
     fn finalize_branch_builder(
@@ -896,11 +1022,12 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             }
             PartialLeaf {
                 page: partial_child_page,
-                deleted_pair,
+                deleted_pairs,
             } => {
                 let partial_child_accessor =
                     LeafAccessor::new(&partial_child_page, K::fixed_width(), V::fixed_width());
                 assert!(partial_child_accessor.num_pairs() > 1);
+                let retained_pairs = partial_child_accessor.num_pairs() - deleted_pairs.len();
 
                 let merge_with = if child_index == 0 { 1 } else { child_index - 1 };
                 assert!(merge_with < accessor.count_children());
@@ -917,11 +1044,15 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     let mut child_builder = LeafBuilder::new(
                         &self.page_allocator,
                         &self.allocated,
-                        partial_child_accessor.num_pairs() - 1,
+                        retained_pairs,
                         K::fixed_width(),
                         V::fixed_width(),
                     );
-                    child_builder.push_all_except(&partial_child_accessor, Some(deleted_pair));
+                    Self::push_all_except_deleted(
+                        &mut child_builder,
+                        &partial_child_accessor,
+                        &deleted_pairs,
+                    );
                     let new_page = child_builder.build()?;
                     builder.push_all(&accessor);
                     builder.replace_child(child_index, new_page.get_page_number(), DEFERRED);
@@ -948,19 +1079,24 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         let mut child_builder = LeafBuilder::new(
                             &self.page_allocator,
                             &self.allocated,
-                            partial_child_accessor.num_pairs() - 1
-                                + merge_with_accessor.num_pairs(),
+                            retained_pairs + merge_with_accessor.num_pairs(),
                             K::fixed_width(),
                             V::fixed_width(),
                         );
                         if child_index < merge_with {
-                            child_builder
-                                .push_all_except(&partial_child_accessor, Some(deleted_pair));
+                            Self::push_all_except_deleted(
+                                &mut child_builder,
+                                &partial_child_accessor,
+                                &deleted_pairs,
+                            );
                         }
                         child_builder.push_all_except(&merge_with_accessor, None);
                         if child_index > merge_with {
-                            child_builder
-                                .push_all_except(&partial_child_accessor, Some(deleted_pair));
+                            Self::push_all_except_deleted(
+                                &mut child_builder,
+                                &partial_child_accessor,
+                                &deleted_pairs,
+                            );
                         }
                         if child_builder.should_split() {
                             let (new_page1, split_key, new_page2) = child_builder.build_split()?;


### PR DESCRIPTION
Buffer retain removals in CursorMut until the scan leaves the current leaf, then delete the collected leaf indices in one mutator operation. Dirty leaves that remain large enough are compacted in place; smaller leaves continue through the existing delete/merge policy.

On a redb_benchmark run after rebasing to master, retain() is about 25% faster

Assisted-by: Codex <codex@openai.com>