### PR TITLE
Correct design doc: non-durable commits may reclaim unpersisted pages

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -325,7 +325,10 @@ Non-durable commits are implemented with an in-memory flag that directs readers 
 even though it is not yet promoted to the primary.
 In the event of a crash, the database will simply rollback to the primary page and the allocator state can be safely
 rebuilt via the normal repair process.
-Note that freeing pages during a non-durable commit is not permitted, because it could be rolled back at anytime.
+Note that a non-durable commit may only free pages that were themselves allocated by an earlier, not-yet-durable
+commit. Such pages cannot be referenced by the last durable commit, so reclaiming them is safe even if the
+non-durable commit is later rolled back. Pages that are durable must never be freed during a non-durable commit,
+since the commit could be rolled back at any time.
 
 ## 1-phase + checksum durable commits (1PC+C)
 A reduced latency commit strategy is used by default. A commit is performed with a single `fsync`.


### PR DESCRIPTION
## Problem

`docs/design.md` states, in the non-durable commit section:

> Note that freeing pages during a non-durable commit is not permitted, because it could be rolled back at anytime.

This is no longer accurate. The "file space reclamation during non-durable transactions" work (4.2.0) made non-durable commits reclaim pages — but only pages that were themselves allocated by an *earlier, not-yet-durable* commit (`process_freed_pages_nondurable` → `free_if_unpersisted`). Those pages can never be referenced by the last durable commit, so reclaiming them is safe even though the non-durable commit may be rolled back. Durable pages still must not be freed during a non-durable commit.

The stale text describes a load-bearing correctness invariant, so a future reader/auditor could draw the wrong conclusion about what the code is allowed to do.

## Change

Doc-only: update the non-durable commit section to describe the actual (safe) reclamation rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcdsenBSiQMmWDWekNjhQ5)_