### PR TITLE
Reject check_integrity() while an ephemeral savepoint exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
   in debug builds) after a persistent savepoint was deleted or restored.
 * Fix a panic when opening a database file that was externally extended to an invalid size; such
   files are now rejected with `StorageError::Corrupted`.
+* `check_integrity()` now returns `DatabaseError::TransactionInProgress` when an ephemeral
+  `Savepoint` is still alive. Previously the check could invalidate the pages such a savepoint
+  referenced while leaving it marked valid, so restoring it afterward could corrupt the database.
 
 ### Python bindings
 * Add `Database.create(path)` for creating or opening a database file.

--- a/src/db.rs
+++ b/src/db.rs
@@ -576,10 +576,16 @@ impl Database {
     /// Returns `Ok(true)` if the database passed integrity checks; `Ok(false)` if it failed but was repaired,
     /// and `Err(Corrupted)` if the check failed and the file could not be repaired.
     ///
-    /// Returns [`DatabaseError::TransactionInProgress`] if any read or write transaction is still
-    /// alive when this method is called.
+    /// Returns [`DatabaseError::TransactionInProgress`] if any read or write transaction, or an
+    /// ephemeral [`Savepoint`](crate::Savepoint), is still alive when this method is called.
     pub fn check_integrity(&mut self) -> Result<bool, DatabaseError> {
         if Arc::get_mut(&mut self.mem).is_none() {
+            return Err(DatabaseError::TransactionInProgress);
+        }
+        // An ephemeral savepoint may pin a non-durable transaction whose pages the reload below
+        // discards; restoring it afterwards could corrupt the database. Persistent savepoints are
+        // durable, so they are unaffected.
+        if self.transaction_tracker.any_ephemeral_savepoint_exists() {
             return Err(DatabaseError::TransactionInProgress);
         }
 

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -273,6 +273,16 @@ impl TransactionTracker {
         !self.state.lock().unwrap().persistent_savepoints.is_empty()
     }
 
+    // True if an ephemeral (non-persistent) savepoint exists. Unlike persistent ones, it may pin a
+    // non-durable transaction whose pages a reload would discard.
+    pub(crate) fn any_ephemeral_savepoint_exists(&self) -> bool {
+        let state = self.state.lock().unwrap();
+        state
+            .valid_savepoints
+            .keys()
+            .any(|id| !state.persistent_savepoints.contains(id))
+    }
+
     // Excludes internal read refs that only pin durable ancestors of pending
     // non-durable commits.
     pub(crate) fn any_user_read_reference_exists(&self) -> bool {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2181,6 +2181,77 @@ fn check_integrity_clean_after_delete() {
     assert!(db.check_integrity().unwrap());
 }
 
+// A savepoint references roots and allocator state that check_integrity() invalidates, so the
+// check must refuse to run while an ephemeral one exists: a savepoint that stayed "valid" across
+// the check could be restored after its pages were freed and reused, corrupting the database.
+#[test]
+fn check_integrity_with_live_savepoint_on_nondurable_commit() {
+    let table2: TableDefinition<u64, &[u8]> = TableDefinition::new("x2");
+
+    let tmpfile = create_tempfile();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+
+    // Durable baseline
+    let txn = db.begin_write().unwrap();
+    {
+        let mut t = txn.open_table(U64_TABLE).unwrap();
+        t.insert(0, 0).unwrap();
+    }
+    txn.commit().unwrap();
+
+    // Non-durable commit with real data
+    let mut txn = db.begin_write().unwrap();
+    txn.set_durability(Durability::None).unwrap();
+    {
+        let mut t = txn.open_table(U64_TABLE).unwrap();
+        for k in 1..100u64 {
+            t.insert(k, k * 10).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    // Ephemeral savepoint referencing the non-durable root
+    let txn = db.begin_write().unwrap();
+    let savepoint = txn.ephemeral_savepoint().unwrap();
+    txn.abort().unwrap();
+
+    // The check must refuse to run while the savepoint exists
+    assert!(matches!(
+        db.check_integrity(),
+        Err(DatabaseError::TransactionInProgress)
+    ));
+
+    // The savepoint must still be restorable
+    let mut txn = db.begin_write().unwrap();
+    txn.restore_savepoint(&savepoint).unwrap();
+    txn.commit().unwrap();
+    drop(savepoint);
+
+    // Write a bunch of unrelated data, to reuse any pages the allocator thinks are free
+    let txn = db.begin_write().unwrap();
+    {
+        let mut t = txn.open_table(table2).unwrap();
+        let big = vec![0xABu8; 4096];
+        for k in 0..100u64 {
+            t.insert(k, big.as_slice()).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    // The restored data must be intact
+    let read = db.begin_read().unwrap();
+    let t = read.open_table(U64_TABLE).unwrap();
+    for k in 1..100u64 {
+        let v = t.get(k).unwrap();
+        assert_eq!(v.map(|x| x.value()), Some(k * 10), "key {k} corrupted");
+    }
+    drop(t);
+    drop(read);
+
+    // Once the savepoint is gone, the check runs and the database is healthy
+    assert!(db.check_integrity().unwrap());
+}
+
 #[test]
 fn multimap_stats() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
## Problem

This is the first of three smaller PRs splitting up #1275, whose single commit bundled three separable issues. This PR carries only the **ephemeral-savepoint** fix.

An ephemeral `Savepoint` holds only an `Arc<TransactionTracker>`, so the `Arc::get_mut(&mut self.mem)` exclusivity guard at the top of `check_integrity()` cannot see it. The check reloads the database state from disk, which frees the pages the savepoint referenced while leaving the savepoint still marked valid. Restoring it afterward then reused those freed pages, corrupting the database:

* debug builds hit the `debug_assert!(!page_allocator.uncommitted(page))` assertion on the next commit;
* release builds silently clobbered committed data.

## Fix

`check_integrity()` now returns `DatabaseError::TransactionInProgress` when an **ephemeral** savepoint is alive. Persistent savepoints reference durable state (they require `Immediate` durability and live in the on-disk savepoint table), so the reload handles them correctly and they remain permitted — preserving the behavior covered by `check_integrity_with_persistent_savepoint_then_restore` (#1274).

## Tests

* `check_integrity_with_live_savepoint_on_nondurable_commit` — takes an ephemeral savepoint over non-durable state, asserts the check refuses to run, then restores the savepoint and writes unrelated data to reuse any pages the allocator thinks are free, verifying the restored data stays intact.

`just test` is green; `cargo fmt --check` and `cargo clippy --all-targets --all-features` are clean.

## Follow-ups

The remaining two issues from #1275 will come as separate PRs once this lands:
1. Bounds-check page numbers during repair (`mark_page_allocated` panicking on a corrupt freed tree).
2. Preserve non-durable commits across `check_integrity()` (the core fix plus its corruption-masking guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUbh5Lyi6oofNDZMHfYtV6)_