### PR TITLE
Poison the transaction when retain drops rejected entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
   / `VacantEntry` accessors.
 * `Table::retain()`, `Table::retain_in()`, `Table::extract_if()`, and `Table::extract_from_if()`
   now poison the write transaction if their predicate panics, causing `WriteTransaction::commit()`
-  to return `CommitError::TransactionPoisoned`.
+  to return `CommitError::TransactionPoisoned`. `retain()` and `retain_in()` also poison the
+  transaction if an internal error prevents removals from being applied.
 * Add `ExtractIf::close()` to explicitly finalize an extract iterator without removing unread
   entries.
 * Optimize `Table::pop_first()` and `Table::pop_last()` to be about 2x faster.

--- a/src/table.rs
+++ b/src/table.rs
@@ -190,8 +190,14 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         predicate: F,
     ) -> Result {
         let mut panic_guard = RetainPanicGuard::new(self.transaction);
-        let result = self.tree.retain_in::<K::SelfType<'_>, F>(predicate, ..);
+        let mut lost_removals = false;
+        let result = self
+            .tree
+            .retain_in::<K::SelfType<'_>, F>(predicate, .., &mut lost_removals);
         panic_guard.disarm();
+        if lost_removals {
+            self.transaction.poison();
+        }
         result
     }
 
@@ -211,8 +217,12 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
         let mut panic_guard = RetainPanicGuard::new(self.transaction);
-        let result = self.tree.retain_in(predicate, range);
+        let mut lost_removals = false;
+        let result = self.tree.retain_in(predicate, range, &mut lost_removals);
         panic_guard.disarm();
+        if lost_removals {
+            self.transaction.poison();
+        }
         result
     }
 

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -697,10 +697,14 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         Ok(result)
     }
 
+    // Sets `lost_removals` if an error left entries in the tree that the
+    // predicate had already rejected; the caller must then poison the
+    // transaction so they cannot be committed.
     pub(crate) fn retain_in<'a, KR, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
         &mut self,
         mut predicate: F,
         range: impl RangeBounds<KR> + 'a,
+        lost_removals: &mut bool,
     ) -> Result
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
@@ -721,6 +725,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
             upper_bound.as_ref().map(Vec::as_slice),
             &mut predicate,
             &mut freed,
+            lost_removals,
         );
 
         // The cursor updates the root incrementally, so pages queued before an
@@ -737,6 +742,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         upper_bound: Bound<&[u8]>,
         predicate: &mut F,
         freed: &mut Vec<PageNumber>,
+        lost_removals: &mut bool,
     ) -> Result
     where
         F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
@@ -747,6 +753,25 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
             freed,
             &self.allocated_pages,
         );
+        let result = Self::retain_scan(&mut cursor, lower_bound, upper_bound, predicate);
+        if result.is_err() {
+            // Best effort: apply any pending removals so the failure does not
+            // silently drop entries the predicate already rejected.
+            let _ = cursor.finish_pending_removals();
+        }
+        *lost_removals = cursor.lost_removals();
+        result
+    }
+
+    fn retain_scan<F>(
+        cursor: &mut CursorMut<'_, '_, K, V>,
+        lower_bound: Bound<&[u8]>,
+        upper_bound: Bound<&[u8]>,
+        predicate: &mut F,
+    ) -> Result
+    where
+        F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+    {
         match lower_bound {
             Bound::Included(key) => cursor.seek_to(Position::Before(key))?,
             Bound::Excluded(key) => cursor.seek_to(Position::After(key))?,

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -394,6 +394,10 @@ pub(super) struct CursorMut<'a, 'b, K: Key + 'static, V: Value + 'static> {
     position: Option<CursorPosition>,
     // Pending removals from the current leaf, recorded in strictly increasing order.
     removed_indexes: Vec<usize>,
+    // True when a flush consumed pending removals but failed to apply them.
+    // The caller must not let the transaction commit, since entries already
+    // reported as removed may remain in the tree.
+    lost_removals: bool,
     _key_type: PhantomData<K>,
     _value_type: PhantomData<V>,
     _lifetime: PhantomData<&'a ()>,
@@ -443,6 +447,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
             allocated,
             position: None,
             removed_indexes: vec![],
+            lost_removals: false,
             _key_type: PhantomData,
             _value_type: PhantomData,
             _lifetime: PhantomData,
@@ -633,6 +638,12 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         Ok(())
     }
 
+    /// True if a failed flush may have left entries in the tree that the
+    /// caller was told were removed. The transaction must not commit.
+    pub(super) fn lost_removals(&self) -> bool {
+        self.lost_removals
+    }
+
     fn flush_removed_entries(&mut self) -> Result<Option<Vec<u8>>> {
         if self.removed_indexes.is_empty() {
             return Ok(None);
@@ -650,7 +661,12 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
             &mut *self.freed,
             Arc::clone(self.allocated),
         );
-        helper.delete_leaf_entries(leaf.page, path, &removed_indexes)?;
+        let result = helper.delete_leaf_entries(leaf.page, path, &removed_indexes);
+        if result.is_err() {
+            // The batch was consumed, so the removals can no longer be applied.
+            self.lost_removals = true;
+        }
+        result?;
         removed_indexes.clear();
         self.removed_indexes = removed_indexes;
 


### PR DESCRIPTION
Second preparation PR for the extract_if optimization (#1263), containing the logically standalone retain fix.

A failed flush inside `retain`/`retain_in` consumes the batched removals, so entries the predicate already rejected could survive if the caller handles the error and commits anyway. This tracks the loss in the cursor, attempts a best-effort flush of whatever is still pending when the retain scan fails (so the common outcome of an error is "removals applied, no poison"), and poisons the write transaction from the table layer only when removals were genuinely lost. For I/O errors the backend latch already fails every later commit; this covers non-latched errors such as checksum failures.

This is the same hardening #1263 applies to extract_if, ported to master's cursor shape. I also evaluated the other candidates for splitting out (the `allow_in_place` flag, the detached-removal cleanup, `delete_key` visibility) but none are standalone — they're scaffolding whose only callers arrive with the optimization itself.

Verified: `just test` green, deny-warnings fuzz build, 20K fuzz executions clean. After this merges I'll rebase #1263 onto master, squash it to a single implementation-only commit, and it should land at roughly +500/−340 in src/.

https://claude.ai/code/session_01VHFEUA4q6ndWPBd4ory7ai

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHFEUA4q6ndWPBd4ory7ai)_