### PR TITLE
Recompute root table counts during integrity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # redb - Changelog
 
 ## 4.2.0 - 2026-XX-XX
+* `check_integrity()` now recomputes the table counts stored alongside the data and system roots,
+  repairing a file whose counts disagree with its trees. Such a file previously passed the check
+  and then panicked, including from `Database::drop`.
 * Fix a crash during a transaction that grows the database file leaving the database permanently
   unopenable afterward.
 * Fix a potential deadlock when removing a value from a multimap table causes its value-set to

--- a/src/db.rs
+++ b/src/db.rs
@@ -685,7 +685,11 @@ impl Database {
         match Self::verify_primary_checksums(self.mem.clone()) {
             Ok(true) => {
                 let live_allocator_hash = self.mem.allocator_hash();
+                let live_roots = [self.mem.get_data_root(), self.mem.get_system_root()];
                 match Self::rebuild_allocator_state(&mut self.mem, &|_| {}) {
+                    // Only a durable root can be rewritten from here, so a live root whose table
+                    // count was recomputed must be rolled back and repaired by the reload below
+                    Ok(roots) if roots != live_roots => Ok(None),
                     Ok(_) => Ok(Some(live_allocator_hash == self.mem.allocator_hash())),
                     Err(DatabaseError::Storage(StorageError::Corrupted(_))) => Ok(None),
                     Err(err) => Err(err),
@@ -996,17 +1000,21 @@ impl Database {
     // Rebuilds the in-memory allocator state by marking every page reachable from the current
     // roots (including the pages referenced by the freed-page tables) as allocated. Operates
     // purely on in-memory state and does not modify the file.
+    //
+    // The returned roots carry table counts recounted from the trees that were walked. These
+    // counts are stored in the commit slot rather than in a page, so no page checksum covers
+    // them; recounting here is what lets the rest of the codebase trust them.
     fn rebuild_allocator_state(
         mem: &mut Arc<TransactionalMemory>, // Only &mut to ensure exclusivity
         repair_callback: &(dyn Fn(&mut RepairSession) + 'static),
     ) -> Result<[Option<BtreeHeader>; 2], DatabaseError> {
         mem.reset_allocator_state()?;
 
-        let data_root = mem.get_data_root();
-        {
+        let data_root = {
+            let root = mem.get_data_root();
             let untracked = Arc::new(TransactionGuard::untracked());
             let tables = TableTree::new(
-                data_root,
+                root,
                 PageHint::None,
                 untracked,
                 PageResolver::new(mem.clone()),
@@ -1015,7 +1023,8 @@ impl Database {
                 mem.mark_page_allocated(path.page_number());
                 Ok(())
             })?;
-        }
+            Self::with_recounted_length(root, tables.count_tables()?)
+        };
 
         // 0.9 because the repair takes 3 full scans and the third is done now. There is just some system tables left
         let mut handle = RepairSession::new(0.9);
@@ -1024,11 +1033,11 @@ impl Database {
             return Err(DatabaseError::RepairAborted);
         }
 
-        let system_root = mem.get_system_root();
-        {
+        let system_root = {
+            let root = mem.get_system_root();
             let untracked = Arc::new(TransactionGuard::untracked());
             let system_tables = TableTree::new(
-                system_root,
+                root,
                 PageHint::None,
                 untracked,
                 PageResolver::new(mem.clone()),
@@ -1037,7 +1046,8 @@ impl Database {
                 mem.mark_page_allocated(path.page_number());
                 Ok(())
             })?;
-        }
+            Self::with_recounted_length(root, system_tables.count_tables()?)
+        };
 
         Self::visit_freed_tree(system_root, DATA_FREED_TABLE, mem.clone(), |page| {
             mem.mark_page_allocated(page);
@@ -1053,6 +1063,10 @@ impl Database {
         }
 
         Ok([data_root, system_root])
+    }
+
+    fn with_recounted_length(root: Option<BtreeHeader>, length: u64) -> Option<BtreeHeader> {
+        root.map(|header| BtreeHeader::new(header.root, header.checksum, length))
     }
 
     fn new(

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -937,6 +937,96 @@ mod test {
         );
     }
 
+    fn read_root_length(path: &std::path::Path, root_offset: usize) -> u64 {
+        let mut header = [0u8; DB_HEADER_SIZE];
+        OpenOptions::new()
+            .read(true)
+            .open(path)
+            .unwrap()
+            .read_exact(&mut header)
+            .unwrap();
+        let slot = primary_slot_offset(header[GOD_BYTE_OFFSET]);
+        // The count is the last field of the serialized BtreeHeader
+        super::get_u64(
+            &header
+                [slot + root_offset + super::BtreeHeader::serialized_size() - size_of::<u64>()..],
+        )
+    }
+
+    // Re-checksums the slot, so the count is indistinguishable from one redb wrote itself
+    fn overwrite_root_length(path: &std::path::Path, root_offset: usize, length: u64) {
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+        let mut header = [0u8; DB_HEADER_SIZE];
+        file.read_exact(&mut header).unwrap();
+
+        let slot = primary_slot_offset(header[GOD_BYTE_OFFSET]);
+        let offset = slot + root_offset + super::BtreeHeader::serialized_size() - size_of::<u64>();
+        header[offset..offset + size_of::<u64>()].copy_from_slice(&length.to_le_bytes());
+        let checksum = super::xxh3_checksum(&header[slot..slot + super::SLOT_CHECKSUM_OFFSET]);
+        let checksum_offset = slot + super::SLOT_CHECKSUM_OFFSET;
+        header[checksum_offset..checksum_offset + size_of::<super::Checksum>()]
+            .copy_from_slice(&checksum.to_le_bytes());
+
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.write_all(&header).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    fn create_database_with_one_table(path: &std::path::Path) {
+        let db = Database::create(path).unwrap();
+        let txn = db.begin_write().unwrap();
+        txn.open_table(X).unwrap().insert("k", "v").unwrap();
+        txn.commit().unwrap();
+    }
+
+    // A root's table count is not covered by any page checksum, so repair has to recount it. Left
+    // wrong, it reaches the assertion in MutateHelper::finish_deletion -- for the system root, via
+    // the commit every Database::drop makes. See https://github.com/cberner/redb/issues/1303
+    #[test]
+    fn check_integrity_recomputes_root_lengths() {
+        let tmpfile = crate::create_tempfile();
+        create_database_with_one_table(tmpfile.path());
+        let data_length = read_root_length(tmpfile.path(), super::USER_ROOT_OFFSET);
+        let system_length = read_root_length(tmpfile.path(), super::SYSTEM_ROOT_OFFSET);
+        overwrite_root_length(tmpfile.path(), super::USER_ROOT_OFFSET, u64::MAX);
+        overwrite_root_length(tmpfile.path(), super::SYSTEM_ROOT_OFFSET, u64::MAX);
+
+        let mut db = Database::create(tmpfile.path()).unwrap();
+        // Repaired, so not clean, even though every checksum in the file verifies
+        assert!(!db.check_integrity().unwrap());
+        {
+            let txn = db.begin_read().unwrap();
+            let table = txn.open_table(X).unwrap();
+            assert_eq!(table.get("k").unwrap().unwrap().value(), "v");
+        }
+        // Deletes the allocator state table from the system tree, which asserts on a bad count
+        drop(db);
+
+        assert_eq!(
+            read_root_length(tmpfile.path(), super::USER_ROOT_OFFSET),
+            data_length
+        );
+        assert_eq!(
+            read_root_length(tmpfile.path(), super::SYSTEM_ROOT_OFFSET),
+            system_length
+        );
+        let db = Database::create(tmpfile.path()).unwrap();
+        let txn = db.begin_read().unwrap();
+        assert_eq!(
+            txn.open_table(X)
+                .unwrap()
+                .get("k")
+                .unwrap()
+                .unwrap()
+                .value(),
+            "v"
+        );
+    }
+
     // A backend that can report a `len()` larger than the data it actually holds, without
     // allocating it -- used to simulate an externally created (e.g. sparse) file.
     #[derive(Clone, Debug, Default)]

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -137,6 +137,16 @@ impl TableTree {
         Ok(true)
     }
 
+    // Counts the tables present, rather than returning the count stored in the tree's header
+    pub(crate) fn count_tables(&self) -> Result<u64> {
+        let mut count = 0;
+        for entry in self.tree.range::<RangeFull, &str>(&(..))? {
+            entry?;
+            count += 1;
+        }
+        Ok(count)
+    }
+
     // root_page: the root of the master table
     pub(crate) fn list_tables(&self, table_type: TableType) -> Result<Vec<String>> {
         let iter = self.tree.range::<RangeFull, &str>(&(..))?;

--- a/tests/check_integrity_nondurable.rs
+++ b/tests/check_integrity_nondurable.rs
@@ -174,6 +174,41 @@ fn check_integrity_preserves_growing_nondurable_commit() {
     );
 }
 
+// A non-durable commit that creates a table changes the number of tables in the live state. A
+// passing check must promote such a commit like any other.
+#[test]
+fn check_integrity_preserves_nondurable_commit_that_creates_a_table() {
+    const OTHER: TableDefinition<u64, &[u8]> = TableDefinition::new("other");
+
+    let backend = PatchBackend::default();
+    let mut db = make_db(backend.clone(), 1);
+    {
+        let mut txn = db.begin_write().unwrap();
+        txn.set_durability(Durability::None).unwrap();
+        txn.open_table(OTHER)
+            .unwrap()
+            .insert(&7u64, [0xCDu8; 8].as_slice())
+            .unwrap();
+        txn.commit().unwrap();
+    }
+
+    assert!(db.check_integrity().unwrap());
+
+    drop(db);
+    let db = Database::builder().create_with_backend(backend).unwrap();
+    let read = db.begin_read().unwrap();
+    assert_eq!(read.list_tables().unwrap().count(), 2);
+    assert_eq!(
+        read.open_table(OTHER)
+            .unwrap()
+            .get(&7u64)
+            .unwrap()
+            .unwrap()
+            .value(),
+        [0xCDu8; 8]
+    );
+}
+
 // If an external writer extends the file while a non-durable commit is pending, the file is longer
 // than the in-memory layout. check_integrity() must not promote the commit then (a layout
 // inconsistent with the file would corrupt subsequent opens). It must detect the mismatch and leave


### PR DESCRIPTION
## Summary
Fix a bug where `check_integrity()` would pass even when root table counts were corrupted, leading to a panic during subsequent operations like `Database::drop()`. The fix adds logic to recompute table counts from the actual tree structure during integrity checks and repair operations.

## Key Changes
- **Added test helper functions** in `header.rs`:
  - `read_root_length()`: Reads the table count from a root header in the database file
  - `overwrite_root_length()`: Corrupts a root's table count while maintaining valid checksums
  - `create_database_with_one_table()`: Helper to set up test database
  - `check_integrity_recomputes_root_lengths()`: Test verifying the fix works correctly

- **Enhanced `rebuild_allocator_state()`** in `db.rs`:
  - Now recounts tables by walking the actual tree structure for both data and system roots
  - Returns roots with corrected table counts instead of stale counts from headers
  - Added logic to detect when roots were modified during repair and trigger a reload

- **Added `with_recounted_length()`** helper in `db.rs`:
  - Creates a new `BtreeHeader` with corrected table count while preserving root page and checksum

- **Added `count_tables()`** method in `table_tree.rs`:
  - Iterates through all entries in a table tree to get an accurate count
  - Used during repair to recompute counts from actual tree structure

- **Updated `check_integrity()`** logic in `db.rs`:
  - Detects when roots were rewritten with corrected counts during repair
  - Returns `Ok(None)` to trigger a reload when counts were fixed, ensuring consistency

## Notable Details
Root table counts are stored in the commit slot rather than in any page, so they're not covered by page checksums. This makes them invisible to normal integrity checks. The fix ensures these counts are recomputed from the actual tree structure during repair, allowing corrupted counts to be detected and fixed before they cause panics.

https://claude.ai/code/session_01ReyAksqQwF774ALwWWTJZA