### PR TITLE
Distinguish composite types of user types from built-in composites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@
   occurred while recovering from an earlier crash. Triggering it required two crashes -- one
   interrupting a commit and another during the subsequent repair on the next open -- and it did
   not affect transactions committed with two-phase commit.
+* Fix composite types (`Option`, `Vec`, tuples, and arrays) of a user-defined type sharing a
+  type identity with the same composite of a built-in type when the two happened to have the same
+  name. A table using such a composite of a user type can no longer be silently opened under the
+  built-in composite (and vice versa); the mismatch is now reported as `TableError::TableTypeMismatch`.
+  Existing databases created by older versions remain readable.
 
 ### Python bindings
 * Add `Database.create(path)` for creating or opening a database file.

--- a/src/complex_types.rs
+++ b/src/complex_types.rs
@@ -88,6 +88,8 @@ impl<T: Value> Value for Vec<T> {
     }
 
     fn type_name() -> TypeName {
-        TypeName::internal(&format!("Vec<{}>", T::type_name().name()))
+        let inner = T::type_name();
+        TypeName::internal(&format!("Vec<{}>", inner.name()))
+            .into_user_defined_if(inner.is_user_defined())
     }
 }

--- a/src/tree_store/table_tree_base.rs
+++ b/src/tree_store/table_tree_base.rs
@@ -154,12 +154,20 @@ impl InternalTableDefinition {
     ) -> Result<(), TableError> {
         self.check_match_untyped(table_type, name)?;
 
-        if self.private_key_type() != K::type_name() || self.private_value_type() != V::type_name()
-        {
+        let stored_key = self.private_key_type();
+        let stored_value = self.private_value_type();
+        // Accept the current type name, or the spelling an older redb version may have stored for
+        // the same type (see `TypeName::matches_legacy`).
+        let expected_key = K::type_name();
+        let expected_value = V::type_name();
+        let key_matches = stored_key == expected_key || expected_key.matches_legacy(&stored_key);
+        let value_matches =
+            stored_value == expected_value || expected_value.matches_legacy(&stored_value);
+        if !key_matches || !value_matches {
             return Err(TableError::TableTypeMismatch {
                 table: name.to_string(),
-                key: self.private_key_type(),
-                value: self.private_value_type(),
+                key: stored_key,
+                value: stored_value,
             });
         }
         if self.private_get_fixed_key_size() != K::fixed_width() {

--- a/src/tuple_types.rs
+++ b/src/tuple_types.rs
@@ -109,11 +109,15 @@ macro_rules! type_name_impl {
             )+
             result.push(')');
 
-            if Self::fixed_width().is_some() {
+            let any_user_defined = <$head>::type_name().is_user_defined()
+                $(|| <$tail>::type_name().is_user_defined())+;
+
+            let natural = if Self::fixed_width().is_some() {
                 TypeName::internal(&result)
             } else {
                 TypeName::internal2(&result)
-            }
+            };
+            natural.into_user_defined_if(any_user_defined)
         }
     };
 }
