### PR TITLE
Coalesce sparse leaf rewrites into packed replacement runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## 4.2.0 - 2026-XX-XX
 * Fix a crash during a transaction that grows the database file leaving the database permanently
   unopenable afterward.
-* Optimize `Table::retain()` and `Table::retain_in()`. Some benchmarks on large tables show a 25x speedup.
+* Optimize `Table::retain()` and `Table::retain_in()`. Some benchmarks on large tables show a 25-50x speedup.
 * Optimize `Table::extract_if()` and `Table::extract_from_if()`. Benchmarks on large tables show
-  a 1.6-4x speedup, depending on the fraction of entries extracted, and iterating the extract
+  a 2-4x speedup, depending on the fraction of entries extracted, and iterating the extract
   iterator from both ends no longer degrades the removal batching.
+* After the extract iterator returns an error, later calls keep returning an error instead of
+  continuing.
 * Add `Table::entry()` and the associated `Entry`, `OccupiedEntry`, and `VacantEntry`
   types, mirroring `std::collections::BTreeMap::entry`. Supports `or_insert`,
   `or_insert_with`, `or_insert_with_key`, `and_modify`, and the usual `OccupiedEntry`

--- a/src/table.rs
+++ b/src/table.rs
@@ -148,6 +148,11 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     ///
     /// Note: values not read from the iterator will not be removed
     ///
+    /// If the iterator returns an error, later calls keep returning an error
+    /// (the failure is not recoverable). Entries already yielded stay
+    /// removed; if finalizing their removal fails too, the write transaction
+    /// is poisoned and cannot be committed.
+    ///
     /// The predicate must not panic. If it panics, the write transaction is
     /// poisoned and [`crate::WriteTransaction::commit`] will return
     /// [`crate::CommitError::TransactionPoisoned`].
@@ -162,6 +167,11 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     /// `predicate` evaluates to `true` are returned in an iterator, and those which are read from the iterator are removed
     ///
     /// Note: values not read from the iterator will not be removed
+    ///
+    /// If the iterator returns an error, later calls keep returning an error
+    /// (the failure is not recoverable). Entries already yielded stay
+    /// removed; if finalizing their removal fails too, the write transaction
+    /// is poisoned and cannot be committed.
     ///
     /// The predicate must not panic. If it panics, the write transaction is
     /// poisoned and [`crate::WriteTransaction::commit`] will return
@@ -190,12 +200,12 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         predicate: F,
     ) -> Result {
         let mut panic_guard = RetainPanicGuard::new(self.transaction);
-        let mut lost_removals = false;
+        let mut poisoned = false;
         let result = self
             .tree
-            .retain_in::<K::SelfType<'_>, F>(predicate, .., &mut lost_removals);
+            .retain_in::<K::SelfType<'_>, F>(predicate, .., &mut poisoned);
         panic_guard.disarm();
-        if lost_removals {
+        if poisoned {
             self.transaction.poison();
         }
         result
@@ -217,10 +227,10 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
         let mut panic_guard = RetainPanicGuard::new(self.transaction);
-        let mut lost_removals = false;
-        let result = self.tree.retain_in(predicate, range, &mut lost_removals);
+        let mut poisoned = false;
+        let result = self.tree.retain_in(predicate, range, &mut poisoned);
         panic_guard.disarm();
-        if lost_removals {
+        if poisoned {
             self.transaction.poison();
         }
         result
@@ -660,7 +670,8 @@ impl<
     /// Entries already returned by the iterator remain removed, and unread
     /// entries are not tested by the predicate or removed. Dropping the iterator
     /// also closes it, but this method returns any error encountered while
-    /// finalizing the iterator.
+    /// finalizing the iterator, including when the iterator already closed
+    /// itself after an iteration error.
     pub fn close(mut self) -> Result {
         self.inner.close()
     }
@@ -675,9 +686,11 @@ impl<
     fn drop(&mut self) {
         // Entries already yielded may have removals pending; if a flush
         // failed the table would silently keep them, so poison the
-        // transaction instead of letting it commit.
-        let close_failed = self.inner.close().is_err() || self.inner.close_failed();
-        if (close_failed || self.inner.predicate_panicked())
+        // transaction instead of letting it commit. An iteration error
+        // alone must not poison: close_failed reports lost removals, and
+        // close() also re-raises after a cleanly finalized error.
+        let _ = self.inner.close();
+        if (self.inner.close_failed() || self.inner.predicate_panicked())
             && let Some(transaction) = self.poison_target
         {
             transaction.poison();

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1285,9 +1285,25 @@ impl WriteTransaction {
             };
             let mut system_tables = self.system_tables.lock().unwrap();
             let mut data_freed = system_tables.open_system_table(self, DATA_FREED_TABLE)?;
-            for entry in data_freed.extract_from_if(lower.., |_, _| true)? {
-                entry?;
+            let drain = || -> Result<(), StorageError> {
+                let mut iter = data_freed.extract_from_if(lower.., |_, _| true)?;
+                for entry in &mut iter {
+                    entry?;
+                }
+                // Defensive: exhaustion has already closed the iterator and
+                // surfaced any finalization error through the loop; this only
+                // keeps errors from being swallowed if the loop ever gains an
+                // early exit.
+                iter.close()
+            };
+            let result = drain();
+            if result.is_err() {
+                // The table tree root was already restored above, so a partial
+                // purge must not be committed. System-table extract iterators
+                // carry no poison target, so poison the transaction directly.
+                self.poison();
             }
+            result?;
             // No need to process the system freed table, because it only rolls forward
         }
 

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -697,14 +697,14 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         Ok(result)
     }
 
-    // Sets `lost_removals` if an error left entries in the tree that the
+    // Sets `poisoned` if an error left entries in the tree that the
     // predicate had already rejected; the caller must then poison the
     // transaction so they cannot be committed.
     pub(crate) fn retain_in<'a, KR, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
         &mut self,
         mut predicate: F,
         range: impl RangeBounds<KR> + 'a,
-        lost_removals: &mut bool,
+        poisoned: &mut bool,
     ) -> Result
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
@@ -725,7 +725,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
             upper_bound.as_ref().map(Vec::as_slice),
             &mut predicate,
             &mut freed,
-            lost_removals,
+            poisoned,
         );
 
         // The cursor updates the root incrementally, so pages queued before an
@@ -742,7 +742,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         upper_bound: Bound<&[u8]>,
         predicate: &mut F,
         freed: &mut Vec<PageNumber>,
-        lost_removals: &mut bool,
+        poisoned: &mut bool,
     ) -> Result
     where
         F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
@@ -756,10 +756,11 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         let result = Self::retain_scan(&mut cursor, lower_bound, upper_bound, predicate);
         if result.is_err() {
             // Best effort: apply any pending removals so the failure does not
-            // silently drop entries the predicate already rejected.
+            // silently drop entries the predicate already rejected. If the
+            // cursor is poisoned this re-raises without touching the tree.
             let _ = cursor.finish_pending_removals();
         }
-        *lost_removals = cursor.lost_removals();
+        *poisoned = cursor.poisoned();
         result
     }
 

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -6,6 +6,7 @@ use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{Result, StorageError};
 use std::borrow::Borrow;
 use std::cmp::Ordering;
+use std::collections::VecDeque;
 use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ops::Range;
@@ -659,6 +660,79 @@ pub(super) struct LeafBuilder<'a, 'b> {
     allocated_pages: &'b Mutex<PageTrackerPolicy>,
 }
 
