### PR TITLE
Re-mark the region tracker at the merged order when freeing pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
   additional transaction.
 * Fix a bug where calling `compact()` on a database could cause the file to grow
   rather than shrink in some cases.
+* Fix a bug where the database file could grow unnecessarily instead of reusing freed space, and
+  where `compact()` could stop before fully shrinking the file.
 * Enforce the maximum value size limit when replacing a value in place via `Table::get_mut()`
   or `Entry::and_modify()`. Previously these paths could bypass the limit that `Table::insert()`
   and the `entry()` accessors enforce, returning `StorageError::ValueTooLarge` only inconsistently.

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -417,28 +417,32 @@ impl BuddyAllocator {
     }
 
     /// data must have been initialized by `Self::init_new()`
-    pub(crate) fn free(&mut self, page_number: u32, order: u8) {
+    ///
+    /// Returns the order of the resulting free block, which is `>= order` when buddies merge.
+    pub(crate) fn free(&mut self, page_number: u32, order: u8) -> u8 {
         debug_assert!(self.get_order_free_mut(order).get(page_number));
 
         // Update the free index and merge free pages
-        self.free_inner(page_number, order);
+        self.free_inner(page_number, order)
     }
 
-    pub(crate) fn free_inner(&mut self, page_number: u32, order: u8) {
+    // Returns the order of the resulting free block, i.e. the order at which merging stopped.
+    pub(crate) fn free_inner(&mut self, page_number: u32, order: u8) -> u8 {
         if order == self.max_order {
             let allocator = self.get_order_free_mut(order);
             allocator.clear(page_number);
-            return;
+            return order;
         }
 
         let allocator = self.get_order_free_mut(order);
         let buddy = buddy_page(page_number);
         if buddy >= allocator.len() || allocator.get(buddy) {
             allocator.clear(page_number);
+            order
         } else {
             // Merge into higher order page
             allocator.set(buddy);
-            self.free_inner(next_higher_order(page_number), order + 1);
+            self.free_inner(next_higher_order(page_number), order + 1)
         }
     }
 

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1048,14 +1048,16 @@ impl TransactionalMemory {
         allocated.remove(page);
         let mut state = self.state.lock().unwrap();
         let region_index = page.region;
-        // Free in the regional allocator
-        state
+        // Free in the regional allocator. free() returns the order of the resulting block, which is
+        // larger than page_order when buddies merged.
+        let freed_order = state
             .get_region_mut(region_index)
             .free(page.page_index, page.page_order);
-        // Ensure that the region is marked as having free space
+        // Mark the region free at the merged order, not just page_order: leaving the tracker's
+        // higher-order bits stale after a merge would hide the reclaimed space from find_free.
         state
             .get_region_tracker_mut()
-            .mark_free(page.page_order, region_index);
+            .mark_free(freed_order, region_index);
 
         let address_range = page.address_range(
             self.page_size.into(),
@@ -1431,5 +1433,69 @@ mod test {
 
         let mut db = Database::open(tmpfile).unwrap();
         assert!(db.check_integrity().unwrap());
+    }
+
+    // Freeing pages that buddy-merge into a higher order must re-mark the region tracker at the
+    // merged order. Otherwise the tracker stays marked full at that order, find_free skips the
+    // region even though a free block exists, and the file grows (and compact() stalls) instead of
+    // reusing the space.
+    #[test]
+    fn free_merge_remarks_region_tracker() {
+        use super::TransactionalMemory;
+        use crate::tree_store::{InMemoryBackend, Page, PageTrackerPolicy};
+
+        // Small pages and regions keep the reproduction cheap to set up.
+        let page_size = 128 * 1024;
+        let region_size = 16 * page_size as u64;
+        let mem = TransactionalMemory::new(
+            Box::new(InMemoryBackend::new()),
+            true,
+            page_size,
+            Some(region_size),
+            0,
+            false,
+        )
+        .unwrap();
+        mem.reset_allocator_state().unwrap();
+
+        let mut ignore = PageTrackerPolicy::Ignore;
+
+        // Fill region 0 with order-0 pages. The allocation that spills past region 0 fails on it
+        // first, which marks region 0 full at every order.
+        let mut region0_pages = vec![];
+        loop {
+            let page = mem.allocate_helper(1, false).unwrap();
+            let number = page.get_page_number();
+            drop(page);
+            if number.region == 0 {
+                region0_pages.push(number);
+            } else {
+                // First page past region 0: it has done its job of forcing region 0 full. Give it
+                // back so the spilled-into region is left entirely free.
+                mem.free(number, &mut ignore);
+                break;
+            }
+        }
+        assert!(
+            region0_pages.len() >= 2,
+            "test needs at least two pages in region 0, got {}",
+            region0_pages.len()
+        );
+
+        // Free everything in region 0. The order-0 pages buddy-merge back into larger blocks, so
+        // region 0 regains free space above order 0.
+        for page in region0_pages {
+            mem.free(page, &mut ignore);
+        }
+
+        // An order-1 allocation must reuse region 0's merged free block. Before the fix the tracker
+        // still marked region 0 full above order 0, so find_free skipped it and this landed in a
+        // higher region.
+        let reused = mem.allocate_helper(2 * page_size, false).unwrap();
+        assert_eq!(
+            reused.get_page_number().region,
+            0,
+            "order-1 allocation should reuse the merged free block in region 0"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Freeing a page could leave the allocator's per-order free-space index (the region tracker) stale, so the database file could grow instead of reusing freed space, and `compact()` could stop before fully shrinking the file.

## Root cause

`free_helper()` marked the region tracker free only at the freed page's own order. But freeing a page can buddy-merge it into a block of a higher order. Once a region had been marked full at some order K (`mark_full`, when an allocation of order K failed on it), only a free at order >= K would clear that bit, because `mark_free(order)` clears orders `0..=order`. A free at a lower order that merged up into a free order-K block left the bit set.

With the bit stale, `find_free(K)` skipped the region even though it held a free block, so allocations grew the file instead of reusing the space, and `compact()`'s `allocate_lowest` probe was steered to a higher page and hit its `new >= old` early break. The buddy allocator itself stayed exact, so no data was corrupted.

## Fix

`BuddyAllocator::free()` now returns the order of the resulting (possibly merged) block, and `free_helper()` marks the region tracker free at that order. Returning it costs nothing — it is the terminal order of the existing merge recursion — and avoids re-scanning every order to recompute the region's highest free order on each free.

## Testing

- Added `free_merge_remarks_region_tracker`, which fills a region, frees it so the pages merge back up, and asserts the next allocation reuses the region instead of spilling into a new one. Confirmed it fails before the fix and passes after.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features` (deny warnings), and `cargo test --all-features` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016n3Q5CXgzQTFNC8qbPheGp

---
_Generated by [Claude Code](https://claude.ai/code/session_016n3Q5CXgzQTFNC8qbPheGp)_