### PR TITLE
Refuse writes after a failed integrity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # redb - Changelog
 
 ## 4.2.0 - 2026-XX-XX
+* Fix a panic, including one raised while dropping a `Database`, after `check_integrity()` returned
+  an error. Such a database now refuses to begin a write transaction or to re-run the check,
+  returning `StorageError::Corrupted`, and is no longer recorded as cleanly shut down.
 * `check_integrity()` now recomputes the table counts stored alongside the data and system roots,
   repairing a file whose counts disagree with its trees. Such a file previously passed the check
   and then panicked, including from `Database::drop`.

--- a/src/db.rs
+++ b/src/db.rs
@@ -605,6 +605,26 @@ impl Database {
             return Err(DatabaseError::TransactionInProgress);
         }
 
+        // Rebuilding the allocator state is what this does, so there is nothing to retry once a
+        // previous call has failed at it
+        if !self.mem.allocator_state_loaded() {
+            return Err(StorageError::Corrupted(
+                "Allocator state was discarded by a failed integrity check".to_string(),
+            )
+            .into());
+        }
+
+        // Repairing rebuilds the allocator state, so a failure part way through leaves one that
+        // describes neither the file nor anything else. Holding an allocator state must continue
+        // to mean it describes the file.
+        let result = self.check_integrity_inner();
+        if result.is_err() {
+            self.mem.invalidate_allocator_state();
+        }
+        result
+    }
+
+    fn check_integrity_inner(&mut self) -> Result<bool, DatabaseError> {
         // A pending Durability::None commit is acknowledged, live data that the reload below would
         // discard. If the live state verifies, promote it to durable rather than losing it -- even
         // if the durable state it replaces turns out to be corrupt, in which case we recover from
@@ -1214,6 +1234,13 @@ impl Database {
     ) -> Result<WriteTransaction, TransactionError> {
         // Fail early if there has been an I/O error -- nothing can be committed in that case
         self.mem.check_io_errors()?;
+        // Every durable commit allocates and frees pages, which requires an allocator state
+        if !self.mem.allocator_state_loaded() {
+            return Err(StorageError::Corrupted(
+                "Allocator state was discarded by a failed integrity check".to_string(),
+            )
+            .into());
+        }
         let guard = TransactionGuard::new_write(
             self.transaction_tracker.start_write_transaction(),
             self.transaction_tracker.clone(),

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -603,6 +603,19 @@ impl TransactionalMemory {
         Ok(())
     }
 
+    // Discards an allocator state that no longer describes the file. Callers that allocate or free
+    // must check for one first, since those paths have no way to work without it.
+    pub(crate) fn invalidate_allocator_state(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.allocators = None;
+        #[cfg(debug_assertions)]
+        self.allocated_pages.lock().unwrap().clear();
+    }
+
+    pub(crate) fn allocator_state_loaded(&self) -> bool {
+        self.state.lock().unwrap().allocators.is_some()
+    }
+
     pub(crate) fn mark_page_allocated(&self, page_number: PageNumber) {
         let mut state = self.state.lock().unwrap();
         let region_index = page_number.region;
@@ -1369,7 +1382,9 @@ impl TransactionalMemory {
     fn flush_shutdown_header(&self) -> Result {
         if self.storage.check_io_errors().is_ok() && !thread::panicking() {
             let mut state = self.state.lock()?;
-            if self.storage.flush().is_ok() {
+            // Clearing the flag asserts that this process left the file consistent, which requires
+            // an allocator state describing what it wrote. Without one there is nothing to assert.
+            if state.allocators.is_some() && self.storage.flush().is_ok() {
                 state.header.recovery_required = false;
                 self.write_header(&state.header)?;
                 self.storage.flush()?;

--- a/tests/check_integrity_failure.rs
+++ b/tests/check_integrity_failure.rs
@@ -1,0 +1,125 @@
+//! Tests for the state a `Database` is left in when `check_integrity()` fails. The check rebuilds
+//! the allocator state, so a failure part way through leaves one that no longer describes the file.
+//! The database must refuse to write rather than allocate against it.
+
+use redb::{
+    Database, DatabaseError, ReadableDatabase, StorageBackend, StorageError, TableDefinition,
+};
+use std::sync::{Arc, RwLock};
+
+const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("t");
+
+// A backend backed by a shared Vec<u8> so the test can patch on-disk bytes, simulating corruption.
+#[derive(Clone, Debug, Default)]
+struct PatchBackend {
+    inner: Arc<RwLock<Vec<u8>>>,
+}
+
+impl PatchBackend {
+    // The god byte's recovery-required bit, which a clean shutdown clears.
+    fn recovery_required(&self) -> bool {
+        self.inner.read().unwrap()[9] & 2 != 0
+    }
+
+    // Flip all bits in the first occurrence of `needle`. Returns whether anything was patched.
+    fn corrupt_first_occurrence(&self, needle: &[u8]) -> bool {
+        let mut guard = self.inner.write().unwrap();
+        let mut i = 0;
+        while i + needle.len() <= guard.len() {
+            if &guard[i..i + needle.len()] == needle {
+                for b in &mut guard[i..i + needle.len()] {
+                    *b ^= 0xFF;
+                }
+                return true;
+            }
+            i += 1;
+        }
+        false
+    }
+}
+
+impl StorageBackend for PatchBackend {
+    fn len(&self) -> Result<u64, std::io::Error> {
+        Ok(self.inner.read().unwrap().len() as u64)
+    }
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
+        let offset = usize::try_from(offset).unwrap();
+        let guard = self.inner.read().unwrap();
+        if offset + out.len() > guard.len() {
+            return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof));
+        }
+        out.copy_from_slice(&guard[offset..offset + out.len()]);
+        Ok(())
+    }
+    fn set_len(&self, len: u64) -> Result<(), std::io::Error> {
+        self.inner
+            .write()
+            .unwrap()
+            .resize(len.try_into().unwrap(), 0);
+        Ok(())
+    }
+    fn sync_data(&self) -> Result<(), std::io::Error> {
+        Ok(())
+    }
+    fn write(&self, offset: u64, data: &[u8]) -> Result<(), std::io::Error> {
+        let offset = usize::try_from(offset).unwrap();
+        let mut guard = self.inner.write().unwrap();
+        if offset + data.len() > guard.len() {
+            return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof));
+        }
+        guard[offset..offset + data.len()].copy_from_slice(data);
+        Ok(())
+    }
+}
+
+// Corruption in a data page, which opening does not read, so the check is what finds it -- after
+// it has already discarded the allocator state it was rebuilding.
+#[test]
+fn writes_are_refused_after_a_failed_check_integrity() {
+    let backend = PatchBackend::default();
+    let marker = vec![0xC7u8; 2000];
+    {
+        let db = Database::builder()
+            .create_with_backend(backend.clone())
+            .unwrap();
+        let txn = db.begin_write().unwrap();
+        txn.open_table(TABLE)
+            .unwrap()
+            .insert(&1u64, marker.as_slice())
+            .unwrap();
+        txn.commit().unwrap();
+    }
+    assert!(
+        backend.corrupt_first_occurrence(&marker),
+        "could not locate the value on disk to corrupt"
+    );
+
+    let mut db = Database::builder()
+        .create_with_backend(backend.clone())
+        .unwrap();
+    assert!(matches!(
+        db.check_integrity(),
+        Err(DatabaseError::Storage(StorageError::Corrupted(_)))
+    ));
+
+    assert!(matches!(
+        db.begin_write(),
+        Err(redb::TransactionError::Storage(StorageError::Corrupted(_)))
+    ));
+
+    // Retrying rebuilds the same allocator state the first call failed to rebuild
+    assert!(matches!(
+        db.check_integrity(),
+        Err(DatabaseError::Storage(StorageError::Corrupted(_)))
+    ));
+
+    // Reads do not allocate, so they are still served.
+    assert_eq!(db.begin_read().unwrap().list_tables().unwrap().count(), 1);
+
+    // Database::drop commits the allocator state table, and must report the failure, not panic.
+    drop(db);
+
+    // Clearing the flag would assert that this process left the file consistent, which it cannot
+    // know without an allocator state.
+    assert!(backend.recovery_required());
+}


### PR DESCRIPTION
`check_integrity()` rebuilds the allocator state: `clear_cache_and_reload()` discards the one in memory, because it described the layout from before the reload, and the repair that follows repopulates it. A failure anywhere in between leaves no allocator state at all, or one holding only the pages the walk reached before it stopped -- neither of which describes the file.

The database stayed usable in that state. Every durable commit frees pages, so the next write ran the allocation paths against it: with no allocator state the free path hit the assertion guarding it, and with a partial one it would allocate over pages that are still live. `Database::drop` makes such a commit unconditionally, to write the allocator state table, so a caller that did nothing but check a corrupt file and drop it got a panic raised while dropping -- an abort, if the thread was already unwinding.

Reproducing needs only one corrupted page in a cleanly shut down database:

```
check_integrity -> Err(DB corrupted: Primary is corrupted despite 2-phase commit)
drop panicked: true
```

```
5: redb::tree_store::page_store::page_manager::InMemoryState::allocators_mut
6: redb::tree_store::page_store::page_manager::InMemoryState::get_region_mut
7: redb::tree_store::page_store::page_manager::TransactionalMemory::free_helper
...
13: redb::transactions::WriteTransaction::process_freed_pages
14: redb::transactions::WriteTransaction::durable_commit
...
17: redb::db::Database::ensure_allocator_state_table_and_trim
```

## Changes

- `check_integrity()`'s fallible body moves into `check_integrity_inner()`, and every error path discards the allocator state. Holding one therefore always means it describes the file, which also covers the partial-rebuild case that would have corrupted silently rather than panicked.
- `begin_write` refuses without one, returning `StorageError::Corrupted`. The commit in `Database::drop` then reports the failure through its existing warning path.
- `TransactionalMemory` gains `invalidate_allocator_state()` and `allocator_state_loaded()`.

The assertion in `free_helper` is left in place: it guards a genuine invariant, and this makes the reachable path an error instead of removing the guard.

## Testing

`tests/check_integrity_failure.rs` corrupts a page that only the tree walk finds, then asserts the check fails, the write is refused, and the drop is clean. It fails without this change.

`cargo fmt --check`, `cargo clippy --all --all-targets --all-features`, `cargo test --all --all-features`, and a 3 minute fuzz run (55k executions) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReyAksqQwF774ALwWWTJZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReyAksqQwF774ALwWWTJZA)_