### PR TITLE
Fix extract_if panic when iterating from both directions

### DIFF
--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -726,8 +726,10 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         direction: Direction,
     ) -> (AccessGuard<'a, K>, AccessGuard<'a, V>) {
         // The Arc-backed guards stay valid because the page store hands out a
-        // fresh buffer whenever a freed page number is reused, and the
-        // detached flush below never mutates this leaf's bytes in place.
+        // fresh buffer whenever a freed page number is reused, and no flush
+        // that can run while these guards exist mutates leaf bytes in place:
+        // the detached flush below and `RangeMut`'s batch resolution by key
+        // both rewrite leaves instead.
         let index = self.record_removal(direction);
         self.state.detached_guards = true;
         let leaf = &self
@@ -840,6 +842,9 @@ enum EndState {
 
 // Pending removals of a parked end. The snapshot holds no page references,
 // so the other end is free to restructure the tree, including this leaf.
+// However, `leaf_bytes` may share the buffer of a live dirty leaf, so tree
+// mutations that can run while the batch exists must not modify leaf memory
+// in place.
 struct ParkedBatch {
     bound: Bound<Vec<u8>>,
     leaf_bytes: Arc<[u8]>,
@@ -1133,7 +1138,10 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
                 &mut self.freed,
                 Arc::clone(&self.allocated),
             );
-            let result = helper.delete_key(key);
+            // In-place deletion must be disabled: the other end's pending
+            // snapshot and any deferred-removal guards handed to the caller
+            // may share the buffer of the live leaf containing this key.
+            let result = helper.delete_key(key, false);
             self.drain_freed();
             match result {
                 Ok(removed) => debug_assert!(removed.is_some()),

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -119,16 +119,25 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     }
 
     pub(crate) fn delete(&mut self, key: &K::SelfType<'_>) -> Result<Option<AccessGuard<'a, V>>> {
-        self.delete_key(K::as_bytes(key).as_ref())
+        self.delete_key(K::as_bytes(key).as_ref(), true)
     }
 
-    pub(super) fn delete_key(&mut self, key: &[u8]) -> Result<Option<AccessGuard<'a, V>>> {
+    // If `allow_in_place` is false, leaf memory is never modified in place, so guards and
+    // snapshots backed by leaf buffers remain valid after the deletion.
+    pub(super) fn delete_key(
+        &mut self,
+        key: &[u8],
+        allow_in_place: bool,
+    ) -> Result<Option<AccessGuard<'a, V>>> {
         if let Some(BtreeHeader {
             root: p, length, ..
         }) = *self.root
         {
-            let (deletion_result, found) =
-                self.delete_helper(self.page_allocator.get_page(p, PageHint::None)?, key)?;
+            let (deletion_result, found) = self.delete_helper(
+                self.page_allocator.get_page(p, PageHint::None)?,
+                key,
+                allow_in_place,
+            )?;
             if found.is_none() {
                 // The tree was not modified; leave *self.root untouched so that any clean
                 // root page keeps its already-valid checksum.
@@ -766,6 +775,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         &mut self,
         page: PageImpl,
         key: &[u8],
+        allow_in_place: bool,
     ) -> Result<(DeletionResult, Option<AccessGuard<'a, V>>)> {
         let (position, found) = {
             let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
@@ -776,7 +786,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             return Ok((Subtree(page.get_page_number()), None));
         }
         let (result, key_guard, value_guard) =
-            self.delete_leaf_at_position(page, position, false, true)?;
+            self.delete_leaf_at_position(page, position, false, allow_in_place)?;
         assert!(key_guard.is_none());
         Ok((result, Some(value_guard)))
     }
@@ -911,6 +921,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         &mut self,
         page: PageImpl,
         key: &[u8],
+        allow_in_place: bool,
     ) -> Result<(DeletionResult, Option<AccessGuard<'a, V>>)> {
         let original_page_number = page.get_page_number();
         let (child_index, child_page_number) = {
@@ -921,6 +932,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             self.page_allocator
                 .get_page(child_page_number, PageHint::None)?,
             key,
+            allow_in_place,
         )?;
         if found.is_none() {
             // Subtree unchanged; caller identifies this via `found.is_none()`.
@@ -1265,11 +1277,12 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         &mut self,
         page: PageImpl,
         key: &[u8],
+        allow_in_place: bool,
     ) -> Result<(DeletionResult, Option<AccessGuard<'a, V>>)> {
         let node_mem = page.memory();
         match node_mem[0] {
-            LEAF => self.delete_leaf_helper(page, key),
-            BRANCH => self.delete_branch_helper(page, key),
+            LEAF => self.delete_leaf_helper(page, key, allow_in_place),
+            BRANCH => self.delete_branch_helper(page, key, allow_in_place),
             _ => unreachable!(),
         }
     }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -622,6 +622,193 @@ fn extract_from_if_alternating_directions() {
     write_txn.commit().unwrap();
 }
 
+// Strictly alternating next()/next_back() over a multi-leaf tree with dense
+// removals repeatedly re-parks and resolves each end's pending removal batch.
+// Resolving a batch must not modify a leaf in place while the other end's
+// snapshot still references the same leaf buffer.
+#[test]
+fn extract_if_alternating_directions_dense_removals() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let n = 300u64;
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..n {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        let mut got: Vec<u64> = vec![];
+        {
+            // Remove everything except key 0, alternating directions.
+            let mut extracted = table.extract_if(|k, _| k != 0).unwrap();
+            let mut front = true;
+            loop {
+                let entry = if front {
+                    extracted.next()
+                } else {
+                    extracted.next_back()
+                };
+                front = !front;
+                match entry {
+                    Some(item) => got.push(item.unwrap().0.value()),
+                    None => break,
+                }
+            }
+        }
+        got.sort_unstable();
+        assert_eq!(got, (1..n).collect::<Vec<_>>());
+        assert_eq!(table.len().unwrap(), 1);
+        assert_eq!(table.get(&0).unwrap().unwrap().value(), 0);
+    }
+    write_txn.commit().unwrap();
+}
+
+// Dropping the iterator partway through a mixed-direction scan applies both
+// ends' pending removal batches from close().
+#[test]
+fn extract_if_alternating_directions_partial_consumption() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let n = 300u64;
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..n {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        {
+            let mut extracted = table.extract_if(|k, _| k != 0).unwrap();
+            let mut front = true;
+            // Consume most of the range, then drop the iterator.
+            for _ in 0..280 {
+                let entry = if front {
+                    extracted.next()
+                } else {
+                    extracted.next_back()
+                };
+                front = !front;
+                if let Some(item) = entry {
+                    item.unwrap();
+                } else {
+                    break;
+                }
+            }
+        }
+        assert_eq!(table.len().unwrap(), n - 280);
+    }
+    write_txn.commit().unwrap();
+}
+
+// Even an occasional direction switch during an otherwise forward scan must
+// hand the pending batch safely between the two ends.
+#[test]
+fn extract_if_mostly_forward_occasional_next_back() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let n = 1000u64;
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..n {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        let mut got: Vec<u64> = vec![];
+        {
+            let mut extracted = table.extract_if(|k, _| k != 0).unwrap();
+            let mut i = 0u64;
+            loop {
+                let entry = if i % 50 == 0 {
+                    extracted.next_back()
+                } else {
+                    extracted.next()
+                };
+                i += 1;
+                match entry {
+                    Some(item) => got.push(item.unwrap().0.value()),
+                    None => break,
+                }
+            }
+        }
+        got.sort_unstable();
+        assert_eq!(got, (1..n).collect::<Vec<_>>());
+    }
+    write_txn.commit().unwrap();
+}
+
+// Guards yielded during a mixed-direction scan stay valid after the iterator
+// is dropped, even though they reference leaf buffers that batch resolution
+// later restructures.
+#[test]
+fn extract_if_alternating_directions_held_guards() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let n = 300u64;
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..n {
+            table.insert(&i, &(i + 1000)).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        let mut held = vec![];
+        {
+            let mut extracted = table.extract_if(|k, _| k != 0).unwrap();
+            let mut front = true;
+            loop {
+                let entry = if front {
+                    extracted.next()
+                } else {
+                    extracted.next_back()
+                };
+                front = !front;
+                match entry {
+                    Some(item) => held.push(item.unwrap()),
+                    None => break,
+                }
+            }
+        }
+        held.sort_by_key(|(key, _)| key.value());
+        assert_eq!(held.len() as u64, n - 1);
+        for (i, (key, value)) in held.iter().enumerate() {
+            let expected = i as u64 + 1;
+            assert_eq!(key.value(), expected);
+            assert_eq!(value.value(), expected + 1000);
+        }
+        drop(held);
+
+        assert_eq!(table.len().unwrap(), 1);
+        assert_eq!(table.get(&0).unwrap().unwrap().value(), 1000);
+    }
+    write_txn.commit().unwrap();
+}
+
 #[test]
 fn retain() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