+// Key-value pairs copied into owned memory, so they survive any tree mutation.
+// The buffer stays in ascending key order: `extend_from_leaf` appends leaves
+// that are entirely greater at the back and prepends smaller ones at the
+// front; `data` grows append-only since the pair ranges are absolute offsets
+// into it.
+#[derive(Default)]
+pub(super) struct OwnedEntryBuffer {
+    pairs: VecDeque<(Range<usize>, Range<usize>)>,
+    data: Vec<u8>,
+}
+
+impl OwnedEntryBuffer {
+    fn store(&mut self, key: &[u8], value: &[u8]) -> (Range<usize>, Range<usize>) {
+        let key_start = self.data.len();
+        self.data.extend_from_slice(key);
+        let key_end = self.data.len();
+        self.data.extend_from_slice(value);
+        let value_end = self.data.len();
+        (key_start..key_end, key_end..value_end)
+    }
+
+    // Copies all of the leaf's pairs except `removed_indexes` (which must be
+    // strictly ascending). The leaf must be entirely greater than the buffered
+    // entries when `back` is true, and entirely smaller otherwise, keeping the
+    // buffer in ascending key order.
+    pub(super) fn extend_from_leaf(
+        &mut self,
+        accessor: &LeafAccessor<'_>,
+        removed_indexes: &[usize],
+        back: bool,
+    ) {
+        debug_assert!(removed_indexes.windows(2).all(|pair| pair[0] < pair[1]));
+        let num_pairs = accessor.num_pairs();
+        self.pairs.reserve(num_pairs - removed_indexes.len());
+        self.data.reserve(accessor.length_of_pairs(0, num_pairs));
+
+        let mut retained = Vec::with_capacity(num_pairs - removed_indexes.len());
+        let mut next_removed = 0;
+        for index in 0..num_pairs {
+            if removed_indexes.get(next_removed) == Some(&index) {
+                next_removed += 1;
+                continue;
+            }
+            let entry = accessor.entry(index).unwrap();
+            retained.push(self.store(entry.key(), entry.value()));
+        }
+        debug_assert_eq!(next_removed, removed_indexes.len());
+        if back {
+            self.pairs.extend(retained);
+        } else {
+            // Prepending in reverse leaves the leaf's entries ascending at the
+            // front.
+            for pair in retained.into_iter().rev() {
+                self.pairs.push_front(pair);
+            }
+        }
+    }
+
+    pub(super) fn num_pairs(&self) -> usize {
+        self.pairs.len()
+    }
+
+    pub(super) fn total_bytes(&self) -> usize {
+        self.data.len()
+    }
+
+    pub(super) fn entries(&self) -> impl Iterator<Item = (&[u8], &[u8])> {
+        self.pairs
+            .iter()
+            .map(|(key, value)| (&self.data[key.clone()], &self.data[value.clone()]))
+    }
+}
+
 impl<'a, 'b> LeafBuilder<'a, 'b> {
     pub(super) fn required_bytes(&self, num_pairs: usize, keys_values_bytes: usize) -> usize {
         RawLeafBuilder::required_bytes(
@@ -725,16 +799,13 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
     }
 
     pub(super) fn should_split(&self) -> bool {
-        let required_size = self.required_bytes(
+        leaf_split_required(
             self.pairs.len(),
             self.total_key_bytes + self.total_value_bytes,
-        );
-        // num_pairs is stored as a u16, so a leaf must split once it would exceed u16::MAX pairs
-        // even if it still fits in a page (possible with large page sizes and tiny pairs);
-        // otherwise build() would panic in RawLeafBuilder::new. build_split() clamps each half.
-        let too_many_pairs = self.pairs.len() > usize::from(u16::MAX);
-        (required_size > self.page_allocator.get_page_size() || too_many_pairs)
-            && self.pairs.len() > 1
+            self.fixed_key_size,
+            self.fixed_value_size,
+            self.page_allocator.get_page_size(),
+        )
     }
 
     pub(super) fn build_split<'txn>(self) -> Result<(PageMut<'txn>, &'a [u8], PageMut<'txn>)> {
@@ -827,6 +898,74 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
         drop(builder);
         Ok(page)
     }
+}
+
+// The leaf split policy, for a hypothetical set of pairs. A leaf must split once it would
+// exceed the page size, or u16::MAX pairs even if they still fit in a page (possible with large
+// page sizes and tiny pairs); otherwise build() would panic in RawLeafBuilder::new.
+// build_split() clamps each half. A single pair never splits: it gets its own larger page,
+// matching the single-large-value handling elsewhere. Shared by LeafBuilder::should_split and
+// the mutator's run repacking (build_replacement_leaves), which must agree.
+pub(super) fn leaf_split_required(
+    num_pairs: usize,
+    keys_values_bytes: usize,
+    fixed_key_size: Option<usize>,
+    fixed_value_size: Option<usize>,
+    page_size: usize,
+) -> bool {
+    let required = RawLeafBuilder::required_bytes(
+        num_pairs,
+        keys_values_bytes,
+        fixed_key_size,
+        fixed_value_size,
+    );
+    let too_many_pairs = num_pairs > usize::from(u16::MAX);
+    (required > page_size || too_many_pairs) && num_pairs > 1
+}
+
+// Merge a leaf when it is less than 33% full: splits occur when a page is full and produce two
+// 50% full pages, so 33% avoids merge/split oscillation. Shared by the mutator's delete
+// planning and splice policy (plan_leaf_delete, replace_leaf_children,
+// build_replacement_leaves) and the cursor's decision to coalesce sparse leaves into a run,
+// which must agree.
+pub(super) fn leaf_below_merge_threshold(
+    num_pairs: usize,
+    keys_values_bytes: usize,
+    fixed_key_size: Option<usize>,
+    fixed_value_size: Option<usize>,
+    page_size: usize,
+) -> bool {
+    let required = RawLeafBuilder::required_bytes(
+        num_pairs,
+        keys_values_bytes,
+        fixed_key_size,
+        fixed_value_size,
+    );
+    required < page_size / 3
+}
+
+// A leaf holding a single pair at least a page in size is never merged with: absorbing it
+// would copy and rewrite the value without making its neighbor any healthier. Shared by the
+// mutator's insert fast path, merge planning, and splice absorption (replace_leaf_children),
+// which must agree.
+pub(super) fn is_single_large_value(accessor: &LeafAccessor<'_>, page_size: usize) -> bool {
+    accessor.num_pairs() == 1 && accessor.total_length() >= page_size
+}
+
+// The pair count and key-value bytes a leaf retains after removing `removed_indexes`. Shared
+// by the mutator's delete planning and the cursor's run-opening decision, which must agree on
+// the resulting disposition.
+pub(super) fn retained_after_removals(
+    accessor: &LeafAccessor<'_>,
+    removed_indexes: &[usize],
+) -> (usize, usize) {
+    let removed_bytes: usize = removed_indexes
+        .iter()
+        .map(|&index| accessor.length_of_pairs(index, index + 1))
+        .sum();
+    let retained_pairs = accessor.num_pairs() - removed_indexes.len();
+    let retained_bytes = accessor.length_of_pairs(0, accessor.num_pairs()) - removed_bytes;
+    (retained_pairs, retained_bytes)
 }
 
 // Note the caller is responsible for ensuring that the buffer is large enough

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -1,11 +1,14 @@
 use crate::AccessGuard;
-use crate::Result;
-use crate::tree_store::btree_base::{BRANCH, BranchAccessor, LEAF, LeafAccessor};
+use crate::tree_store::btree_base::{
+    BRANCH, BranchAccessor, LEAF, LeafAccessor, OwnedEntryBuffer, leaf_below_merge_threshold,
+    retained_after_removals,
+};
 use crate::tree_store::btree_iters::EntryGuard;
 use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageHint, PageImpl};
 use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageResolver, PageTrackerPolicy};
 use crate::types::{Key, Value};
+use crate::{Result, StorageError};
 use std::cmp::Ordering;
 use std::collections::Bound;
 use std::collections::Bound::{Excluded, Included, Unbounded};
@@ -26,6 +29,25 @@ impl Branch {
 
     fn into_parts(self) -> (PageImpl, usize) {
         (self.page, self.child_index)
+    }
+
+    // The index and page of the child adjacent to `child_index` in `direction`,
+    // if the branch has one. Shared by the stepping code and the run machinery,
+    // whose "the step stays under this parent" invariant requires they agree.
+    fn adjacent_child(
+        &self,
+        direction: Direction,
+        fixed_key_width: Option<usize>,
+    ) -> Option<(usize, PageNumber)> {
+        let accessor = BranchAccessor::new(&self.page, fixed_key_width);
+        let child_index = match direction {
+            Direction::Next => {
+                let next = self.child_index + 1;
+                (next < accessor.count_children()).then_some(next)?
+            }
+            Direction::Previous => self.child_index.checked_sub(1)?,
+        };
+        Some((child_index, accessor.child_page(child_index).unwrap()))
     }
 }
 
