### PR TITLE
Clamp post-commit free horizon to the savepoint purge horizon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@
   `CompactionError::TransactionInProgress` when a savepoint blocks compaction.
 * Fix `check_integrity()` incorrectly reporting a healthy database as corrupted (and panicking
   in debug builds) after a persistent savepoint was deleted or restored.
+* Fix `check_integrity()` incorrectly reporting a healthy database as corrupted (and panicking
+  in debug builds) when an ephemeral `Savepoint` was dropped from another thread while the same
+  write transaction was committing.
 * Fix a panic when opening a database file that was externally extended to an invalid size; such
   files are now rejected with `StorageError::Corrupted`.
 * Fix a hang on Windows when opening a truncated or corrupt database file. Reads past the end of the

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1683,7 +1683,12 @@ impl WriteTransaction {
     // previously unpersisted allocations that are now becoming durable. Must be called AFTER
     // `process_freed_pages` so that pages reclaimed during this commit are already dropped from
     // the in-memory `unpersisted_allocations` map and not written to disk as stale records.
-    fn flush_data_allocated_pages(&self, data_allocated_pages: Vec<PageNumber>) -> Result {
+    //
+    // Returns the purge horizon (the oldest savepoint transaction id kept, or `u64::MAX` if no
+    // savepoint survives this commit). `process_data_freed_pages_after_commit()` clamps its free
+    // horizon to this value so that a savepoint dropped concurrently after the purge cannot cause
+    // the epilogue to free a page that a surviving DATA_ALLOCATED_TABLE entry still names.
+    fn flush_data_allocated_pages(&self, data_allocated_pages: Vec<PageNumber>) -> Result<u64> {
         // Catch scenarios like a page getting allocated and then deallocated within the same
         // transaction, but errantly left in the allocated pages list.
         #[cfg(debug_assertions)]
@@ -1735,7 +1740,7 @@ impl WriteTransaction {
             entry?;
         }
 
-        Ok(())
+        Ok(oldest)
     }
 
     fn write_allocated_pages_entry(
@@ -1809,7 +1814,7 @@ impl WriteTransaction {
         // Flush allocated pages (including previously unpersisted allocations that are now
         // becoming durable) AFTER process_freed_pages, so that any pages reclaimed here have
         // already been dropped from the in-memory `unpersisted_allocations` map.
-        self.flush_data_allocated_pages(allocated_pages)?;
+        let savepoint_horizon = self.flush_data_allocated_pages(allocated_pages)?;
 
         let mut system_tables = self.system_tables.lock().unwrap();
         let system_freed_pages = system_tables.system_freed_pages();
@@ -1884,7 +1889,11 @@ impl WriteTransaction {
         self.apply_savepoint_state_on_commit();
 
         if self.post_commit_free == PostCommitFree::Enabled {
-            self.process_data_freed_pages_after_commit(user_root, &page_allocator)?;
+            self.process_data_freed_pages_after_commit(
+                user_root,
+                &page_allocator,
+                savepoint_horizon,
+            )?;
         }
 
         Ok(())
@@ -1894,12 +1903,23 @@ impl WriteTransaction {
         &self,
         user_root: Option<BtreeHeader>,
         page_allocator: &PageAllocator,
+        savepoint_horizon: u64,
     ) -> Result {
         let epilogue_transaction = self.transaction_id.next();
-        let free_until = self
+        let mut free_until = self
             .transaction_tracker
             .oldest_live_read_transaction()
             .map_or(epilogue_transaction, |x| x.next());
+        // Clamp the free horizon to the savepoint horizon captured during the purge. A savepoint
+        // is also a live read, so absent concurrency `oldest_live_read_transaction()` never
+        // exceeds it and this is a no-op. But an ephemeral `Savepoint::drop` racing this commit
+        // (legal since `WriteTransaction: Sync`) can land between the purge and here, advancing
+        // the oldest live read past the savepoint the purge kept entries for. Freeing those pages
+        // would leave DATA_ALLOCATED_TABLE naming freed pages; the dropped savepoint's entries are
+        // instead re-purged by the next durable commit.
+        if savepoint_horizon != u64::MAX {
+            free_until = free_until.min(TransactionId::new(savepoint_horizon).next());
+        }
 
         let mut freed_any = false;
         let (system_root, stored_system_freed_pages, extracted_data_transactions) = {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1930,6 +1930,77 @@ fn check_integrity_after_persistent_savepoint_restore_and_delete() {
     }
 }
 
+// Invariant: an ephemeral Savepoint dropped concurrently with a durable commit -- legal since
+// WriteTransaction is Sync -- must not leave DATA_ALLOCATED_TABLE naming freed pages. The drop
+// can land between the allocated-pages purge (which keeps the entries the savepoint pins) and the
+// post-commit free epilogue (which computes its horizon from the live read transactions). If the
+// drop advances that horizon past the savepoint, the epilogue would free pages the surviving
+// entries still name.
+#[test]
+fn check_integrity_ephemeral_savepoint_drop_racing_commit() {
+    let tmpfile = create_tempfile();
+    let table_def: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+    let sync_state = Arc::new(BlockingSyncState::new());
+    let backend = BlockingSyncBackend {
+        inner: FileBackend::new(tmpfile.into_file()).unwrap(),
+        state: sync_state.clone(),
+    };
+    let mut db = Database::builder().create_with_backend(backend).unwrap();
+
+    // Transaction T0: initial data. The ephemeral savepoint created below pins T0.
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        for k in 0..1000u64 {
+            table
+                .insert(&k, savepoint_integrity_value(k, 60).as_slice())
+                .unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    // Transaction T1: create the ephemeral savepoint before opening any table so it pins T0 and
+    // keeps allocation tracking enabled. The pages allocated here are recorded in
+    // DATA_ALLOCATED_TABLE because the savepoint is live.
+    let txn = db.begin_write().unwrap();
+    let savepoint = txn.ephemeral_savepoint().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        for k in 2000..2500u64 {
+            table
+                .insert(&k, savepoint_integrity_value(k, 60).as_slice())
+                .unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    // Transaction T2: free those pages. They are queued in DATA_FREED_TABLE rather than freed,
+    // because the savepoint still pins them.
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        for k in 2000..2500u64 {
+            table.remove(&k).unwrap();
+        }
+    }
+
+    // Block the commit's fsync, which happens after the DATA_ALLOCATED_TABLE purge but before the
+    // post-commit free epilogue, and drop the savepoint inside that window.
+    sync_state.block_next_sync();
+    let commit_handle = thread::spawn(move || txn.commit().unwrap());
+    sync_state.wait_until_blocked();
+    drop(savepoint);
+    sync_state.release();
+    commit_handle.join().unwrap();
+
+    // In debug builds, check_integrity() asserts every DATA_ALLOCATED_TABLE page is still
+    // allocated. Before the fix, the epilogue freed pages that surviving entries still named.
+    assert!(
+        db.check_integrity().unwrap(),
+        "false corruption after an ephemeral savepoint was dropped during commit"
+    );
+}
+
 #[test]
 fn regression20() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
## Summary

`WriteTransaction` is `Sync`, so an ephemeral `Savepoint` can be dropped from a different
thread than the one committing the transaction that created it. During a durable commit:

- `flush_data_allocated_pages()` purges `DATA_ALLOCATED_TABLE` down to the oldest savepoint's
  transaction, keeping the entries that savepoint pins.
- The post-commit free epilogue (`process_data_freed_pages_after_commit()`) frees
  `DATA_FREED_TABLE` pages up to a horizon derived from the live read transactions.

A savepoint is also a live read, so absent concurrency the two horizons agree. But if the
ephemeral `Savepoint::drop` lands **between** the purge and the epilogue, it removes the
savepoint's read reference and the epilogue's horizon advances past the savepoint the purge
accounted for. The epilogue then frees pages that surviving `DATA_ALLOCATED_TABLE` entries
still name. This is the concurrent-drop sibling of the staged-deletion bug fixed in d098d3b.

## Impact

`check_integrity()` hits the `assert!` in `check_repaired_allocated_pages_table`, i.e. a
debug-build panic / false corruption report. No durable corruption is reachable: the stale
entries are always for transactions strictly older than any restorable savepoint (the drop
only advances the horizon when the dropped savepoint was the sole oldest live read, so the
over-freed pages are older than the next oldest read, hence older than every surviving
savepoint), and `restore_savepoint()` only reads `DATA_ALLOCATED_TABLE` entries newer than the
restored savepoint. The next durable commit re-purges the stale entries regardless.

## Fix

Return the purge horizon from `flush_data_allocated_pages()` and clamp the epilogue's free
horizon to it. The clamp is a no-op in every non-racy case (a live savepoint always bounds
`oldest_live_read_transaction()`); a concurrently-dropped savepoint's entries are simply
reclaimed by the next durable commit.

## Testing

- New deterministic regression test `check_integrity_ephemeral_savepoint_drop_racing_commit`
  uses the existing `BlockingSyncBackend` to pause the commit at its fsync (between the purge
  and the epilogue), drops the savepoint in that window, then asserts `check_integrity()`. It
  panics at `check_repaired_allocated_pages_table` without the fix and passes with it.
- `cargo test --all-features`, `cargo fmt --check`, and
  `cargo clippy --all-targets --all-features` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rKhoFerkDeoUn1DqpJn3t

---
_Generated by [Claude Code](https://claude.ai/code/session_019rKhoFerkDeoUn1DqpJn3t)_