### PR TITLE
Split a leaf before its u32 byte offsets overflow

### DIFF
--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -1048,6 +1048,14 @@ impl<'b> LeafMutator<'b> {
             .unwrap_or_default();
         let required_delta = isize::try_from(new_value.len()).unwrap()
             - isize::try_from(existing_value_len).unwrap();
+        // See sufficient_insert_inplace_space: leaf offsets are u32, so an in-place replace
+        // that grows the value must not push the leaf's total length past u32::MAX. Computed in
+        // u64 so it can't overflow or panic on 32-bit targets (where the bound is unreachable).
+        let new_total_length =
+            accessor.total_length() as u64 - existing_value_len as u64 + new_value.len() as u64;
+        if new_total_length > u64::from(u32::MAX) {
+            return false;
+        }
         required_delta <= isize::try_from(remaining).unwrap()
     }
 
@@ -1076,6 +1084,15 @@ impl<'b> LeafMutator<'b> {
         }
         if fixed_value_size.is_none() {
             required_delta += size_of::<u32>();
+        }
+        // key_end/value_end offsets within a leaf are stored as u32, so the leaf's total
+        // length must stay within u32::MAX. The in-place append path bypasses should_split,
+        // so on a large (oversized-span) page it could otherwise grow a leaf past 4GiB and
+        // overflow those offsets -- e.g. appending small pairs after a near-MAX_PAIR_LENGTH
+        // pair, whose buddy-allocated page rounds up to a ~4GiB span. Force a split instead.
+        // Computed in u64 so it can't overflow or panic on 32-bit targets (where it never trips).
+        if accessor.total_length() as u64 + required_delta as u64 > u64::from(u32::MAX) {
+            return false;
         }
         required_delta <= remaining
     }

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -1048,9 +1048,7 @@ impl<'b> LeafMutator<'b> {
             .unwrap_or_default();
         let required_delta = isize::try_from(new_value.len()).unwrap()
             - isize::try_from(existing_value_len).unwrap();
-        // See sufficient_insert_inplace_space: leaf offsets are u32, so an in-place replace
-        // that grows the value must not push the leaf's total length past u32::MAX. Computed in
-        // u64 so it can't overflow or panic on 32-bit targets (where the bound is unreachable).
+        // Same u32 total-length bound as sufficient_insert_inplace_space.
         let new_total_length =
             accessor.total_length() as u64 - existing_value_len as u64 + new_value.len() as u64;
         if new_total_length > u64::from(u32::MAX) {
@@ -1085,12 +1083,8 @@ impl<'b> LeafMutator<'b> {
         if fixed_value_size.is_none() {
             required_delta += size_of::<u32>();
         }
-        // key_end/value_end offsets within a leaf are stored as u32, so the leaf's total
-        // length must stay within u32::MAX. The in-place append path bypasses should_split,
-        // so on a large (oversized-span) page it could otherwise grow a leaf past 4GiB and
-        // overflow those offsets -- e.g. appending small pairs after a near-MAX_PAIR_LENGTH
-        // pair, whose buddy-allocated page rounds up to a ~4GiB span. Force a split instead.
-        // Computed in u64 so it can't overflow or panic on 32-bit targets (where it never trips).
+        // Leaf offsets are u32, so total length must stay under u32::MAX. The in-place append
+        // path bypasses should_split, so guard it here too. (u64 math avoids 32-bit overflow.)
         if accessor.total_length() as u64 + required_delta as u64 > u64::from(u32::MAX) {
             return false;
         }


### PR DESCRIPTION
## Summary

A leaf node's `key_end`/`value_end` byte offsets are stored as **`u32`**, so a leaf's total content length must stay below `u32::MAX` (4 GiB). But the in-place `LeafMutator` fast paths (`sufficient_insert_inplace_space` / `sufficient_replace_inplace_space`) bypass `should_split` and bound growth only by the **allocated page span** (`page.memory().len()`), not by the offset width.

A single near-`MAX_PAIR_LENGTH` pair (3.75 GiB) is stored **inline** in a leaf whose buddy-allocated page rounds up to a **~4 GiB span**. `should_split` never splits it (it's a single pair, and `MAX_PAIR_LENGTH` is deliberately < 4 GiB to keep *one* pair's offsets in range). `sufficient_insert_inplace_space` then allows appending further small pairs in-place — `page.get_page_number().page_order > 0 && position < num_pairs` only blocks interior inserts, not appends — until cumulative content crosses 4 GiB, at which point:

```rust
let inserted_value_end: u32 = dest.try_into().unwrap();  // btree_base.rs:1175 — panics
let inserted_key_end:   u32 = dest.try_into().unwrap();  // btree_base.rs:1186 — panics
```

(and the `update_value_end`/`update_key_end` casts) panic with `TryFromIntError`. `sufficient_replace_inplace_space` has the same gap when growing a value.

## Relationship to #1284 / #1285

This is the **byte-offset analog** of the `u16` `num_pairs` guards. `sufficient_insert_inplace_space` already carries a `u16` count guard with a comment describing this exact "large page with free space" hazard — but it bounds the *count*, not the *byte offsets*. `MAX_PAIR_LENGTH < 4 GiB` protects a single pair, but **not the combination** of a near-max pair plus appended pairs on its oversized-span page.

## Fix

Add a `u32` total-length guard to both in-place space checks (computed in `u64` so it never overflows or panics on 32-bit targets, where the bound is unreachable), so the leaf is split via the normal `should_split`/`build_split` path instead of overflowing its offsets. These are the only two paths that bypass the builder; every builder path is already implicitly safe, because any leaf reaching 2³² bytes necessarily exceeds `page_size` (a `u32` header field, always < 2³²), so `should_split` already fires.

## Known limitation / follow-up (get_mut / and_modify)

@chatgpt-codex-connector correctly noted that the `AccessGuardMut::insert` path used by `Table::get_mut` / `Entry::and_modify` (btree_base.rs:346-364) rebuilds the leaf with `builder.build()` directly, **without** a `should_split`/`build_split` step. So a grow-replace that pushes a multi-entry leaf past 4 GiB still panics in `RawLeafBuilder`, independent of this PR's guard. Fixing it properly requires teaching that path to split a leaf and propagate a new sibling up the tree — machinery `AccessGuardMut` doesn't currently have (it only rewrites a single child pointer in the parent). I've deliberately scoped that out of this PR (same ~4 GiB-scale, separate machinery) and am happy to follow up with it as a dedicated change if you'd like.

## Testing

`cargo fmt`, `cargo clippy --all-targets`, the lib + `basic_tests` + `multimap_tests` suites, and a `wasm32-wasip1-threads` compile all pass. The guards only engage above 4 GiB of leaf content, so normal paths are unchanged.

I could **not** add a CI regression test: triggering the overflow fundamentally requires materializing ~4 GiB of key/value bytes in a single transaction (the offsets are byte positions — there's no cheaper trigger, even via `set_page_size`). I verified the bug by code analysis: values are stored inline in the leaf page, a 3.75 GiB pair yields a 2³²-byte span page, and the in-place append path is reachable from `Table::insert` and gated only by the span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)