### PR TITLE
Simplify AllPageNumbersBtreeIter with stack-based traversal

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -763,10 +763,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                 let all_pages = AllPageNumbersBtreeIter::new(
                     root,
                     V::fixed_width(),
-                    <() as Value>::fixed_width(),
                     self.page_allocator.resolver(),
                     PageHint::None,
-                )?;
+                );
                 for page in all_pages {
                     pages.push(page?);
                 }

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -367,18 +367,15 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn all_pages_iter(&self) -> Result<Option<AllPageNumbersBtreeIter>> {
-        if let Some(root) = self.root.map(|x| x.root) {
-            Ok(Some(AllPageNumbersBtreeIter::new(
-                root,
+    pub(crate) fn all_pages_iter(&self) -> Option<AllPageNumbersBtreeIter> {
+        self.root.map(|x| {
+            AllPageNumbersBtreeIter::new(
+                x.root,
                 K::fixed_width(),
-                V::fixed_width(),
                 self.page_allocator.resolver(),
                 PageHint::None,
-            )?))
-        } else {
-            Ok(None)
-        }
+            )
+        })
     }
 
     pub(crate) fn visit_all_pages<F>(&self, visitor: F) -> Result

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -1,7 +1,6 @@
 use crate::Result;
 use crate::tree_store::btree_base::{BRANCH, LEAF};
 use crate::tree_store::btree_base::{BranchAccessor, LeafAccessor};
-use crate::tree_store::btree_iters::RangeIterState::{BranchChild, Enter, Leaf};
 use crate::tree_store::page_store::{Page, PageHint, PageImpl};
 use crate::tree_store::{PageNumber, PageResolver};
 use crate::types::{Key, Value};
@@ -10,32 +9,6 @@ use std::borrow::Borrow;
 use std::collections::Bound;
 use std::marker::PhantomData;
 use std::ops::{Range, RangeBounds};
-
-#[derive(Debug, Clone)]
-enum RangeIterState {
-    Enter {
-        page: PageImpl,
-        fixed_key_size: Option<usize>,
-        fixed_value_size: Option<usize>,
-        parent: Option<Box<RangeIterState>>,
-    },
-    Leaf {
-        page: PageImpl,
-        fixed_key_size: Option<usize>,
-        fixed_value_size: Option<usize>,
-        entry: usize,
-        start: usize,
-        end: usize,
-        parent: Option<Box<RangeIterState>>,
-    },
-    BranchChild {
-        page: PageImpl,
-        fixed_key_size: Option<usize>,
-        fixed_value_size: Option<usize>,
-        child: usize,
-        parent: Option<Box<RangeIterState>>,
-    },
-}
 
 pub(super) fn lower_bound_entry<K: Key>(accessor: &LeafAccessor<'_>, bound: Bound<&[u8]>) -> usize {
     match bound {
@@ -47,19 +20,6 @@ pub(super) fn lower_bound_entry<K: Key>(accessor: &LeafAccessor<'_>, bound: Boun
             position
         }
         Unbounded => 0,
-    }
-}
-
-fn upper_bound_entry<K: Key>(accessor: &LeafAccessor<'_>, bound: Bound<&[u8]>) -> usize {
-    match bound {
-        Included(query) | Excluded(query) => {
-            let (mut position, found) = accessor.position::<K>(query);
-            if matches!(bound, Included(_)) && found {
-                position += 1;
-            }
-            position
-        }
-        Unbounded => accessor.num_pairs(),
     }
 }
 
@@ -76,184 +36,6 @@ pub(super) fn child_to_visit<K: Key>(
             } else {
                 0
             }
-        }
-    }
-}
-
-fn leaf_entries<K: Key>(
-    accessor: &LeafAccessor<'_>,
-    left_bound: Bound<&[u8]>,
-    right_bound: Bound<&[u8]>,
-) -> Range<usize> {
-    let start = lower_bound_entry::<K>(accessor, left_bound);
-    let end = upper_bound_entry::<K>(accessor, right_bound);
-    start..end
-}
-
-impl RangeIterState {
-    fn page_number(&self) -> PageNumber {
-        match self {
-            Enter { page, .. } | Leaf { page, .. } | BranchChild { page, .. } => {
-                page.get_page_number()
-            }
-        }
-    }
-
-    fn next<K: Key>(
-        self,
-        left_bound: Bound<&[u8]>,
-        right_bound: Bound<&[u8]>,
-        reverse: bool,
-        manager: &PageResolver,
-        hint: PageHint,
-    ) -> Result<Option<RangeIterState>> {
-        match self {
-            Enter {
-                page,
-                fixed_key_size,
-                fixed_value_size,
-                parent,
-            } => match page.memory()[0] {
-                LEAF => {
-                    let accessor =
-                        LeafAccessor::new(page.memory(), fixed_key_size, fixed_value_size);
-                    let entry_count = accessor.num_pairs();
-                    // TODO: Track when a descended subtree is fully inside the
-                    // range, so interior leaves can skip these bound searches.
-                    let entries = leaf_entries::<K>(&accessor, left_bound, right_bound);
-                    Ok(if entries.start < entries.end {
-                        let entry = if reverse {
-                            entries.end - 1
-                        } else {
-                            entries.start
-                        };
-                        Some(Leaf {
-                            page,
-                            fixed_key_size,
-                            fixed_value_size,
-                            entry,
-                            start: entries.start,
-                            end: entries.end,
-                            parent,
-                        })
-                    } else if (!reverse && !matches!(right_bound, Unbounded) && entries.end == 0)
-                        || (reverse
-                            && !matches!(left_bound, Unbounded)
-                            && entries.start == entry_count)
-                    {
-                        None
-                    } else {
-                        parent.map(|x| *x)
-                    })
-                }
-                BRANCH => {
-                    let accessor = BranchAccessor::new(&page, fixed_key_size);
-                    let seek_bound = if reverse { right_bound } else { left_bound };
-                    let child = child_to_visit::<K>(&accessor, seek_bound, reverse);
-                    Ok(Some(BranchChild {
-                        child,
-                        page,
-                        fixed_key_size,
-                        fixed_value_size,
-                        parent,
-                    }))
-                }
-                _ => unreachable!(),
-            },
-            Leaf {
-                page,
-                fixed_key_size,
-                fixed_value_size,
-                entry,
-                start,
-                end,
-                parent,
-            } => {
-                let next_entry = if reverse {
-                    entry.checked_sub(1).filter(|entry| *entry >= start)
-                } else {
-                    let next_entry = entry + 1;
-                    (next_entry < end).then_some(next_entry)
-                };
-                if let Some(entry) = next_entry {
-                    Ok(Some(Leaf {
-                        page,
-                        fixed_key_size,
-                        fixed_value_size,
-                        entry,
-                        start,
-                        end,
-                        parent,
-                    }))
-                } else {
-                    Ok(parent.map(|x| *x))
-                }
-            }
-            BranchChild {
-                page,
-                fixed_key_size,
-                fixed_value_size,
-                child,
-                parent,
-            } => {
-                let (child_page, child_count) = {
-                    let accessor = BranchAccessor::new(&page, fixed_key_size);
-                    let child_count = accessor.count_children();
-                    let child_page = manager.get_page(accessor.child_page(child).unwrap(), hint)?;
-                    (child_page, child_count)
-                };
-                let parent = Self::next_branch_child(
-                    BranchChild {
-                        page,
-                        fixed_key_size,
-                        fixed_value_size,
-                        child,
-                        parent,
-                    },
-                    child_count,
-                    reverse,
-                );
-                Ok(Some(Enter {
-                    page: child_page,
-                    fixed_key_size,
-                    fixed_value_size,
-                    parent,
-                }))
-            }
-        }
-    }
-
-    fn next_branch_child(
-        state: RangeIterState,
-        child_count: usize,
-        reverse: bool,
-    ) -> Option<Box<RangeIterState>> {
-        let BranchChild {
-            page,
-            fixed_key_size,
-            fixed_value_size,
-            child,
-            parent,
-        } = state
-        else {
-            unreachable!("next branch child requires a branch child state");
-        };
-        let next_child = if reverse {
-            child.checked_sub(1)
-        } else {
-            let next_child = child + 1;
-            (next_child < child_count).then_some(next_child)
-        };
-        if let Some(child) = next_child {
-            Some(Box::new(BranchChild {
-                page,
-                fixed_key_size,
-                fixed_value_size,
-                child,
-                parent,
-            }))
-        } else {
-            parent
         }
     }
 }