## Problem

`Table::extract_if`/`extract_from_if` panics with `called 'Option::unwrap()' on a 'None' value` in `WritablePage::mem_mut` whenever the iterator is consumed from both directions on a multi-leaf table with dense removals — even a single `next_back()` per 50 `next()` calls triggers it. Introduced by the paired-mutable-range-cursor optimization (411377a, unreleased 4.2.0), so no changelog entry is included.

## Root cause

When one end of the paired cursor parks a pending-removal batch, `ParkedBatch::leaf_bytes` snapshots the leaf as an `Arc` clone of the live dirty leaf's write-cache buffer (deferred-removal guards handed to the caller clone the same buffer). If the snapshot mismatches on reactivation, `RangeMut::resolve_batch()` deletes the snapshotted entries by key via `MutateHelper::delete_key()`, which was hard-wired to the in-place deletion fast path on uncommitted leaves. The in-place path requires exclusive ownership of the buffer (`Arc::get_mut().unwrap()`), but the other end's snapshot or a caller-held guard can alias the very leaf the key now lives in, so the unwrap panicked. The unwind also dropped the consumed batch, silently keeping entries already yielded as removed.

## Fix

Thread an `allow_in_place` flag through `MutateHelper::delete_key()` and disable the in-place fast path during batch resolution, so resolved removals always rewrite the leaf instead of mutating shared memory. All other delete paths (e.g. `Table::remove`) keep the fast path, and the per-leaf removal batching is unchanged — the by-key resolution only runs on the rare snapshot-mismatch path.

## Testing

* New deterministic regression tests in `tests/basic_tests.rs` covering strict alternation, partial consumption with drop-time flush, occasional direction switches, and guards held past the iterator's lifetime — all panicked before the fix and pass after.
* `just test` passes (deny, fmt, clippy, full test suite) and `just fuzz_ci` (60s smoke, 36k runs) found no crashes.

---

Found by a codebase audit; the original failing repro is on the `claude/codebase-bug-audit-h638r8` branch.

https://claude.ai/code/session_01GGotvNGnZVJjsf5stQzS8o

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGotvNGnZVJjsf5stQzS8o)_