### PR TITLE
Add owned accessors that keep the read transaction alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 * `check_integrity()` now recomputes the table counts stored alongside the data and system roots,
   repairing a file whose counts disagree with its trees. Such a file previously passed the check
   and then panicked, including from `Database::drop`.
+* Add `ReadOnlyTable::get_owned()`, `ReadOnlyTable::range_owned()`,
+  `ReadOnlyMultimapTable::get_owned()`, and `ReadOnlyMultimapTable::range_owned()`, which
+  return the new `OwnedAccessGuard`, `OwnedRange`, `OwnedMultimapValue`, and
+  `OwnedMultimapRange` types. These keep the read transaction alive until they are dropped,
+  including the guards yielded by the iterators, which may outlive the iterator that produced
+  them.
 * Fix a crash during a transaction that grows the database file leaving the database permanently
   unopenable afterward.
 * Fix a potential deadlock when removing a value from a multimap table causes its value-set to

--- a/crates/redb-bench/benches/common.rs
+++ b/crates/redb-bench/benches/common.rs
@@ -1,6 +1,9 @@
 use fjall::Readable as _;
 use heed::{CompactionOption, EnvFlags, EnvInfo, FlagSetMode};
-use redb::{AccessGuard, Durability, ReadableDatabase, ReadableTableMetadata, TableDefinition};
+use redb::{
+    AccessGuard, Durability, ReadableDatabase, ReadableTable, ReadableTableMetadata,
+    TableDefinition,
+};
 use rocksdb::{
     Direction, IteratorMode, OptimisticTransactionDB, OptimisticTransactionOptions, WriteOptions,
 };
@@ -828,11 +831,17 @@ impl BenchReader for RedbBenchReader {
         Self: 'out;
 
     fn get<'a>(&'a mut self, key: &[u8]) -> Option<Self::Output<'a>> {
-        self.table.get(key).unwrap().map(RedbAccessGuard::new)
+        // Explicit trait call, so that the benchmark measures the lifetime-bound accessor
+        // rather than the inherent reference-counted one that shadows it
+        ReadableTable::get(&self.table, key)
+            .unwrap()
+            .map(RedbAccessGuard::new)
     }
 
     fn range_from<'a>(&'a mut self, key: &'a [u8]) -> Self::Iterator<'a> {
-        let iter = self.table.range(key..).unwrap();
+        // Explicit trait call, so that the benchmark measures the lifetime-bound accessor
+        // rather than the inherent reference-counted one that shadows it
+        let iter = ReadableTable::range(&self.table, key..).unwrap();
         RedbBenchIterator { iter }
     }
 

--- a/examples/derive_value_impl.rs
+++ b/examples/derive_value_impl.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Error> {
 
     let read_txn = db.begin_read()?;
     let table = read_txn.open_table(TABLE)?;
-    assert_eq!(table.get(&key)?.unwrap().value(), 0);
+    assert_eq!(table.get_owned(&key)?.unwrap().value(), 0);
 
     Ok(())
 }

--- a/examples/int_keys.rs
+++ b/examples/int_keys.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Error> {
 
     let read_txn = db.begin_read()?;
     let table = read_txn.open_table(TABLE)?;
-    assert_eq!(table.get(0)?.unwrap().value(), 0);
+    assert_eq!(table.get_owned(0)?.unwrap().value(), 0);
 
     Ok(())
 }

