### PR TITLE
Convert a multimap value-set to a subtree before its u16 count overflows

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -490,7 +490,12 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                         <() as Value>::fixed_width(),
                     );
 
-                    if required_inline_bytes < self.page_allocator.get_page_size() / 2 {
+                    // Keep the value-set inline only while it fits in half a page AND its entry
+                    // count stays within the u16 num_pairs field of an inline leaf; otherwise
+                    // convert to a subtree (RawLeafBuilder::new would panic on a u16 overflow).
+                    if required_inline_bytes < self.page_allocator.get_page_size() / 2
+                        && u16::try_from(new_pairs).is_ok()
+                    {
                         let mut data = vec![0; required_inline_bytes];
                         let mut builder = RawLeafBuilder::new(
                             &mut data,


### PR DESCRIPTION
A multimap value-set is stored **inline** (encoded as a leaf node, whose `num_pairs` is a `u16`) until it no longer fits in half a page, at which point it converts to a subtree. The inline-vs-subtree decision in `MultimapTable::insert` was **purely byte-based**, so with a large page size more than `u16::MAX` values can fit inline, and `RawLeafBuilder::new` panicked on the `u16` count overflow:

```
thread '...' panicked at src/tree_store/btree_base.rs:884:
called `Result::unwrap()` on an `Err` value: TryFromIntError(())
```

This is the multimap analog of #1284 (leaf/branch `should_split`). That fix lives in `LeafBuilder::should_split`, but the multimap inline path calls `RawLeafBuilder::new` directly and never goes through `should_split`, so it needs its own count guard. Once the value-set converts to a subtree, the subtree's leaves split correctly via the (already-fixed) `should_split` path.

## Fix

Keep the value-set inline only while it both fits in half a page **and** its entry count stays within `u16`; otherwise convert to a subtree. The new-key path (always 1 value) and the remove path (count only shrinks) can't overflow and are unchanged.

## Note on testing

Like #1284 this is only reachable with a page size larger than the default (the test/fuzzing-only `set_page_size`); at the default 4 KiB page the value-set converts to a subtree by byte size long before `u16::MAX` values. Unlike #1284, there is no builder-level shortcut to test it — the inline path is internal to `MultimapTable::insert`, and reproducing it requires inserting `u16::MAX + 1` values under one key, which takes minutes (each insert re-encodes the growing inline leaf, O(n²) via the one-value-at-a-time API). I verified manually that the scenario panics without this change and passes with it; a dedicated regression test is omitted to avoid an ~8-minute addition to the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcdsenBSiQMmWDWekNjhQ5)_