@@ -302,7 +306,9 @@ impl<T: Value> Value for (T,) {
     }
 
     fn type_name() -> TypeName {
-        TypeName::internal(&format!("({},)", T::type_name().name()))
+        let inner = T::type_name();
+        TypeName::internal(&format!("({},)", inner.name()))
+            .into_user_defined_if(inner.is_user_defined())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,11 +35,26 @@ impl TypeClassification {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct TypeName {
     classification: TypeClassification,
     name: String,
+    // In-memory only; never serialized. For a composite (`Option`, `Vec`, tuple, array) of a
+    // user-defined type, whose classification is bubbled up to user-defined, this records the
+    // classification that older redb versions stored, so that their tables still match on open.
+    // `None` for leaf types, flat user-defined types, and every deserialized name.
+    legacy_classification: Option<TypeClassification>,
 }
+
+// Equality is on-disk identity: the auxiliary `legacy_classification` never participates, so a
+// freshly built name compares equal to the same name after a serialize/deserialize round trip.
+impl PartialEq for TypeName {
+    fn eq(&self, other: &Self) -> bool {
+        self.classification == other.classification && self.name == other.name
+    }
+}
+
+impl Eq for TypeName {}
 
 impl TypeName {
     /// It is recommended that `name` be prefixed with the crate name to minimize the chance of
@@ -48,6 +63,7 @@ impl TypeName {
         Self {
             classification: TypeClassification::UserDefined,
             name: name.to_string(),
+            legacy_classification: None,
         }
     }
 
@@ -55,6 +71,7 @@ impl TypeName {
         Self {
             classification: TypeClassification::Internal,
             name: name.to_string(),
+            legacy_classification: None,
         }
     }
 
@@ -62,6 +79,7 @@ impl TypeName {
         Self {
             classification: TypeClassification::Internal2,
             name: name.to_string(),
+            legacy_classification: None,
         }
     }
 
@@ -79,11 +97,42 @@ impl TypeName {
         Self {
             classification,
             name,
+            legacy_classification: None,
         }
     }
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    pub(crate) fn is_user_defined(&self) -> bool {
+        matches!(self.classification, TypeClassification::UserDefined)
+    }
+
+    // Reclassify this (composite) type name as user-defined when it wraps a user-defined type.
+    // A composite such as `Option<T>` builds its name only from the inner type's name string,
+    // which would let `Option<u32>` (built-in) collide with `Option<MyType>` where `MyType` is a
+    // user type named "u32". Bubbling the user-defined classification up keeps them distinct, and
+    // the classification being replaced is remembered so that older databases still match on open.
+    pub(crate) fn into_user_defined_if(mut self, user_defined: bool) -> Self {
+        if user_defined {
+            self.legacy_classification = Some(self.classification.clone());
+            self.classification = TypeClassification::UserDefined;
+        }
+        self
+    }
+
+    // Whether `stored` (read from an existing database) is the spelling an older redb version
+    // wrote for this same type. Before composites of a user-defined type were bubbled up, they
+    // were classified `Internal` (or `Internal2` for variable width tuples); accepting that
+    // spelling keeps those databases readable, while a flat user-defined type -- which has no
+    // recorded legacy classification -- never matches a differently classified stored name.
+    pub(crate) fn matches_legacy(&self, stored: &TypeName) -> bool {
+        if let Some(natural) = &self.legacy_classification {
+            *natural == stored.classification && self.name == stored.name
+        } else {
+            false
+        }
     }
 }
 
@@ -286,7 +335,9 @@ impl<T: Value> Value for Option<T> {
     }
 
     fn type_name() -> TypeName {
-        TypeName::internal(&format!("Option<{}>", T::type_name().name()))
+        let inner = T::type_name();
+        TypeName::internal(&format!("Option<{}>", inner.name()))
+            .into_user_defined_if(inner.is_user_defined())
     }
 }
 
@@ -449,7 +500,9 @@ impl<const N: usize, T: Value> Value for [T; N] {
     fn type_name() -> TypeName {
         // Uses the same type name as [T;N] so that tables are compatible with [u8;N] and &[u8;N] types
         // This requires that the binary encoding be the same
-        TypeName::internal(&format!("[{};{N}]", T::type_name().name()))
+        let inner = T::type_name();
+        TypeName::internal(&format!("[{};{N}]", inner.name()))
+            .into_user_defined_if(inner.is_user_defined())
     }
 }
 
@@ -663,3 +716,153 @@ le_impl!(i64);
 le_impl!(i128);
 le_value!(f32);
 le_value!(f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A user-defined type whose name deliberately collides with the built-in `u32`, and whose
+    // fixed width matches it. Before composite classifications bubbled up, `Option<FakeU32>` and
+    // `Option<u32>` produced byte-identical `TypeName`s, letting one silently open as the other.
+    #[derive(Debug)]
+    struct FakeU32;
+
+    impl Value for FakeU32 {
+        type SelfType<'a> = u32;
+        type AsBytes<'a> = [u8; 4];
+
+        fn fixed_width() -> Option<usize> {
+            Some(4)
+        }
+
+        fn from_bytes<'a>(data: &'a [u8]) -> u32
+        where
+            Self: 'a,
+        {
+            u32::from_le_bytes(data.try_into().unwrap())
+        }
+
+        fn as_bytes<'a, 'b: 'a>(value: &'a u32) -> [u8; 4]
+        where
+            Self: 'b,
+        {
+            value.to_le_bytes()
+        }
+
+        fn type_name() -> TypeName {
+            TypeName::new("u32")
+        }
+    }
+
+    impl Key for FakeU32 {
+        fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+            data1.cmp(data2)
+        }
+    }
+
+    #[test]
+    fn builtin_composites_are_unchanged() {
+        // Composites of only built-in types must keep their exact classification (and therefore
+        // their on-disk bytes), so existing databases open unchanged.
+        assert!(!<Option<u32> as Value>::type_name().is_user_defined());
+        assert!(!<Vec<u32> as Value>::type_name().is_user_defined());
+        assert!(!<[u32; 3] as Value>::type_name().is_user_defined());
+        assert!(!<(u32,) as Value>::type_name().is_user_defined());
+        // Fixed-width tuple -> Internal; variable-width tuple -> Internal2. Neither is user-defined.
+        assert!(!<(u32, u64) as Value>::type_name().is_user_defined());
+        assert!(!<(u32, &str) as Value>::type_name().is_user_defined());
+        assert_eq!(
+            <(u32, u64) as Value>::type_name(),
+            TypeName::internal("(u32,u64)")
+        );
+        assert_eq!(
+            <(u32, &str) as Value>::type_name(),
+            TypeName::internal2("(u32,&str)")
+        );
+        // Nesting only built-in types never bubbles.
+        assert!(!<Vec<Option<u32>> as Value>::type_name().is_user_defined());
+
+        // A built-in composite records no legacy classification, so it never legacy-matches a
+        // differently classified stored name.
+        assert!(
+            !<Option<u32> as Value>::type_name().matches_legacy(&TypeName::internal("Option<u32>"))
+        );
+        assert!(
+            !<(u32, u64) as Value>::type_name().matches_legacy(&TypeName::internal("(u32,u64)"))
+        );
+    }
+
+    #[test]
+    fn composite_of_user_type_no_longer_collides_with_builtin() {
+        // The bug: these pairs were equal before the fix.
+        assert_ne!(
+            <Option<u32> as Value>::type_name(),
+            <Option<FakeU32> as Value>::type_name()
+        );
+        assert_ne!(
+            <Vec<u32> as Value>::type_name(),
+            <Vec<FakeU32> as Value>::type_name()
+        );
+        assert_ne!(
+            <[u32; 2] as Value>::type_name(),
+            <[FakeU32; 2] as Value>::type_name()
+        );
+        assert_ne!(
+            <(u32, u64) as Value>::type_name(),
+            <(FakeU32, u64) as Value>::type_name()
+        );
+        assert_ne!(
+            <(u32, &str) as Value>::type_name(),
+            <(FakeU32, &str) as Value>::type_name()
+        );
+
+        // Only the classification differs; the human-readable name string is unchanged, and the
+        // user composite is now classified user-defined.
+        assert_eq!(
+            <Option<u32> as Value>::type_name().name(),
+            <Option<FakeU32> as Value>::type_name().name()
+        );
+        assert!(<Option<FakeU32> as Value>::type_name().is_user_defined());
+        // Bubbling is transitive through nesting.
+        assert!(<Vec<Option<FakeU32>> as Value>::type_name().is_user_defined());
+    }
+
+    #[test]
+    fn legacy_matching_accepts_pre_bubbling_spelling() {
+        // Option/Vec/array/(T,) were stored as Internal in every prior version.
+        assert!(
+            <Option<FakeU32> as Value>::type_name()
+                .matches_legacy(&TypeName::internal("Option<u32>"))
+        );
+        assert!(
+            <Vec<FakeU32> as Value>::type_name().matches_legacy(&TypeName::internal("Vec<u32>"))
+        );
+        assert!(<(FakeU32,) as Value>::type_name().matches_legacy(&TypeName::internal("(u32,)")));
+        // Fixed-width tuple: legacy spelling is Internal.
+        assert!(
+            <(FakeU32, u64) as Value>::type_name().matches_legacy(&TypeName::internal("(u32,u64)"))
+        );
+        // Variable-width tuple: legacy spelling is Internal2, NOT Internal. redb 2.6 used a
+        // different variable-width tuple encoding (it had no Internal2), so its Internal-tagged
+        // tables are deliberately not re-accepted.
+        assert!(
+            <(FakeU32, &str) as Value>::type_name()
+                .matches_legacy(&TypeName::internal2("(u32,&str)"))
+        );
+        assert!(
+            !<(FakeU32, &str) as Value>::type_name()
+                .matches_legacy(&TypeName::internal("(u32,&str)"))
+        );
+
+        // A legacy match must still agree on the name.
+        assert!(
+            !<Option<FakeU32> as Value>::type_name()
+                .matches_legacy(&TypeName::internal("Option<u64>"))
+        );
+
+        // Crucially, a flat user-defined type carries no legacy classification, so it never
+        // matches an `Internal` stored name -- this is what keeps a user type named "u32" from
+        // aliasing the built-in `u32` at the top level.
+        assert!(!<FakeU32 as Value>::type_name().matches_legacy(&TypeName::internal("u32")));
+    }
+}

