### PR TITLE
Avoid rewriting the parent tree when removing an absent subtree value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Fix a potential deadlock when removing a value from a multimap table causes its value-set to
   shrink from a subtree back to inline storage, while another table of the same write transaction
   is used concurrently from a different thread.
+* Avoid unnecessary write amplification when removing a value that is not present from a multimap
+  table. Such a removal is now a no-op.
 * Fix a crash during a commit that resizes the database file leaving the database permanently
   unopenable, and reporting corruption on subsequent opens, even though every committed transaction
   was intact and fully recoverable.

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -686,7 +686,12 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                     self.allocated_pages.clone(),
                 );
                 drop(guard);
-                let existed = subtree.remove(value.borrow())?.is_some();
+                if subtree.remove(value.borrow())?.is_none() {
+                    // The value wasn't present, so the subtree is unmodified. Return early to
+                    // avoid needlessly copy-on-writing the parent tree (write amplification) and
+                    // to avoid flipping the subtree back to inline storage on a logical no-op.
+                    return Ok(false);
+                }
 
                 if let Some(BtreeHeader {
                     root: new_root,
@@ -744,7 +749,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                     self.tree.remove(key.borrow())?;
                 }
 
-                existed
+                true
             }
         };
 

--- a/tests/multimap_tests.rs
+++ b/tests/multimap_tests.rs
@@ -594,3 +594,56 @@ fn multimap_remove_collapses_committed_subtree_to_inline() {
         .collect();
     assert_eq!(values, vec![small_a.to_vec(), small_b.to_vec()]);
 }
+
+#[test]
+fn multimap_remove_nonexistent_value_from_subtree_does_not_churn() {
+    // Removing a value that isn't present from a subtree-backed key is a logical no-op and must
+    // not rewrite the parent tree. There was a bug where MultimapTable::remove() re-inserted the
+    // unchanged collection into the parent tree unconditionally, copy-on-writing the root->leaf
+    // path and queuing the old pages to be freed even though nothing changed.
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_TABLE).unwrap();
+        // Enough values for key 0 to be promoted from inline storage to a subtree.
+        for v in 0..1000u64 {
+            table.insert(&0u64, &v).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    // Finalize the cleanup of the freed pages from the setup so the baseline is at steady state.
+    db.begin_write().unwrap().commit().unwrap();
+    db.begin_write().unwrap().commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    let baseline = txn.stats().unwrap().allocated_pages();
+    txn.commit().unwrap();
+
+    // Remove a value that was never inserted. This returns false and, with the fix, leaves the
+    // tree entirely untouched. Without the fix the parent tree is copy-on-written, so the old
+    // pages linger as not-yet-reclaimed frees and inflate the allocated page count.
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_TABLE).unwrap();
+        assert!(!table.remove(&0u64, &123_456u64).unwrap());
+        assert_eq!(table.len().unwrap(), 1000);
+    }
+    write_txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    let after = txn.stats().unwrap().allocated_pages();
+    txn.commit().unwrap();
+    assert_eq!(
+        baseline, after,
+        "removing a nonexistent value from a subtree-backed key must not allocate or free pages"
+    );
+
+    // The contents are unchanged and still fully readable.
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_multimap_table(U64_TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 1000);
+    assert_eq!(table.get(&0u64).unwrap().len(), 1000);
+}


### PR DESCRIPTION
## Summary

`MultimapTable::remove()` computed whether the value existed in the subtree but then ran its re-insert block unconditionally. When the removed value was **not present**, `subtree.remove()` returned `None` and left the subtree untouched (`delete_key` leaves the root untouched when the key isn't found), yet the collection was still re-inserted into the parent tree. That copy-on-wrote the root→leaf path, queued the old pages to be freed, and could even flip the value-set from subtree back to inline storage — all for a logical no-op. The inline arm and `Table::remove()` already short-circuit correctly.

The fix returns early when the value was not present, matching the inline arm.

## Impact

Contents, length, and integrity were already unaffected — this only removes the wasted write amplification for a common operation (removing a value that isn't present from a subtree-backed key).

## Testing

- New regression test `multimap_remove_nonexistent_value_from_subtree_does_not_churn` asserts that a no-op removal on a subtree-backed key allocates and frees zero pages. It **fails before** the fix (baseline 7 → 10 allocated pages from the transient CoW churn) and **passes after**.
- Full gate green: `cargo fmt --check`, `cargo clippy --all-targets --all-features`, and `cargo test --all-features` (310 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHrwK7untocWhi8S4VV9V2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHrwK7untocWhi8S4VV9V2)_