### PR TITLE
Serialize ephemeral_savepoint() against the first table-open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
 * Fix `check_integrity()` incorrectly reporting a healthy database as corrupted (and panicking
   in debug builds) when an ephemeral `Savepoint` was dropped from another thread while the same
   write transaction was committing.
+* Fix a leak of database space when an ephemeral `Savepoint` was created from one thread while the
+  same write transaction was first accessing a table from another thread, and that savepoint was
+  later restored. The leaked space was only reclaimed by a full repair.
 * Fix a panic when opening a database file that was externally extended to an invalid size; such
   files are now rejected with `StorageError::Corrupted`.
 * Fix a hang on Windows when opening a truncated or corrupt database file. Reads past the end of the

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1201,11 +1201,20 @@ impl WriteTransaction {
     ///
     /// Returns `[SavepointError::InvalidSavepoint`], if the transaction is "dirty" (any tables have been opened)
     pub fn ephemeral_savepoint(&self) -> Result<Savepoint, SavepointError> {
-        if self.dirty.load(Ordering::Acquire) {
-            return Err(SavepointError::InvalidSavepoint);
-        }
-
-        let (id, transaction_id) = self.allocate_savepoint()?;
+        // Serialize the dirty check and savepoint registration against
+        // `TableNamespace::set_dirty()`, which runs under the same tables lock. Without this,
+        // a concurrent first table-open (legal since `WriteTransaction: Sync`) can read the
+        // dirty flag and `any_savepoint_exists()` in between, observe no savepoint, and disable
+        // allocation tracking -- leaving a live savepoint with tracking `Ignore`d. A later
+        // `restore_savepoint()` would then fail to free this transaction's pages, leaking them
+        // (reclaimed only by a full repair).
+        let (id, transaction_id) = {
+            let _tables = self.tables.lock().unwrap();
+            if self.dirty.load(Ordering::Acquire) {
+                return Err(SavepointError::InvalidSavepoint);
+            }
+            self.allocate_savepoint()?
+        };
         #[cfg(feature = "logging")]
         debug!("Creating savepoint id={id:?}, txn_id={transaction_id:?}");
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2001,6 +2001,81 @@ fn check_integrity_ephemeral_savepoint_drop_racing_commit() {
     );
 }
 
+// Invariant: ephemeral_savepoint() racing the first table-open of the same transaction (legal
+// since WriteTransaction is Sync) must never register a live savepoint while the racing open
+// disables allocation tracking. If it does, the pages allocated after the savepoint are not
+// tracked, so restore_savepoint() cannot free them and they leak. This exercises the race in a
+// loop; check_integrity()'s allocator rebuild reports any leaked (allocated but unreachable) page.
+#[test]
+fn ephemeral_savepoint_racing_first_open_no_leak() {
+    let tmpfile = create_tempfile();
+    let table_def: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+    let mut db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(table_def).unwrap();
+        table
+            .insert(&0, savepoint_integrity_value(0, 100).as_slice())
+            .unwrap();
+    }
+    txn.commit().unwrap();
+
+    // Several savepoint-creating threads race one table-opening thread. Multiple creators widen
+    // the window on the tracker's lock in which the open can observe "no savepoint" and disable
+    // allocation tracking just before a savepoint is registered.
+    const CREATORS: usize = 6;
+    for i in 0..600u64 {
+        let mut txn = db.begin_write().unwrap();
+        let barrier = std::sync::Barrier::new(CREATORS + 1);
+        let savepoints = thread::scope(|s| {
+            let handles: Vec<_> = (0..CREATORS)
+                .map(|_| {
+                    s.spawn(|| {
+                        barrier.wait();
+                        txn.ephemeral_savepoint()
+                    })
+                })
+                .collect();
+            barrier.wait();
+            {
+                let mut table = txn.open_table(table_def).unwrap();
+                table
+                    .insert(&(1000 + i), savepoint_integrity_value(i, 200).as_slice())
+                    .unwrap();
+            }
+            handles
+                .into_iter()
+                .map(|h| h.join().unwrap())
+                .collect::<Vec<_>>()
+        });
+
+        // All created savepoints pin the same (last committed) transaction, so restoring any one
+        // of them must free every page allocated by this transaction.
+        let created: Vec<_> = savepoints.into_iter().flatten().collect();
+        if let Some(savepoint) = created.first() {
+            {
+                let mut table = txn.open_table(table_def).unwrap();
+                for k in 3000..3100u64 {
+                    table
+                        .insert(&k, savepoint_integrity_value(k, 200).as_slice())
+                        .unwrap();
+                }
+            }
+            txn.restore_savepoint(savepoint).unwrap();
+            txn.commit().unwrap();
+        } else {
+            // The open won the race and dirtied the transaction first; no savepoint created.
+            txn.abort().unwrap();
+        }
+    }
+
+    assert!(
+        db.check_integrity().unwrap(),
+        "ephemeral savepoint racing the first table-open leaked pages"
+    );
+}
+
 #[test]
 fn regression20() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
## Summary

`WriteTransaction` is `Sync`, so `ephemeral_savepoint()` and the first table-open of the same
transaction can run on different threads. `ephemeral_savepoint()` checks the dirty flag and then
registers the savepoint, while `TableNamespace::set_dirty()` sets the dirty flag and then, if no
savepoint exists, disables allocation tracking. Their opposite-order accesses to the dirty flag
and the savepoint set can interleave:

1. `ephemeral_savepoint()` reads `dirty == false`
2. `set_dirty()` stores `dirty = true`, observes no savepoint, and sets allocation tracking to `Ignore`
3. `ephemeral_savepoint()` registers the savepoint

That leaves a live savepoint with allocation tracking disabled.

## Impact

A later `restore_savepoint()` relies on that tracking to free the pages allocated since the
savepoint; with it `Ignore`d, those pages are leaked and reclaimed only by a full repair
(quick-repair does not recover them). A leak, not corruption. This is the concurrent sibling of
the drop-vs-commit race fixed in #1296.

## Fix

`set_dirty()` always runs under the tables lock, so take that same lock across the dirty check and
savepoint registration in `ephemeral_savepoint()`. This orders the two operations: either the
savepoint is registered before `set_dirty()` checks for it (tracking stays enabled), or
`set_dirty()` has already set the dirty flag and the savepoint call returns `InvalidSavepoint`.

## Testing

- New regression test `ephemeral_savepoint_racing_first_open_no_leak` races several
  savepoint-creating threads against one table-opening thread across many iterations, then
  restores a savepoint; `check_integrity()`'s allocator rebuild reports any leaked (allocated but
  unreachable) page. It reliably fails without the fix and passes with it.
- `cargo test --all-features`, `cargo fmt --check`, and
  `cargo clippy --all-targets --all-features` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rKhoFerkDeoUn1DqpJn3t

---
_Generated by [Claude Code](https://claude.ai/code/session_019rKhoFerkDeoUn1DqpJn3t)_