### PR TITLE
Fix composite type identity collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,11 +71,13 @@
   occurred while recovering from an earlier crash. Triggering it required two crashes -- one
   interrupting a commit and another during the subsequent repair on the next open -- and it did
   not affect transactions committed with two-phase commit.
-* Fix composite types (`Option`, `Vec`, tuples, and arrays) of a user-defined type sharing a
+* Fix new composite types (`Option`, `Vec`, tuples, and arrays) of a user-defined type sharing a
   type identity with the same composite of a built-in type when the two happened to have the same
   name. A table using such a composite of a user type can no longer be silently opened under the
   built-in composite (and vice versa); the mismatch is now reported as `TableError::TableTypeMismatch`.
-  Existing databases created by older versions remain readable.
+  Existing databases created by older versions remain readable. If an older database already used
+  such a colliding composite name, its stored type identity remains ambiguous and may still open
+  under either spelling.
 
 ### Python bindings
 * Add `Database.create(path)` for creating or opening a database file.

--- a/src/complex_types.rs
+++ b/src/complex_types.rs
@@ -90,6 +90,6 @@ impl<T: Value> Value for Vec<T> {
     fn type_name() -> TypeName {
         let inner = T::type_name();
         TypeName::internal(&format!("Vec<{}>", inner.name()))
-            .into_user_defined_if(inner.is_user_defined())
+            .into_composite(inner.is_user_defined())
     }
 }

--- a/src/tuple_types.rs
+++ b/src/tuple_types.rs
@@ -117,7 +117,7 @@ macro_rules! type_name_impl {
             } else {
                 TypeName::internal2(&result)
             };
-            natural.into_user_defined_if(any_user_defined)
+            natural.into_composite(any_user_defined)
         }
     };
 }