@@ -299,7 +81,8 @@ impl<K: Key, V: Value> EntryGuard<K, V> {
 }
 
 pub(crate) struct AllPageNumbersBtreeIter {
-    next: Option<RangeIterState>,
+    pending: Vec<PageNumber>,
+    fixed_key_size: Option<usize>,
     manager: PageResolver,
     hint: PageHint,
 }
@@ -308,22 +91,15 @@ impl AllPageNumbersBtreeIter {
     pub(crate) fn new(
         root: PageNumber,
         fixed_key_size: Option<usize>,
-        fixed_value_size: Option<usize>,
         manager: PageResolver,
         hint: PageHint,
-    ) -> Result<Self> {
-        let root_page = manager.get_page(root, hint)?;
-        let start = Enter {
-            page: root_page,
+    ) -> Self {
+        Self {
+            pending: vec![root],
             fixed_key_size,
-            fixed_value_size,
-            parent: None,
-        };
-        Ok(Self {
-            next: Some(start),
             manager,
             hint,
-        })
+        }
     }
 }
 
@@ -331,40 +107,23 @@ impl Iterator for AllPageNumbersBtreeIter {
     type Item = Result<PageNumber>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let state = self.next.take()?;
-            let value = state.page_number();
-            // Only return each page number once
-            let once = match &state {
-                Enter {
-                    page,
-                    fixed_key_size,
-                    fixed_value_size,
-                    ..
-                } => match page.memory()[0] {
-                    BRANCH => true,
-                    LEAF => {
-                        LeafAccessor::new(page.memory(), *fixed_key_size, *fixed_value_size)
-                            .num_pairs()
-                            == 0
-                    }
-                    _ => unreachable!(),
-                },
-                Leaf { entry, .. } => *entry == 0,
-                BranchChild { .. } => false,
-            };
-            match state.next::<()>(Unbounded, Unbounded, false, &self.manager, self.hint) {
-                Ok(next) => {
-                    self.next = next;
-                }
-                Err(err) => {
-                    return Some(Err(err));
+        let page_number = self.pending.pop()?;
+        let page = match self.manager.get_page(page_number, self.hint) {
+            Ok(page) => page,
+            Err(err) => return Some(Err(err)),
+        };
+        match page.memory()[0] {
+            LEAF => {}
+            BRANCH => {
+                let accessor = BranchAccessor::new(&page, self.fixed_key_size);
+                // Push in reverse so children are popped left-to-right.
+                for child in (0..accessor.count_children()).rev() {
+                    self.pending.push(accessor.child_page(child).unwrap());
                 }
             }
-            if once {
-                return Some(Ok(value));
-            }
+            _ => unreachable!(),
         }
+        Some(Ok(page_number))
     }
 }
 

--- a/src/tree_store/multimap_btree.rs
+++ b/src/tree_store/multimap_btree.rs
@@ -170,13 +170,8 @@ pub(super) fn verify_tree_and_subtree_checksums(
             return Ok(false);
         }
 
-        let table_pages_iter = AllPageNumbersBtreeIter::new(
-            header.root,
-            key_size,
-            DynamicCollection::<()>::fixed_width_with(value_size),
-            mem.clone(),
-            hint,
-        )?;
+        let table_pages_iter =
+            AllPageNumbersBtreeIter::new(header.root, key_size, mem.clone(), hint);
         for table_page in table_pages_iter {
             let page = mem.get_page(table_page?, hint)?;
             let subtree_roots = parse_subtree_roots(&page, key_size, value_size);


### PR DESCRIPTION
## Summary
Refactored `AllPageNumbersBtreeIter` to use a simpler stack-based traversal approach instead of maintaining complex recursive state machines. This eliminates the `RangeIterState` enum and related helper functions that were only used by this iterator.

## Key Changes
- Removed `RangeIterState` enum and its three variants (`Enter`, `Leaf`, `BranchChild`) along with all associated methods
- Removed unused helper functions: `upper_bound_entry()` and `leaf_entries()`
- Replaced stateful traversal with a `pending` vector that acts as a stack of page numbers to visit
- Simplified `AllPageNumbersBtreeIter::new()` to return `Self` directly instead of `Result<Self>`
- Updated `BtreeMut::all_pages_iter()` return type from `Result<Option<AllPageNumbersBtreeIter>>` to `Option<AllPageNumbersBtreeIter>`
- Removed `fixed_value_size` parameter from `AllPageNumbersBtreeIter::new()` as it's no longer needed
- Updated all call sites in `btree.rs` and `multimap_btree.rs` to match the new signature

## Implementation Details
The new implementation uses a straightforward depth-first traversal:
- Maintains a stack (`pending`) of page numbers to visit
- For each page, checks if it's a leaf (terminal) or branch node
- For branch nodes, pushes child page numbers onto the stack in reverse order to maintain left-to-right traversal order
- Returns each page number exactly once without complex state tracking

This approach is more maintainable and easier to understand while providing the same functionality.

https://claude.ai/code/session_01FjAnvpv4K1pPnshfkNX7Pn