### PR TITLE
Add extract_if interleaved-direction tests and fuzz coverage

### DIFF
--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -138,6 +138,7 @@ pub(crate) enum FuzzOperation {
         modulus: U64Between<1, 8>,
         take: BoundedUSize<10>,
         reversed: bool,
+        alternate: bool,
     },
     ExtractFromIf {
         start_key: BoundedU64<KEY_SPACE>,
@@ -145,6 +146,7 @@ pub(crate) enum FuzzOperation {
         take: BoundedUSize<10>,
         modulus: U64Between<1, 8>,
         reversed: bool,
+        alternate: bool,
     },
     Range {
         start_key: BoundedU64<KEY_SPACE>,

--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -422,6 +422,63 @@ fn handle_multimap_table_op(
     Ok(())
 }
 
+// Drives an extract iterator from the front, the back, or alternating ends,
+// checking each yielded entry against the expected matching entries. Returns
+// the keys that were removed.
+fn check_extract_iter<F: for<'f> FnMut(u64, &'f [u8]) -> bool>(
+    mut iter: redb::ExtractIf<u64, &'static [u8], F>,
+    matching: &[(u64, usize)],
+    take: usize,
+    reversed: bool,
+    alternate: bool,
+) -> Result<Vec<u64>, redb::StorageError> {
+    let mut front_index = 0;
+    let mut back_index = matching.len();
+    let mut from_front = !reversed;
+    let mut removed = vec![];
+    for _ in 0..take {
+        let expected = if front_index < back_index {
+            if from_front {
+                front_index += 1;
+                Some(matching[front_index - 1])
+            } else {
+                back_index -= 1;
+                Some(matching[back_index])
+            }
+        } else {
+            None
+        };
+        let entry = if from_front {
+            iter.next()
+        } else {
+            iter.next_back()
+        };
+        if alternate {
+            from_front = !from_front;
+        }
+        match (expected, entry) {
+            (Some((ref_key, ref_value_len)), Some(entry)) => {
+                let (key, value) = entry?;
+                assert_eq!(ref_key, key.value());
+                assert_eq!(ref_value_len, value.value().len());
+                removed.push(ref_key);
+            }
+            (None, None) => break,
+            (None, Some(entry)) => {
+                // Propagate I/O errors so the crash-support harness can
+                // reopen the database before the next operation.
+                let (key, _) = entry?;
+                panic!("unexpected entry {}", key.value());
+            }
+            (Some(expected), None) => {
+                panic!("expected {:?} but the iterator was exhausted", expected)
+            }
+        }
+    }
+    iter.close()?;
+    Ok(removed)
+}
+
 fn handle_table_op(
     op: &FuzzOperation,
     reference: &mut BTreeMap<u64, usize>,
@@ -504,37 +561,17 @@ fn handle_table_op(
             take,
             modulus,
             reversed,
+            alternate,
         } => {
             let modulus = modulus.value;
-            let mut reference_iter: Box<dyn Iterator<Item = (&u64, &usize)>> = if *reversed {
-                Box::new(reference.iter().rev().take(take.value))
-            } else {
-                Box::new(reference.iter().take(take.value))
-            };
-            let mut iter = table.extract_if(|x, _| x % modulus == 0)?;
-            let mut remaining = take.value;
-            let mut remove_from_reference = vec![];
-            while let Some((ref_key, ref_value_len)) = reference_iter.next() {
-                if *ref_key % modulus != 0 {
-                    continue;
-                }
-                if remaining == 0 {
-                    break;
-                }
-                remaining -= 1;
-                let next = if *reversed {
-                    iter.next_back()
-                } else {
-                    iter.next()
-                };
-                let (key, value) = next.unwrap()?;
-                remove_from_reference.push(*ref_key);
-                assert_eq!(*ref_key, key.value());
-                assert_eq!(*ref_value_len, value.value().len());
-            }
-            iter.close()?;
-            drop(reference_iter);
-            for x in remove_from_reference {
+            let matching: Vec<(u64, usize)> = reference
+                .iter()
+                .filter(|(key, _)| *key % modulus == 0)
+                .map(|(key, value_len)| (*key, *value_len))
+                .collect();
+            let iter = table.extract_if(|x, _| x % modulus == 0)?;
+            let removed = check_extract_iter(iter, &matching, take.value, *reversed, *alternate)?;
+            for x in removed {
                 reference.remove(&x);
             }
         }
@@ -544,39 +581,19 @@ fn handle_table_op(
             take,
             modulus,
             reversed,
+            alternate,
         } => {
             let start = start_key.value;
             let end = start + range_len.value;
             let modulus = modulus.value;
-            let mut reference_iter: Box<dyn Iterator<Item = (&u64, &usize)>> = if *reversed {
-                Box::new(reference.range(start..end).rev().take(take.value))
-            } else {
-                Box::new(reference.range(start..end).take(take.value))
-            };
-            let mut iter = table.extract_from_if(start..end, |x, _| x % modulus == 0)?;
-            let mut remaining = take.value;
-            let mut remove_from_reference = vec![];
-            while let Some((ref_key, ref_value_len)) = reference_iter.next() {
-                if *ref_key % modulus != 0 {
-                    continue;
-                }
-                if remaining == 0 {
-                    break;
-                }
-                remaining -= 1;
-                let next = if *reversed {
-                    iter.next_back()
-                } else {
-                    iter.next()
-                };
-                let (key, value) = next.unwrap()?;
-                remove_from_reference.push(*ref_key);
-                assert_eq!(*ref_key, key.value());
-                assert_eq!(*ref_value_len, value.value().len());
-            }
-            iter.close()?;
-            drop(reference_iter);
-            for x in remove_from_reference {
+            let matching: Vec<(u64, usize)> = reference
+                .range(start..end)
+                .filter(|(key, _)| *key % modulus == 0)
+                .map(|(key, value_len)| (*key, *value_len))
+                .collect();
+            let iter = table.extract_from_if(start..end, |x, _| x % modulus == 0)?;
+            let removed = check_extract_iter(iter, &matching, take.value, *reversed, *alternate)?;
+            for x in removed {
                 reference.remove(&x);
             }
         }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -458,6 +458,170 @@ fn extract_if_returned_guards_survive_finalize() {
     write_txn.commit().unwrap();
 }
 
+// Guards from many extracted entries must stay readable for the life of the
+// transaction, even after the iterator is gone, for both dirty and committed
+// pages.
+#[test]
+fn extract_if_all_guards_survive_iteration() {
+    let elements = 10_000u64;
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    // First pass: uncommitted pages, since the inserts are part of the same transaction.
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..elements {
+            table.insert(&i, &(i * 10)).unwrap();
+        }
+        let mut guards = vec![];
+        for entry in table.extract_if(|key, _| key % 2 == 0).unwrap() {
+            guards.push(entry.unwrap());
+        }
+        assert_eq!(guards.len() as u64, elements / 2);
+        for (i, (key, value)) in guards.iter().enumerate() {
+            assert_eq!(key.value(), 2 * i as u64);
+            assert_eq!(value.value(), 20 * i as u64);
+        }
+        drop(guards);
+        assert_eq!(table.len().unwrap(), elements / 2);
+    }
+    write_txn.commit().unwrap();
+
+    // Second pass: committed pages.
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        let mut guards = vec![];
+        let mut iter = table.extract_if(|_, _| true).unwrap();
+        for entry in &mut iter {
+            guards.push(entry.unwrap());
+        }
+        iter.close().unwrap();
+        assert_eq!(guards.len() as u64, elements / 2);
+        for (i, (key, value)) in guards.iter().enumerate() {
+            assert_eq!(key.value(), 2 * i as u64 + 1);
+            assert_eq!(value.value(), 10 * (2 * i as u64 + 1));
+        }
+        drop(guards);
+        assert_eq!(table.len().unwrap(), 0);
+    }
+    write_txn.commit().unwrap();
+}
+
+// Draining every entry with alternating calls forces leaf deletions and
+// merges between the converging ends.
+#[test]
+fn extract_from_if_alternating_drain() {
+    let elements = 10_000u64;
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..elements {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        let mut extracted = table.extract_from_if(1000..9000, |_, _| true).unwrap();
+        let mut front_next = 1000;
+        let mut back_next = 8999;
+        let mut front = true;
+        loop {
+            let entry = if front {
+                extracted.next()
+            } else {
+                extracted.next_back()
+            };
+            let Some(entry) = entry else {
+                break;
+            };
+            let (key, value) = entry.unwrap();
+            let expected = if front {
+                front_next += 1;
+                front_next - 1
+            } else {
+                back_next -= 1;
+                back_next + 1
+            };
+            assert_eq!(key.value(), expected);
+            assert_eq!(value.value(), expected);
+            front = !front;
+        }
+        drop(extracted);
+        assert_eq!(front_next, back_next + 1);
+
+        assert_eq!(table.len().unwrap(), 2000);
+        assert!(table.get(&5000).unwrap().is_none());
+        assert_eq!(table.get(&999).unwrap().unwrap().value(), 999);
+        assert_eq!(table.get(&9000).unwrap().unwrap().value(), 9000);
+    }
+    write_txn.commit().unwrap();
+}
+
+// Alternating next()/next_back() converges without yielding any entry twice,
+// even when the cursors meet inside a leaf.
+#[test]
+fn extract_from_if_alternating_directions() {
+    let elements = 10_000u64;
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..elements {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        let mut expected: std::collections::BTreeSet<u64> =
+            (1000..9000).filter(|key| key % 3 == 0).collect();
+        let mut extracted = table
+            .extract_from_if(1000..9000, |key, _| key % 3 == 0)
+            .unwrap();
+        let mut front = true;
+        loop {
+            let entry = if front {
+                extracted.next()
+            } else {
+                extracted.next_back()
+            };
+            let Some(entry) = entry else {
+                break;
+            };
+            let (key, value) = entry.unwrap();
+            let expected_key = if front {
+                expected.pop_first().unwrap()
+            } else {
+                expected.pop_last().unwrap()
+            };
+            assert_eq!(key.value(), expected_key);
+            assert_eq!(value.value(), expected_key);
+            front = !front;
+        }
+        drop(extracted);
+        assert!(expected.is_empty());
+
+        assert_eq!(
+            table.len().unwrap(),
+            elements - (1000..9000).filter(|key| key % 3 == 0).count() as u64
+        );
+        for key in 1000..9000 {
+            assert_eq!(table.get(&key).unwrap().is_none(), key % 3 == 0);
+        }
+    }
+    write_txn.commit().unwrap();
+}
+
 #[test]
 fn retain() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
Preparation PR for the extract_if optimization (#1263): the new tests and fuzzer coverage, verified green against master's current implementation, so the optimization PR can be reviewed as pure implementation changes.

Fuzzer: the extract ops only ever drove the iterator all-forward or all-backward within one operation. This adds an `alternate` mode that switches ends per step, validated against the matching reference entries consumed from both ends, with injected I/O errors propagated so the crash-support harness can reopen the database.

Tests: behaviors any extract_if implementation must preserve — guards staying readable for the life of the transaction across many extracted entries (dirty and committed pages), and alternating next()/next_back() converging without yielding an entry twice, including a full alternating drain.

Verified: `just test` green (94 basic_tests), deny-warnings fuzz build, ~30K fuzz executions clean against master. After this merges I'll rebase #1263, where these hunks will drop out.

https://claude.ai/code/session_01VHFEUA4q6ndWPBd4ory7ai

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHFEUA4q6ndWPBd4ory7ai)_