--- a/examples/multithread.rs
+++ b/examples/multithread.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Error> {
                 let read_txn = db.begin_read()?;
                 // Print every (key, value) pair in the table
                 let table = read_txn.open_table(definition)?;
-                for (k, v) in table.range("0"..)?.flatten() {
+                for (k, v) in table.range_owned("0"..)?.flatten() {
                     println!("From read_thread #{}: {:?}, {:?}", i, k.value(), v.value());
                 }
             }
@@ -76,7 +76,7 @@ fn main() -> Result<(), Error> {
 
     // Print every (key, value) pair in the table
     let table = read_txn.open_table(definition)?;
-    for (k, v) in table.range("0"..)?.flatten() {
+    for (k, v) in table.range_owned("0"..)?.flatten() {
         println!("{:?}, {:?}", k.value(), v.value());
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,7 +5,8 @@ use crate::tree_store::{
 };
 use crate::types::{Key, Value};
 use crate::{
-    CompactionError, DatabaseError, Error, ReadOnlyTable, SavepointError, StorageError, TableError,
+    CompactionError, DatabaseError, Error, ReadOnlyTable, ReadableTable, SavepointError,
+    StorageError, TableError,
 };
 use crate::{ReadTransaction, Result, WriteTransaction};
 use std::fmt::{Debug, Display, Formatter};
@@ -836,7 +837,7 @@ impl Database {
                 Arc::new(TransactionGuard::untracked()),
                 resolver,
             )?;
-            for result in table.range::<TransactionIdWithPagination>(..)? {
+            for result in ReadableTable::range::<TransactionIdWithPagination>(&table, ..)? {
                 let (_, pages) = result?;
                 for i in 0..pages.value().len() {
                     assert!(mem.is_allocated(pages.value().get(i)));
@@ -893,7 +894,7 @@ impl Database {
                     Arc::new(TransactionGuard::untracked()),
                     resolver,
                 )?;
-            for result in table.range::<TransactionIdWithPagination>(..)? {
+            for result in ReadableTable::range::<TransactionIdWithPagination>(&table, ..)? {
                 let (_, page_list) = result?;
                 for i in 0..page_list.value().len() {
                     visitor(page_list.value().get(i))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!
 //!     let read_txn = db.begin_read()?;
 //!     let table = read_txn.open_table(TABLE)?;
-//!     assert_eq!(table.get("my_key")?.unwrap().value(), 123);
+//!     assert_eq!(table.get_owned("my_key")?.unwrap().value(), 123);
 //!
 //!     Ok(())
 //! }
@@ -70,12 +70,12 @@ pub use error::{
     StorageError, TableError, TransactionError,
 };
 pub use multimap_table::{
-    MultimapRange, MultimapTable, MultimapValue, ReadOnlyMultimapTable,
-    ReadOnlyUntypedMultimapTable, ReadableMultimapTable,
+    MultimapRange, MultimapTable, MultimapValue, OwnedMultimapRange, OwnedMultimapValue,
+    ReadOnlyMultimapTable, ReadOnlyUntypedMultimapTable, ReadableMultimapTable,
 };
 pub use table::{
-    Entry, ExtractIf, OccupiedEntry, Range, ReadOnlyTable, ReadOnlyUntypedTable, ReadableTable,
-    ReadableTableMetadata, Table, TableStats, VacantEntry,
+    Entry, ExtractIf, OccupiedEntry, OwnedAccessGuard, OwnedRange, Range, ReadOnlyTable,
+    ReadOnlyUntypedTable, ReadableTable, ReadableTableMetadata, Table, TableStats, VacantEntry,
 };
 pub use transactions::{DatabaseStats, Durability, ReadTransaction, WriteTransaction};
 pub use tree_store::{AccessGuard, AccessGuardMut, AccessGuardMutInPlace, Savepoint};

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -1,7 +1,7 @@
 use crate::db::TransactionGuard;
 use crate::multimap_table::DynamicCollectionType::{Inline, SubtreeV2};
 use crate::sealed::Sealed;
-use crate::table::{ReadableTableMetadata, TableStats};
+use crate::table::{OwnedAccessGuard, ReadableTableMetadata, TableStats};
 use crate::tree_store::{
     AllPageNumbersBtreeIter, BRANCH, Btree, BtreeCursorRange, BtreeHeader, BtreeMut,
     DynamicCollection, DynamicCollectionType, LEAF, LeafAccessor, MAX_PAIR_LENGTH,
@@ -382,6 +382,99 @@ impl<K: Key + 'static, V: Key + 'static> DoubleEndedIterator for MultimapRange<'
             }
             Err(err) => Some(Err(err)),
         }
+    }
+}
+
+/// A [`MultimapValue`] which also keeps the transaction alive
+///
+/// Returned by [`ReadOnlyMultimapTable::get_owned()`]. The iterator and the [`OwnedAccessGuard`]s it
+/// yields keep the read transaction alive until they are dropped.
+pub struct OwnedMultimapValue<V: Key + 'static> {
+    inner: MultimapValue<'static, V>,
+    transaction_guard: Arc<TransactionGuard>,
+}
+
+impl<V: Key + 'static> OwnedMultimapValue<V> {
+    fn new(inner: MultimapValue<'static, V>, guard: Arc<TransactionGuard>) -> Self {
+        Self {
+            inner,
+            transaction_guard: guard,
+        }
+    }
+
+    /// Returns the number of times this iterator will return `Some(Ok(_))`
+    ///
+    /// Note that `Some` may be returned from `next()` more than `len()` times if `Some(Err(_))` is returned
+    pub fn len(&self) -> u64 {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+impl<V: Key + 'static> Iterator for OwnedMultimapValue<V> {
+    type Item = Result<OwnedAccessGuard<V>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|x| x.map(|value| OwnedAccessGuard::new(value, self.transaction_guard.clone())))
+    }
+}
+
+impl<V: Key + 'static> DoubleEndedIterator for OwnedMultimapValue<V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(|x| x.map(|value| OwnedAccessGuard::new(value, self.transaction_guard.clone())))
+    }
+}
+
+/// A [`MultimapRange`] which also keeps the transaction alive
+///
+/// Returned by [`ReadOnlyMultimapTable::range_owned()`]. The iterator and the entries it yields keep
+/// the read transaction alive until they are dropped.
+pub struct OwnedMultimapRange<K: Key + 'static, V: Key + 'static> {
+    inner: MultimapRange<'static, K, V>,
+    transaction_guard: Arc<TransactionGuard>,
+}
+
+impl<K: Key + 'static, V: Key + 'static> OwnedMultimapRange<K, V> {
+    fn new(inner: MultimapRange<'static, K, V>, guard: Arc<TransactionGuard>) -> Self {
+        Self {
+            inner,
+            transaction_guard: guard,
+        }
+    }
+}
+
+impl<K: Key + 'static, V: Key + 'static> Iterator for OwnedMultimapRange<K, V> {
+    type Item = Result<(OwnedAccessGuard<K>, OwnedMultimapValue<V>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|x| {
+            x.map(|(key, values)| {
+                (
+                    OwnedAccessGuard::new(key, self.transaction_guard.clone()),
+                    OwnedMultimapValue::new(values, self.transaction_guard.clone()),
+                )
+            })
+        })
+    }
+}
+
+impl<K: Key + 'static, V: Key + 'static> DoubleEndedIterator for OwnedMultimapRange<K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(|x| {
+            x.map(|(key, values)| {
+                (
+                    OwnedAccessGuard::new(key, self.transaction_guard.clone()),
+                    OwnedMultimapValue::new(values, self.transaction_guard.clone()),
+                )
+            })
+        })
     }
 }
 
