### PR TITLE
Fix StorageBackend::close() not being called when shutdown I/O fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 * Fix a panic in `insert()` when a single leaf page accumulated 65536 entries via in-place
   appends, e.g. by inserting a large value and then many small values in ascending key order
   within the same transaction.
+* `StorageBackend::close()` is now called when the `Database` is dropped even if an I/O error
+  occurs during shutdown. Previously a shutdown I/O error could skip the `close()` call, leaking
+  any resources the backend releases there.
 
 ### Python bindings
 * Add `Database.create(path)` for creating or opening a database file.

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1308,6 +1308,14 @@ impl TransactionalMemory {
     }
 
     pub(crate) fn close(&self) -> Result {
+        let shutdown_result = self.flush_shutdown_header();
+        // The backend's close() contract guarantees it is called exactly once, so it must be
+        // called even if the shutdown writes above failed
+        let close_result = self.storage.close();
+        shutdown_result.and(close_result)
+    }
+
+    fn flush_shutdown_header(&self) -> Result {
         if self.storage.check_io_errors().is_ok() && !thread::panicking() {
             let mut state = self.state.lock()?;
             if self.storage.flush().is_ok() {
@@ -1316,8 +1324,6 @@ impl TransactionalMemory {
                 self.storage.flush()?;
             }
         }
-
-        self.storage.close()?;
 
         Ok(())
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -252,6 +252,121 @@ fn previous_io_error() {
     ));
 }
 
+// StorageBackend::close() is documented to be called exactly once when the Database is
+// dropped. Verify that this holds even when an I/O error occurs during shutdown.
+#[test]
+fn close_called_exactly_once_on_shutdown_io_error() {
+    use redb::backends::InMemoryBackend;
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::sync::atomic::{AtomicI64, AtomicU64};
+
+    #[derive(Debug)]
+    struct FaultBackend {
+        inner: InMemoryBackend,
+        // Counts every write/sync/set_len op
+        ops: Arc<AtomicU64>,
+        // The op that decrements this to zero fails. i64::MAX means never fail.
+        countdown: Arc<AtomicI64>,
+        close_calls: Arc<AtomicU64>,
+    }
+
+    impl FaultBackend {
+        fn new() -> (Self, Arc<AtomicU64>, Arc<AtomicI64>, Arc<AtomicU64>) {
+            let ops = Arc::new(AtomicU64::new(0));
+            let countdown = Arc::new(AtomicI64::new(i64::MAX));
+            let close_calls = Arc::new(AtomicU64::new(0));
+            (
+                Self {
+                    inner: InMemoryBackend::new(),
+                    ops: ops.clone(),
+                    countdown: countdown.clone(),
+                    close_calls: close_calls.clone(),
+                },
+                ops,
+                countdown,
+                close_calls,
+            )
+        }
+
+        fn should_fail(&self) -> bool {
+            self.ops.fetch_add(1, Ordering::SeqCst);
+            self.countdown.fetch_sub(1, Ordering::SeqCst) == 1
+        }
+    }
+
+    impl StorageBackend for FaultBackend {
+        fn len(&self) -> Result<u64, std::io::Error> {
+            self.inner.len()
+        }
+
+        fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
+            self.inner.read(offset, out)
+        }
+
+        fn set_len(&self, len: u64) -> Result<(), std::io::Error> {
+            if self.should_fail() {
+                return Err(std::io::Error::other("injected fault"));
+            }
+            self.inner.set_len(len)
+        }
+
+        fn sync_data(&self) -> Result<(), std::io::Error> {
+            if self.should_fail() {
+                return Err(std::io::Error::other("injected fault"));
+            }
+            self.inner.sync_data()
+        }
+
+        fn write(&self, offset: u64, data: &[u8]) -> Result<(), std::io::Error> {
+            if self.should_fail() {
+                return Err(std::io::Error::other("injected fault"));
+            }
+            self.inner.write(offset, data)
+        }
+
+        fn close(&self) -> Result<(), std::io::Error> {
+            self.close_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn workload(db: &Database) {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(U64_TABLE).unwrap();
+            table.insert(&0, &0).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    // Probe how many write/sync/set_len ops a clean shutdown performs, and verify that a clean
+    // drop calls close() exactly once
+    let (backend, ops, _countdown, close_calls) = FaultBackend::new();
+    let db = Database::builder().create_with_backend(backend).unwrap();
+    workload(&db);
+    ops.store(0, Ordering::SeqCst);
+    drop(db);
+    let shutdown_ops = ops.load(Ordering::SeqCst);
+    assert_eq!(close_calls.load(Ordering::SeqCst), 1);
+    assert!(shutdown_ops > 0);
+
+    // Fail each shutdown op in turn; close() must still be called exactly once
+    for fail_at in 0..shutdown_ops {
+        let (backend, ops, countdown, close_calls) = FaultBackend::new();
+        let db = Database::builder().create_with_backend(backend).unwrap();
+        workload(&db);
+        ops.store(0, Ordering::SeqCst);
+        countdown.store(i64::try_from(fail_at).unwrap() + 1, Ordering::SeqCst);
+        catch_unwind(AssertUnwindSafe(|| drop(db)))
+            .unwrap_or_else(|_| panic!("shutdown fail_at={fail_at}: panic during Database::drop"));
+        assert_eq!(
+            close_calls.load(Ordering::SeqCst),
+            1,
+            "shutdown fail_at={fail_at}: close() call count"
+        );
+    }
+}
+
 #[test]
 fn mixed_durable_commit() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
## Problem

`StorageBackend::close()` is documented to be called exactly once when the `Database` is dropped ("redb will not access the backend after calling this method and will call it exactly once"). However, in `TransactionalMemory::close()`, an error from the shutdown header write or the subsequent flush propagated via `?` past the `self.storage.close()` call. Since `Database::drop` ignores the error, the backend's `close()` was never invoked in that case. Custom backends that release file locks or other resources in `close()` leaked them. Present in released versions (verified against v4.1.0).

## Fix

Restructure `TransactionalMemory::close()` so the backend's `close()` is always attempted exactly once: the shutdown header write/flush logic moves into a private `flush_shutdown_header()`, its result is captured, `close()` is then called unconditionally, and the shutdown error (if any) is returned in preference to the close error. The `recovery_required` flag is still only cleared on disk when the header write and flushes succeed. There is no other path to `TransactionalMemory::close()` (no `Drop` impl on it; `Database::drop` calls it exactly once), so the exactly-once contract holds across all paths.

## Tests

New regression test `close_called_exactly_once_on_shutdown_io_error`: wraps `InMemoryBackend` in a fault-injecting backend with a close-call counter, probes the number of write/sync/set_len ops a clean shutdown performs, then fails each shutdown op in turn and asserts `close()` is called exactly once with no panic (and on a clean drop). Fails before the fix (close called zero times for faults hitting the header write or final flush) and passes after.

`just test` is fully green.

---

Found by a codebase audit; the original failing repro is on the `claude/codebase-bug-audit-h638r8` branch.

https://claude.ai/code/session_01GGotvNGnZVJjsf5stQzS8o

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGotvNGnZVJjsf5stQzS8o)_