### PR TITLE
Fix check_integrity() discarding live non-durable state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@
   in debug builds) after a persistent savepoint was deleted or restored.
 * Fix a panic when opening a database file that was externally extended to an invalid size; such
   files are now rejected with `StorageError::Corrupted`.
+* Fix a bug where `Database::check_integrity()` silently rolled back transactions that were
+  committed with `Durability::None`. A clean check now makes pending non-durable commits durable
+  instead of discarding them. `check_integrity()` also now returns
+  `DatabaseError::TransactionInProgress` if a `Savepoint` exists, since restoring a savepoint
+  that survived the check could corrupt the database.
+* Fix a panic in `check_integrity()` when repairing a corrupt database whose freed-page list
+  references an out-of-range page; such corruption is now reported instead of panicking.
 
 ### Python bindings
 * Add `Database.create(path)` for creating or opening a database file.

--- a/src/db.rs
+++ b/src/db.rs
@@ -576,10 +576,20 @@ impl Database {
     /// Returns `Ok(true)` if the database passed integrity checks; `Ok(false)` if it failed but was repaired,
     /// and `Err(Corrupted)` if the check failed and the file could not be repaired.
     ///
-    /// Returns [`DatabaseError::TransactionInProgress`] if any read or write transaction is still
-    /// alive when this method is called.
+    /// Returns [`DatabaseError::TransactionInProgress`] if any read or write transaction, or an
+    /// ephemeral [`Savepoint`](crate::Savepoint), is still alive when this method is called.
+    ///
+    /// Transactions committed with [`Durability::None`](crate::Durability::None) that have not yet
+    /// been made durable are made durable if the check passes, or rolled back if the database must
+    /// be repaired.
     pub fn check_integrity(&mut self) -> Result<bool, DatabaseError> {
         if Arc::get_mut(&mut self.mem).is_none() {
+            return Err(DatabaseError::TransactionInProgress);
+        }
+        // An ephemeral savepoint may pin a non-durable transaction whose pages the reload below
+        // discards; restoring it afterwards could corrupt the database. Persistent savepoints are
+        // durable, so they are unaffected.
+        if self.transaction_tracker.any_ephemeral_savepoint_exists() {
             return Err(DatabaseError::TransactionInProgress);
         }
 
@@ -602,6 +612,23 @@ impl Database {
             Ok(false) | Err(StorageError::Corrupted(_)) => false,
             Err(err) => return Err(err.into()),
         };
+
+        // The reload below would discard acknowledged non-durable commits, so make them durable
+        // first when the live state is clean. Skip the flush if the on-disk header was modified
+        // externally, since committing would overwrite it and hide that corruption from the
+        // checks below. If they can't be flushed safely, rolling them back is reported as unclean.
+        if self.mem.pending_non_durable_commit() {
+            if was_clean && self.mem.durable_primary_unmodified()? {
+                let mut txn = self
+                    .begin_write()
+                    .map_err(|e| DatabaseError::Storage(e.into_storage_error()))?;
+                txn.disable_post_commit_free();
+                txn.commit()
+                    .map_err(|e| DatabaseError::Storage(e.into_storage_error()))?;
+            } else {
+                was_clean = false;
+            }
+        }
 
         let mem = Arc::get_mut(&mut self.mem).unwrap();
         if !mem.clear_cache_and_reload()? {
@@ -927,7 +954,7 @@ impl Database {
                 PageResolver::new(mem.clone()),
             )?;
             tables.visit_all_pages(|path| {
-                mem.mark_page_allocated(path.page_number());
+                mem.mark_page_allocated(path.page_number())?;
                 Ok(())
             })?;
         }
@@ -949,17 +976,17 @@ impl Database {
                 PageResolver::new(mem.clone()),
             )?;
             system_tables.visit_all_pages(|path| {
-                mem.mark_page_allocated(path.page_number());
+                mem.mark_page_allocated(path.page_number())?;
                 Ok(())
             })?;
         }
 
         Self::visit_freed_tree(system_root, DATA_FREED_TABLE, mem.clone(), |page| {
-            mem.mark_page_allocated(page);
+            mem.mark_page_allocated(page)?;
             Ok(())
         })?;
         Self::visit_freed_tree(system_root, SYSTEM_FREED_TABLE, mem.clone(), |page| {
-            mem.mark_page_allocated(page);
+            mem.mark_page_allocated(page)?;
             Ok(())
         })?;
         #[cfg(debug_assertions)]

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -273,6 +273,16 @@ impl TransactionTracker {
         !self.state.lock().unwrap().persistent_savepoints.is_empty()
     }
 
+    // True if an ephemeral (non-persistent) savepoint exists. Unlike persistent ones, it may pin a
+    // non-durable transaction whose pages a reload would discard.
+    pub(crate) fn any_ephemeral_savepoint_exists(&self) -> bool {
+        let state = self.state.lock().unwrap();
+        state
+            .valid_savepoints
+            .keys()
+            .any(|id| !state.persistent_savepoints.contains(id))
+    }
+
     // Excludes internal read refs that only pin durable ancestors of pending
     // non-durable commits.
     pub(crate) fn any_user_read_reference_exists(&self) -> bool {

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -217,6 +217,13 @@ impl BuddyAllocator {
         self.len
     }
 
+    // True if `page_number` at `order` is in range for this region's allocator. Used to validate
+    // page numbers read from a possibly-corrupt freed tree during repair, before `record_alloc`
+    // (which assumes a valid page and would otherwise panic).
+    pub(crate) fn is_valid_page(&self, page_number: u32, order: u8) -> bool {
+        order <= self.max_order && page_number < self.get_order_free(order).len()
+    }
+
     pub(crate) fn resize(&mut self, new_size: u32) {
         self.debug_check_consistency();
         if new_size > self.len() {

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -152,6 +152,28 @@ impl UnrepairedDatabaseHeader {
         self.inner.page_size
     }
 
+    // True if the durable primary commit still matches `current`: the primary slot bytes and
+    // checksum, the 2-phase flag, and the immutable metadata (page size, region geometry). The
+    // secondary slot, layout, and recovery flag are excluded, since non-durable commits and grow()
+    // change those only in memory.
+    pub(super) fn primary_slot_unchanged(&self, current: &DatabaseHeader) -> bool {
+        !self.primary_corrupted
+            && self.inner.primary_slot == current.primary_slot
+            && self.inner.two_phase_commit == current.two_phase_commit
+            && self.inner.page_size == current.page_size
+            && self.inner.region_header_pages == current.region_header_pages
+            && self.inner.region_max_data_pages == current.region_max_data_pages
+            && self.inner.primary_slot().to_bytes() == current.primary_slot().to_bytes()
+    }
+
+    // True if the on-disk layout fields (the region count and trailing-region size, which are not
+    // covered by the slot checksum) match `current`. Only meaningful when the in-memory layout has
+    // not grown ahead of the durable one; see `durable_primary_unmodified`.
+    pub(super) fn layout_matches(&self, current: &DatabaseHeader) -> bool {
+        self.inner.full_regions == current.full_regions
+            && self.inner.trailing_partial_region_pages == current.trailing_partial_region_pages
+    }
+
     // Returns true if the header needs to be repaired before use: either the recovery_required
     // flag is set on disk, or the stored layout no longer matches the current file length (e.g.
     // the file was truncated or extended externally). Callers must pass the actual file length

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -245,6 +245,10 @@ struct InMemoryState {
     // to readers until a durable commit promotes it to the primary slot on disk. Protected by the
     // enclosing Mutex so updates happen atomically with the header changes they describe.
     read_from_secondary: bool,
+    // True if grow() has extended the file (and the in-memory layout) since the last durable
+    // commit, so the in-memory layout is ahead of the durable header's layout. When false, the two
+    // layouts match, so a divergence indicates external corruption.
+    layout_grown_since_durable: bool,
 }
 
 impl InMemoryState {
@@ -253,6 +257,7 @@ impl InMemoryState {
             header,
             allocators: None,
             read_from_secondary: false,
+            layout_grown_since_durable: false,
         }
     }
 
@@ -538,6 +543,8 @@ impl TransactionalMemory {
             let mut state = self.state.lock().unwrap();
             state.header = header;
             state.read_from_secondary = false;
+            // The reloaded layout is the durable one, so the in-memory layout is no longer ahead.
+            state.layout_grown_since_durable = false;
             // Drop the previous allocator state -- it described the layout that was in memory
             // before the reload. The caller is required to repopulate it (via reset_allocator_state or
             // load_allocator_state) before any allocation/free path runs.
@@ -591,13 +598,26 @@ impl TransactionalMemory {
         Ok(())
     }
 
-    pub(crate) fn mark_page_allocated(&self, page_number: PageNumber) {
+    // Marks a page allocated while rebuilding the allocator during repair. The page number may come
+    // from a corrupt freed tree, so it is bounds-checked against the layout and reported as
+    // corruption rather than panicking in `record_alloc`.
+    pub(crate) fn mark_page_allocated(&self, page_number: PageNumber) -> Result<(), StorageError> {
         let mut state = self.state.lock().unwrap();
         let region_index = page_number.region;
+        if region_index >= state.header.layout().num_regions()
+            || !state
+                .get_region(region_index)
+                .is_valid_page(page_number.page_index, page_number.page_order)
+        {
+            return Err(StorageError::Corrupted(format!(
+                "Page {page_number:?} is out of range for the database layout"
+            )));
+        }
         let allocator = state.get_region_mut(region_index);
         allocator.record_alloc(page_number.page_index, page_number.page_order);
         #[cfg(debug_assertions)]
         assert!(self.allocated_pages.lock().unwrap().insert(page_number));
+        Ok(())
     }
 
     fn write_header(&self, header: &DatabaseHeader) -> Result {
@@ -833,6 +853,8 @@ impl TransactionalMemory {
         );
         state.header = header;
         state.read_from_secondary = false;
+        // This layout is now durable, so the in-memory layout is no longer ahead of it.
+        state.layout_grown_since_durable = false;
         drop(state);
 
         Ok(())
@@ -961,6 +983,30 @@ impl TransactionalMemory {
     pub(crate) fn get_last_durable_transaction_id(&self) -> Result<TransactionId> {
         let state = self.state.lock()?;
         Ok(state.header.primary_slot().transaction_id)
+    }
+
+    // True when a non-durable commit has been made visible to readers but not yet flushed to the
+    // durable primary slot.
+    pub(crate) fn pending_non_durable_commit(&self) -> bool {
+        self.state.lock().unwrap().read_from_secondary
+    }
+
+    // True if the on-disk header's durable primary commit still matches the in-memory copy. Used
+    // to detect external header modification before a commit would overwrite it.
+    pub(crate) fn durable_primary_unmodified(&self) -> Result<bool, DatabaseError> {
+        let header_bytes = self.storage.read_direct(0, DB_HEADER_SIZE)?;
+        let disk_header = UnrepairedDatabaseHeader::from_bytes(&header_bytes)?;
+        let file_len = self.storage.raw_file_len()?;
+        let state = self.state.lock().unwrap();
+        // The file must be at least as large as the in-memory layout: if an external writer
+        // truncated it (e.g. below a length that a pending non-durable commit had grown it to),
+        // flushing would commit a layout pointing past the end of the file. And unless grow() has
+        // moved the in-memory layout ahead of the durable header, the on-disk layout fields must
+        // still match the in-memory ones. A divergence in either is external corruption that the
+        // caller must not overwrite by flushing.
+        let layout_unmodified = file_len >= state.header.layout().len()
+            && (state.layout_grown_since_durable || disk_header.layout_matches(&state.header));
+        Ok(disk_header.primary_slot_unchanged(&state.header) && layout_unmodified)
     }
 
     pub(crate) fn free(&self, page: PageNumber, allocated: &mut PageTrackerPolicy) {
@@ -1263,6 +1309,8 @@ impl TransactionalMemory {
 
         state.allocators_mut().resize_to(new_layout);
         state.header.set_layout(new_layout);
+        // The in-memory layout is now ahead of the durable header until the next durable commit.
+        state.layout_grown_since_durable = true;
         Ok(())
     }
 

--- a/tests/check_integrity_corrupt_repair.rs
+++ b/tests/check_integrity_corrupt_repair.rs
@@ -1,0 +1,269 @@
+//! Regression test: `check_integrity()` must not panic when repairing a corrupt database that has
+//! a pending `Durability::None` commit. The non-durable flush can drive the repair's allocator
+//! rebuild to walk a freed tree containing an out-of-range page number; that must be reported as
+//! corruption (a graceful `Err`/`Ok(false)`), not panic in the allocator bitmap.
+
+use redb::{
+    Database, Durability, ReadableDatabase, ReadableTableMetadata, StorageBackend, TableDefinition,
+};
+use std::sync::{Arc, RwLock};
+
+const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("t");
+
+// Offset of the trailing-region page count (a layout field) in the database header.
+const TRAILING_REGION_DATA_PAGES_OFFSET: usize = 28;
+
+// A backend backed by a shared Vec<u8> so the test can patch arbitrary on-disk bytes, simulating
+// external file modification / corruption.
+#[derive(Clone, Debug, Default)]
+struct PatchBackend {
+    inner: Arc<RwLock<Vec<u8>>>,
+}
+
+impl PatchBackend {
+    fn read_u32(&self, offset: usize) -> u32 {
+        let guard = self.inner.read().unwrap();
+        u32::from_le_bytes(guard[offset..offset + 4].try_into().unwrap())
+    }
+    fn write_u32(&self, offset: usize, value: u32) {
+        self.inner.write().unwrap()[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    }
+    fn file_len(&self) -> usize {
+        self.inner.read().unwrap().len()
+    }
+    fn truncate(&self, len: usize) {
+        self.inner.write().unwrap().truncate(len);
+    }
+    // Flip all bits in the first occurrence of `needle`. Returns whether anything was patched.
+    fn corrupt_first_occurrence(&self, needle: &[u8]) -> bool {
+        let mut guard = self.inner.write().unwrap();
+        let mut i = 0;
+        while i + needle.len() <= guard.len() {
+            if &guard[i..i + needle.len()] == needle {
+                for b in &mut guard[i..i + needle.len()] {
+                    *b ^= 0xFF;
+                }
+                return true;
+            }
+            i += 1;
+        }
+        false
+    }
+}
+
+impl StorageBackend for PatchBackend {
+    fn len(&self) -> Result<u64, std::io::Error> {
+        Ok(self.inner.read().unwrap().len() as u64)
+    }
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
+        let offset = usize::try_from(offset).unwrap();
+        let guard = self.inner.read().unwrap();
+        if offset + out.len() > guard.len() {
+            return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof));
+        }
+        out.copy_from_slice(&guard[offset..offset + out.len()]);
+        Ok(())
+    }
+    fn set_len(&self, len: u64) -> Result<(), std::io::Error> {
+        self.inner
+            .write()
+            .unwrap()
+            .resize(len.try_into().unwrap(), 0);
+        Ok(())
+    }
+    fn sync_data(&self) -> Result<(), std::io::Error> {
+        Ok(())
+    }
+    fn write(&self, offset: u64, data: &[u8]) -> Result<(), std::io::Error> {
+        let offset = usize::try_from(offset).unwrap();
+        let mut guard = self.inner.write().unwrap();
+        if offset + data.len() > guard.len() {
+            return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof));
+        }
+        guard[offset..offset + data.len()].copy_from_slice(data);
+        Ok(())
+    }
+}
+
+fn make_db(backend: PatchBackend, n: u64) -> Database {
+    let db = Database::builder().create_with_backend(backend).unwrap();
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        for k in 0..n {
+            let v = vec![(k as u8).wrapping_add(0xA0); 64];
+            table.insert(&k, v.as_slice()).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+    db
+}
+
+#[test]
+fn check_integrity_corrupt_repair_with_pending_nondurable_commit_does_not_panic() {
+    let backend = PatchBackend::default();
+    let db = make_db(backend.clone(), 10);
+
+    let durable_val = vec![0xC2u8; 64];
+    {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            table.insert(&2u64, durable_val.as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+    // A pending non-durable commit on a different key, so the durable value's leaf stays reachable
+    // from the live root and the non-durable state is what check_integrity() flushes.
+    {
+        let mut txn = db.begin_write().unwrap();
+        txn.set_durability(Durability::None).unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            table.insert(&8u64, [0x88u8; 64].as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    assert!(
+        backend.corrupt_first_occurrence(&durable_val),
+        "could not locate the value on disk to corrupt"
+    );
+
+    // check_integrity() must report the corruption gracefully, never panic and never falsely
+    // report the corrupt database as clean.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut db = db;
+        let r = db.check_integrity();
+        // The database is corrupt; its Drop may itself fail, so leak it rather than risk a
+        // double panic obscuring the result.
+        std::mem::forget(db);
+        r
+    }));
+
+    match result {
+        Err(_) => panic!("check_integrity() panicked instead of reporting corruption"),
+        Ok(Ok(true)) => panic!("check_integrity() reported a corrupt database as clean"),
+        Ok(Ok(false)) | Ok(Err(_)) => {}
+    }
+}
+
+// When a non-durable commit is pending, check_integrity() makes it durable by writing the
+// in-memory header before reloading. The unchecksummed layout fields (region count / trailing
+// region size) must still be validated against the durable header, so external corruption of
+// those bytes is reported rather than overwritten and masked as clean.
+fn check_integrity_reports_corrupt_layout_field(delta: i64) {
+    let backend = PatchBackend::default();
+    let db = make_db(backend.clone(), 50);
+    // A small pending non-durable commit that does not grow the file, so the in-memory layout
+    // still matches the durable header.
+    {
+        let mut txn = db.begin_write().unwrap();
+        txn.set_durability(Durability::None).unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            table.insert(&0u64, [0x99u8; 100].as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    let original = backend.read_u32(TRAILING_REGION_DATA_PAGES_OFFSET);
+    let corrupted = u32::try_from((i64::from(original) + delta).max(0)).unwrap();
+    assert_ne!(original, corrupted, "test did not change the layout field");
+    backend.write_u32(TRAILING_REGION_DATA_PAGES_OFFSET, corrupted);
+
+    let mut db = db;
+    if let Ok(true) = db.check_integrity() {
+        panic!("externally corrupted layout field reported as clean");
+    }
+}
+
+#[test]
+fn check_integrity_reports_layout_field_corrupted_larger() {
+    check_integrity_reports_corrupt_layout_field(1);
+}
+
+#[test]
+fn check_integrity_reports_layout_field_corrupted_smaller() {
+    check_integrity_reports_corrupt_layout_field(-1);
+}
+
+// A non-durable commit that grows the file moves the in-memory layout legitimately ahead of the
+// durable header; check_integrity() must still flush and preserve it, not mistake it for
+// corruption.
+#[test]
+fn check_integrity_preserves_growing_nondurable_commit() {
+    let backend = PatchBackend::default();
+    let mut db = make_db(backend.clone(), 1);
+
+    let len_before = backend.inner.read().unwrap().len();
+    {
+        let mut txn = db.begin_write().unwrap();
+        txn.set_durability(Durability::None).unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            for k in 1000..3000u64 {
+                table.insert(&k, vec![0xEEu8; 2000].as_slice()).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+    assert!(
+        backend.inner.read().unwrap().len() > len_before,
+        "the non-durable commit was expected to grow the file"
+    );
+
+    assert!(db.check_integrity().unwrap());
+
+    let read = db.begin_read().unwrap();
+    let table = read.open_table(TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 2001);
+    assert_eq!(
+        table.get(&2500u64).unwrap().unwrap().value(),
+        [0xEEu8; 2000]
+    );
+}
+
+// If an external writer truncates the file after a non-durable commit grew it, the in-memory
+// (grown) layout is ahead of the file. check_integrity() must not flush that grown layout over the
+// durable header -- doing so would commit a layout pointing past the end of the file, destroying
+// the recoverable durable state. It must instead detect the mismatch and leave the durable state
+// recoverable.
+#[test]
+fn check_integrity_detects_truncation_after_nondurable_growth() {
+    let backend = PatchBackend::default();
+    let mut db = make_db(backend.clone(), 1);
+    let durable_len = backend.file_len();
+
+    {
+        let mut txn = db.begin_write().unwrap();
+        txn.set_durability(Durability::None).unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            for k in 1000..3000u64 {
+                table.insert(&k, vec![0xEEu8; 2000].as_slice()).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+    assert!(
+        backend.file_len() > durable_len,
+        "the non-durable commit was expected to grow the file"
+    );
+
+    // External truncation back to the last durable length (the grown pages remain cached, so the
+    // live checksum pass still succeeds).
+    backend.truncate(durable_len);
+
+    if let Ok(true) = db.check_integrity() {
+        panic!("truncation after non-durable growth reported as clean");
+    }
+    drop(db);
+
+    // The durable state must still be recoverable on reopen.
+    let mut reopened = Database::builder().create_with_backend(backend).unwrap();
+    assert!(reopened.check_integrity().unwrap());
+    let read = reopened.begin_read().unwrap();
+    let table = read.open_table(TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 1);
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2181,6 +2181,179 @@ fn check_integrity_clean_after_delete() {
     assert!(db.check_integrity().unwrap());
 }
 
+// A non-durable commit is acknowledged to the application and visible to readers, so it is part
+// of the live state of the database. check_integrity() on a healthy database must not silently
+// roll it back; it makes it durable instead.
+#[test]
+fn check_integrity_preserves_non_durable_commit() {
+    let tmpfile = create_tempfile();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for k in 0..100u64 {
+            table.insert(&k, &(k * 10)).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let mut txn = db.begin_write().unwrap();
+    txn.set_durability(Durability::None).unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        table.insert(&7777u64, &42u64).unwrap();
+        table.remove(&0u64).unwrap();
+    }
+    txn.commit().unwrap();
+
+    // The non-durable commit is visible before the check
+    {
+        let read = db.begin_read().unwrap();
+        let table = read.open_table(U64_TABLE).unwrap();
+        assert_eq!(table.get(&7777u64).unwrap().unwrap().value(), 42);
+        assert!(table.get(&0u64).unwrap().is_none());
+    }
+
+    assert!(db.check_integrity().unwrap());
+
+    // ... and must still be visible afterwards
+    let read = db.begin_read().unwrap();
+    let table = read.open_table(U64_TABLE).unwrap();
+    assert_eq!(
+        table.get(&7777u64).unwrap().map(|v| v.value()),
+        Some(42),
+        "check_integrity rolled back a non-durable commit (insert lost)"
+    );
+    assert!(
+        table.get(&0u64).unwrap().is_none(),
+        "check_integrity rolled back a non-durable commit (remove undone)"
+    );
+    drop(table);
+    drop(read);
+
+    // The check made the non-durable commit durable, so it must survive reopening
+    drop(db);
+    let db = Database::open(tmpfile.path()).unwrap();
+    let read = db.begin_read().unwrap();
+    let table = read.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.get(&7777u64).unwrap().unwrap().value(), 42);
+    assert!(table.get(&0u64).unwrap().is_none());
+}
+
+// The pre-flush header guard must also cover the immutable metadata fields (page size and
+// region geometry): if an external write corrupts them while a non-durable commit is pending,
+// check_integrity() must not flush the in-memory header over the corruption and report clean.
+#[test]
+fn check_integrity_detects_external_header_corruption_with_pending_commit() {
+    // A shared backend stands in for external file modification, since the OS file lock
+    // prevents writing to the database file from a second handle on some platforms
+    let backend = SharedInMemoryBackend::default();
+    let mut db = Database::builder()
+        .create_with_backend(backend.clone())
+        .unwrap();
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for k in 0..100u64 {
+            table.insert(&k, &(k * 10)).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let mut txn = db.begin_write().unwrap();
+    txn.set_durability(Durability::None).unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        table.insert(&7777u64, &42u64).unwrap();
+    }
+    txn.commit().unwrap();
+
+    // Externally corrupt the immutable region-geometry field in the header
+    // (region_max_data_pages, a u32 at byte offset 20)
+    let mut field = [0u8; 4];
+    backend.read(20, &mut field).unwrap();
+    let corrupted = (u32::from_le_bytes(field) ^ 1).to_le_bytes();
+    backend.write(20, &corrupted).unwrap();
+
+    // The corruption must be reported (Ok(false) or Err), never masked as clean
+    let result = db.check_integrity();
+    assert!(
+        !matches!(result, Ok(true)),
+        "externally corrupted header reported as clean: {result:?}"
+    );
+}
+
+// A savepoint references roots and allocator state that check_integrity() invalidates, so the
+// check must refuse to run while one exists: a savepoint that stayed "valid" across the check
+// could be restored after its pages were freed and reused, corrupting the database.
+#[test]
+fn check_integrity_with_live_savepoint_on_nondurable_commit() {
+    let table2: TableDefinition<u64, &[u8]> = TableDefinition::new("x2");
+
+    let tmpfile = create_tempfile();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+
+    // Durable baseline
+    let txn = db.begin_write().unwrap();
+    {
+        let mut t = txn.open_table(U64_TABLE).unwrap();
+        t.insert(0, 0).unwrap();
+    }
+    txn.commit().unwrap();
+
+    // Non-durable commit with real data
+    let mut txn = db.begin_write().unwrap();
+    txn.set_durability(Durability::None).unwrap();
+    {
+        let mut t = txn.open_table(U64_TABLE).unwrap();
+        for k in 1..100u64 {
+            t.insert(k, k * 10).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    // Ephemeral savepoint referencing the non-durable root
+    let txn = db.begin_write().unwrap();
+    let savepoint = txn.ephemeral_savepoint().unwrap();
+    txn.abort().unwrap();
+
+    // The check must refuse to run while the savepoint exists
+    assert!(matches!(
+        db.check_integrity(),
+        Err(DatabaseError::TransactionInProgress)
+    ));
+
+    // The savepoint must still be restorable
+    let mut txn = db.begin_write().unwrap();
+    txn.restore_savepoint(&savepoint).unwrap();
+    txn.commit().unwrap();
+    drop(savepoint);
+
+    // Write a bunch of unrelated data, to reuse any pages the allocator thinks are free
+    let txn = db.begin_write().unwrap();
+    {
+        let mut t = txn.open_table(table2).unwrap();
+        let big = vec![0xABu8; 4096];
+        for k in 0..100u64 {
+            t.insert(k, big.as_slice()).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    // The restored data must be intact
+    let read = db.begin_read().unwrap();
+    let t = read.open_table(U64_TABLE).unwrap();
+    for k in 1..100u64 {
+        let v = t.get(k).unwrap();
+        assert_eq!(v.map(|x| x.value()), Some(k * 10), "key {k} corrupted");
+    }
+    drop(t);
+    drop(read);
+
+    // Once the savepoint is gone, the check runs and the database is healthy
+    assert!(db.check_integrity().unwrap());
+}
+
 #[test]
 fn multimap_stats() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
## Problem

`Database::check_integrity()` reloaded the database state from disk, which silently rolled back transactions committed with `Durability::None`: the data was acknowledged by `commit()` and visible to readers, but vanished while the check reported the database as clean (`Ok(true)`). Worse, an **ephemeral** `Savepoint` taken on non-durable state survived the check still marked valid while the pages it referenced were freed by the allocator rebuild — restoring it afterwards corrupted the database (debug builds hit `debug_assert!(!page_allocator.uncommitted(page))` on the next commit; release builds silently clobbered committed data).

The silent rollback existed in released versions (4.1's `check_integrity()` also reloaded from disk); the savepoint hole exists because a `Savepoint` holds only an `Arc<TransactionTracker>`, so the `Arc::get_mut(&mut self.mem)` exclusivity guard could not see it.

## Fix

* `check_integrity()` now returns `DatabaseError::TransactionInProgress` if an **ephemeral** savepoint exists. Persistent savepoints reference durable state (they require `Immediate` durability and are stored in the on-disk savepoint table), so the reload handles them correctly and they remain permitted — this preserves the behavior covered by `check_integrity_with_persistent_savepoint_then_restore`.
* Pending non-durable commits are made durable before the reload (the same flush `Database::drop` performs, with post-commit-free disabled), so a clean check preserves them. The flush only runs when the live state verified clean **and** a `durable_primary_unmodified()` check confirms the on-disk header's primary slot is unmodified — so externally injected corruption is still detected rather than overwritten. When pending commits cannot be flushed safely, rolling them back is reported as `Ok(false)`.

## Tests

- `check_integrity_preserves_non_durable_commit` — failed on master in both debug and release (committed keys vanished while the check reported clean).
- `check_integrity_with_live_savepoint_on_nondurable_commit` — failed on master (allocator corruption after restoring an ephemeral savepoint).
- The existing persistent-savepoint integrity tests continue to pass.

`just test` is green and `just fuzz_ci` found no crashes.

---

Found by a codebase audit; the original failing repros are on the `claude/codebase-bug-audit-h638r8` branch.

https://claude.ai/code/session_01GGotvNGnZVJjsf5stQzS8o