@@ -1030,6 +1123,19 @@ impl<K: Key + 'static, V: Key + 'static> ReadOnlyMultimapTable<K, V> {
         Ok(iter)
     }
 
+    /// This method is like [`ReadableMultimapTable::get()`], but the returned iterator is
+    /// reference counted and keeps the transaction alive until it is dropped, as do the
+    /// [`OwnedAccessGuard`]s it yields.
+    pub fn get_owned<'a>(
+        &self,
+        key: impl Borrow<K::SelfType<'a>>,
+    ) -> Result<OwnedMultimapValue<V>> {
+        Ok(OwnedMultimapValue::new(
+            self.get(key)?,
+            self.transaction_guard.clone(),
+        ))
+    }
+
     /// This method is like [`ReadableMultimapTable::range()`], but the iterator is reference counted and keeps the transaction
     /// alive until it is dropped.
     pub fn range<'a, KR>(&self, range: impl RangeBounds<KR>) -> Result<MultimapRange<'static, K, V>>
@@ -1041,6 +1147,22 @@ impl<K: Key + 'static, V: Key + 'static> ReadOnlyMultimapTable<K, V> {
             inner,
             self.transaction_guard.clone(),
             self.mem.clone(),
+        ))
+    }
+
+    /// This method is like [`ReadableMultimapTable::range()`], but the returned iterator is
+    /// reference counted and keeps the transaction alive until it is dropped, as do the entries
+    /// it yields.
+    pub fn range_owned<'a, KR>(
+        &self,
+        range: impl RangeBounds<KR>,
+    ) -> Result<OwnedMultimapRange<K, V>>
+    where
+        KR: Borrow<K::SelfType<'a>>,
+    {
+        Ok(OwnedMultimapRange::new(
+            self.range(range)?,
+            self.transaction_guard.clone(),
         ))
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -576,6 +576,17 @@ impl<K: Key + 'static, V: Value + 'static> ReadOnlyTable<K, V> {
         self.tree.get(key.borrow())
     }
 
+    /// This method is like [`ReadableTable::get()`], but the returned [`OwnedAccessGuard`] is
+    /// reference counted and keeps the transaction alive until it is dropped.
+    pub fn get_owned<'a>(
+        &self,
+        key: impl Borrow<K::SelfType<'a>>,
+    ) -> Result<Option<OwnedAccessGuard<V>>> {
+        Ok(self
+            .get(key)?
+            .map(|x| OwnedAccessGuard::new(x, self.transaction_guard.clone())))
+    }
+
     /// This method is like [`ReadableTable::range()`], but the iterator is reference counted and keeps the transaction
     /// alive until it is dropped.
     pub fn range<'a, KR>(&self, range: impl RangeBounds<KR>) -> Result<Range<'static, K, V>>
