### PR TITLE
Update pyo3 to 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Add `Database.begin_write()`, which returns a `WriteTransaction`
   context manager. Exiting the `with` block commits the transaction on success
   and aborts it if an exception propagates out of the block.
+* The minimum supported Python version is now 3.8 (Python 3.7 is end-of-life).
 
 ## 4.1.0 - 2026-04-19
 **This release contains a large number of bug fixes discovered by AI coding agents**

--- a/crates/redb-python/Cargo.toml
+++ b/crates/redb-python/Cargo.toml
@@ -16,10 +16,10 @@ doc = false
 crate-type = ["cdylib"]
 
 [build-dependencies]
-pyo3-build-config = "0.28.1"
+pyo3-build-config = "0.29.0"
 
 [dependencies]
-pyo3 = { version = "0.28.1", features=["extension-module", "abi3-py37"] }
+pyo3 = { version = "0.29.0", features=["extension-module", "abi3-py38"] }
 redb = { path = "../.." }
 
 [dev-dependencies]

--- a/crates/redb-python/pyproject.toml
+++ b/crates/redb-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redb"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dynamic = ["version"]
 classifier = ["Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Bump `pyo3` and `pyo3-build-config` from `0.28.1` to `0.29.0` in the `redb-python` crate.

## Changes

- **`crates/redb-python/Cargo.toml`**: `pyo3` and `pyo3-build-config` `0.28.1` → `0.29.0`; ABI feature `abi3-py37` → `abi3-py38`.
- **`crates/redb-python/pyproject.toml`**: `requires-python` `>=3.7` → `>=3.8`.

## Why the ABI / Python bump

pyo3 0.29 [drops support for Python 3.7](https://github.com/PyO3/pyo3/pull/5912) and removed the `abi3-py37` feature, so the build fails to select it. Switched to `abi3-py38` (the new lowest stable-ABI target) and updated `requires-python` to match so the wheel metadata stays consistent.

The other 0.29 breaking changes (UTF-8/16 `PyErr` conversions, tuple-based `#[new]` superclass init, `PyCapsule`/`PyCFunction::new_closure`/`PyClassGuard` soundness changes) don't apply to this crate, so no source changes were required.

## Verification

- `cargo build -p redb-python` — compiles cleanly against 0.29.0
- `cargo test -p redb-python` — passes
- `maturin develop` — builds the `abi3-py3.8` wheel and installs it
- `pytest ./crates/redb-python/test` — 13 passed, 5 skipped (skips are pre-existing "API not yet implemented", unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKhoXSCpjxr8HnRCukJA86)_