### PR TITLE
Fix database becoming permanently unopenable after a crash during a file-growing commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # redb - Changelog
 
 ## 4.2.0 - 2026-XX-XX
+* Fix a crash during a transaction that grows the database file leaving the database permanently
+  unopenable afterward.
 * Optimize `Table::retain()` and `Table::retain_in()`. Some benchmarks on large tables show a 25x speedup.
 * Optimize `Table::extract_if()` and `Table::extract_from_if()`. Benchmarks on large tables show
   a 1.6-4x speedup, depending on the fraction of entries extracted, and iterating the extract

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -423,6 +423,14 @@ impl PagedCachedFile {
         self.file.sync_data()
     }
 
+    // Make the backing file durable without flushing the in-memory write buffer. `set_len` is
+    // issued directly to the file (it is not buffered), so this is enough to make the current file
+    // length durable, and unlike `flush()` it is safe to call while writable pages are still
+    // outstanding (e.g. during `grow()`).
+    pub(super) fn sync_file(&self) -> Result {
+        self.file.sync_data()
+    }
+
     // Make writes visible to readers, but does not guarantee any durability
     pub(super) fn write_barrier(&self) -> Result {
         // TODO: non-durable commits would be much faster, if this did not issues writes to disk,

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1253,6 +1253,13 @@ impl TransactionalMemory {
         assert!(new_layout.len() >= layout.len());
 
         self.storage.resize(new_layout.len())?;
+        // Make the larger file durable before its layout can reach the on-disk header. A
+        // subsequent commit writes this layout into the header, whose layout fields are shared by
+        // both commit slots; if a crash persisted that header but not the file extension, every
+        // open would fail with "File truncated below stored layout" even though the previous
+        // durable state was intact. This mirrors the shrink path, which reduces the file only
+        // after the smaller layout is durable.
+        self.storage.sync_file()?;
 
         state.allocators_mut().resize_to(new_layout);
         state.header.set_layout(new_layout);

--- a/tests/crash_consistency.rs
+++ b/tests/crash_consistency.rs
@@ -1,0 +1,165 @@
+//! Regression test for a crash during a transaction that grows the database file.
+//!
+//! `grow()` extends the file with `set_len` and a subsequent commit writes the grown layout into
+//! the header, whose layout fields are shared by both commit slots. If a crash persisted that
+//! header but not the file extension, every later open failed with
+//! `Corrupted("File truncated below stored layout")` -- permanent data loss -- even though the
+//! previous durable state was intact. The fix makes the file extension durable as the file grows.
+
+use redb::backends::InMemoryBackend;
+use redb::{Database, ReadableDatabase, StorageBackend, TableDefinition};
+use std::io::ErrorKind;
+use std::sync::{Arc, Mutex};
+
+const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+
+#[derive(Debug, Default)]
+struct CrashState {
+    // Current file contents (every write is applied here immediately).
+    live: Vec<u8>,
+    // Contents made durable by a completed sync.
+    durable: Vec<u8>,
+    // The most recent write to offset 0 (the header), which reaches the disk page cache even when
+    // the following sync does not complete.
+    last_header: Vec<u8>,
+    syncs: u64,
+    // Once `syncs` reaches this value, syncs stop advancing `durable` (the simulated crash point).
+    freeze_from: Option<u64>,
+}
+
+// A backend that can reconstruct the file image left by a crash in which the header write reached
+// the disk but the file extension and the data written after the file grew did not.
+#[derive(Clone, Debug, Default)]
+struct CrashBackend {
+    state: Arc<Mutex<CrashState>>,
+}
+
+impl CrashBackend {
+    fn syncs(&self) -> u64 {
+        self.state.lock().unwrap().syncs
+    }
+
+    fn freeze_at(&self, sync: u64) {
+        self.state.lock().unwrap().freeze_from = Some(sync);
+    }
+
+    // The bytes that survive the crash: everything durable, with the header write overlaid (it
+    // reached the page cache) but the file length and post-grow data left at their durable values.
+    fn crash_image(&self) -> Vec<u8> {
+        let state = self.state.lock().unwrap();
+        let mut image = state.durable.clone();
+        if !state.last_header.is_empty() && image.len() >= state.last_header.len() {
+            image[..state.last_header.len()].copy_from_slice(&state.last_header);
+        }
+        image
+    }
+}
+
+impl StorageBackend for CrashBackend {
+    fn len(&self) -> Result<u64, std::io::Error> {
+        Ok(self.state.lock().unwrap().live.len() as u64)
+    }
+
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
+        let state = self.state.lock().unwrap();
+        let offset = usize::try_from(offset).unwrap();
+        if offset + out.len() > state.live.len() {
+            return Err(std::io::Error::from(ErrorKind::UnexpectedEof));
+        }
+        out.copy_from_slice(&state.live[offset..offset + out.len()]);
+        Ok(())
+    }
+
+    fn set_len(&self, len: u64) -> Result<(), std::io::Error> {
+        self.state
+            .lock()
+            .unwrap()
+            .live
+            .resize(usize::try_from(len).unwrap(), 0);
+        Ok(())
+    }
+
+    fn sync_data(&self) -> Result<(), std::io::Error> {
+        let mut state = self.state.lock().unwrap();
+        state.syncs += 1;
+        if state.freeze_from.is_none_or(|f| state.syncs < f) {
+            state.durable = state.live.clone();
+        }
+        Ok(())
+    }
+
+    fn write(&self, offset: u64, data: &[u8]) -> Result<(), std::io::Error> {
+        let mut state = self.state.lock().unwrap();
+        let offset = usize::try_from(offset).unwrap();
+        if offset + data.len() > state.live.len() {
+            state.live.resize(offset + data.len(), 0);
+        }
+        state.live[offset..offset + data.len()].copy_from_slice(data);
+        if offset == 0 {
+            state.last_header = data.to_vec();
+        }
+        Ok(())
+    }
+}
+
+// Runs a small workload that commits a baseline durably and then commits a transaction large
+// enough to grow the file.
+fn workload(db: &Database) {
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        table.insert(&0, [0u8; 100].as_slice()).unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        let value = vec![0xAB; 4096];
+        for k in 1..2000u64 {
+            table.insert(&k, value.as_slice()).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+}
+
+#[test]
+fn crash_during_growing_commit_is_recoverable() {
+    // Pass 1: count the syncs performed through the growing commit (before the Database is dropped,
+    // whose own shutdown performs additional syncs).
+    let probe = CrashBackend::default();
+    let total_syncs = {
+        let db = Database::builder()
+            .create_with_backend(probe.clone())
+            .unwrap();
+        workload(&db);
+        probe.syncs()
+    };
+
+    // Pass 2: freeze durability at the growing commit's final flush, simulating a crash in which
+    // the header reached the disk but the file extension did not.
+    let backend = CrashBackend::default();
+    backend.freeze_at(total_syncs);
+    let image = {
+        let db = Database::builder()
+            .create_with_backend(backend.clone())
+            .unwrap();
+        workload(&db);
+        backend.crash_image()
+    };
+
+    // The recovered database must open and expose a valid committed state. The baseline commit was
+    // durable before the file grew, so its data must survive.
+    let recovered = InMemoryBackend::new();
+    recovered.set_len(image.len() as u64).unwrap();
+    recovered.write(0, &image).unwrap();
+    let mut db = Database::builder()
+        .create_with_backend(recovered)
+        .expect("database must be recoverable after a crash during a file-growing commit");
+    {
+        let txn = db.begin_read().unwrap();
+        let table = txn.open_table(TABLE).unwrap();
+        assert_eq!(table.get(&0).unwrap().unwrap().value(), [0u8; 100]);
+    }
+    assert!(db.check_integrity().unwrap());
+}


### PR DESCRIPTION
## Problem

`grow()` extends the database file with `set_len`, and the only barrier ordering that extension against the subsequent header write was the commit's final fsync. The header's layout fields (`full_regions` / `trailing_partial_region_pages`) are shared by **both** commit slots. If the commit's fsync failed (commit correctly returns `Err`) and the process then crashed such that the header write persisted but the file extension did not, every subsequent open failed with `Corrupted("File truncated below stored layout")` — even though the previous durable state was fully intact in the file. Because the layout fields are shared, both commit slots are unusable: permanent data loss. In v4.1.0 and earlier the equivalent open-path `assert!(raw_file_len >= layout.len())` panicked on every open instead, so released versions are equally affected.

## Fix

The shrink path already maintains the invariant `file_len >= layout_len` by reducing the file only *after* the smaller layout is durable. Growth was asymmetric: it extended the file without making the extension durable before the larger layout reached the header.

Restore the symmetry — make the file extension durable in `grow()`, right after it is requested and before any commit can write the larger layout into the header. This uses a new `sync_file()` that fsyncs the backing file **without** flushing the in-memory write buffer, so it is safe to call while writable page guards are still outstanding during allocation (`set_len` is issued directly to the backend, not buffered, and `fdatasync` persists file-size changes). With `file_len >= layout_len` preserved at every crash point, the existing strict rejection of a short file stays correct, so no recovery-path changes are needed.

The whole production change is ~17 lines.

## Tests

`tests/crash_consistency.rs` reconstructs the post-crash file image in which the header write reached the disk but the file extension (and the data written after the file grew) did not, and asserts the database still opens to a valid committed state with integrity intact. The test fails before this change (open returns the "truncated below stored layout" error) and passes after.

`just test` is green and `just fuzz_ci` found no crashes.

---

Found by a codebase audit; the original failing repros are on the `claude/codebase-bug-audit-h638r8` branch.

https://claude.ai/code/session_01GGotvNGnZVJjsf5stQzS8o