### PR TITLE
Enhance multimap_stats test with leaf page and consistency checks

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1837,7 +1837,11 @@ fn multimap_stats() {
         let mut txn = db.begin_write().unwrap();
         txn.set_durability(Durability::None).unwrap();
         let mut table = txn.open_multimap_table(table_def).unwrap();
+        if i == 0 {
+            assert_eq!(table.stats().unwrap().leaf_pages(), 0);
+        }
         table.insert(0, i).unwrap();
+        assert!(table.stats().unwrap().leaf_pages() > 0);
         drop(table);
         txn.commit().unwrap();
 
@@ -1846,6 +1850,20 @@ fn multimap_stats() {
         assert!(bytes > last_size, "{i}");
         last_size = bytes;
     }
+
+    let read_txn = db.begin_read().unwrap();
+    let typed_stats = read_txn
+        .open_multimap_table(table_def)
+        .unwrap()
+        .stats()
+        .unwrap();
+    let untyped_stats = read_txn
+        .open_untyped_multimap_table(table_def)
+        .unwrap()
+        .stats()
+        .unwrap();
+    assert_eq!(typed_stats.leaf_pages(), untyped_stats.leaf_pages());
+    assert_eq!(typed_stats.stored_bytes(), untyped_stats.stored_bytes());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Enhanced the `multimap_stats` integration test to verify leaf page allocation behavior and ensure consistency between typed and untyped multimap table statistics.

## Key Changes
- Added assertion to verify that leaf pages are initially 0 before any inserts
- Added assertion to verify that leaf pages are allocated after the first insert
- Added validation that typed and untyped multimap tables report identical statistics (leaf_pages and stored_bytes)

## Implementation Details
The test now performs more comprehensive validation:
1. Checks that a newly created multimap table has 0 leaf pages
2. Verifies that inserting data allocates leaf pages
3. Compares statistics between `open_multimap_table()` and `open_untyped_multimap_table()` to ensure both APIs report consistent metrics

This improves test coverage for the multimap statistics functionality and helps catch potential inconsistencies between the typed and untyped table interfaces.

https://claude.ai/code/session_01DuGMtcuPt1UYqzfU342tqq