### PR TITLE
Fix stale allocated-pages entries after deleting a persistent savepoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 * `compact()` now returns `CompactionError::PersistentSavepointExists` or
   `CompactionError::EphemeralSavepointExists` instead of the misleading
   `CompactionError::TransactionInProgress` when a savepoint blocks compaction.
+* Fix `check_integrity()` incorrectly reporting a healthy database as corrupted (and panicking
+  in debug builds) after a persistent savepoint was deleted or restored.
 
 ### Python bindings
 * Add `Database.create(path)` for creating or opening a database file.

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -344,13 +344,20 @@ impl TransactionTracker {
         }
     }
 
-    pub(crate) fn oldest_savepoint(&self) -> Option<(SavepointId, TransactionId)> {
+    // The oldest savepoint, ignoring the given savepoint ids. Used by committing transactions
+    // to compute the savepoint horizon as it will be after their staged savepoint deletions
+    // are applied on commit.
+    pub(crate) fn oldest_savepoint_excluding(
+        &self,
+        exclude: &BTreeSet<SavepointId>,
+    ) -> Option<(SavepointId, TransactionId)> {
         self.state
             .lock()
             .unwrap()
             .valid_savepoints
-            .first_key_value()
-            .map(|x| (*x.0, *x.1))
+            .iter()
+            .find(|(id, _)| !exclude.contains(id))
+            .map(|(id, txn_id)| (*id, *txn_id))
     }
 
     pub(crate) fn oldest_live_read_transaction(&self) -> Option<TransactionId> {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -813,6 +813,12 @@ impl SavepointTransactionState {
         self.invalidated.contains(&id)
     }
 
+    // Persistent savepoints whose deletion is staged in this transaction. They are still
+    // present in the shared tracker until apply_on_commit() runs.
+    fn pending_deleted_ids(&self) -> BTreeSet<SavepointId> {
+        self.deleted_persistent.iter().map(|(id, _)| *id).collect()
+    }
+
     fn has_created_or_deleted(&self) -> bool {
         !self.created_persistent.is_empty() || !self.deleted_persistent.is_empty()
     }
@@ -1695,10 +1701,15 @@ impl WriteTransaction {
             data_allocated_pages,
         )?;
 
-        // Purge any transactions that are no longer referenced
+        // Purge any transactions that are no longer referenced. The horizon must reflect the
+        // savepoints that will exist after this commit: savepoints deleted in this transaction
+        // are still in the tracker (they are removed post-commit), but the pages they pinned
+        // may be freed by this commit's epilogue, and DATA_ALLOCATED_TABLE must never name a
+        // page that is no longer allocated.
+        let deleted_savepoints = self.savepoint_state.lock().unwrap().pending_deleted_ids();
         let oldest = self
             .transaction_tracker
-            .oldest_savepoint()
+            .oldest_savepoint_excluding(&deleted_savepoints)
             .map_or(u64::MAX, |(_, x)| x.raw_id());
         let key = TransactionIdWithPagination {
             transaction_id: oldest,

--- a/tests/backward_compatibility.rs
+++ b/tests/backward_compatibility.rs
@@ -337,3 +337,81 @@ fn mixed_width() {
     test_helper::<u8, &[u8]>();
     test_helper::<&[u8; 5], &str>();
 }
+
+// Invariant: a persistent savepoint created by redb 2.6 (file format v3) must remain fully
+// usable in the current version: restoring and deleting it must leave the allocated-pages
+// bookkeeping referencing only allocated pages, so check_integrity() reports a clean database.
+#[test]
+fn restore_and_delete_redb2_6_persistent_savepoint() {
+    let table_def: redb::TableDefinition<u64, &[u8]> = redb::TableDefinition::new("table");
+    let table_def_26: redb2_6::TableDefinition<u64, &[u8]> = redb2_6::TableDefinition::new("table");
+    fn value_for(i: u64, len: usize) -> Vec<u8> {
+        vec![(i % 250) as u8 + 1; len]
+    }
+
+    let tmpfile = create_tempfile();
+    let savepoint_id;
+    {
+        let db = redb2_6::Database::builder()
+            .create_with_file_format_v3(true)
+            .create(tmpfile.path())
+            .unwrap();
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(table_def_26).unwrap();
+            for i in 0..100u64 {
+                table.insert(i, value_for(i, 100).as_slice()).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+
+        let txn = db.begin_write().unwrap();
+        savepoint_id = txn.persistent_savepoint().unwrap();
+        txn.commit().unwrap();
+
+        // Modify the data after the savepoint (still in redb 2.6)
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(table_def_26).unwrap();
+            for i in 0..50u64 {
+                table.remove(i).unwrap();
+            }
+            for i in 100..200u64 {
+                table.insert(i, value_for(i, 100).as_slice()).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    let mut db = redb::Database::open(tmpfile.path()).unwrap();
+    let ids: Vec<u64> = {
+        let txn = db.begin_write().unwrap();
+        let ids = txn.list_persistent_savepoints().unwrap().collect();
+        txn.abort().unwrap();
+        ids
+    };
+    assert_eq!(ids, vec![savepoint_id]);
+
+    let mut txn = db.begin_write().unwrap();
+    let savepoint = txn.get_persistent_savepoint(savepoint_id).unwrap();
+    txn.restore_savepoint(&savepoint).unwrap();
+    drop(savepoint);
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    assert!(txn.delete_persistent_savepoint(savepoint_id).unwrap());
+    txn.commit().unwrap();
+
+    // Must not panic
+    assert!(db.check_integrity().unwrap());
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(table_def).unwrap();
+    assert_eq!(table.len().unwrap(), 100);
+    for i in 0..100u64 {
+        assert_eq!(
+            table.get(i).unwrap().unwrap().value(),
+            value_for(i, 100).as_slice()
+        );
+    }
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1612,6 +1612,181 @@ fn regression19() {
     tx.open_table(table_def).unwrap();
 }
 
+fn savepoint_integrity_value(i: u64, len: usize) -> Vec<u8> {
+    vec![(i % 250) as u8 + 1; len]
+}
+
+// Invariant: DATA_ALLOCATED_TABLE entries must only reference allocated pages, and must be
+// purged once no savepoint needs them. Deleting a persistent savepoint must not leave entries
+// behind that name pages freed by the same commit's epilogue.
+#[test]
+fn check_integrity_after_persistent_savepoint_delete() {
+    let tmpfile = create_tempfile();
+    let table_def: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+    let mut db = Database::create(tmpfile.path()).unwrap();
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        for k in 0..1000u64 {
+            table
+                .insert(&k, savepoint_integrity_value(k, 60).as_slice())
+                .unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    let savepoint_id = txn.persistent_savepoint().unwrap();
+    txn.commit().unwrap();
+
+    // While the savepoint exists, new allocations are recorded in the allocated-pages table
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        for k in 2000..2500u64 {
+            table
+                .insert(&k, savepoint_integrity_value(k, 60).as_slice())
+                .unwrap();
+        }
+    }
+    txn.commit().unwrap();
+    // ... and freeing them queues them in the freed table, but they stay allocated as long as
+    // the savepoint pins them
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        for k in 2000..2500u64 {
+            table.remove(&k).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    txn.delete_persistent_savepoint(savepoint_id).unwrap();
+    txn.commit().unwrap();
+
+    assert!(
+        db.check_integrity().unwrap(),
+        "false corruption report after deleting a persistent savepoint"
+    );
+}
+
+// Invariant: restoring and later deleting a persistent savepoint must leave the allocated-pages
+// bookkeeping referencing only allocated pages
+#[test]
+fn check_integrity_with_persistent_savepoint_then_restore() {
+    let tmpfile = create_tempfile();
+    let table_def: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+    let mut db = Database::create(tmpfile.path()).unwrap();
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        for k in 0..1000u64 {
+            table
+                .insert(&k, savepoint_integrity_value(k, 60).as_slice())
+                .unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    let savepoint_id = txn.persistent_savepoint().unwrap();
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        for k in 0..900u64 {
+            table.remove(&k).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    assert!(
+        db.check_integrity().unwrap(),
+        "false corruption report while a persistent savepoint exists"
+    );
+
+    let mut txn = db.begin_write().unwrap();
+    let savepoint = txn.get_persistent_savepoint(savepoint_id).unwrap();
+    txn.restore_savepoint(&savepoint).unwrap();
+    drop(savepoint);
+    txn.commit().unwrap();
+
+    let read = db.begin_read().unwrap();
+    let table = read.open_table(table_def).unwrap();
+    assert_eq!(table.len().unwrap(), 1000);
+    drop(table);
+    drop(read);
+
+    let txn = db.begin_write().unwrap();
+    txn.delete_persistent_savepoint(savepoint_id).unwrap();
+    txn.commit().unwrap();
+    assert!(db.check_integrity().unwrap());
+}
+
+// Invariant: restore_savepoint() queues pages from the allocated-pages table to be freed; once
+// the savepoint is deleted and those pages are actually freed, no entry may still name them
+#[test]
+fn check_integrity_after_persistent_savepoint_restore_and_delete() {
+    let tmpfile = create_tempfile();
+    let table_def: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+    let mut db = Database::create(tmpfile.path()).unwrap();
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        for i in 0..100u64 {
+            table
+                .insert(&i, savepoint_integrity_value(i, 100).as_slice())
+                .unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    let id = txn.persistent_savepoint().unwrap();
+    txn.commit().unwrap();
+
+    // Allocate data pages after the savepoint; these get recorded in the allocated-pages table
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        for i in 0..50u64 {
+            table.remove(&i).unwrap();
+        }
+        for i in 100..200u64 {
+            table
+                .insert(&i, savepoint_integrity_value(i, 100).as_slice())
+                .unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    // Restore the savepoint and then delete it
+    let mut txn = db.begin_write().unwrap();
+    let savepoint = txn.get_persistent_savepoint(id).unwrap();
+    txn.restore_savepoint(&savepoint).unwrap();
+    drop(savepoint);
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    assert!(txn.delete_persistent_savepoint(id).unwrap());
+    txn.commit().unwrap();
+
+    // Must not panic
+    assert!(db.check_integrity().unwrap());
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(table_def).unwrap();
+    assert_eq!(table.len().unwrap(), 100);
+    for i in 0..100u64 {
+        assert_eq!(
+            table.get(&i).unwrap().unwrap().value(),
+            savepoint_integrity_value(i, 100).as_slice()
+        );
+    }
+}
+
 #[test]
 fn regression20() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
## Problem

After a persistent savepoint is deleted (or restored and then deleted), the system `DATA_ALLOCATED_TABLE` retains stale entries naming pages that are no longer allocated. `Database::check_integrity()` then panics in debug builds at the internal invariant `assert!(mem.is_allocated(..))` in `check_repaired_allocated_pages_table`; before the live-state allocator rebuild was added, the same stale state surfaced as `Ok(false)` false-corruption reports, so the underlying flaw exists in released versions. Also reproducible with persistent savepoints created by redb 2.6 in format-v3 files.

## Root cause

The transaction that deletes the savepoint purges `DATA_ALLOCATED_TABLE` in `flush_data_allocated_pages` with a horizon computed from the tracker's savepoint state — which still includes the savepoint being deleted, because the tracker is only updated post-commit by `apply_savepoint_state_on_commit`. Entries pinned by the doomed savepoint therefore survive the purge, while the post-commit epilogue (`process_data_freed_pages_after_commit`) goes on to free the pages they list.

## Fix

Compute the purge horizon excluding savepoints whose deletion is staged in the committing transaction (new `oldest_savepoint_excluding()` on the tracker, fed from the transaction's `deleted_persistent` set). Crash safety is unaffected: the purge is part of the same durable commit that makes the savepoint deletion durable, so recovery sees either both or neither.

## Tests

Three new integration tests (delete only; restore then delete via `get_persistent_savepoint`; restore then delete with heavier churn) plus a backward-compatibility test that creates the savepoint with redb 2.6 in a format-v3 file and restores/deletes it with the current version. All four panic at `db.rs:736` before the fix and pass after.

`just test` checks are fully green (deny/fmt/clippy/all-features tests) and a fuzz smoke run (30k iterations) found no crashes.

---

Found by a codebase audit; the original failing repros are on the `claude/codebase-bug-audit-h638r8` branch.

https://claude.ai/code/session_01GGotvNGnZVJjsf5stQzS8o

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGotvNGnZVJjsf5stQzS8o)_