### PR TITLE
Fix lock-order inversion in MultimapTable::remove subtree collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 4.2.0 - 2026-XX-XX
 * Fix a crash during a transaction that grows the database file leaving the database permanently
   unopenable afterward.
+* Fix a potential deadlock when removing a value from a multimap table causes its value-set to
+  shrink from a subtree back to inline storage, while another table of the same write transaction
+  is used concurrently from a different thread.
 * Optimize `Table::retain()` and `Table::retain_in()`. Some benchmarks on large tables show a
   30-100x speedup, depending on the fraction of entries retained.
 * Optimize `Table::extract_if()` and `Table::extract_from_if()`. Benchmarks on large tables show

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -709,13 +709,17 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                                 self.tree
                                     .insert(key.borrow(), &DynamicCollection::new(&inline_data))?;
                                 drop(page);
+                                // Lock freed_pages before allocated_pages, matching the ordering
+                                // used everywhere else. Two tables of one WriteTransaction share
+                                // these mutexes and may be used from different threads, so the
+                                // reverse order risks an ABBA deadlock with a concurrent insert.
+                                let mut freed_pages = self.freed_pages.lock().unwrap();
                                 let mut allocated_pages = self.allocated_pages.lock().unwrap();
-                                if !self
-                                    .page_allocator
-                                    .free_if_uncommitted(new_root, &mut allocated_pages)
-                                {
-                                    (*self.freed_pages).lock().unwrap().push(new_root);
-                                }
+                                self.page_allocator.conditional_free(
+                                    new_root,
+                                    &mut allocated_pages,
+                                    &mut freed_pages,
+                                );
                             } else {
                                 let subtree_data =
                                     DynamicCollection::<V>::make_subtree_data(BtreeHeader::new(

--- a/tests/multimap_tests.rs
+++ b/tests/multimap_tests.rs
@@ -7,6 +7,8 @@ const STR_TABLE: MultimapTableDefinition<&str, &str> = MultimapTableDefinition::
 const SLICE_U64_TABLE: MultimapTableDefinition<&[u8], u64> =
     MultimapTableDefinition::new("slice_to_u64");
 const U64_TABLE: MultimapTableDefinition<u64, u64> = MultimapTableDefinition::new("u64");
+const U64_SLICE_TABLE: MultimapTableDefinition<u64, &[u8]> =
+    MultimapTableDefinition::new("u64_to_slice");
 
 fn create_tempfile() -> tempfile::NamedTempFile {
     if cfg!(target_os = "wasi") {
@@ -542,4 +544,53 @@ fn multimap_remove_subtree_backed_key() {
     let mut iter = table.get(&0u64).unwrap();
     assert_eq!(iter.next().unwrap().unwrap().value(), 999);
     assert!(iter.next().is_none());
+}
+
+#[test]
+fn multimap_remove_collapses_committed_subtree_to_inline() {
+    // A subtree whose branch root collapses to a *committed* leaf drives
+    // MultimapTable::remove()'s subtree->inline conversion down the path that frees a
+    // committed page. Two small values plus one large value build a subtree with a branch
+    // (small values in one leaf, the large value in another); after committing, removing the
+    // large value collapses the branch and leaves the untouched committed small-value leaf as
+    // the new root, which is below half a page and so is rewritten back to inline storage.
+    let small_a = [0x00u8; 300];
+    let small_b = [0x01u8; 300];
+    // Sorts last (0xFF), so the split keeps both small values together in the first leaf.
+    let large = [0xFFu8; 3700];
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_SLICE_TABLE).unwrap();
+        table.insert(&0u64, small_a.as_slice()).unwrap();
+        table.insert(&0u64, small_b.as_slice()).unwrap();
+        table.insert(&0u64, large.as_slice()).unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_SLICE_TABLE).unwrap();
+        assert!(table.remove(&0u64, large.as_slice()).unwrap());
+        let values: Vec<Vec<u8>> = table
+            .get(&0u64)
+            .unwrap()
+            .map(|v| v.unwrap().value().to_vec())
+            .collect();
+        assert_eq!(values, vec![small_a.to_vec(), small_b.to_vec()]);
+    }
+    write_txn.commit().unwrap();
+
+    // The two small values survive and the large value is gone after the collapse.
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_multimap_table(U64_SLICE_TABLE).unwrap();
+    let values: Vec<Vec<u8>> = table
+        .get(&0u64)
+        .unwrap()
+        .map(|v| v.unwrap().value().to_vec())
+        .collect();
+    assert_eq!(values, vec![small_a.to_vec(), small_b.to_vec()]);
 }


### PR DESCRIPTION
## Problem

`MultimapTable::remove()`'s subtree→inline conversion locked the two page-tracking mutexes in the wrong order. When the collapsed subtree root is a **committed** page, it locked `allocated_pages` and then, while still holding it, locked `freed_pages`:

```rust
let mut allocated_pages = self.allocated_pages.lock().unwrap();       // A
if !self.page_allocator.free_if_uncommitted(new_root, &mut allocated_pages) {
    (*self.freed_pages).lock().unwrap().push(new_root);               // B, while holding A
}
```

Every other site takes these locks in the opposite order, `freed_pages` → `allocated_pages`: `Btree::insert` (`freed_pages` held while `LeafBuilder::build` locks `allocated_pages`), `Btree::get_mut`, `MultimapValue::drop`, and table removal in `table_tree.rs`.

All tables in one `WriteTransaction` share the same two `Arc<Mutex>`es, and using two tables from two threads is allowed (`WriteTransaction: Sync`). A concurrent insert on a sibling table holds `freed_pages` and then waits on `allocated_pages` inside `LeafBuilder::build`, so it can deadlock against the conversion holding `allocated_pages` and waiting on `freed_pages` — an ABBA cycle that permanently hangs the writer.

The inverted branch is reachable, not just theoretical: insert two small values plus one large value (the value-set is promoted to a subtree with a branch root), commit, then remove the large value. The branch collapses and leaves the untouched **committed** small-value leaf as the new root; it is below half a page, so it is rewritten back to inline storage and the committed leaf is freed via `freed_pages` — exactly the branch with the reversed lock order.

This is present in the released **v4.1.0**, not a master-only regression, so it's included in the changelog.

## Fix

Lock `freed_pages` before `allocated_pages` here, matching every other site, and use the existing `conditional_free()` helper for the free-or-defer logic.

## Testing

- Added `multimap_remove_collapses_committed_subtree_to_inline`, which reproduces the exact collapse-to-committed-leaf scenario. I verified (via a temporary probe) that no existing test reached the committed-root branch and that this test does. The test is single-threaded, so it locks in correctness of the code path but cannot itself trigger the timing-dependent deadlock — the guarantee comes from the lock order now being globally consistent.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features` (no warnings), and `cargo test --all-features` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBCeHTcEZagQHCFMCcnqKn

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBCeHTcEZagQHCFMCcnqKn)_