### PR TITLE
Implement `[Multimap]TableHandle` for remaining table types

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -885,6 +885,7 @@ pub trait ReadableMultimapTable<K: Key + 'static, V: Key + 'static>: ReadableTab
 
 /// A read-only untyped multimap table
 pub struct ReadOnlyUntypedMultimapTable {
+    name: String,
     num_values: u64,
     tree: RawBtree,
     hint: PageHint,
@@ -894,6 +895,12 @@ pub struct ReadOnlyUntypedMultimapTable {
 }
 
 impl Sealed for ReadOnlyUntypedMultimapTable {}
+
+impl MultimapTableHandle for ReadOnlyUntypedMultimapTable {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
 
 impl ReadableTableMetadata for ReadOnlyUntypedMultimapTable {
     /// Retrieves information about storage usage for the table
@@ -923,6 +930,7 @@ impl ReadableTableMetadata for ReadOnlyUntypedMultimapTable {
 
 impl ReadOnlyUntypedMultimapTable {
     pub(crate) fn new(
+        name: &str,
         root: Option<BtreeHeader>,
         num_values: u64,
         hint: PageHint,
@@ -931,6 +939,7 @@ impl ReadOnlyUntypedMultimapTable {
         mem: PageResolver,
     ) -> Self {
         Self {
+            name: name.to_string(),
             num_values,
             tree: RawBtree::new(
                 root,
@@ -949,6 +958,7 @@ impl ReadOnlyUntypedMultimapTable {
 
 /// A read-only multimap table
 pub struct ReadOnlyMultimapTable<K: Key + 'static, V: Key + 'static> {
+    name: String,
     tree: Btree<K, &'static DynamicCollection<V>>,
     num_values: u64,
     mem: PageResolver,
@@ -956,8 +966,15 @@ pub struct ReadOnlyMultimapTable<K: Key + 'static, V: Key + 'static> {
     _value_type: PhantomData<V>,
 }
 
+impl<K: Key + 'static, V: Key + 'static> MultimapTableHandle for ReadOnlyMultimapTable<K, V> {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
 impl<K: Key + 'static, V: Key + 'static> ReadOnlyMultimapTable<K, V> {
     pub(crate) fn new(
+        name: &str,
         root: Option<BtreeHeader>,
         num_values: u64,
         hint: PageHint,
@@ -965,6 +982,7 @@ impl<K: Key + 'static, V: Key + 'static> ReadOnlyMultimapTable<K, V> {
         mem: PageResolver,
     ) -> Result<ReadOnlyMultimapTable<K, V>> {
         Ok(ReadOnlyMultimapTable {
+            name: name.to_string(),
             tree: Btree::new(root, hint, guard.clone(), mem.clone())?,
             num_values,
             mem,

--- a/src/table.rs
+++ b/src/table.rs
@@ -471,10 +471,17 @@ pub trait ReadableTable<K: Key + 'static, V: Value + 'static>: ReadableTableMeta
 
 /// A read-only untyped table
 pub struct ReadOnlyUntypedTable {
+    name: String,
     tree: RawBtree,
 }
 
 impl Sealed for ReadOnlyUntypedTable {}
+
+impl TableHandle for ReadOnlyUntypedTable {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
 
 impl ReadableTableMetadata for ReadOnlyUntypedTable {
     /// Retrieves information about storage usage for the table
@@ -498,6 +505,7 @@ impl ReadableTableMetadata for ReadOnlyUntypedTable {
 
 impl ReadOnlyUntypedTable {
     pub(crate) fn new(
+        name: &str,
         root_page: Option<BtreeHeader>,
         hint: PageHint,
         fixed_key_size: Option<usize>,
@@ -505,6 +513,7 @@ impl ReadOnlyUntypedTable {
         mem: PageResolver,
     ) -> Self {
         Self {
+            name: name.to_string(),
             tree: RawBtree::new(root_page, fixed_key_size, fixed_value_size, mem, hint),
         }
     }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2448,10 +2448,11 @@ impl ReadTransaction {
         &self,
         handle: impl TableHandle,
     ) -> Result<ReadOnlyUntypedTable, TableError> {
+        let name = handle.name();
         let header = self
             .tree
-            .get_table_untyped(handle.name(), TableType::Normal)?
-            .ok_or_else(|| TableError::TableDoesNotExist(handle.name().to_string()))?;
+            .get_table_untyped(name, TableType::Normal)?
+            .ok_or_else(|| TableError::TableDoesNotExist(name.to_string()))?;
 
         match header {
             InternalTableDefinition::Normal {
@@ -2460,6 +2461,7 @@ impl ReadTransaction {
                 fixed_value_size,
                 ..
             } => Ok(ReadOnlyUntypedTable::new(
+                name,
                 table_root,
                 PageHint::Clean,
                 fixed_key_size,
@@ -2487,6 +2489,7 @@ impl ReadTransaction {
                 table_length,
                 ..
             } => Ok(ReadOnlyMultimapTable::new(
+                definition.name(),
                 table_root,
                 table_length,
                 PageHint::Clean,
@@ -2501,10 +2504,11 @@ impl ReadTransaction {
         &self,
         handle: impl MultimapTableHandle,
     ) -> Result<ReadOnlyUntypedMultimapTable, TableError> {
+        let name = handle.name();
         let header = self
             .tree
-            .get_table_untyped(handle.name(), TableType::Multimap)?
-            .ok_or_else(|| TableError::TableDoesNotExist(handle.name().to_string()))?;
+            .get_table_untyped(name, TableType::Multimap)?
+            .ok_or_else(|| TableError::TableDoesNotExist(name.to_string()))?;
 
         match header {
             InternalTableDefinition::Normal { .. } => unreachable!(),
@@ -2515,6 +2519,7 @@ impl ReadTransaction {
                 fixed_value_size,
                 ..
             } => Ok(ReadOnlyUntypedMultimapTable::new(
+                name,
                 table_root,
                 table_length,
                 PageHint::Clean,


### PR DESCRIPTION
Implements `TableHandle` for `ReadOnlyUntypedTable`, and `MultimapTableHandle` for `ReadOnlyUntypedMultimapTable` and `ReadOnlyMultimapTable`. The other table types already had `Handle` implementations - this patch expands coverage to all table types.

Being able to get the name of a table is useful for logging and error reporting.