--- a/tests/backward_compatibility.rs
+++ b/tests/backward_compatibility.rs
@@ -2,6 +2,67 @@ use redb::{ReadableDatabase, ReadableTableMetadata};
 
 const ELEMENTS: usize = 3;
 
+// A user-defined value type whose type name deliberately collides with the built-in `u32` and
+// whose width and encoding match it. It implements both the current and the redb 2.6 `Value`
+// trait so the same table can be written by one version and read by the other.
+#[derive(Debug)]
+#[allow(dead_code)]
+struct CollidingUserType;
+
+impl redb::Value for CollidingUserType {
+    type SelfType<'a> = u32;
+    type AsBytes<'a> = [u8; 4];
+
+    fn fixed_width() -> Option<usize> {
+        Some(4)
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> u32
+    where
+        Self: 'a,
+    {
+        u32::from_le_bytes(data.try_into().unwrap())
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a u32) -> [u8; 4]
+    where
+        Self: 'b,
+    {
+        value.to_le_bytes()
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("u32")
+    }
+}
+
+impl redb2_6::Value for CollidingUserType {
+    type SelfType<'a> = u32;
+    type AsBytes<'a> = [u8; 4];
+
+    fn fixed_width() -> Option<usize> {
+        Some(4)
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> u32
+    where
+        Self: 'a,
+    {
+        u32::from_le_bytes(data.try_into().unwrap())
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a u32) -> [u8; 4]
+    where
+        Self: 'b,
+    {
+        value.to_le_bytes()
+    }
+
+    fn type_name() -> redb2_6::TypeName {
+        redb2_6::TypeName::new("u32")
+    }
+}
+
 trait TestData: redb::Value + redb2_6::Value {
     fn make_data_v2_6<'a>() -> [<Self as redb2_6::Value>::SelfType<'a>; ELEMENTS]
     where
@@ -414,4 +475,63 @@ fn restore_and_delete_redb2_6_persistent_savepoint() {
             value_for(i, 100).as_slice()
         );
     }
+}
+
+// A composite (`Option<T>`) of a user-defined type written by redb 2.6 stored its type name with
+// the `Internal` classification. The current version bubbles the inner user-defined classification
+// up to the composite, so opening such a table must succeed via the legacy `Internal` spelling.
+#[test]
+fn composite_of_user_type_created_by_redb2_6_still_opens() {
+    let tmpfile = create_tempfile();
+    {
+        let db = redb2_6::Database::builder()
+            .create_with_file_format_v3(true)
+            .create(tmpfile.path())
+            .unwrap();
+        let def: redb2_6::TableDefinition<u64, Option<CollidingUserType>> =
+            redb2_6::TableDefinition::new("table");
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(def).unwrap();
+            table.insert(&1u64, &Some(7u32)).unwrap();
+            table.insert(&2u64, &None).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    let db = redb::Database::open(tmpfile.path()).unwrap();
+    let def: redb::TableDefinition<u64, Option<CollidingUserType>> =
+        redb::TableDefinition::new("table");
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(def).unwrap();
+    assert_eq!(table.len().unwrap(), 2);
+    assert_eq!(table.get(&1u64).unwrap().unwrap().value(), Some(7u32));
+    assert_eq!(table.get(&2u64).unwrap().unwrap().value(), None);
+}
+
+// The bug this guards against: a composite of a user-defined type must never silently alias the
+// built-in composite with the same name string. Opening an `Option<user "u32">` table under the
+// built-in `Option<u32>` must now fail with a type mismatch rather than misinterpreting the data.
+#[test]
+fn composite_of_user_type_does_not_alias_builtin() {
+    let tmpfile = create_tempfile();
+    let db = redb::Database::create(tmpfile.path()).unwrap();
+    {
+        let def: redb::TableDefinition<u64, Option<CollidingUserType>> =
+            redb::TableDefinition::new("table");
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(def).unwrap();
+            table.insert(&1u64, &Some(7u32)).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    let builtin_def: redb::TableDefinition<u64, Option<u32>> = redb::TableDefinition::new("table");
+    let txn = db.begin_write().unwrap();
+    assert!(matches!(
+        txn.open_table(builtin_def),
+        Err(redb::TableError::TableTypeMismatch { .. })
+    ));
+    txn.abort().unwrap();
 }


### PR DESCRIPTION
## Problem

A composite type (`Option`, `Vec`, tuple, or array) built its `TypeName` from only the inner type's name string, discarding the inner type's user-defined-vs-built-in classification. So `Option<u32>` (built-in) and `Option<MyType>`, where `MyType` is a user type named `"u32"`, produced **byte-identical** type names.

A table created with one could then be opened as the other with no error, silently reading the stored bytes under the wrong encoding and yielding wrong results or unreachable keys. The classification byte exists precisely to keep a user type named `"u32"` from colliding with the built-in `u32`, but that protection was lost one nesting level down.

## Fix

Bubble the classification up: a composite that wraps a user-defined type is now itself classified user-defined, keeping the same name string. Composites of only built-in types are **byte-for-byte unchanged**, so existing databases open unchanged.

To keep tables created by older versions readable, `TypeName` carries an **in-memory-only** record of the classification it was bubbled from (never serialized), and `check_match` accepts that prior spelling in addition to the current one:

- For fixed-width composites the prior spelling is `Internal`, which also matches redb 2.6.
- For variable-width tuples it is `Internal2` only, so redb 2.6's incompatible variable-tuple encoding is still correctly rejected rather than silently misread.
- A flat user-defined type records no such classification, so this never lets a user type named `"u32"` alias the built-in `u32` at the top level.

The `Value`/`Key` public traits are untouched — the whole mechanism lives in `TypeName` plus the composite `type_name()` impls (which already had to change for the fix).

### Known limitation

An old `Option<user-type>` table is byte-identical on disk to a built-in `Option<u32>` table, so a name-colliding user type can still open a built-in table in the *reverse* direction. This is inherent to preserving backwards compatibility and only reachable if a user names their type to collide with a built-in (which the docs already advise against). It is strictly better than before, where the alias happened unconditionally in both directions.

## Tests

- Crate-internal unit tests in `src/types.rs`: built-in composites keep their exact classification (unchanged on-disk bytes); a composite of a name-colliding user type no longer equals its built-in counterpart; `matches_legacy` accepts the right `Internal`/`Internal2` prior spellings; and a flat user type never legacy-matches an `Internal` name.
- Cross-version tests in `tests/backward_compatibility.rs` using the real `redb 2.6.0` dev-dependency: an `Option<user-type>` table **written by redb 2.6 still opens and reads back correctly**, and an `Option<user-type>` table **can no longer be opened as the built-in `Option<u32>`** (returns `TableError::TableTypeMismatch`).

`cargo fmt --check`, `cargo clippy --all-targets --all-features`, and the full `cargo test --all-features` suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4cggr4Aoc9BVkEndj5Uyf)_