@@ -585,6 +596,19 @@ impl<K: Key + 'static, V: Value + 'static> ReadOnlyTable<K, V> {
         self.tree
             .range(&range)
             .map(|x| Range::new(x, self.transaction_guard.clone()))
+    }
+
+    /// This method is like [`ReadableTable::range()`], but the returned iterator is reference
+    /// counted and keeps the transaction alive until it is dropped, as do the
+    /// [`OwnedAccessGuard`]s it yields.
+    pub fn range_owned<'a, KR>(&self, range: impl RangeBounds<KR>) -> Result<OwnedRange<K, V>>
+    where
+        KR: Borrow<K::SelfType<'a>>,
+    {
+        Ok(OwnedRange::new(
+            self.range(range)?,
+            self.transaction_guard.clone(),
+        ))
     }
 }
 
@@ -764,6 +788,79 @@ impl<K: Key + 'static, V: Value + 'static> DoubleEndedIterator for Range<'_, K, 
                 let key = AccessGuard::with_page(page.clone(), key_range);
                 let value = AccessGuard::with_page(page, value_range);
                 (key, value)
+            })
+        })
+    }
+}
+
+/// An [`AccessGuard`] which also keeps the transaction alive
+///
+/// Returned by the reference-counted accessors of [`ReadOnlyTable`] and
+/// [`crate::ReadOnlyMultimapTable`], such as [`ReadOnlyTable::get_owned()`]: in addition to
+/// providing access to the data, it keeps the read transaction alive until it is dropped.
+pub struct OwnedAccessGuard<V: Value + 'static> {
+    // Declared before the transaction guard so the page reference is released before the
+    // transaction is deallocated
+    inner: AccessGuard<'static, V>,
+    _transaction_guard: Arc<TransactionGuard>,
+}
+
+impl<V: Value + 'static> OwnedAccessGuard<V> {
+    pub(crate) fn new(inner: AccessGuard<'static, V>, guard: Arc<TransactionGuard>) -> Self {
+        Self {
+            inner,
+            _transaction_guard: guard,
+        }
+    }
+
+    /// Access the stored value
+    pub fn value(&self) -> V::SelfType<'_> {
+        self.inner.value()
+    }
+}
+
+/// A [`Range`] which also keeps the transaction alive
+///
+/// Returned by [`ReadOnlyTable::range_owned()`]. The iterator and the [`OwnedAccessGuard`]s it
+/// yields keep the read transaction alive until they are dropped.
+#[derive(Clone)]
+pub struct OwnedRange<K: Key + 'static, V: Value + 'static> {
+    inner: Range<'static, K, V>,
+    transaction_guard: Arc<TransactionGuard>,
+}
+
+impl<K: Key + 'static, V: Value + 'static> OwnedRange<K, V> {
+    pub(super) fn new(inner: Range<'static, K, V>, guard: Arc<TransactionGuard>) -> Self {
+        Self {
+            inner,
+            transaction_guard: guard,
+        }
+    }
+}
+
+impl<K: Key + 'static, V: Value + 'static> Iterator for OwnedRange<K, V> {
+    type Item = Result<(OwnedAccessGuard<K>, OwnedAccessGuard<V>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|x| {
+            x.map(|(key, value)| {
+                (
+                    OwnedAccessGuard::new(key, self.transaction_guard.clone()),
+                    OwnedAccessGuard::new(value, self.transaction_guard.clone()),
+                )
+            })
+        })
+    }
+}
+
+impl<K: Key + 'static, V: Value + 'static> DoubleEndedIterator for OwnedRange<K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(|x| {
+            x.map(|(key, value)| {
+                (
+                    OwnedAccessGuard::new(key, self.transaction_guard.clone()),
+                    OwnedAccessGuard::new(value, self.transaction_guard.clone()),
+                )
             })
         })
     }

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -777,7 +777,7 @@ mod test {
         {
             let read_txn = db2.begin_read().unwrap();
             let table = read_txn.open_table(X).unwrap();
-            assert_eq!(table.get("hello").unwrap().unwrap().value(), "world");
+            assert_eq!(table.get_owned("hello").unwrap().unwrap().value(), "world");
         }
         let write_txn = db2.begin_write().unwrap();
         {
@@ -799,8 +799,11 @@ mod test {
         {
             let read_txn = db2.begin_read().unwrap();
             let table = read_txn.open_table(X).unwrap();
-            assert_eq!(table.get("hello").unwrap().unwrap().value(), "world");
-            assert_eq!(table.get("hello2").unwrap().unwrap().value(), "world2");
+            assert_eq!(table.get_owned("hello").unwrap().unwrap().value(), "world");
+            assert_eq!(
+                table.get_owned("hello2").unwrap().unwrap().value(),
+                "world2"
+            );
         }
 
         db2_backend_control.corrupt_all_slot_checksums().unwrap();
@@ -1260,7 +1263,7 @@ mod test {
             let db = Database::open(tmpfile.path()).unwrap();
             let read_txn = db.begin_read().unwrap();
             let table = read_txn.open_table(X).unwrap();
-            assert_eq!(table.get("hello").unwrap().unwrap().value(), "world");
+            assert_eq!(table.get_owned("hello").unwrap().unwrap().value(), "world");
         }
 
         // Both counts torn to zero describes zero regions: previously rejected as

--- a/src/types/chrono_v0_4.rs
+++ b/src/types/chrono_v0_4.rs
@@ -460,7 +460,7 @@ mod tests {
         {
             let table = read_txn.open_table(FIXED_OFFSET_TABLE).unwrap();
             let offset = FixedOffset::east_opt(3600).unwrap(); // +01:00
-            let value = table.get(&offset).unwrap().unwrap();
+            let value = table.get_owned(&offset).unwrap().unwrap();
             assert_eq!(value.value(), 1);
         }
     }
@@ -479,7 +479,7 @@ mod tests {
         {
             let table = read_txn.open_table(NAIVE_DATE_TABLE).unwrap();
             let date = NaiveDate::from_ymd_opt(2023, 10, 5).unwrap();
-            let value = table.get(&date).unwrap().unwrap();
+            let value = table.get_owned(&date).unwrap().unwrap();
             assert_eq!(value.value(), 1);
         }
     }
@@ -498,7 +498,7 @@ mod tests {
         {
             let table = read_txn.open_table(NAIVE_TIME_TABLE).unwrap();
             let time = NaiveTime::from_hms_opt(12, 30, 45).unwrap();
-            let value = table.get(&time).unwrap().unwrap();
+            let value = table.get_owned(&time).unwrap().unwrap();
             assert_eq!(value.value(), 1);
         }
     }
@@ -522,7 +522,7 @@ mod tests {
             let date = NaiveDate::from_ymd_opt(2023, 10, 5).unwrap();
             let time = NaiveTime::from_hms_opt(12, 30, 45).unwrap();
             let datetime = NaiveDateTime::new(date, time);
-            let value = table.get(&datetime).unwrap().unwrap();
+            let value = table.get_owned(&datetime).unwrap().unwrap();
             assert_eq!(value.value(), 1);
         }
     }
@@ -540,7 +540,7 @@ mod tests {
         let read_txn = db.begin_read().unwrap();
         {
             let table = read_txn.open_table(DATETIME_FIXED_OFFSET_TABLE).unwrap();
-            let value = table.get(&now).unwrap().unwrap();
+            let value = table.get_owned(&now).unwrap().unwrap();
             assert_eq!(value.value(), 1);
         }
     }

--- a/src/types/uuid.rs
+++ b/src/types/uuid.rs
@@ -76,7 +76,7 @@ mod tests {
         let read_txn = db.begin_read().unwrap();
         {
             let table = read_txn.open_table(UUID_TABLE).unwrap();
-            let value = table.get(&uuid1).unwrap().unwrap();
+            let value = table.get_owned(&uuid1).unwrap().unwrap();
             assert_eq!(value.value(), uuid2);
         }
     }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -5,7 +5,7 @@ use redb::CommitError;
 use redb::DatabaseError;
 use redb::backends::InMemoryBackend;
 use redb::{
-    Database, Key, MultimapTableDefinition, MultimapTableHandle, Range, ReadOnlyDatabase,
+    Database, Key, MultimapTableDefinition, MultimapTableHandle, OwnedRange, ReadOnlyDatabase,
     ReadableDatabase, ReadableTable, ReadableTableMetadata, TableDefinition, TableError,
     TableHandle, TypeName, Value,
 };
@@ -2130,7 +2130,7 @@ fn i128_type() {
     let read_txn = db.begin_read().unwrap();
     let table = read_txn.open_table(definition).unwrap();
     assert_eq!(-2, table.get(&-1).unwrap().unwrap().value());
-    let mut iter: Range<i128, i128> = table.range::<i128>(..).unwrap();
+    let mut iter: OwnedRange<i128, i128> = table.range_owned::<i128>(..).unwrap();
     for i in -11..10 {
         assert_eq!(iter.next().unwrap().unwrap().1.value(), i);
     }
@@ -2178,7 +2178,7 @@ fn str_type() {
     assert_eq!(iter.next().unwrap().unwrap().1.value(), "world");
     assert!(iter.next().is_none());
 
-    let mut iter: Range<&str, &str> = table.range("a".."z").unwrap();
+    let mut iter: OwnedRange<&str, &str> = table.range_owned("a".."z").unwrap();
     assert_eq!(iter.next().unwrap().unwrap().1.value(), "world");
     assert!(iter.next().is_none());
 }
@@ -2210,7 +2210,8 @@ fn string_type() {
     assert_eq!(iter.next().unwrap().unwrap().1.value(), "world");
     assert!(iter.next().is_none());
 
-    let mut iter: Range<String, String> = table.range("a".to_string().."z".to_string()).unwrap();
+    let mut iter: OwnedRange<String, String> =
+        table.range_owned("a".to_string().."z".to_string()).unwrap();
     assert_eq!(iter.next().unwrap().unwrap().1.value(), "world");
     assert!(iter.next().is_none());
 }
@@ -2305,7 +2306,7 @@ fn array_type() {
     let hello = b"hello";
     assert_eq!(b"world_123", table.get(hello).unwrap().unwrap().value());
 
-    let mut iter: Range<&[u8; 5], &[u8; 9]> = table.range::<&[u8; 5]>(..).unwrap();
+    let mut iter: OwnedRange<&[u8; 5], &[u8; 9]> = table.range_owned::<&[u8; 5]>(..).unwrap();
     assert_eq!(iter.next().unwrap().unwrap().1.value(), b"world_123");
     assert!(iter.next().is_none());
 }
@@ -3039,12 +3040,12 @@ fn owned_get_signatures() {
 
     assert_eq!(2, table.get(&1).unwrap().unwrap().value());
 
-    let mut iter: Range<u32, u32> = table.range::<u32>(..).unwrap();
+    let mut iter: OwnedRange<u32, u32> = table.range_owned::<u32>(..).unwrap();
     for i in 0..10 {
         assert_eq!(iter.next().unwrap().unwrap().1.value(), i + 1);
     }
     assert!(iter.next().is_none());
-    let mut iter: Range<u32, u32> = table.range(0..10).unwrap();
+    let mut iter: OwnedRange<u32, u32> = table.range_owned(0..10).unwrap();
     for i in 0..10 {
         assert_eq!(iter.next().unwrap().unwrap().1.value(), i + 1);
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1164,6 +1164,94 @@ fn explicit_close() {
 }
 
 #[test]
+fn read_only_get_guard_keeps_transaction_alive() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..100 {
+            table.insert(i, i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    let guard = table.get_owned(&5).unwrap().unwrap();
+
+    // The guard alone must keep the transaction registered
+    drop(table);
+    assert!(matches!(
+        read_txn.close(),
+        Err(TransactionError::ReadTransactionStillInUse(_))
+    ));
+
+    // Concurrent writers must not reclaim the pages referenced by the guard, even though
+    // every other object referencing the read transaction has been dropped
+    for _ in 0..10 {
+        let write_txn = db.begin_write().unwrap();
+        {
+            let mut table = write_txn.open_table(U64_TABLE).unwrap();
+            for i in 0..100 {
+                table.insert(i, i + 1).unwrap();
+            }
+        }
+        write_txn.commit().unwrap();
+    }
+
+    assert_eq!(guard.value(), 5);
+}
+
+#[test]
+fn read_only_range_guards_keep_transaction_alive() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..100 {
+            table.insert(i, i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    let mut range = table.range_owned(5..).unwrap();
+    let (key, value) = range.next().unwrap().unwrap();
+    let (back_key, back_value) = range.next_back().unwrap().unwrap();
+
+    // The yielded guards alone must keep the transaction registered
+    drop(range);
+    drop(table);
+    assert!(matches!(
+        read_txn.close(),
+        Err(TransactionError::ReadTransactionStillInUse(_))
+    ));
+
+    // Concurrent writers must not reclaim the pages referenced by the guards, even though
+    // every other object referencing the read transaction has been dropped
+    for _ in 0..10 {
+        let write_txn = db.begin_write().unwrap();
+        {
+            let mut table = write_txn.open_table(U64_TABLE).unwrap();
+            for i in 0..100 {
+                table.insert(i, i + 1).unwrap();
+            }
+        }
+        write_txn.commit().unwrap();
+    }
+
+    assert_eq!(key.value(), 5);
+    assert_eq!(value.value(), 5);
+    assert_eq!(back_key.value(), 99);
+    assert_eq!(back_value.value(), 99);
+}
+
+#[test]
 fn large_keys() {
     let tmpfile = create_tempfile();
 

--- a/tests/multimap_tests.rs
+++ b/tests/multimap_tests.rs
@@ -1,6 +1,6 @@
 use redb::{
     Database, MultimapTableDefinition, ReadableDatabase, ReadableMultimapTable,
-    ReadableTableMetadata, TableError,
+    ReadableTableMetadata, TableError, TransactionError,
 };
 
 const STR_TABLE: MultimapTableDefinition<&str, &str> = MultimapTableDefinition::new("str_to_str");
@@ -646,4 +646,93 @@ fn multimap_remove_nonexistent_value_from_subtree_does_not_churn() {
     let table = read_txn.open_multimap_table(U64_TABLE).unwrap();
     assert_eq!(table.len().unwrap(), 1000);
     assert_eq!(table.get(&0u64).unwrap().len(), 1000);
+}
+
+fn overwrite_multimap_10_times(db: &Database) {
+    for _ in 0..10 {
+        let write_txn = db.begin_write().unwrap();
+        {
+            let mut table = write_txn.open_multimap_table(U64_TABLE).unwrap();
+            table.remove_all(&0u64).unwrap();
+            // Enough values for key 0 to be promoted from inline storage to a subtree
+            for v in 0..1000u64 {
+                table.insert(&0u64, &v).unwrap();
+            }
+            table.remove_all(&1u64).unwrap();
+            // Few enough values for key 1 to stay inline
+            for v in 0..3u64 {
+                table.insert(&1u64, &v).unwrap();
+            }
+        }
+        write_txn.commit().unwrap();
+    }
+}
+
+#[test]
+fn read_only_get_value_guards_keep_transaction_alive() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    overwrite_multimap_10_times(&db);
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_multimap_table(U64_TABLE).unwrap();
+    let mut subtree_values = table.get_owned(&0u64).unwrap();
+    assert_eq!(subtree_values.len(), 1000);
+    assert!(!subtree_values.is_empty());
+    let subtree_value = subtree_values.next().unwrap().unwrap();
+    let subtree_back_value = subtree_values.next_back().unwrap().unwrap();
+    assert_eq!(subtree_values.len(), 998);
+    let mut inline_values = table.get_owned(&1u64).unwrap();
+    let inline_value = inline_values.next().unwrap().unwrap();
+
+    // The yielded guards alone must keep the transaction registered
+    drop(subtree_values);
+    drop(inline_values);
+    drop(table);
+    assert!(matches!(
+        read_txn.close(),
+        Err(TransactionError::ReadTransactionStillInUse(_))
+    ));
+
+    // Concurrent writers must not reclaim the pages referenced by the guards, even though
+    // every other object referencing the read transaction has been dropped
+    overwrite_multimap_10_times(&db);
+
+    assert_eq!(subtree_value.value(), 0);
+    assert_eq!(subtree_back_value.value(), 999);
+    assert_eq!(inline_value.value(), 0);
+}
+
+#[test]
+fn read_only_range_entries_keep_transaction_alive() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    overwrite_multimap_10_times(&db);
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_multimap_table(U64_TABLE).unwrap();
+    let mut range = table.range_owned(0u64..).unwrap();
+    let (key, mut values) = range.next().unwrap().unwrap();
+    let value = values.next().unwrap().unwrap();
+    let (back_key, mut back_values) = range.next_back().unwrap().unwrap();
+    let back_value = back_values.next_back().unwrap().unwrap();
+
+    // The yielded guards alone must keep the transaction registered
+    drop(values);
+    drop(back_values);
+    drop(range);
+    drop(table);
+    assert!(matches!(
+        read_txn.close(),
+        Err(TransactionError::ReadTransactionStillInUse(_))
+    ));
+
+    // Concurrent writers must not reclaim the pages referenced by the guards, even though
+    // every other object referencing the read transaction has been dropped
+    overwrite_multimap_10_times(&db);
+
+    assert_eq!(key.value(), 0);
+    assert_eq!(value.value(), 0);
+    assert_eq!(back_key.value(), 1);
+    assert_eq!(back_value.value(), 2);
 }


### PR DESCRIPTION
## Problem

`ReadOnlyTable::get()` documents that its guard "is reference counted and keeps the transaction alive until it is dropped", but nothing is actually kept alive: the guard holds only the page. The same applies to the guards and entries yielded by the `'static` iterators from `ReadOnlyTable::range()`, `ReadOnlyMultimapTable::get()`, and `ReadOnlyMultimapTable::range()`, which may outlive the iterator that produced them.

Holding any of these past the `ReadTransaction` unregisters the read snapshot, so a concurrent writer is free to reclaim the referenced pages: the writer's `commit()` panics on the `read_page_ref_counts` assertion in debug builds (reproduced with a simple insert/get/drop-txn/overwrite loop; the first commit panics).

## Change

Adds `get_owned()` and `range_owned()` to `ReadOnlyTable` and `ReadOnlyMultimapTable`, returning new `OwnedAccessGuard`, `OwnedRange`, `OwnedMultimapValue`, and `OwnedMultimapRange` types. These wrap the plain guard or iterator together with the transaction guard, keeping the transaction alive until the last of them is dropped (naming follows tokio's `OwnedMutexGuard` convention). `ReadTransaction::close()` correctly reports the transaction as still in use while any of them is alive.

The existing methods are untouched (`src/table.rs` has zero deletions); deprecating them is planned as a follow-up PR.

## Why wrapper types

Storing the transaction inside `AccessGuard` (as a field or an `EitherPage` variant) slowed range scans by 4-7% on the paths that never pin, through a combination of guard size (96 -> 104 bytes), drop glue that no longer inlined cross-crate, and branchier iterators. With wrapper types, cachegrind shows the existing paths at exact instruction parity with master (2,888.6M vs 2,888.9M instructions on 2M-entry range scans), and the owned paths cost about 1.5% more instructions than the borrowing ones.

The benchmark harness now calls the `ReadableTable` trait methods explicitly so it measures the lifetime-bound accessors, which are the ones comparable to the other engines' cursor semantics.

## Testing

- Four new regression tests covering `get_owned()` guards, `range_owned()` yields, and multimap owned values (inline and subtree) held past table + transaction drop while a writer commits repeatedly; each fails on master
- Full suite passes (327 tests), clippy pedantic and fmt clean, cargo-deny clean
- Examples and the crate-level doc example showcase the new accessors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCYPuM4nb94pF36ZX7R8sa

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCYPuM4nb94pF36ZX7R8sa)_