### PR TITLE
Fix check_integrity() falsely reporting corruption on a healthy database after commits that freed pages

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -579,9 +579,34 @@ impl Database {
     /// Returns [`DatabaseError::TransactionInProgress`] if any read or write transaction is still
     /// alive when this method is called.
     pub fn check_integrity(&mut self) -> Result<bool, DatabaseError> {
-        let allocator_hash = self.mem.allocator_hash();
-        let mem = Arc::get_mut(&mut self.mem).ok_or(DatabaseError::TransactionInProgress)?;
-        let mut was_clean = mem.clear_cache_and_reload()?;
+        if Arc::get_mut(&mut self.mem).is_none() {
+            return Err(DatabaseError::TransactionInProgress);
+        }
+
+        // The live in-memory state may be ahead of the durable state, because durable commits
+        // process pending freed pages after committing and publish the result as a non-durable
+        // commit. The live allocator state corresponds to the live roots, so it must be checked
+        // against a rebuild from the live roots: comparing it against the rebuild from the
+        // durable roots (after the reload below) would falsely report corruption.
+        let mut was_clean = match Self::verify_primary_checksums(self.mem.clone()) {
+            Ok(true) => {
+                let live_allocator_hash = self.mem.allocator_hash();
+                match Self::rebuild_allocator_state(&mut self.mem, &|_| {}) {
+                    Ok(_) => live_allocator_hash == self.mem.allocator_hash(),
+                    Err(DatabaseError::Storage(StorageError::Corrupted(_))) => false,
+                    Err(err) => return Err(err),
+                }
+            }
+            // The live state is corrupted. The reload and repair below verify the durable state
+            // and repair from it.
+            Ok(false) | Err(StorageError::Corrupted(_)) => false,
+            Err(err) => return Err(err.into()),
+        };
+
+        let mem = Arc::get_mut(&mut self.mem).unwrap();
+        if !mem.clear_cache_and_reload()? {
+            was_clean = false;
+        }
 
         let old_roots = [self.mem.get_data_root(), self.mem.get_system_root()];
 
@@ -590,7 +615,7 @@ impl Database {
             _ => unreachable!(),
         })?;
 
-        if old_roots != new_roots || allocator_hash != self.mem.allocator_hash() {
+        if old_roots != new_roots {
             was_clean = false;
         }
 
@@ -855,7 +880,25 @@ impl Database {
             return Err(DatabaseError::RepairAborted);
         }
 
-        mem.begin_repair()?;
+        let [data_root, system_root] = Self::rebuild_allocator_state(mem, repair_callback)?;
+
+        mem.clear_recovery_required()?;
+
+        // We need to invalidate the userspace cache, because we're about to implicitly free the freed table
+        // by storing an empty root during the below commit()
+        mem.clear_read_cache();
+
+        Ok([data_root, system_root])
+    }
+
+    // Rebuilds the in-memory allocator state by marking every page reachable from the current
+    // roots (including the pages referenced by the freed-page tables) as allocated. Operates
+    // purely on in-memory state and does not modify the file.
+    fn rebuild_allocator_state(
+        mem: &mut Arc<TransactionalMemory>, // Only &mut to ensure exclusivity
+        repair_callback: &(dyn Fn(&mut RepairSession) + 'static),
+    ) -> Result<[Option<BtreeHeader>; 2], DatabaseError> {
+        mem.reset_allocator_state()?;
 
         let data_root = mem.get_data_root();
         {
@@ -906,12 +949,6 @@ impl Database {
         {
             Self::check_repaired_allocated_pages_table(system_root, mem.clone())?;
         }
-
-        mem.end_repair()?;
-
-        // We need to invalidate the userspace cache, because we're about to implicitly free the freed table
-        // by storing an empty root during the below commit()
-        mem.clear_read_cache();
 
         Ok([data_root, system_root])
     }

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -2013,7 +2013,7 @@ mod tests {
             false,
         )
         .unwrap();
-        mem.begin_repair().unwrap();
+        mem.reset_allocator_state().unwrap();
         PageAllocator::new(Arc::new(mem), AllocationPolicy::Default)
     }
 

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -1304,7 +1304,7 @@ mod tests {
             false,
         )
         .unwrap();
-        mem.begin_repair().unwrap();
+        mem.reset_allocator_state().unwrap();
         let mem = Arc::new(mem);
         let page_allocator = PageAllocator::new(mem, AllocationPolicy::Default);
         let allocated_pages = Mutex::new(PageTrackerPolicy::new_tracking());

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -539,7 +539,7 @@ impl TransactionalMemory {
             state.header = header;
             state.read_from_secondary = false;
             // Drop the previous allocator state -- it described the layout that was in memory
-            // before the reload. The caller is required to repopulate it (via begin_repair or
+            // before the reload. The caller is required to repopulate it (via reset_allocator_state or
             // load_allocator_state) before any allocation/free path runs.
             state.allocators = None;
         }
@@ -580,7 +580,9 @@ impl TransactionalMemory {
         state.header.swap_primary_slot();
     }
 
-    pub(crate) fn begin_repair(&self) -> Result<()> {
+    // Replaces the in-memory allocator state with a fresh, empty one sized to the current
+    // layout. The caller is responsible for repopulating it by marking reachable pages allocated.
+    pub(crate) fn reset_allocator_state(&self) -> Result<()> {
         let mut state = self.state.lock().unwrap();
         state.allocators = Some(Allocators::new(state.header.layout()));
         #[cfg(debug_assertions)]
@@ -607,7 +609,8 @@ impl TransactionalMemory {
         Ok(())
     }
 
-    pub(crate) fn end_repair(&self) -> Result<()> {
+    // Durably clears the recovery flag, marking the repair as complete.
+    pub(crate) fn clear_recovery_required(&self) -> Result<()> {
         let mut state = self.state.lock().unwrap();
         state.header.recovery_required = false;
         self.write_header(&state.header)?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1825,6 +1825,43 @@ fn check_integrity_clean() {
     assert!(db.check_integrity().unwrap());
 }
 
+// check_integrity() on a live handle to a healthy database must return true, including after
+// commits that freed data pages. Durable commits process pending freed pages in a post-commit
+// epilogue that updates only the live (non-durable) state, so the live allocator must be
+// validated against the live roots rather than the reloaded durable state.
+#[test]
+fn check_integrity_clean_after_delete() {
+    let tmpfile = create_tempfile();
+
+    let table_def: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+
+    let mut db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(table_def).unwrap();
+        for i in 0..1000u64 {
+            table.insert(&i, [1u8; 20].as_slice()).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    // Remove a key from the committed multi-level tree, so that the commit frees data pages
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(table_def).unwrap();
+        assert!(table.remove(&0u64).unwrap().is_some());
+    }
+    write_txn.commit().unwrap();
+
+    // The database is healthy, so check_integrity() must report it as clean. (Reopening the
+    // file and checking returns true, which proves the persisted state is consistent; the live
+    // handle must agree.)
+    assert!(db.check_integrity().unwrap());
+    // And it must remain clean when checked repeatedly
+    assert!(db.check_integrity().unwrap());
+}
+
 #[test]
 fn multimap_stats() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
## Problem

`Database::check_integrity()` on a live database handle deterministically returned `Ok(false)` ("failed integrity checks but was repaired") on a perfectly healthy database after any committed transaction that freed data pages — e.g. committing a multi-level table and then removing a single key. It also performed a spurious repair commit. Reopening the same file and re-running the check returned `true`, proving the persisted state was consistent.

## Root cause

Durable commits run a post-commit epilogue (`process_data_freed_pages_after_commit`) that frees the pages pending in `DATA_FREED_TABLE` in the live in-memory allocator and removes the entries via a non-durable commit, so the live state is routinely ahead of the durable state. `check_integrity()` captured `allocator_hash` from this live post-epilogue state, but `clear_cache_and_reload()` reverts to the last durable state — where the freed-table entries still exist and the listed pages still count as allocated — so the repair-rebuilt allocator legitimately differed from the captured hash.

This is an unreleased regression from the 4.2.0 "reuse pages freed by a durable write transaction one transaction sooner" work, so no changelog entry is included.

## Fix

Compare like with like:

1. Validate the live allocator against an allocator rebuilt from the **live** roots (new `rebuild_allocator_state()` helper, factored out of `do_repair()`; it performs no file writes, so externally-injected corruption is not disturbed before the reload). This preserves leak/double-free detection, including state loaded from a stale allocator state table.
2. Verify the durable state exactly as before: `clear_cache_and_reload()` (header/layout reconciliation), `do_repair()` (checksum verification, primary-slot repair), and the root comparison. Unclean shutdowns and external modifications are still reported as `false`-and-repaired.

No double-free can result from reverting the live state to the durable roots: the still-registered pending non-durable commit pins freed-page processing at its durable ancestor until the next durable commit.

## Testing

* New regression test `check_integrity_clean_after_delete` (fails before the fix, passes after), asserting that a healthy live handle reports clean after a freeing commit, including on repeated calls.
* `just test` passes: cargo deny, fmt, clippy (`-D warnings`), and the full test suite, including the existing repair, savepoint, and integrity tests.

---

Found by a codebase audit; the original failing repro is on the `claude/codebase-bug-audit-h638r8` branch.

https://claude.ai/code/session_01GGotvNGnZVJjsf5stQzS8o

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGotvNGnZVJjsf5stQzS8o)_