@@ -307,8 +307,7 @@ impl<T: Value> Value for (T,) {
 
     fn type_name() -> TypeName {
         let inner = T::type_name();
-        TypeName::internal(&format!("({},)", inner.name()))
-            .into_user_defined_if(inner.is_user_defined())
+        TypeName::internal(&format!("({},)", inner.name())).into_composite(inner.is_user_defined())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,6 +14,8 @@ enum TypeClassification {
     // Used by variable width tuple encoding in version 3.0 and newer. This differentiates the encoding
     // from the old encoding used previously
     Internal2,
+    // Used by composite types written by version 4.2 and newer
+    Internal3,
 }
 
 impl TypeClassification {
@@ -22,6 +24,7 @@ impl TypeClassification {
             TypeClassification::Internal => 1,
             TypeClassification::UserDefined => 2,
             TypeClassification::Internal2 => 3,
+            TypeClassification::Internal3 => 4,
         }
     }
 
@@ -30,6 +33,7 @@ impl TypeClassification {
             1 => TypeClassification::Internal,
             2 => TypeClassification::UserDefined,
             3 => TypeClassification::Internal2,
+            4 => TypeClassification::Internal3,
             _ => unreachable!(),
         }
     }
@@ -39,10 +43,10 @@ impl TypeClassification {
 pub struct TypeName {
     classification: TypeClassification,
     name: String,
-    // In-memory only; never serialized. For a composite (`Option`, `Vec`, tuple, array) of a
-    // user-defined type, whose classification is bubbled up to user-defined, this records the
-    // classification that older redb versions stored, so that their tables still match on open.
-    // `None` for leaf types, flat user-defined types, and every deserialized name.
+    // In-memory only; never serialized. For a composite (`Option`, `Vec`, tuple, array), this
+    // records the classification that older redb versions stored, so that their tables still
+    // match on open. That old spelling is ambiguous for colliding user and built-in composites.
+    // `None` for leaf types, flat user-defined types, and deserialized names.
     legacy_classification: Option<TypeClassification>,
 }
 
@@ -109,24 +113,27 @@ impl TypeName {
         matches!(self.classification, TypeClassification::UserDefined)
     }
 
-    // Reclassify this (composite) type name as user-defined when it wraps a user-defined type.
-    // A composite such as `Option<T>` builds its name only from the inner type's name string,
-    // which would let `Option<u32>` (built-in) collide with `Option<MyType>` where `MyType` is a
-    // user type named "u32". Bubbling the user-defined classification up keeps them distinct, and
-    // the classification being replaced is remembered so that older databases still match on open.
-    pub(crate) fn into_user_defined_if(mut self, user_defined: bool) -> Self {
+    // Classify a composite as user-defined when it wraps a user-defined type, and Internal3
+    // otherwise. The previous natural classification is retained so older databases still match.
+    pub(crate) fn into_composite(mut self, user_defined: bool) -> Self {
+        debug_assert!(matches!(
+            &self.classification,
+            TypeClassification::Internal | TypeClassification::Internal2
+        ));
+        self.legacy_classification = Some(self.classification.clone());
         if user_defined {
-            self.legacy_classification = Some(self.classification.clone());
             self.classification = TypeClassification::UserDefined;
+        } else {
+            self.classification = TypeClassification::Internal3;
         }
         self
     }
 
     // Whether `stored` (read from an existing database) is the spelling an older redb version
-    // wrote for this same type. Before composites of a user-defined type were bubbled up, they
-    // were classified `Internal` (or `Internal2` for variable width tuples); accepting that
-    // spelling keeps those databases readable, while a flat user-defined type -- which has no
-    // recorded legacy classification -- never matches a differently classified stored name.
+    // wrote for this same composite. Composites were classified `Internal` (or `Internal2` for
+    // variable-width tuples); accepting that spelling keeps those databases readable, but cannot
+    // distinguish legacy colliding user composites from built-in composites. A flat user-defined
+    // type has no recorded legacy classification.
     pub(crate) fn matches_legacy(&self, stored: &TypeName) -> bool {
         if let Some(natural) = &self.legacy_classification {
             *natural == stored.classification && self.name == stored.name
@@ -337,7 +344,7 @@ impl<T: Value> Value for Option<T> {
     fn type_name() -> TypeName {
         let inner = T::type_name();
         TypeName::internal(&format!("Option<{}>", inner.name()))
-            .into_user_defined_if(inner.is_user_defined())
+            .into_composite(inner.is_user_defined())
     }
 }
 
@@ -428,7 +435,7 @@ impl<const N: usize> Value for &[u8; N] {
     }
 
     fn type_name() -> TypeName {
-        TypeName::internal(&format!("[u8;{N}]"))
+        TypeName::internal(&format!("[u8;{N}]")).into_composite(false)
     }
 }
 
@@ -502,7 +509,7 @@ impl<const N: usize, T: Value> Value for [T; N] {
         // This requires that the binary encoding be the same
         let inner = T::type_name();
         TypeName::internal(&format!("[{};{N}]", inner.name()))
-            .into_user_defined_if(inner.is_user_defined())
+            .into_composite(inner.is_user_defined())
     }
 }
 
@@ -761,34 +768,39 @@ mod tests {
     }
 
     #[test]
-    fn builtin_composites_are_unchanged() {
-        // Composites of only built-in types must keep their exact classification (and therefore
-        // their on-disk bytes), so existing databases open unchanged.
-        assert!(!<Option<u32> as Value>::type_name().is_user_defined());
-        assert!(!<Vec<u32> as Value>::type_name().is_user_defined());
-        assert!(!<[u32; 3] as Value>::type_name().is_user_defined());
-        assert!(!<(u32,) as Value>::type_name().is_user_defined());
-        // Fixed-width tuple -> Internal; variable-width tuple -> Internal2. Neither is user-defined.
-        assert!(!<(u32, u64) as Value>::type_name().is_user_defined());
-        assert!(!<(u32, &str) as Value>::type_name().is_user_defined());
-        assert_eq!(
-            <(u32, u64) as Value>::type_name(),
-            TypeName::internal("(u32,u64)")
-        );
-        assert_eq!(
-            <(u32, &str) as Value>::type_name(),
-            TypeName::internal2("(u32,&str)")
-        );
-        // Nesting only built-in types never bubbles.
-        assert!(!<Vec<Option<u32>> as Value>::type_name().is_user_defined());
+    fn builtin_composites_use_internal3_and_match_legacy() {
+        fn assert_internal3(name: TypeName) {
+            assert!(matches!(name.classification, TypeClassification::Internal3));
+        }
 
-        // A built-in composite records no legacy classification, so it never legacy-matches a
-        // differently classified stored name.
+        assert_internal3(<Option<u32> as Value>::type_name());
+        assert_internal3(<Vec<u32> as Value>::type_name());
+        assert_internal3(<[u32; 3] as Value>::type_name());
+        assert_internal3(<&[u8; 3] as Value>::type_name());
+        assert_internal3(<(u32,) as Value>::type_name());
+        assert_internal3(<(u32, u64) as Value>::type_name());
+        assert_internal3(<(u32, &str) as Value>::type_name());
+        assert_internal3(<Vec<Option<u32>> as Value>::type_name());
+
+        // The owned and borrowed byte-array types remain compatible.
+        assert_eq!(
+            <[u8; 3] as Value>::type_name(),
+            <&[u8; 3] as Value>::type_name()
+        );
+
+        // Built-in composites accept their pre-4.2 classifications. Variable-width tuples only
+        // accept Internal2, preserving the encoding distinction introduced in version 3.0.
         assert!(
-            !<Option<u32> as Value>::type_name().matches_legacy(&TypeName::internal("Option<u32>"))
+            <Option<u32> as Value>::type_name().matches_legacy(&TypeName::internal("Option<u32>"))
         );
         assert!(
-            !<(u32, u64) as Value>::type_name().matches_legacy(&TypeName::internal("(u32,u64)"))
+            <(u32, u64) as Value>::type_name().matches_legacy(&TypeName::internal("(u32,u64)"))
+        );
+        assert!(
+            <(u32, &str) as Value>::type_name().matches_legacy(&TypeName::internal2("(u32,&str)"))
+        );
+        assert!(
+            !<(u32, &str) as Value>::type_name().matches_legacy(&TypeName::internal("(u32,&str)"))
         );
     }
 
@@ -817,7 +829,7 @@ mod tests {
         );
 
         // Only the classification differs; the human-readable name string is unchanged, and the
-        // user composite is now classified user-defined.
+        // user composite is classified user-defined.
         assert_eq!(
             <Option<u32> as Value>::type_name().name(),
             <Option<FakeU32> as Value>::type_name().name()

--- a/tests/backward_compatibility.rs
+++ b/tests/backward_compatibility.rs
@@ -509,6 +509,38 @@ fn composite_of_user_type_created_by_redb2_6_still_opens() {
     assert_eq!(table.get(&2u64).unwrap().unwrap().value(), None);
 }
 
+// redb 2.6 wrote `Option<u32>` and `Option<user "u32">` with the same stored type name:
+// `Internal + Option<u32>`. Current redb accepts that legacy spelling for built-in composites so
+// old built-in tables remain readable, which means this already-ambiguous legacy table also opens
+// under the built-in spelling.
+#[test]
+fn legacy_colliding_user_composite_can_still_open_as_builtin() {
+    let tmpfile = create_tempfile();
+    {
+        let db = redb2_6::Database::builder()
+            .create_with_file_format_v3(true)
+            .create(tmpfile.path())
+            .unwrap();
+        let def: redb2_6::TableDefinition<u64, Option<CollidingUserType>> =
+            redb2_6::TableDefinition::new("table");
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(def).unwrap();
+            table.insert(&1u64, &Some(7u32)).unwrap();
+            table.insert(&2u64, &None).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    let db = redb::Database::open(tmpfile.path()).unwrap();
+    let def: redb::TableDefinition<u64, Option<u32>> = redb::TableDefinition::new("table");
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(def).unwrap();
+    assert_eq!(table.len().unwrap(), 2);
+    assert_eq!(table.get(&1u64).unwrap().unwrap().value(), Some(7u32));
+    assert_eq!(table.get(&2u64).unwrap().unwrap().value(), None);
+}
+
 // The bug this guards against: a composite of a user-defined type must never silently alias the
 // built-in composite with the same name string. Opening an `Option<user "u32">` table under the
 // built-in `Option<u32>` must now fail with a type mismatch rather than misinterpreting the data.
@@ -531,6 +563,32 @@ fn composite_of_user_type_does_not_alias_builtin() {
     let txn = db.begin_write().unwrap();
     assert!(matches!(
         txn.open_table(builtin_def),
+        Err(redb::TableError::TableTypeMismatch { .. })
+    ));
+    txn.abort().unwrap();
+}
+
+// Built-in composites use the new Internal3 classification, so the legacy compatibility rule for
+// a user composite must not allow it to open a newly created built-in composite in reverse.
+#[test]
+fn builtin_composite_does_not_alias_user_type() {
+    let tmpfile = create_tempfile();
+    let db = redb::Database::create(tmpfile.path()).unwrap();
+    {
+        let def: redb::TableDefinition<u64, Option<u32>> = redb::TableDefinition::new("table");
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(def).unwrap();
+            table.insert(&1u64, &Some(7u32)).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    let user_def: redb::TableDefinition<u64, Option<CollidingUserType>> =
+        redb::TableDefinition::new("table");
+    let txn = db.begin_write().unwrap();
+    assert!(matches!(
+        txn.open_table(user_def),
         Err(redb::TableError::TableTypeMismatch { .. })
     ));
     txn.abort().unwrap();


### PR DESCRIPTION
Classify newly-written built-in composites with Internal3 and bubble user-defined classifications through composites so current databases reject built-in/user composite aliases in both directions.

Keep legacy Internal/Internal2 matching so existing pre-4.2 composite tables remain readable, and document the ambiguous old colliding case.

Assisted-by: Codex <codex@openai.com>