### PR TITLE
Prevent Infinite Recursion on Cyclic Page Corruption

### DIFF
--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -1262,9 +1262,21 @@ mod tests {
 
     #[test]
     fn test_page_path_cycle_detection() {
-        let p1 = PageNumber { region: 0, page_index: 1, page_order: 0 };
-        let p2 = PageNumber { region: 0, page_index: 2, page_order: 0 };
-        let p3 = PageNumber { region: 0, page_index: 3, page_order: 0 };
+        let p1 = PageNumber {
+            region: 0,
+            page_index: 1,
+            page_order: 0,
+        };
+        let p2 = PageNumber {
+            region: 0,
+            page_index: 2,
+            page_order: 0,
+        };
+        let p3 = PageNumber {
+            region: 0,
+            page_index: 3,
+            page_order: 0,
+        };
 
         let path = PagePath::new_root(p1);
         // No cycle yet: children p2 and p3 are clean
@@ -1282,20 +1294,118 @@ mod tests {
 
     #[test]
     fn test_verify_checksum_cycle_detection() {
-        let p1 = PageNumber { region: 0, page_index: 1, page_order: 0 };
-        let p2 = PageNumber { region: 0, page_index: 2, page_order: 0 };
+        let p1 = PageNumber {
+            region: 0,
+            page_index: 1,
+            page_order: 0,
+        };
+        let p2 = PageNumber {
+            region: 0,
+            page_index: 2,
+            page_order: 0,
+        };
 
-        let mut visited = Vec::new();
-        visited.push(p1);
-        visited.push(p2);
+        let visited = [p1, p2];
 
         // p1 and p2 are in the active path, so they should be detected as cycles
         assert!(visited.contains(&p1));
         assert!(visited.contains(&p2));
 
         // p3 is not in the active path, so no cycle
-        let p3 = PageNumber { region: 0, page_index: 3, page_order: 0 };
+        let p3 = PageNumber {
+            region: 0,
+            page_index: 3,
+            page_order: 0,
+        };
         assert!(!visited.contains(&p3));
     }
-}
 
+    #[test]
+    fn test_cycle_detection_in_btree() {
+        use crate::tree_store::btree_base::RawBranchBuilder;
+        use crate::tree_store::{
+            AllocationPolicy, InMemoryBackend, PAGE_SIZE, TransactionalMemory,
+        };
+
+        let mem = TransactionalMemory::new(
+            Box::new(InMemoryBackend::new()),
+            true,
+            PAGE_SIZE,
+            None,
+            0,
+            false,
+        )
+        .unwrap();
+        mem.reset_allocator_state().unwrap();
+        let mem = Arc::new(mem);
+        let page_allocator = PageAllocator::new(mem.clone(), AllocationPolicy::Default);
+        let allocated_pages = Mutex::new(PageTrackerPolicy::new_tracking());
+        let mut allocated_guard = allocated_pages.lock().unwrap();
+
+        let mut p1_mut = page_allocator
+            .allocate(PAGE_SIZE, &mut allocated_guard)
+            .unwrap();
+        let mut p2_mut = page_allocator
+            .allocate(PAGE_SIZE, &mut allocated_guard)
+            .unwrap();
+
+        let p1 = p1_mut.get_page_number();
+        let p2 = p2_mut.get_page_number();
+
+        // Write p2 first, pointing to p1 with a dummy checksum (e.g. 0)
+        {
+            let mut builder2 = RawBranchBuilder::new(p2_mut.memory_mut(), 1, Some(8));
+            builder2.write_first_page(p1, 0);
+            builder2.write_nth_key(b"key12345", p1, 0, 0);
+        }
+
+        // Compute checksum of p2
+        let p2_checksum = branch_checksum(&p2_mut, Some(8)).unwrap();
+
+        // Write p1 pointing to p2 with p2_checksum
+        {
+            let mut builder1 = RawBranchBuilder::new(p1_mut.memory_mut(), 1, Some(8));
+            builder1.write_first_page(p2, p2_checksum);
+            builder1.write_nth_key(b"key12345", p2, p2_checksum, 0);
+        }
+
+        // Compute checksum of p1
+        let p1_checksum = branch_checksum(&p1_mut, Some(8)).unwrap();
+
+        drop(p1_mut);
+        drop(p2_mut);
+        drop(allocated_guard);
+
+        // Construct the UntypedBtree and RawBtree
+        let header = BtreeHeader {
+            root: p1,
+            checksum: p1_checksum,
+            length: 1,
+        };
+
+        let resolver = PageResolver::new(mem);
+        let raw_btree = RawBtree::new(
+            Some(header),
+            Some(8),
+            Some(8),
+            resolver.clone(),
+            PageHint::None,
+        );
+        let untyped_btree =
+            UntypedBtree::new(Some(header), resolver, PageHint::None, Some(8), Some(8));
+
+        // Test RawBtree verify_checksum cycle detection: should return Ok(false) due to cycle
+        let verify_res = raw_btree.verify_checksum();
+        assert!(verify_res.is_ok());
+        assert!(!verify_res.unwrap());
+
+        // Test UntypedBtree visit_all_pages cycle detection: should return Err containing "Cycle detected"
+        let visit_res = untyped_btree.visit_all_pages(|_| Ok(()));
+        assert!(visit_res.is_err());
+        let err_str = format!("{:?}", visit_res.err().unwrap());
+        assert!(
+            err_str.contains("Cycle detected in Btree pages"),
+            "Expected cycle error, got: {err_str}"
+        );
+    }
+}

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -116,6 +116,11 @@ impl UntypedBtree {
                 let accessor = BranchAccessor::new(&page, self.key_width);
                 for i in 0..accessor.count_children() {
                     let child_page = accessor.child_page(i).unwrap();
+                    if path.parents().contains(&child_page) || path.page_number() == child_page {
+                        return Err(crate::StorageError::Corrupted(
+                            "Cycle detected in Btree pages".to_string(),
+                        ));
+                    }
                     let child_path = path.with_child(child_page);
                     self.visit_pages_helper(child_path, visitor)?;
                 }
@@ -877,7 +882,8 @@ impl RawBtree {
 
     pub(crate) fn verify_checksum(&self) -> Result<bool> {
         if let Some(header) = self.root {
-            self.verify_checksum_helper(header.root, header.checksum)
+            let mut visited = Vec::new();
+            self.verify_checksum_helper(header.root, header.checksum, &mut visited)
         } else {
             Ok(true)
         }
@@ -887,10 +893,16 @@ impl RawBtree {
         &self,
         page_number: PageNumber,
         expected_checksum: Checksum,
+        visited: &mut Vec<PageNumber>,
     ) -> Result<bool> {
+        if visited.contains(&page_number) {
+            return Ok(false);
+        }
+        visited.push(page_number);
+
         let page = self.mem.get_page(page_number, self.hint)?;
         let node_mem = page.memory();
-        Ok(match node_mem[0] {
+        let result = Ok(match node_mem[0] {
             LEAF => {
                 if let Ok(computed) =
                     leaf_checksum(&page, self.fixed_key_size, self.fixed_value_size)
@@ -913,6 +925,7 @@ impl RawBtree {
                     if !self.verify_checksum_helper(
                         accessor.child_page(i).unwrap(),
                         accessor.child_checksum(i).unwrap(),
+                        visited,
                     )? {
                         return Ok(false);
                     }
@@ -920,7 +933,10 @@ impl RawBtree {
                 true
             }
             _ => false,
-        })
+        });
+
+        visited.pop();
+        result
     }
 }
 
@@ -1239,3 +1255,47 @@ fn stats_helper(
         _ => unreachable!(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_page_path_cycle_detection() {
+        let p1 = PageNumber { region: 0, page_index: 1, page_order: 0 };
+        let p2 = PageNumber { region: 0, page_index: 2, page_order: 0 };
+        let p3 = PageNumber { region: 0, page_index: 3, page_order: 0 };
+
+        let path = PagePath::new_root(p1);
+        // No cycle yet: children p2 and p3 are clean
+        assert!(!(path.parents().contains(&p2) || path.page_number() == p2));
+
+        let path = path.with_child(p2);
+        assert!(!(path.parents().contains(&p3) || path.page_number() == p3));
+
+        // Self-loop on current page (p2)
+        assert!(path.parents().contains(&p2) || path.page_number() == p2);
+
+        // Loop back to ancestor (p1)
+        assert!(path.parents().contains(&p1) || path.page_number() == p1);
+    }
+
+    #[test]
+    fn test_verify_checksum_cycle_detection() {
+        let p1 = PageNumber { region: 0, page_index: 1, page_order: 0 };
+        let p2 = PageNumber { region: 0, page_index: 2, page_order: 0 };
+
+        let mut visited = Vec::new();
+        visited.push(p1);
+        visited.push(p2);
+
+        // p1 and p2 are in the active path, so they should be detected as cycles
+        assert!(visited.contains(&p1));
+        assert!(visited.contains(&p2));
+
+        // p3 is not in the active path, so no cycle
+        let p3 = PageNumber { region: 0, page_index: 3, page_order: 0 };
+        assert!(!visited.contains(&p3));
+    }
+}
+


### PR DESCRIPTION
During database startup/recovery or integrity checks on a corrupted `.redb` file, _B-tree_ tree-walking operations could get stuck in an infinite recursion, eventually exhausting the call stack and crashing the application.

This was occurring in two main recursive operations:
1. `RawBtree::verify_checksum_helper`: Recursing down branch children to verify leaf checksums.
2. `UntypedBtree::visit_pages_helper`: Recursing down branch children to visit pages.

If page corruption introduces cyclic pointers (e.g., a child page number points to an ancestor page), these functions would loop indefinitely.

This commit resolves the issue by introducing cycle detection:
- In `RawBtree::verify_checksum_helper`, we track the active DFS traversal path via a visited stack (`Vec<PageNumber>`). If a page has already been visited in the active path, it shotcircuits to return `Ok(false)` (checksum verification failure) instead of looping, allowing standard database repair/rollback to recover or fail gracefully.
- In `UntypedBtree::visit_pages_helper`, we verify if a child page is already part of the active path (`path.parents()` or `current page_number`). If a cycle is detected, it returns a `StorageError::Corrupted` error.

Added unit tests:
- `test_page_path_cycle_detection` to verify loop detection on PagePaths.
- `test_verify_checksum_cycle_detection` to verify loop detection on active verify stacks.

I met this issue in the real project.