### PR TITLE
Fuzz two-phase commit in the fuzz_redb harness

### DIFF
--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -160,6 +160,7 @@ pub(crate) struct FuzzTransaction {
     pub ops: Vec<FuzzOperation>,
     pub durable: bool,
     pub quick_repair: bool,
+    pub two_phase: bool,
     pub commit: bool,
     pub close_db: bool,
     pub create_ephemeral_savepoint: bool,

--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -773,6 +773,7 @@ fn exec_table_crash_support<T: Clone + Debug>(
             txn.set_durability(Durability::None).unwrap();
         }
         txn.set_quick_repair(transaction.quick_repair);
+        txn.set_two_phase_commit(transaction.two_phase);
         let mut counter_table = txn.open_table(COUNTER_TABLE).unwrap();
         let uncommitted_id = txn_id as u64 + 1;
         counter_table.insert((), uncommitted_id)?;


### PR DESCRIPTION
## Problem

The `fuzz_redb` harness never exercised 2-phase commit: `FuzzTransaction` toggled `durable` and `quick_repair`, but never called `WriteTransaction::set_two_phase_commit`. As a result the explicit 2-phase commit path (the slot write + fsync + god-byte flip + fsync sequence, and the corresponding crash/recovery slot-selection logic) went unfuzzed.

## Change

Add a `two_phase: bool` field to `FuzzTransaction` and call `txn.set_two_phase_commit(transaction.two_phase)` alongside the existing `set_quick_repair`, so the fuzzer now covers both 1-phase and 2-phase commits (and their interaction with `Durability::None`, quick-repair, savepoints, and crash recovery).

No production code change. A 25-minute run with this change (415k executions) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcdsenBSiQMmWDWekNjhQ5)_