@@ -132,22 +154,9 @@ where
     F: FnMut(PageNumber) -> Result<PageImpl>,
 {
     for index in (0..path.len()).rev() {
-        let next_child = {
-            let frame = &path[index];
-            let accessor = BranchAccessor::new(&frame.page, K::fixed_width());
-            if direction.is_next() {
-                let child_index = frame.child_index + 1;
-                (child_index < accessor.count_children())
-                    .then(|| (child_index, accessor.child_page(child_index).unwrap()))
-            } else {
-                frame
-                    .child_index
-                    .checked_sub(1)
-                    .map(|child_index| (child_index, accessor.child_page(child_index).unwrap()))
-            }
-        };
-
-        if let Some((child_index, child_page)) = next_child {
+        if let Some((child_index, child_page)) =
+            path[index].adjacent_child(direction, K::fixed_width())
+        {
             path[index].child_index = child_index;
             path.truncate(index + 1);
             let page = get_page(child_page)?;
@@ -219,11 +228,92 @@ fn key_data<K: Key + 'static, V: Value + 'static>(leaf: &Leaf, position: usize) 
         .to_vec()
 }
 
+// The key a scan reseeks past after this leaf is flushed or spliced away: the
+// leaf's key furthest in the scan direction.
+fn scan_boundary_key<K: Key + 'static, V: Value + 'static>(
+    leaf: &Leaf,
+    direction: Direction,
+) -> Vec<u8> {
+    match direction {
+        Direction::Next => key_data::<K, V>(leaf, leaf.len - 1),
+        Direction::Previous => key_data::<K, V>(leaf, 0),
+    }
+}
+
 #[derive(Clone)]
 struct Leaf {
     page: PageImpl,
     position: usize,
     len: usize,
+}
+
+// A contiguous run of leaf children under one parent branch. When deleting
+// from a leaf would leave it sparse, the cursor buffers the run's retained
+// entries and replaces the originals with packed leaves in one parent update,
+// instead of merging each sparse leaf into its neighbor one rewrite at a time.
+//
+// While a run is open the tree is never mutated, so cursor paths stay valid.
+// The buffered entries hold no page references, so an open run also survives
+// foreign mutations; only the parent path captured at splice time must be
+// current. Runs grow in either scan direction.
+struct LeafRunRewrite {
+    parent_page: PageNumber,
+    direction: Direction,
+    // The parent's children consumed so far: a contiguous range extended
+    // upward by forward scans and downward by backward scans.
+    replaced_children: Range<usize>,
+    // All retained entries of the run, kept in ascending key order: forward
+    // scans append at the back, backward scans prepend at the front. Only
+    // leaves left below the merge threshold accumulate (each retaining less
+    // than a third of a page) plus at most one run-ending leaf, so the buffer
+    // is bounded by roughly fanout x page_size / 3.
+    entries: OwnedEntryBuffer,
+    removed_pairs: u64,
+}
+
+impl LeafRunRewrite {
+    fn new(parent_page: PageNumber, child_index: usize, direction: Direction) -> Self {
+        let origin = match direction {
+            Direction::Next => child_index,
+            Direction::Previous => child_index + 1,
+        };
+        let replaced_children = origin..origin;
+        Self {
+            parent_page,
+            direction,
+            replaced_children,
+            entries: OwnedEntryBuffer::default(),
+            removed_pairs: 0,
+        }
+    }
+
+    fn append_entries_from<K: Key, V: Value>(
+        &mut self,
+        page: PageImpl,
+        child_index: usize,
+        removed_indexes: &[usize],
+    ) {
+        debug_assert!(removed_indexes.windows(2).all(|pair| pair[0] < pair[1]));
+        // Hard asserts: a violation would splice the wrong children out of
+        // the parent, so it must not be compiled out of release builds.
+        match self.direction {
+            Direction::Next => {
+                assert_eq!(child_index, self.replaced_children.end);
+                self.replaced_children.end += 1;
+            }
+            Direction::Previous => {
+                assert_eq!(child_index + 1, self.replaced_children.start);
+                self.replaced_children.start -= 1;
+            }
+        }
+        self.removed_pairs += removed_indexes.len() as u64;
+
+        // A forward scan's leaf is entirely greater than the run so far, and a
+        // backward scan's entirely smaller.
+        let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
+        self.entries
+            .extend_from_leaf(&accessor, removed_indexes, self.direction.is_next());
+    }
 }
 
 pub(super) struct EntryRef<'a, K: Key + 'static, V: Value + 'static> {
@@ -406,10 +496,27 @@ pub(super) struct CursorState {
     // True when guards backed by the current leaf's memory were handed out for
     // pending removals: the flush must not modify the leaf memory in place.
     detached_guards: bool,
-    // True when a flush consumed pending removals but failed to apply them.
-    // The caller must not let the transaction commit, since entries already
-    // reported as removed may remain in the tree.
-    lost_removals: bool,
+    // Set when an error interrupted removals that were already reported to
+    // the caller: they may remain in the tree, so the transaction must not
+    // commit. Every cursor operation re-raises instead of touching the tree,
+    // since the position and run were discarded at the point of failure.
+    poisoned: bool,
+    // An in-progress sparse-leaf coalescing run. It holds no page references,
+    // so it may outlive the position; it is spliced before the tree is
+    // observed.
+    leaf_run_rewrite: Option<LeafRunRewrite>,
+}
+
+enum LeafCloseOutcome {
+    // The leaf had no pending removals and remains the current cursor leaf.
+    Unchanged,
+    // The tree was rewritten and the cursor position consumed; resume the
+    // scan from `resume_key`.
+    Flushed { resume_key: Vec<u8> },
+    // The leaf was absorbed into the open run, whose parent has more children
+    // to consume. The tree is untouched, so the cursor position (still on the
+    // absorbed leaf) remains valid.
+    AbsorbedIntoRun,
 }
 
 pub(super) struct CursorMut<'a, 'b, K: Key + 'static, V: Value + 'static> {
@@ -494,6 +601,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     }
 
     pub(super) fn seek_to(&mut self, target: Position<'_>) -> Result {
+        self.check_not_poisoned()?;
+        assert!(self.state.leaf_run_rewrite.is_none());
         assert!(self.state.removed_indexes.is_empty());
         self.state.position = None;
         let Some(header) = *self.root else {
@@ -535,6 +644,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     // entry on that side or the cursor reaches the tree edge. Leaving a leaf
     // flushes its pending removals and reseeks past it in the updated tree.
     fn ensure_has_entry(&mut self, direction: Direction) -> Result<bool> {
+        self.check_not_poisoned()?;
         self.check_pending_removals(direction);
         loop {
             let Some(position) = self.state.position.as_ref() else {
@@ -543,19 +653,58 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
             if position.has_entry(direction) {
                 return Ok(true);
             }
-            if !self.state.removed_indexes.is_empty() {
-                let resume_key = self
-                    .flush_removed_entries(direction)?
-                    .expect("pending removals exist");
-                let resume = match direction {
-                    Direction::Next => Position::After(resume_key.as_slice()),
-                    Direction::Previous => Position::Before(resume_key.as_slice()),
-                };
-                self.seek_to(resume)?;
-                continue;
+            if !self.advance_past_closed_leaf(direction)? {
+                return Ok(false);
             }
-            return self.step_to_adjacent_leaf(direction);
         }
+    }
+
+    // Closes the exhausted leaf (flushing its pending removals directly or
+    // into a coalescing run) and positions the cursor at the adjacent leaf.
+    // Returns false at the edge of the tree, leaving the cursor parked on the
+    // edge leaf so that `park_bound` still describes the consumed position.
+    fn advance_past_closed_leaf(&mut self, direction: Direction) -> Result<bool> {
+        match self.close_current_leaf(direction)? {
+            LeafCloseOutcome::Unchanged => self.step_to_adjacent_leaf(direction),
+            LeafCloseOutcome::Flushed { resume_key } => {
+                self.resume_after_rewrite(direction, &resume_key)?;
+                Ok(self.state.position.is_some())
+            }
+            LeafCloseOutcome::AbsorbedIntoRun => {
+                // The immediate parent has an adjacent child (else the run
+                // would have been spliced), so the ordinary step is guaranteed
+                // to stay under it. A failed step may leave the path partially
+                // updated, so the open run's removals can no longer be
+                // applied.
+                let stepped = self
+                    .step_to_adjacent_leaf(direction)
+                    .inspect_err(|_| self.poison())?;
+                assert!(stepped);
+                Ok(stepped)
+            }
+        }
+    }
+
+    // The parent frame of the open run: while a run is open, the position
+    // stays under the run's parent.
+    fn run_parent_frame(&self) -> &Branch {
+        let position = self
+            .state
+            .position
+            .as_ref()
+            .expect("cursor must be positioned");
+        position
+            .path
+            .last()
+            .expect("leaf runs require a parent branch")
+    }
+
+    // Whether the run's parent branch has another child to consume in the
+    // scan direction.
+    fn run_parent_has_more_children(&self, direction: Direction) -> bool {
+        self.run_parent_frame()
+            .adjacent_child(direction, K::fixed_width())
+            .is_some()
     }
 
     fn step_to_adjacent_leaf(&mut self, direction: Direction) -> Result<bool> {
@@ -750,21 +899,51 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     }
 
     pub(super) fn finish_pending_removals(&mut self) -> Result {
-        // The flush direction only affects the resume key, which is unused here.
-        let _ = self.flush_removed_entries(Direction::Next)?;
+        self.check_not_poisoned()?;
+        let direction = self
+            .state
+            .leaf_run_rewrite
+            .as_ref()
+            .map_or(Direction::Next, |run| run.direction);
+        // A clean current leaf need not be closed: the splice leaves it in
+        // place, and an empty batch has nothing to flush or absorb.
+        if self.state.position.is_some() && !self.state.removed_indexes.is_empty() {
+            self.close_current_leaf(direction)?;
+        }
+        // Splices the run left open when the scan stopped partway through
+        // its parent.
+        self.splice_open_run()
+    }
+
+    /// True if an error interrupted removals that were already reported to
+    /// the caller: they may remain in the tree, so the transaction must not
+    /// commit.
+    pub(super) fn poisoned(&self) -> bool {
+        self.state.poisoned
+    }
+
+    // Marks the removals already reported to the caller as unappliable, after
+    // an error consumed them or broke the paths needed to apply them. Safety
+    // comes from `check_not_poisoned` re-raising at every entry point; the
+    // discards below just release page references and buffers early.
+    fn poison(&mut self) {
+        self.state.poisoned = true;
+        self.state.position = None;
+        self.state.removed_indexes.clear();
+        self.state.leaf_run_rewrite = None;
+    }
+
+    fn check_not_poisoned(&self) -> Result {
+        if self.state.poisoned {
+            return Err(StorageError::PreviousIo);
+        }
         Ok(())
     }
 
-    /// True if a failed flush may have left entries in the tree that the
-    /// caller was told were removed. The transaction must not commit.
-    pub(super) fn lost_removals(&self) -> bool {
-        self.state.lost_removals
-    }
-
-    fn flush_removed_entries(&mut self, direction: Direction) -> Result<Option<Vec<u8>>> {
-        if self.state.removed_indexes.is_empty() {
-            return Ok(None);
-        }
+    // Applies the pending removals, returning the key past which the scan
+    // resumes.
+    fn flush_removed_entries(&mut self, direction: Direction) -> Result<Vec<u8>> {
+        assert!(!self.state.removed_indexes.is_empty());
 
         let position = self
             .state
@@ -774,34 +953,183 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         // Tree mutation invalidates the cursor path. Callers that continue
         // iteration reseek to the first entry past the original leaf in the
         // scan direction.
-        let resume_key = match direction {
-            Direction::Next => key_data::<K, V>(&position.leaf, position.leaf.len - 1),
-            Direction::Previous => key_data::<K, V>(&position.leaf, 0),
-        };
+        let resume_key = scan_boundary_key::<K, V>(&position.leaf, direction);
         let (path, leaf) = position.into_parts();
+        let allow_in_place = !self.state.detached_guards;
+        let removed_indexes = self.take_removals_ascending();
+        let result = self.mutate_helper().delete_leaf_entries(
+            leaf.page,
+            path,
+            &removed_indexes,
+            allow_in_place,
+        );
+        if result.is_err() {
+            // The batch was consumed, so the removals can no longer be applied.
+            self.poison();
+        }
+        result?;
+
+        Ok(resume_key)
+    }
+
+    // Flushes the current leaf's pending removals, either directly or into a
+    // coalescing run. Only a direct flush mutates the tree and consumes the
+    // cursor position; absorbing into a run leaves both untouched.
+    fn close_current_leaf(&mut self, direction: Direction) -> Result<LeafCloseOutcome> {
+        assert!(self.state.position.is_some(), "cursor must be positioned");
+
+        // The short-circuit order matters: `leaf_would_underfill` may only be
+        // consulted for a leaf with pending removals, so a merely-iterated
+        // sparse leaf cannot open a run.
+        let has_removals = !self.state.removed_indexes.is_empty();
+        let underfilling = has_removals && {
+            let position = self.state.position.as_ref().unwrap();
+            self.leaf_would_underfill(&position.leaf) && !position.path.is_empty()
+        };
+        if underfilling {
+            let removed_indexes = self.take_removals_ascending();
+            self.append_leaf_to_run(direction, &removed_indexes);
+            if self.run_parent_has_more_children(direction) {
+                return Ok(LeafCloseOutcome::AbsorbedIntoRun);
+            }
+            // The run consumed its parent's last child in the scan direction,
+            // so nothing more can join it; fall through to the splice.
+        } else if self.state.leaf_run_rewrite.is_some() {
+            // A leaf that stays healthy on its own ends the run, so a run's
+            // rewrites stay proportional to the sparse region. Its pending
+            // removals ride the splice; a fully retained leaf is left in
+            // place, though a run that packs below the merge threshold may
+            // still merge with it when the splice absorbs an adjacent child.
+            if has_removals {
+                let removed_indexes = self.take_removals_ascending();
+                self.append_leaf_to_run(direction, &removed_indexes);
+            }
+        } else if has_removals {
+            let resume_key = self.flush_removed_entries(direction)?;
+            return Ok(LeafCloseOutcome::Flushed { resume_key });
+        } else {
+            return Ok(LeafCloseOutcome::Unchanged);
+        }
+        // Every remaining path ends the run: splice it and resume past this
+        // leaf, whose furthest key bounds everything the run consumed.
+        let position = self.state.position.as_ref().unwrap();
+        let resume_key = scan_boundary_key::<K, V>(&position.leaf, direction);
+        self.splice_open_run()?;
+        Ok(LeafCloseOutcome::Flushed { resume_key })
+    }
+
+    // Takes the pending batch in ascending order; backward scans record their
+    // batch in decreasing order.
+    fn take_removals_ascending(&mut self) -> Vec<usize> {
         let mut removed_indexes = std::mem::take(&mut self.state.removed_indexes);
-        // Backward scans record indexes in decreasing order.
         if removed_indexes.first() > removed_indexes.last() {
             removed_indexes.reverse();
         }
-        let allow_in_place = !self.state.detached_guards;
+        // The batch is consumed, so it no longer constrains flushes.
         self.state.detached_guards = false;
-        let mut helper: MutateHelper<'_, '_, K, V> = MutateHelper::new(
+        removed_indexes
+    }
+
+    fn resume_after_rewrite(&mut self, direction: Direction, key: &[u8]) -> Result {
+        match direction {
+            Direction::Next => self.seek_to(Position::After(key)),
+            Direction::Previous => self.seek_to(Position::Before(key)),
+        }
+    }
+
+    // Absorbs the current leaf into the run, opening one if necessary. The
+    // tree and the cursor position are left untouched.
+    fn append_leaf_to_run(&mut self, direction: Direction, removed_indexes: &[usize]) {
+        let (page, parent_page, child_index) = {
+            let frame = self.run_parent_frame();
+            let position = self.state.position.as_ref().unwrap();
+            (
+                position.leaf.page.clone(),
+                frame.page.get_page_number(),
+                frame.child_index,
+            )
+        };
+        let run = self
+            .state
+            .leaf_run_rewrite
+            .get_or_insert_with(|| LeafRunRewrite::new(parent_page, child_index, direction));
+        // Hard asserts: a stale parent or mixed scan direction would splice
+        // the wrong children, so they must hold in release builds too.
+        assert_eq!(run.parent_page, parent_page);
+        assert!(run.direction == direction);
+        run.append_entries_from::<K, V>(page, child_index, removed_indexes);
+    }
+
+    // Replaces the run's children in the parent with packed leaves built from
+    // the buffered entries, while the cursor path is still valid. The cursor
+    // position is consumed; callers reseek from the run's boundary key. On
+    // error the cursor is poisoned: the run's removals were lost.
+    pub(super) fn splice_open_run(&mut self) -> Result {
+        self.check_not_poisoned()?;
+        let Some(run) = self.state.leaf_run_rewrite.take() else {
+            return Ok(());
+        };
+        let position = self
+            .state
+            .position
+            .take()
+            .expect("open run requires a position");
+        let result = self.splice_run(run, position);
+        if result.is_err() {
+            // The removals the run carried can no longer be applied.
+            self.poison();
+        }
+        result
+    }
+
+    fn splice_run(&mut self, run: LeafRunRewrite, position: CursorPosition) -> Result {
+        // The leaf is one of the pages the splice frees, so its page reference
+        // must be released first; only the parent path is needed below.
+        let CursorPosition { path, leaf } = position;
+        drop(leaf);
+        // Splicing against a stale parent would replace the wrong children.
+        assert_eq!(
+            path.last()
+                .expect("leaf runs require a parent branch")
+                .page
+                .get_page_number(),
+            run.parent_page
+        );
+        self.mutate_helper().replace_leaf_children(
+            path.into_iter().map(Branch::into_parts).collect(),
+            run.replaced_children,
+            run.entries,
+            run.removed_pairs,
+        )
+    }
+
+    // Whether removing the pending entries would leave the leaf below the merge
+    // threshold, matching `MutateHelper::plan_leaf_delete`'s Merge disposition.
+    fn leaf_would_underfill(&self, leaf: &Leaf) -> bool {
+        let accessor = LeafAccessor::new(leaf.page.memory(), K::fixed_width(), V::fixed_width());
+        let (retained_pairs, retained_bytes) =
+            retained_after_removals(&accessor, &self.state.removed_indexes);
+        retained_pairs == 0
+            || leaf_below_merge_threshold(
+                retained_pairs,
+                retained_bytes,
+                K::fixed_width(),
+                V::fixed_width(),
+                self.page_allocator.get_page_size(),
+            )
+    }
+
+    // All tree mutations flow through here. Mutating invalidates saved paths,
+    // so any open run must have been spliced first; a hard assert because a
+    // violation would later splice through a stale path.
+    fn mutate_helper<'c>(&'c mut self) -> MutateHelper<'a, 'c, K, V> {
+        assert!(self.state.leaf_run_rewrite.is_none());
+        MutateHelper::new(
             &mut *self.root,
             (*self.page_allocator).clone(),
             &mut *self.freed,
             Arc::clone(self.allocated),
-        );
-        let result = helper.delete_leaf_entries(leaf.page, path, &removed_indexes, allow_in_place);
-        if result.is_err() {
-            // The batch was consumed, so the removals can no longer be applied.
-            self.state.lost_removals = true;
-        }
-        result?;
-        removed_indexes.clear();
-        self.state.removed_indexes = removed_indexes;
-
-        Ok(Some(resume_key))
+        )
     }
 
     fn remove_leaf_entry(
@@ -812,13 +1140,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     ) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
         assert!(self.state.removed_indexes.is_empty());
         let path = path.into_iter().map(Branch::into_parts).collect();
-        let mut helper = MutateHelper::new(
-            &mut *self.root,
-            (*self.page_allocator).clone(),
-            &mut *self.freed,
-            Arc::clone(self.allocated),
-        );
-        let entry = helper.pop_leaf_entry(leaf, path, index)?;
+        let entry = self.mutate_helper().pop_leaf_entry(leaf, path, index)?;
         Ok(Some(entry))
     }
 }
@@ -870,10 +1192,10 @@ pub(super) struct RangeMut<'a, K: Key + 'static, V: Value + 'static> {
     // Which end, if any, is known to be live and positioned at an in-range
     // entry. Cleared whenever the gap moves or the tree is mutated.
     settled: Option<Direction>,
-    // Set when a flush consumed pending removals but failed to apply them:
-    // entries already yielded as removed may remain in the tree, so the
-    // caller must not let the transaction commit.
-    lost_removals: bool,
+    // Set when an error interrupted removals that were already yielded to the
+    // caller: they may remain in the tree, so the transaction must not
+    // commit. Every range operation re-raises instead of touching the tree.
+    poisoned: bool,
     _key_type: PhantomData<K>,
     _value_type: PhantomData<V>,
 }
@@ -896,7 +1218,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
             front: EndState::Parked(lower_bound),
             back: EndState::Parked(upper_bound),
             settled: None,
-            lost_removals: false,
+            poisoned: false,
             _key_type: PhantomData,
             _value_type: PhantomData,
         }
@@ -938,25 +1260,38 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
 
     /// Flushes pending removals on both ends. Must be called before the tree
     /// root is read or the tree is mutated through another path.
+    ///
+    /// Consumers must treat iteration errors as terminal: an end whose
+    /// position was lost may park a bound that un-consumes entries it already
+    /// yielded, so continuing past an error can re-yield them. Call `close()`
+    /// and stop, like `BtreeExtractIf`'s latch.
     pub(super) fn close(&mut self) -> Result {
         let front = self.flush_end(Direction::Next);
         let back = self.flush_end(Direction::Previous);
         front.and(back)
     }
 
-    /// True if a failed flush may have left entries in the tree that were
-    /// already yielded as removed. The transaction must not commit.
-    pub(super) fn lost_removals(&self) -> bool {
-        self.lost_removals
+    /// True if an error interrupted removals that were already yielded to the
+    /// caller: they may remain in the tree, so the transaction must not
+    /// commit.
+    pub(super) fn poisoned(&self) -> bool {
+        self.poisoned
+    }
+
+    fn check_not_poisoned(&self) -> Result {
+        if self.poisoned {
+            return Err(StorageError::PreviousIo);
+        }
+        Ok(())
     }
 
     // Applies an end's pending removals to the tree, leaving it parked.
     fn flush_end(&mut self, direction: Direction) -> Result {
+        self.check_not_poisoned()?;
         if matches!(self.end_ref(direction), EndState::Live(_)) {
             let result =
                 self.with_live_cursor(direction, |cursor| cursor.finish_pending_removals());
-            self.park(direction);
-            result
+            result.and(self.park(direction))
         } else {
             self.apply_pending(direction)
         }
@@ -1010,6 +1345,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
     // Ensures the cursor for `direction` is live and positioned at an entry,
     // and that the entry is within the range left between the two ends.
     fn settle(&mut self, direction: Direction) -> Result<bool> {
+        self.check_not_poisoned()?;
         if self.settled == Some(direction) {
             return Ok(true);
         }
@@ -1034,7 +1370,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
         if matches!(self.end_ref(direction), EndState::Live(_)) {
             return Ok(());
         }
-        self.park(direction.opposite());
+        self.park(direction.opposite())?;
         let mut state = self.seek_end(direction)?;
         if matches!(self.end_ref(direction), EndState::Pending(_)) {
             let EndState::Pending(batch) =
@@ -1052,7 +1388,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
                 // and reseek. Both steps require this end to hold no pages.
                 drop(state);
                 *self.end_mut(direction) = EndState::Parked(batch.bound.clone());
-                self.resolve_batch(direction, batch)?;
+                self.resolve_batch(batch)?;
                 state = self.seek_end(direction)?;
             }
         }
@@ -1087,14 +1423,18 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
         Ok(state)
     }
 
-    // Reduces a live end to a parked form. This never mutates the tree:
-    // pending removals are snapshotted and applied later.
-    fn park(&mut self, direction: Direction) {
+    // Reduces a live end to a parked form. An open coalescing run is spliced
+    // first, while the cursor path is still valid; mid-leaf pending removals
+    // are snapshotted and applied later.
+    fn park(&mut self, direction: Direction) -> Result {
         self.settled = None;
         let end = self.end_mut(direction);
         let EndState::Live(state) = end else {
-            return;
+            return Ok(());
         };
+        // Capture the parked form before the splice consumes the position.
+        // The splice rewrites the parent, but not this leaf's memory, so the
+        // snapshot stays valid.
         let bound = park_bound::<K, V>(state, direction);
         let parked = if state.removed_indexes.is_empty() {
             EndState::Parked(bound)
@@ -1110,7 +1450,14 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
                 removed_indexes: std::mem::take(&mut state.removed_indexes),
             })
         };
-        *end = parked;
+        let result = if state.leaf_run_rewrite.is_some() {
+            self.with_live_cursor(direction, |cursor| cursor.splice_open_run())
+        } else {
+            Ok(())
+        };
+        *self.end_mut(direction) = parked;
+        self.drain_freed();
+        result
     }
 
     // Applies a parked end's pending removals to the tree.
@@ -1120,14 +1467,23 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
         }
         self.activate(direction)?;
         self.with_live_cursor(direction, |cursor| cursor.finish_pending_removals())?;
-        self.park(direction);
-        Ok(())
+        self.park(direction)
     }
 
     // Applies a snapshotted batch whose leaf was rewritten by the other end:
-    // the pending entries are deleted by key, recovered from the snapshot.
-    fn resolve_batch(&mut self, direction: Direction, mut batch: ParkedBatch) -> Result {
-        while let Some(index) = batch.removed_indexes.pop() {
+    // the pending entries are deleted by key, recovered from the snapshot. On
+    // error the range is poisoned: the batch was consumed, so its removals
+    // can no longer be applied.
+    fn resolve_batch(&mut self, batch: ParkedBatch) -> Result {
+        // Mutating would invalidate an open run's saved parent path; this
+        // mirrors CursorMut::mutate_helper's chokepoint assert, which the raw
+        // MutateHelper below bypasses.
+        for direction in [Direction::Next, Direction::Previous] {
+            if let EndState::Live(state) = self.end_ref(direction) {
+                assert!(state.leaf_run_rewrite.is_none());
+            }
+        }
+        for &index in &batch.removed_indexes {
             let key = LeafAccessor::new(&batch.leaf_bytes, K::fixed_width(), V::fixed_width())
                 .entry(index)
                 .expect("snapshot entry must exist")
@@ -1146,9 +1502,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
             match result {
                 Ok(removed) => debug_assert!(removed.is_some()),
                 Err(err) => {
-                    // Keep the unapplied removals so that close() retries them.
-                    batch.removed_indexes.push(index);
-                    *self.end_mut(direction) = EndState::Pending(batch);
+                    self.poisoned = true;
                     return Err(err);
                 }
             }
@@ -1168,8 +1522,8 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
         let mut cursor = self.cursor(state);
         let result = operation(&mut cursor);
         let state = cursor.into_state();
-        if state.lost_removals {
-            self.lost_removals = true;
+        if state.poisoned {
+            self.poisoned = true;
         }
         *self.end_mut(direction) = EndState::Live(state);
         self.drain_freed();
@@ -1262,39 +1616,37 @@ fn park_bound<K: Key + 'static, V: Value + 'static>(
     state: &CursorState,
     direction: Direction,
 ) -> Bound<Vec<u8>> {
-    // The cursor was never positioned, which only happens when the tree is
-    // empty; any bound is equivalent.
+    // No position: the tree was empty, or a flush/seek error consumed it.
+    // Unbounded is safe only because those paths are terminal (the flush
+    // paths run from close(), and errors poison or latch); parking a live
+    // end Unbounded would un-consume everything it already yielded.
     let Some(position) = state.position.as_ref() else {
         return Unbounded;
     };
     let leaf = &position.leaf;
+    // A consumed leaf edge parks as the same exclusive boundary that flushes
+    // and splices resume from; the two must agree so that neither end of a
+    // range re-yields or skips an entry.
     match direction {
-        Direction::Next => {
-            if leaf.position < leaf.len {
-                Included(key_data::<K, V>(leaf, leaf.position))
-            } else {
-                Excluded(key_data::<K, V>(leaf, leaf.len - 1))
-            }
+        Direction::Next if leaf.position < leaf.len => {
+            Included(key_data::<K, V>(leaf, leaf.position))
         }
-        Direction::Previous => {
-            if leaf.position > 0 {
-                Included(key_data::<K, V>(leaf, leaf.position - 1))
-            } else {
-                Excluded(key_data::<K, V>(leaf, 0))
-            }
+        Direction::Previous if leaf.position > 0 => {
+            Included(key_data::<K, V>(leaf, leaf.position - 1))
         }
+        _ => Excluded(scan_boundary_key::<K, V>(leaf, direction)),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tree_store::btree_base::LeafBuilder;
+    use crate::tree_store::btree_base::{DEFERRED, LeafBuilder};
     use crate::tree_store::{
         AllocationPolicy, InMemoryBackend, PAGE_SIZE, PageTrackerPolicy, TransactionalMemory,
     };
 
-    fn cursor_with_entries(entries: &[u64]) -> Cursor<u64, u64> {
+    fn leaf_root_with_entries(entries: &[u64]) -> (PageAllocator, PageNumber) {
         let mem = TransactionalMemory::new(
             Box::new(InMemoryBackend::new()),
             true,
@@ -1331,6 +1683,11 @@ mod tests {
         let root = page.get_page_number();
         drop(page);
 
+        (page_allocator, root)
+    }
+
+    fn cursor_with_entries(entries: &[u64]) -> Cursor<u64, u64> {
+        let (page_allocator, root) = leaf_root_with_entries(entries);
         let mut cursor = Cursor::<u64, u64>::new(root, page_allocator.resolver(), PageHint::None);
         cursor.seek_to(Position::Start).unwrap();
         cursor
@@ -1357,5 +1714,76 @@ mod tests {
 
         assert_eq!(cursor.next().unwrap().unwrap().key(), 1);
         assert_eq!(cursor.next().unwrap().unwrap().key(), 2);
+    }
+
+    // An exhausted mutable cursor must stay parked on the edge leaf: park_bound
+    // relies on the position to bound the other end of a RangeMut, and an
+    // unpositioned cursor would park as Unbounded, un-consuming the entries.
+    #[test]
+    fn cursor_mut_stays_parked_at_tree_edge() {
+        let (page_allocator, root_page) = leaf_root_with_entries(&[1, 2, 3]);
+        let mut root = Some(BtreeHeader::new(root_page, DEFERRED, 3));
+        let mut freed = vec![];
+        let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+        let mut cursor: CursorMut<'_, '_, u64, u64> =
+            CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+
+        cursor.seek_to(Position::Start).unwrap();
+        for _ in 0..3 {
+            assert!(cursor.next().unwrap());
+        }
+        assert!(cursor.peek_next().unwrap().is_none());
+        assert!(cursor.state.position.is_some());
+        assert!(matches!(
+            park_bound::<u64, u64>(&cursor.state, Direction::Next),
+            Excluded(_)
+        ));
+
+        cursor.seek_to(Position::End).unwrap();
+        for _ in 0..3 {
+            assert!(cursor.peek_prev().unwrap().is_some());
+            cursor
+                .state
+                .position
+                .as_mut()
+                .unwrap()
+                .move_once(Direction::Previous);
+        }
+        assert!(cursor.peek_prev().unwrap().is_none());
+        assert!(cursor.state.position.is_some());
+        assert!(matches!(
+            park_bound::<u64, u64>(&cursor.state, Direction::Previous),
+            Excluded(_)
+        ));
+    }
+
+    // Once poisoned, every cursor operation re-raises instead of touching the
+    // tree, so removals stranded by the original error can never be observed
+    // as applied.
+    #[test]
+    fn poisoned_cursor_mut_re_raises() {
+        let (page_allocator, root_page) = leaf_root_with_entries(&[1, 2, 3]);
+        let mut root = Some(BtreeHeader::new(root_page, DEFERRED, 3));
+        let mut freed = vec![];
+        let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+        let mut cursor: CursorMut<'_, '_, u64, u64> =
+            CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+
+        cursor.seek_to(Position::Start).unwrap();
+        cursor.poison();
+        assert!(cursor.poisoned());
+        assert!(matches!(cursor.peek_next(), Err(StorageError::PreviousIo)));
+        assert!(matches!(
+            cursor.seek_to(Position::Start),
+            Err(StorageError::PreviousIo)
+        ));
+        assert!(matches!(
+            cursor.finish_pending_removals(),
+            Err(StorageError::PreviousIo)
+        ));
+        assert!(matches!(
+            cursor.splice_open_run(),
+            Err(StorageError::PreviousIo)
+        ));
     }
 }

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -1,9 +1,10 @@
 use crate::tree_store::btree_base::{
     BRANCH, BranchAccessor, BranchBuilder, BranchMutator, Checksum, DEFERRED, LEAF, LeafAccessor,
-    LeafBuilder, LeafMutator, RawLeafBuilder,
+    LeafBuilder, LeafMutator, OwnedEntryBuffer, is_single_large_value, leaf_below_merge_threshold,
+    leaf_split_required, retained_after_removals,
 };
 use crate::tree_store::btree_mutator::DeletionResult::{
-    DeletedBranch, DeletedLeaf, PartialBranch, PartialLeaf, Subtree,
+    DeletedBranch, DeletedSubtree, PartialBranch, PartialLeaf, Subtree,
 };
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
@@ -13,14 +14,16 @@ use crate::types::{Key, Value};
 use crate::{AccessGuard, Result};
 use std::cmp::{max, min};
 use std::marker::PhantomData;
+use std::ops::Range;
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug)]
 enum DeletionResult {
     // A proper subtree
     Subtree(PageNumber),
-    // A leaf with zero children
-    DeletedLeaf,
+    // A child subtree was removed completely and should be removed from its parent.
+    // If this reaches the root, the tree becomes empty.
+    DeletedSubtree,
     // A leaf with fewer entries than desired
     PartialLeaf {
         page: Arc<[u8]>,
@@ -110,12 +113,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
 
     fn conditional_free(&mut self, page_number: PageNumber) {
         let mut allocated = self.allocated.lock().unwrap();
-        if !self
-            .page_allocator
-            .free_if_uncommitted(page_number, &mut allocated)
-        {
-            self.freed.push(page_number);
-        }
+        self.page_allocator
+            .conditional_free(page_number, &mut allocated, self.freed);
     }
 
     pub(crate) fn delete(&mut self, key: &K::SelfType<'_>) -> Result<Option<AccessGuard<'a, V>>> {
@@ -153,7 +152,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     fn finish_deletion(&mut self, deletion_result: DeletionResult, new_length: u64) -> Result {
         let new_root = match deletion_result {
             Subtree(page) => Some(BtreeHeader::new(page, DEFERRED, new_length)),
-            DeletedLeaf => None,
+            DeletedSubtree => None,
             PartialLeaf {
                 page,
                 deleted_pairs,
@@ -245,6 +244,218 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         self.finish_deletion(result, length - indexes.len() as u64)
     }
 
+    // Replaces the contiguous `replaced_children` range of the leaf path's
+    // parent branch with packed leaves built from `entries`, then rebuilds the
+    // rest of the path. Each replacement's separator is its own greatest key;
+    // separators for preserved children are reused from the original branch.
+    pub(super) fn replace_leaf_children(
+        &mut self,
+        mut path: Vec<(PageImpl, usize)>,
+        mut replaced_children: Range<usize>,
+        mut entries: OwnedEntryBuffer,
+        removed_pairs: u64,
+    ) -> Result {
+        assert!(!replaced_children.is_empty());
+        let length = self.root.expect("replace requires a root").length;
+        let (parent_page, _) = path
+            .pop()
+            .expect("leaf child replacement requires a parent branch");
+        let parent_page_number = parent_page.get_page_number();
+        let (mut result, removed_leaf_pages) = {
+            let accessor = BranchAccessor::new(&parent_page, K::fixed_width());
+            let old_children = accessor.count_children();
+            assert!(replaced_children.end <= old_children);
+
+            // Entries that pack below the merge threshold would strand a
+            // sparse leaf that nothing later re-merges (inserts only split),
+            // so absorb the adjacent preserved child `plan_leaf_delete` would
+            // merge with, unless it holds a single large value. Empty entries
+            // just remove their children.
+            if entries.num_pairs() > 0
+                && leaf_below_merge_threshold(
+                    entries.num_pairs(),
+                    entries.total_bytes(),
+                    K::fixed_width(),
+                    V::fixed_width(),
+                    self.page_allocator.get_page_size(),
+                )
+            {
+                let neighbor_index = if replaced_children.start == 0 {
+                    replaced_children.end
+                } else {
+                    replaced_children.start - 1
+                };
+                if neighbor_index < old_children {
+                    let page = self
+                        .page_allocator
+                        .get_page(accessor.child_page(neighbor_index).unwrap(), PageHint::None)?;
+                    let neighbor =
+                        LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
+                    if !is_single_large_value(&neighbor, self.page_allocator.get_page_size()) {
+                        let at_back = neighbor_index == replaced_children.end;
+                        entries.extend_from_leaf(&neighbor, &[], at_back);
+                        if at_back {
+                            replaced_children.end += 1;
+                        } else {
+                            replaced_children.start -= 1;
+                        }
+                    }
+                }
+            }
+            let replacement_leaves = self.build_replacement_leaves(&entries)?;
+
+            let removed_leaf_pages = replaced_children
+                .clone()
+                .map(|i| accessor.child_page(i).unwrap())
+                .collect::<Vec<_>>();
+            let new_children = old_children - replaced_children.len() + replacement_leaves.len();
+            let result = if new_children == 0 {
+                DeletedSubtree
+            } else {
+                let mut builder = BranchBuilder::new(
+                    &self.page_allocator,
+                    &self.allocated,
+                    new_children,
+                    K::fixed_width(),
+                );
+                // Preserved children reuse their original checksum and
+                // separator; freshly built replacements have a deferred
+                // checksum and their greatest key as separator.
+                let preserved = |i: usize| {
+                    (
+                        accessor.child_page(i).unwrap(),
+                        accessor.child_checksum(i).unwrap(),
+                        accessor.key(i),
+                    )
+                };
+                let children = (0..replaced_children.start)
+                    .map(&preserved)
+                    .chain(
+                        replacement_leaves
+                            .iter()
+                            .map(|(page, upper_key)| (*page, DEFERRED, Some(upper_key.as_slice()))),
+                    )
+                    .chain((replaced_children.end..old_children).map(&preserved));
+                let mut pushed = 0;
+                for (page, checksum, key) in children {
+                    builder.push_child(page, checksum);
+                    pushed += 1;
+                    // Branches store one separator key after every child
+                    // except the last. The only child whose key is None is the
+                    // branch's original last child, which can only appear here
+                    // as the final pushed child, so the unwrap never runs dry.
+                    if pushed < new_children {
+                        builder.push_key(key.unwrap());
+                    }
+                }
+                debug_assert_eq!(pushed, new_children);
+                Self::finalize_branch_builder(builder, self.page_allocator.get_page_size())?
+            };
+            (result, removed_leaf_pages)
+        };
+        drop(parent_page);
+
+        for (page, child_index) in path.into_iter().rev() {
+            result = self.apply_child_deletion_result(page, child_index, result)?;
+        }
+
+        let new_length = length
+            .checked_sub(removed_pairs)
+            .expect("cursor removed more entries than the tree contains");
+        self.finish_deletion(result, new_length)?;
+        // Freed only after every fallible step, so an error never leaves the
+        // surviving root referencing a freed page.
+        self.conditional_free(parent_page_number);
+        for page_number in removed_leaf_pages {
+            self.conditional_free(page_number);
+        }
+        Ok(())
+    }
+
+    // Packs the buffered entries into full leaves, in key order, returning
+    // each page with its greatest key as separator. No cleanup on error: any
+    // failure here has latched the storage layer's io_failed flag, which
+    // blocks every later commit, so pages already built are transient
+    // in-memory state reclaimed on rollback.
+    fn build_replacement_leaves(
+        &self,
+        buffer: &OwnedEntryBuffer,
+    ) -> Result<Vec<(PageNumber, Vec<u8>)>> {
+        let fixed_key = K::fixed_width();
+        let fixed_value = V::fixed_width();
+        let page_size = self.page_allocator.get_page_size();
+        let entries: Vec<(&[u8], &[u8])> = buffer.entries().collect();
+        let pair_bytes = |(key, value): &(&[u8], &[u8])| key.len() + value.len();
+
+        // Greedy packing: cut a page whenever the next entry would require a
+        // split. Every page is packed as full as the entry stream allows;
+        // like the ordinary merge path, a page can still end up sparse when
+        // the next entry is close to a page in size.
+        let mut plan: Vec<Range<usize>> = vec![];
+        let mut start = 0;
+        let mut bytes = 0;
+        for (index, entry) in entries.iter().enumerate() {
+            let entry_bytes = pair_bytes(entry);
+            if leaf_split_required(
+                index - start + 1,
+                bytes + entry_bytes,
+                fixed_key,
+                fixed_value,
+                page_size,
+            ) {
+                plan.push(start..index);
+                start = index;
+                bytes = 0;
+            }
+            bytes += entry_bytes;
+        }
+        if start < entries.len() {
+            plan.push(start..entries.len());
+        }
+
+        // Greedy packing can strand a sparse trailing page, which nothing
+        // would ever re-merge; rebuild the last two pages with build_split's
+        // balanced division instead. The combined range cannot fit one page,
+        // or greedy would not have cut it.
+        let mut balance_tail = None;
+        if plan.len() >= 2 {
+            let last = plan.last().unwrap();
+            let last_bytes = entries[last.clone()].iter().map(pair_bytes).sum();
+            if leaf_below_merge_threshold(last.len(), last_bytes, fixed_key, fixed_value, page_size)
+            {
+                let last = plan.pop().unwrap();
+                let prev = plan.pop().unwrap();
+                balance_tail = Some(prev.start..last.end);
+            }
+        }
+
+        let fill = |range: &Range<usize>| {
+            let mut builder = LeafBuilder::new(
+                &self.page_allocator,
+                &self.allocated,
+                range.len(),
+                fixed_key,
+                fixed_value,
+            );
+            for (key, value) in &entries[range.clone()] {
+                builder.push(key, value);
+            }
+            builder
+        };
+        // Build the planned pages; each separator key is its page's greatest key.
+        let mut leaves = vec![];
+        for range in &plan {
+            let page = fill(range).build()?;
+            leaves.push((page.get_page_number(), entries[range.end - 1].0.to_vec()));
+        }
+        if let Some(range) = balance_tail {
+            let (page1, split_key, page2) = fill(&range).build_split()?;
+            leaves.push((page1.get_page_number(), split_key.to_vec()));
+            leaves.push((page2.get_page_number(), entries[range.end - 1].0.to_vec()));
+        }
+        Ok(leaves)
+    }
+
     #[allow(clippy::type_complexity)]
     pub(crate) fn insert(
         &mut self,
@@ -322,9 +533,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 let (position, found) = accessor.position::<K>(key);
 
                 // Fast-path to avoid re-building and splitting pages with a single large value
-                let single_large_value = accessor.num_pairs() == 1
-                    && accessor.total_length() >= self.page_allocator.get_page_size();
-                if !found && single_large_value {
+                if !found && is_single_large_value(&accessor, self.page_allocator.get_page_size()) {
                     let mut builder = LeafBuilder::new(
                         &self.page_allocator,
                         &self.allocated,
@@ -708,8 +917,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     )> {
         let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
         assert!(position < accessor.num_pairs());
-        let deleted_bytes = accessor.length_of_pairs(position, position + 1);
-        let plan = self.plan_leaf_delete(&accessor, 1, deleted_bytes);
+        let plan = self.plan_leaf_delete(&accessor, &[position]);
         let uncommitted = self.page_allocator.uncommitted(page.get_page_number());
 
         // Fast-path for dirty pages: perform in-place removal without allocating a new page.
@@ -741,7 +949,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         }
 
         let result = match plan.disposition {
-            LeafDeleteDisposition::Delete => DeletedLeaf,
+            LeafDeleteDisposition::Delete => DeletedSubtree,
             LeafDeleteDisposition::Merge => PartialLeaf {
                 page: page.to_arc(),
                 deleted_pairs: DeletedPairs::One(position),
@@ -803,11 +1011,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
         assert!(*indexes.last().unwrap() < accessor.num_pairs());
 
-        let deleted_bytes: usize = indexes
-            .iter()
-            .map(|&index| accessor.length_of_pairs(index, index + 1))
-            .sum();
-        let plan = self.plan_leaf_delete(&accessor, indexes.len(), deleted_bytes);
+        let plan = self.plan_leaf_delete(&accessor, indexes);
         let page_number = page.get_page_number();
 
         if allow_in_place
@@ -823,7 +1027,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         }
 
         let result = match plan.disposition {
-            LeafDeleteDisposition::Delete => DeletedLeaf,
+            LeafDeleteDisposition::Delete => DeletedSubtree,
             LeafDeleteDisposition::Merge => PartialLeaf {
                 page: page.to_arc(),
                 deleted_pairs: DeletedPairs::Many(indexes.to_vec()),
@@ -838,26 +1042,18 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         Ok(result)
     }
 
-    fn plan_leaf_delete(
-        &self,
-        accessor: &LeafAccessor<'_>,
-        deleted_pairs: usize,
-        deleted_bytes: usize,
-    ) -> LeafDeletePlan {
-        let retained_pairs = accessor.num_pairs() - deleted_pairs;
-        let new_kv_bytes = accessor.length_of_pairs(0, accessor.num_pairs()) - deleted_bytes;
-        let new_required_bytes = RawLeafBuilder::required_bytes(
-            retained_pairs,
-            new_kv_bytes,
-            K::fixed_width(),
-            V::fixed_width(),
-        );
+    fn plan_leaf_delete(&self, accessor: &LeafAccessor<'_>, indexes: &[usize]) -> LeafDeletePlan {
+        let (retained_pairs, retained_bytes) = retained_after_removals(accessor, indexes);
 
-        // Merge when less than 33% full. Splits occur when a page is full and produce two 50%
-        // full pages, so 33% avoids oscillating.
         let disposition = if retained_pairs == 0 {
             LeafDeleteDisposition::Delete
-        } else if new_required_bytes < self.page_allocator.get_page_size() / 3 {
+        } else if leaf_below_merge_threshold(
+            retained_pairs,
+            retained_bytes,
+            K::fixed_width(),
+            V::fixed_width(),
+            self.page_allocator.get_page_size(),
+        ) {
             LeafDeleteDisposition::Merge
         } else {
             LeafDeleteDisposition::Rebuild
@@ -996,7 +1192,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 // Handled in the if above
                 unreachable!();
             }
-            DeletedLeaf => {
+            DeletedSubtree => {
                 for i in 0..accessor.count_children() {
                     if i == child_index {
                         continue;
@@ -1037,10 +1233,9 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 let merge_with_accessor =
                     LeafAccessor::new(merge_with_page.memory(), K::fixed_width(), V::fixed_width());
 
-                let single_large_value = merge_with_accessor.num_pairs() == 1
-                    && merge_with_accessor.total_length() >= self.page_allocator.get_page_size();
                 // Don't try to merge or rebalance, if the sibling contains a single large value
-                if single_large_value {
+                if is_single_large_value(&merge_with_accessor, self.page_allocator.get_page_size())
+                {
                     let mut child_builder = LeafBuilder::new(
                         &self.page_allocator,
                         &self.allocated,

--- a/src/tree_store/extract_if.rs
+++ b/src/tree_store/extract_if.rs
@@ -1,11 +1,22 @@
 use crate::tree_store::btree_cursor::RangeMut;
 use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageTrackerPolicy};
 use crate::types::{Key, Value};
-use crate::{AccessGuard, Result};
+use crate::{AccessGuard, Result, StorageError};
 use std::collections::Bound;
 use std::sync::{Arc, Mutex};
 
 type ExtractItem<'a, K, V> = (AccessGuard<'a, K>, AccessGuard<'a, V>);
+type AdvanceInner<T, R> = fn(&mut T) -> Result<Option<R>>;
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum ExtractState {
+    Running,
+    // Exhausted or explicitly closed: iteration returns None.
+    Closed,
+    // An iteration error was returned: later calls re-raise instead of
+    // continuing, since the failure is not recoverable.
+    Errored,
+}
 
 pub(crate) struct BtreeExtractIf<
     'a,
@@ -16,7 +27,7 @@ pub(crate) struct BtreeExtractIf<
     range: RangeMut<'a, K, V>,
     predicate: F,
     predicate_running: bool,
-    done: bool,
+    state: ExtractState,
     close_failed: bool,
 }
 
@@ -44,7 +55,7 @@ where
             ),
             predicate,
             predicate_running: false,
-            done: false,
+            state: ExtractState::Running,
             close_failed: false,
         }
     }
@@ -54,12 +65,19 @@ where
     }
 
     pub(crate) fn close(&mut self) -> Result {
-        if self.done {
-            return Ok(());
+        if self.state != ExtractState::Running {
+            // Already closed, possibly by latch_error: an explicit close()
+            // must still re-raise an iteration error or a failed
+            // finalization, so Ok always means the scan completed cleanly.
+            return if self.close_failed || self.state == ExtractState::Errored {
+                Err(StorageError::PreviousIo)
+            } else {
+                Ok(())
+            };
         }
-        self.done = true;
+        self.state = ExtractState::Closed;
         let result = self.range.close();
-        if result.is_err() || self.range.lost_removals() {
+        if result.is_err() || self.range.poisoned() {
             self.close_failed = true;
         }
         result
@@ -71,6 +89,17 @@ where
     // this is not implied by an explicit close() returning an error.
     pub(crate) fn close_failed(&self) -> bool {
         self.close_failed
+    }
+
+    // Latches the error state: an end whose position was lost may otherwise
+    // park with a bound that un-consumes entries it already yielded or
+    // tested, letting the other end see them again. close() applies both
+    // ends' pending work while their state is still coherent, and later
+    // calls re-raise instead of continuing. The errors reaching here are
+    // unrecoverable: the storage layer has latched the underlying failure.
+    fn latch_error(&mut self) {
+        let _ = self.close();
+        self.state = ExtractState::Errored;
     }
 
     fn next_inner(&mut self) -> Result<Option<ExtractItem<'a, K, V>>> {
@@ -124,6 +153,24 @@ where
         self.close()?;
         Ok(None)
     }
+
+    // One copy of the latch protocol, shared by both iteration ends so their
+    // error behavior cannot diverge.
+    fn advance(
+        &mut self,
+        inner: AdvanceInner<Self, ExtractItem<'a, K, V>>,
+    ) -> Option<Result<ExtractItem<'a, K, V>>> {
+        match self.state {
+            ExtractState::Errored => return Some(Err(StorageError::PreviousIo)),
+            ExtractState::Closed => return None,
+            ExtractState::Running => {}
+        }
+        let result = inner(self);
+        if result.is_err() {
+            self.latch_error();
+        }
+        result.transpose()
+    }
 }
 
 impl<'a, K: Key + 'static, V: Value + 'static, F> Iterator for BtreeExtractIf<'a, K, V, F>
@@ -133,10 +180,7 @@ where
     type Item = Result<ExtractItem<'a, K, V>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.done {
-            return None;
-        }
-        self.next_inner().transpose()
+        self.advance(Self::next_inner)
     }
 }
 
@@ -145,10 +189,7 @@ where
     F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.done {
-            return None;
-        }
-        self.next_back_inner().transpose()
+        self.advance(Self::next_back_inner)
     }
 }
 

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -207,6 +207,19 @@ impl PageAllocator {
         }
     }
 
+    // Frees the page immediately if it was allocated in this transaction;
+    // otherwise defers it to `freed` for release at commit.
+    pub(crate) fn conditional_free(
+        &self,
+        page: PageNumber,
+        allocated: &mut PageTrackerPolicy,
+        freed: &mut Vec<PageNumber>,
+    ) {
+        if !self.free_if_uncommitted(page, allocated) {
+            freed.push(page);
+        }
+    }
+
     pub(crate) fn uncommitted(&self, page: PageNumber) -> bool {
         self.allocated_since_commit.lock().unwrap().contains(page)
     }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -2710,6 +2710,91 @@ fn retain_variable_sized_sparse_survivors_terminates() {
     write_txn.commit().unwrap();
 }
 
+// A sparse leaf at the end of a retain's scan must merge into a sibling, the
+// same as single deletes; otherwise repeated retains accumulate permanently
+// under-filled leaves that nothing re-merges.
+#[test]
+fn retain_merges_sparse_boundary_leaf() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+    let value = vec![0u8; 100];
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0u64..60 {
+            table.insert(i, value.as_slice()).unwrap();
+        }
+        assert!(table.stats().unwrap().leaf_pages() >= 2);
+
+        // Keep the low half untouched and gut the tail, so the scan closes on
+        // a leaf left far below the merge threshold.
+        table.retain(|key, _| key < 30 || key == 59).unwrap();
+        assert_eq!(table.len().unwrap(), 31);
+        assert!(table.stats().unwrap().leaf_pages() <= 2);
+        for i in 0u64..60 {
+            assert_eq!(table.get(i).unwrap().is_some(), i < 30 || i == 59);
+        }
+    }
+    write_txn.commit().unwrap();
+}
+
+// Removal patterns that never carry a run across a leaf boundary (here:
+// single-key ranges in descending order) must still leave a packed tree.
+#[test]
+fn retain_descending_removals_stay_merged() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+    let value = vec![0u8; 8];
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0u64..5_000 {
+            table.insert(i, value.as_slice()).unwrap();
+        }
+        for key in (0u64..5_000).rev() {
+            if key % 100 != 0 {
+                table.retain_in(key..key + 1, |_, _| false).unwrap();
+            }
+        }
+        assert_eq!(table.len().unwrap(), 50);
+        let leaves = table.stats().unwrap().leaf_pages();
+        assert!(leaves <= 3, "sparse survivors spread over {leaves} leaves");
+    }
+    write_txn.commit().unwrap();
+}
+
+// A run over oversized-value leaves splices early instead of buffering the
+// parent's entire dense tail, so a small removal cannot make the transient
+// buffer grow with fanout x value size.
+#[test]
+fn retain_large_values_bounded_run() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+    let value = vec![0u8; 256 * 1024];
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0u64..32 {
+            table.insert(i, value.as_slice()).unwrap();
+        }
+        table.retain(|key, _| key != 0).unwrap();
+        assert_eq!(table.len().unwrap(), 31);
+        for i in 1u64..32 {
+            assert_eq!(table.get(i).unwrap().unwrap().value(), value.as_slice());
+        }
+    }
+    write_txn.commit().unwrap();
+}
+
 #[cfg(not(target_os = "wasi"))]
 #[test]
 fn retain_predicate_panic_poisons_transaction() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,7 +2,7 @@ use rand::RngExt;
 use rand::prelude::SliceRandom;
 use redb::backends::FileBackend;
 use redb::{
-    AccessGuard, Builder, CompactionError, Database, Durability, Key, MultimapRange,
+    AccessGuard, Builder, CommitError, CompactionError, Database, Durability, Key, MultimapRange,
     MultimapTableDefinition, MultimapValue, Range, ReadableDatabase, ReadableTable,
     ReadableTableMetadata, SetDurabilityError, StorageBackend, TableDefinition, TableStats,
     TransactionError, Value, WriteTransaction,
@@ -187,58 +187,61 @@ fn random_data(count: usize, key_size: usize, value_size: usize) -> Vec<(Vec<u8>
     pairs
 }
 
+// A file backend whose read or sync operations fail while the matching flag
+// is set.
+#[derive(Debug)]
+struct FailingBackend {
+    inner: FileBackend,
+    fail_reads: Arc<AtomicBool>,
+    fail_syncs: Arc<AtomicBool>,
+}
+
+impl FailingBackend {
+    fn new(backend: FileBackend) -> Self {
+        Self {
+            inner: backend,
+            fail_reads: Arc::new(AtomicBool::new(false)),
+            fail_syncs: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl StorageBackend for FailingBackend {
+    fn len(&self) -> Result<u64, std::io::Error> {
+        self.inner.len()
+    }
+
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
+        if self.fail_reads.load(Ordering::SeqCst) {
+            return Err(std::io::Error::from(ErrorKind::Other));
+        }
+        self.inner.read(offset, out)
+    }
+
+    fn set_len(&self, len: u64) -> Result<(), std::io::Error> {
+        self.inner.set_len(len)
+    }
+
+    fn sync_data(&self) -> Result<(), std::io::Error> {
+        if self.fail_syncs.load(Ordering::SeqCst) {
+            return Err(std::io::Error::from(ErrorKind::Other));
+        }
+        self.inner.sync_data()
+    }
+
+    fn write(&self, offset: u64, data: &[u8]) -> Result<(), std::io::Error> {
+        self.inner.write(offset, data)
+    }
+}
+
 #[test]
 fn previous_io_error() {
-    #[derive(Debug)]
-    struct FailingBackend {
-        inner: FileBackend,
-        fail_flag: Arc<AtomicBool>,
-    }
-
-    impl FailingBackend {
-        fn new(backend: FileBackend, fail_flag: Arc<AtomicBool>) -> Self {
-            Self {
-                inner: backend,
-                fail_flag,
-            }
-        }
-    }
-
-    impl StorageBackend for FailingBackend {
-        fn len(&self) -> Result<u64, std::io::Error> {
-            self.inner.len()
-        }
-
-        fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
-            self.inner.read(offset, out)
-        }
-
-        fn set_len(&self, len: u64) -> Result<(), std::io::Error> {
-            self.inner.set_len(len)
-        }
-
-        fn sync_data(&self) -> Result<(), std::io::Error> {
-            if self.fail_flag.load(Ordering::SeqCst) {
-                Err(std::io::Error::from(ErrorKind::Other))
-            } else {
-                self.inner.sync_data()
-            }
-        }
-
-        fn write(&self, offset: u64, data: &[u8]) -> Result<(), std::io::Error> {
-            self.inner.write(offset, data)
-        }
-    }
-
     let tmpfile = create_tempfile();
 
-    let fail_flag = Arc::new(AtomicBool::new(false));
-    let backend = FailingBackend::new(
-        FileBackend::new(tmpfile.into_file()).unwrap(),
-        fail_flag.clone(),
-    );
+    let backend = FailingBackend::new(FileBackend::new(tmpfile.into_file()).unwrap());
+    let fail_syncs = backend.fail_syncs.clone();
     let db = Database::builder().create_with_backend(backend).unwrap();
-    fail_flag.store(true, Ordering::SeqCst);
+    fail_syncs.store(true, Ordering::SeqCst);
     let txn = db.begin_write().unwrap();
     {
         let mut table = txn.open_table(U64_TABLE).unwrap();
@@ -249,6 +252,93 @@ fn previous_io_error() {
     assert!(matches!(
         db.begin_write().err().unwrap(),
         TransactionError::Storage(StorageError::PreviousIo)
+    ));
+}
+
+// After the extract iterator returns an error, later calls must keep
+// returning an error rather than None: the failure is not recoverable and
+// going quiet would look like successful exhaustion.
+#[test]
+fn extract_if_error_latches() {
+    let tmpfile = create_tempfile();
+    let backend = FailingBackend::new(FileBackend::new(tmpfile.into_file()).unwrap());
+    let fail_reads = backend.fail_reads.clone();
+    // Zero cache so iteration must read leaves through the backend.
+    let db = Builder::new()
+        .set_cache_size(0)
+        .create_with_backend(backend)
+        .unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in 0..10_000u64 {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        let mut iter = table.extract_if(|_, _| true).unwrap();
+        assert!(iter.next().unwrap().is_ok());
+        fail_reads.store(true, Ordering::SeqCst);
+        // The current leaf may drain from memory before a read is needed.
+        loop {
+            match iter.next() {
+                Some(Ok(_)) => {}
+                Some(Err(_)) => break,
+                None => panic!("iterator must not report exhaustion"),
+            }
+        }
+        // The error is latched: both ends re-raise instead of continuing.
+        assert!(matches!(iter.next(), Some(Err(StorageError::PreviousIo))));
+        assert!(matches!(
+            iter.next_back(),
+            Some(Err(StorageError::PreviousIo))
+        ));
+        fail_reads.store(false, Ordering::SeqCst);
+    }
+    drop(txn);
+}
+
+// After an extract iterator error, committing reports the underlying
+// storage failure; the iteration error alone does not poison the
+// transaction (no removals were lost).
+#[test]
+fn extract_if_error_commit_reports_storage_failure() {
+    let tmpfile = create_tempfile();
+    let backend = FailingBackend::new(FileBackend::new(tmpfile.into_file()).unwrap());
+    let fail_reads = backend.fail_reads.clone();
+    let db = Builder::new()
+        .set_cache_size(0)
+        .create_with_backend(backend)
+        .unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in 0..1000u64 {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        fail_reads.store(true, Ordering::SeqCst);
+        // The predicate never matches, so no removals are pending when the
+        // read error surfaces and finalization succeeds without I/O.
+        let mut iter = table.extract_if(|_, _| false).unwrap();
+        assert!(iter.next().unwrap().is_err());
+        fail_reads.store(false, Ordering::SeqCst);
+    }
+    let err = txn.commit().unwrap_err();
+    assert!(matches!(
+        err,
+        CommitError::Storage(StorageError::PreviousIo)
     ));
 }
 


### PR DESCRIPTION
Ports the `codex/retain-owned-leaf-builder-prototype` run-coalescing onto the merged cursor machinery, generalized per review to both scan directions and to extract_if.

When removals leave a leaf below the merge threshold, the cursor used to merge it into a sibling one mutator call at a time, re-copying the accumulated survivors as the scan advanced across the parent. Now each consumed leaf's retained entries are buffered in owned memory and packed replacement leaves are spliced into the parent in a single update, freeing the originals.

Beyond the prototype:
- Runs work in both scan directions: buffered entries are kept in key order, so backward scans still emit leaves in key order.
- Runs apply to extract_if's deferred batches too: the buffers hold no page references, so they are safe with outstanding guards, and a range cursor splices its open run when the other end activates (park/close are the existing mutation boundaries).
- Only leaves left below the merge threshold join a run; the first leaf that stays healthy on its own ends it (its pending removals ride the splice). Runs never consume the dense tail, and the buffer is structurally bounded at roughly fanout x page_size / 3 plus one final leaf — no explicit byte cap needed (previously up to fanout x 1MiB transient heap on large-value tables).
- The cursor owns only run bookkeeping (which children, which direction, when to splice); all rewrite policy lives in the mutator's `replace_leaf_children`, next to `plan_leaf_delete`: entries that pack below the merge threshold absorb the same adjacent child `plan_leaf_delete` would merge with (skipping single-large-value neighbors), and the trailing two replacement leaves are divided with the same `build_split` used by ordinary inserts, preserving the same minimum-fill bound as single-key deletes (previously repeated bounded retains could decay leaves toward one entry each).
- Explicit poisoning: an error that interrupts removals already reported to the caller discards the cursor state, every later operation re-raises `StorageError::PreviousIo` (the storage layer has latched the underlying failure), and the transaction is poisoned. An extract iterator latches the first error and later calls keep re-raising it instead of continuing, so iteration cannot re-test entries through a stale range bound.

Benchmarks (1M entries, 24B/150B, committed data, interleaved with master): retain keep-half ~1.9x, retain keep-1-in-8 ~2.1x, and extract_from_if removing every other entry over a third of the keyspace improves a further ~1.8x on top of the cursor rework — matching the throughput of the eager whole-range-rebuild prototype while keeping lazy semantics and memory structurally bounded.

Verified: `just test` green (302 tests, including new regression tests for the sparse-boundary merge, descending-removal decay, and large-value runs), clean fuzz runs (including interleaved-direction extract ops that drive backward runs and park-time splices), and adversarial scenario tests (interior-band retain, alternating double-ended extract with held guards, oversized values).

Known follow-up: replacement leaves other than the balanced tail are packed completely full, which shifts cost to later inserts.

https://claude.ai/code/session_0112BvsuWfD2hRL6VNiLzyyt