### PR TITLE
Keep the database open while a write transaction is live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # redb - Changelog
 
 ## 4.2.0 - 2026-XX-XX
+* Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. A live
+  `WriteTransaction` now keeps the database open: the transaction remains usable after the
+  `Database` is dropped, and the database closes when the transaction commits, aborts, or is
+  dropped.
 * Fix a panic, including one raised while dropping a `Database`, after `check_integrity()` returned
   an error. Such a database now refuses to begin a write transaction or to re-run the check,
   returning `StorageError::Corrupted`, and is no longer recorded as cleanly shut down.

--- a/src/db.rs
+++ b/src/db.rs
@@ -53,7 +53,8 @@ pub trait StorageBackend: 'static + Debug + Send + Sync {
     /// Release any resources held by the backend
     ///
     /// Note: redb will not access the backend after calling this method and will call it exactly
-    /// once when the [`Database`] is dropped
+    /// once when the database is closed: when the [`Database`] is dropped, or, if a
+    /// [`WriteTransaction`] was live at that point, when that transaction completes
     fn close(&self) -> std::result::Result<(), io::Error> {
         Ok(())
     }
@@ -341,7 +342,13 @@ impl Drop for TransactionGuard {
             Self::Write {
                 tracker,
                 transaction_id,
-            } => tracker.end_write_transaction(*transaction_id),
+            } => {
+                if let Some(mem) = tracker.end_write_transaction(*transaction_id) {
+                    // The Database was dropped while this transaction was live, deferring
+                    // the database close to the end of this transaction
+                    close_database(tracker, &mem);
+                }
+            }
             Self::Untracked => {}
         }
     }
@@ -481,6 +488,17 @@ impl ReadOnlyDatabase {
 ///
 /// Multiple reads may be performed concurrently, with each other, and with writes. Only a single write
 /// may be in progress at a time.
+///
+/// # Close semantics
+///
+/// Dropping the [`Database`] closes the database: buffered data is flushed, the file lock is
+/// released, and outstanding [`ReadTransaction`]s are invalidated (their operations will return
+/// [`StorageError::DatabaseClosed`]).
+///
+/// A live [`WriteTransaction`] keeps the database open, however: if one exists when the
+/// [`Database`] is dropped, the transaction remains fully usable and the close described above
+/// is deferred until the transaction commits, aborts, or is dropped. Until then the database
+/// file remains locked, so re-opening it fails with [`DatabaseError::DatabaseAlreadyOpen`].
 ///
 /// # Examples
 ///
@@ -1223,67 +1241,105 @@ impl Database {
     /// Returns a [`WriteTransaction`] which may be used to read/write to the database. Only a single
     /// write may be in progress at a time. If a write is in progress, this function will block
     /// until it completes.
+    ///
+    /// The returned transaction is not lifetime-bound to this [`Database`] and keeps the
+    /// database open: if the [`Database`] is dropped while the transaction is live, the
+    /// transaction remains usable and the database closes when the transaction completes.
     pub fn begin_write(&self) -> Result<WriteTransaction, TransactionError> {
-        self.begin_write_with_allocation_policy(AllocationPolicy::Default)
-    }
-
-    // The allocation policy is fixed for the lifetime of the transaction; every page allocation
-    // this transaction makes goes through it.
-    pub(crate) fn begin_write_with_allocation_policy(
-        &self,
-        allocation_policy: AllocationPolicy,
-    ) -> Result<WriteTransaction, TransactionError> {
-        // Fail early if there has been an I/O error -- nothing can be committed in that case
-        self.mem.check_io_errors()?;
-        // Every durable commit allocates and frees pages, which requires an allocator state
-        if !self.mem.allocator_state_loaded() {
-            return Err(StorageError::Corrupted(
-                "Allocator state was discarded by a failed integrity check".to_string(),
-            )
-            .into());
-        }
-        let guard = TransactionGuard::new_write(
-            self.transaction_tracker.start_write_transaction(),
-            self.transaction_tracker.clone(),
-        );
-        WriteTransaction::new(
-            guard,
-            self.transaction_tracker.clone(),
-            self.mem.clone(),
-            allocation_policy,
+        begin_write_with_allocation_policy(
+            &self.transaction_tracker,
+            &self.mem,
+            AllocationPolicy::Default,
         )
-        .map_err(|e| e.into())
+    }
+}
+
+// The allocation policy is fixed for the lifetime of the transaction; every page allocation
+// this transaction makes goes through it.
+fn begin_write_with_allocation_policy(
+    transaction_tracker: &Arc<TransactionTracker>,
+    mem: &Arc<TransactionalMemory>,
+    allocation_policy: AllocationPolicy,
+) -> Result<WriteTransaction, TransactionError> {
+    // Fail early if there has been an I/O error -- nothing can be committed in that case
+    mem.check_io_errors()?;
+    // Every durable commit allocates and frees pages, which requires an allocator state
+    if !mem.allocator_state_loaded() {
+        return Err(StorageError::Corrupted(
+            "Allocator state was discarded by a failed integrity check".to_string(),
+        )
+        .into());
+    }
+    let guard = TransactionGuard::new_write(
+        transaction_tracker.start_write_transaction(),
+        transaction_tracker.clone(),
+    );
+    WriteTransaction::new(
+        guard,
+        transaction_tracker.clone(),
+        mem.clone(),
+        allocation_policy,
+    )
+    .map_err(|e| e.into())
+}
+
+fn ensure_allocator_state_table_and_trim(
+    transaction_tracker: &Arc<TransactionTracker>,
+    mem: &Arc<TransactionalMemory>,
+) -> Result<(), Error> {
+    // Make a new quick-repair commit to update the allocator state table
+    #[cfg(feature = "logging")]
+    debug!("Writing allocator state table");
+    // If compact() left no free pages, the default allocator lands this
+    // commit's writes at high page indices (see AllocationPolicy::Lowest)
+    // and try_shrink can't reclaim the growth. See
+    // https://github.com/cberner/redb/issues/1165
+    let mut tx =
+        begin_write_with_allocation_policy(transaction_tracker, mem, AllocationPolicy::Lowest)?;
+    tx.set_quick_repair(true);
+    tx.disable_post_commit_free();
+    tx.set_shrink_policy(ShrinkPolicy::Maximum);
+    tx.commit()?;
+
+    Ok(())
+}
+
+// Closes the database: persists the allocator state table, so that the next open does not
+// require a repair, and closes the storage backend. Runs exactly once, when the database
+// closes: from Database::drop, or from the end of the write transaction that was live at
+// that point. In both cases the Database is being, or has been, dropped, so no new write
+// transaction can be started concurrently and the commit in here cannot block on the
+// write-transaction slot.
+fn close_database(transaction_tracker: &Arc<TransactionTracker>, mem: &Arc<TransactionalMemory>) {
+    if !thread::panicking()
+        && ensure_allocator_state_table_and_trim(transaction_tracker, mem).is_err()
+    {
+        #[cfg(feature = "logging")]
+        warn!("Failed to write allocator state table. Repair may be required at restart.");
     }
 
-    fn ensure_allocator_state_table_and_trim(&self) -> Result<(), Error> {
-        // Make a new quick-repair commit to update the allocator state table
+    if mem.close().is_err() {
         #[cfg(feature = "logging")]
-        debug!("Writing allocator state table");
-        // If compact() left no free pages, the default allocator lands this
-        // commit's writes at high page indices (see AllocationPolicy::Lowest)
-        // and try_shrink can't reclaim the growth. See
-        // https://github.com/cberner/redb/issues/1165
-        let mut tx = self.begin_write_with_allocation_policy(AllocationPolicy::Lowest)?;
-        tx.set_quick_repair(true);
-        tx.disable_post_commit_free();
-        tx.set_shrink_policy(ShrinkPolicy::Maximum);
-        tx.commit()?;
-
-        Ok(())
+        warn!("Failed to flush database file. Repair may be required at restart.");
     }
 }
 
 impl Drop for Database {
     fn drop(&mut self) {
-        if !thread::panicking() && self.ensure_allocator_state_table_and_trim().is_err() {
+        if self
+            .transaction_tracker
+            .defer_close_if_write_transaction_live(&self.mem)
+        {
+            // The write transaction holds the memory and tracker alive, so it remains fully
+            // usable; TransactionGuard::drop performs the deferred close when it ends
             #[cfg(feature = "logging")]
-            warn!("Failed to write allocator state table. Repair may be required at restart.");
+            warn!(
+                "Database dropped while a write transaction is in progress. The database will remain open until the write transaction completes."
+            );
+            return;
         }
 
-        if self.mem.close().is_err() {
-            #[cfg(feature = "logging")]
-            warn!("Failed to flush database file. Repair may be required at restart.");
-        }
+        close_database(&self.transaction_tracker, &self.mem);
     }
 }
 

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -7,7 +7,7 @@ use std::collections::btree_map::BTreeMap;
 use std::collections::{BTreeSet, HashMap};
 use std::mem;
 use std::mem::size_of;
-use std::sync::{Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 
 #[derive(Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub(crate) struct TransactionId(u64);
@@ -91,6 +91,10 @@ struct State {
     pending_non_durable_commits: HashMap<TransactionId, TransactionId>,
     // Non-durable commits which have NOT been processed in the freed table
     unprocessed_freed_non_durable_commits: BTreeSet<TransactionId>,
+    // Set when the Database was dropped while a write transaction was live. That transaction
+    // keeps the database open, and end_write_transaction() hands the close back to it when
+    // it ends
+    deferred_close: Option<Arc<TransactionalMemory>>,
 }
 
 pub(crate) struct TransactionTracker {
@@ -110,6 +114,7 @@ impl TransactionTracker {
                 persistent_savepoints: BTreeSet::default(),
                 pending_non_durable_commits: HashMap::default(),
                 unprocessed_freed_non_durable_commits: BTreeSet::default(),
+                deferred_close: None,
             }),
             live_write_transaction_available: Condvar::new(),
         }
@@ -129,11 +134,34 @@ impl TransactionTracker {
         transaction_id
     }
 
-    pub(crate) fn end_write_transaction(&self, id: TransactionId) {
+    // Returns the deferred close, if the Database was dropped while this transaction was live.
+    // The caller must close the database, now that the write transaction has ended
+    pub(crate) fn end_write_transaction(
+        &self,
+        id: TransactionId,
+    ) -> Option<Arc<TransactionalMemory>> {
         let mut state = self.state.lock().unwrap();
         assert_eq!(state.live_write_transaction.unwrap(), id);
         state.live_write_transaction = None;
         self.live_write_transaction_available.notify_one();
+        state.deferred_close.take()
+    }
+
+    // Defers the database close to the end of the live write transaction, if one exists.
+    // Returns false if there is no live write transaction, in which case the caller must close
+    // the database itself. The check and the handoff share the state lock, making this atomic
+    // with end_write_transaction(), so exactly one side performs the close
+    pub(crate) fn defer_close_if_write_transaction_live(
+        &self,
+        mem: &Arc<TransactionalMemory>,
+    ) -> bool {
+        let mut state = self.state.lock().unwrap();
+        if state.live_write_transaction.is_some() {
+            state.deferred_close = Some(mem.clone());
+            true
+        } else {
+            false
+        }
     }
 
     pub(crate) fn clear_pending_non_durable_commits(&self) {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -859,6 +859,10 @@ impl SavepointTransactionState {
 /// A read/write transaction
 ///
 /// Only a single [`WriteTransaction`] may exist at a time
+///
+/// A live [`WriteTransaction`] keeps the database open: if the [`Database`](crate::Database) is
+/// dropped while this transaction is live, the transaction remains usable and the database
+/// closes when the transaction commits, aborts, or is dropped
 pub struct WriteTransaction {
     transaction_tracker: Arc<TransactionTracker>,
     mem: Arc<TransactionalMemory>,

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -6,8 +6,8 @@ use redb::DatabaseError;
 use redb::backends::InMemoryBackend;
 use redb::{
     Database, Key, MultimapTableDefinition, MultimapTableHandle, OwnedRange, ReadOnlyDatabase,
-    ReadableDatabase, ReadableTable, ReadableTableMetadata, TableDefinition, TableError,
-    TableHandle, TypeName, Value,
+    ReadableDatabase, ReadableTable, ReadableTableMetadata, StorageError, TableDefinition,
+    TableError, TableHandle, TypeName, Value, WriteTransaction,
 };
 use std::cmp::Ordering;
 #[cfg(not(target_os = "wasi"))]
@@ -84,6 +84,103 @@ fn read_only() {
     ));
     drop(db);
     drop(db2);
+}
+
+#[test]
+fn write_transaction_keeps_database_open() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    // The live write transaction keeps the database open and remains usable
+    drop(db);
+    {
+        let mut table = write_txn.open_table(STR_TABLE).unwrap();
+        table.insert("hello", "world").unwrap();
+    }
+
+    // The file stays locked until the transaction completes
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    assert!(matches!(
+        Database::open(tmpfile.path()),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+
+    write_txn.commit().unwrap();
+
+    // The deferred close ran when the transaction completed, so re-opening succeeds and
+    // does not require a repair
+    let db = Database::builder()
+        .set_repair_callback(|session| session.abort())
+        .open(tmpfile.path())
+        .unwrap();
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(STR_TABLE).unwrap();
+    assert_eq!(table.get("hello").unwrap().unwrap().value(), "world");
+}
+
+#[test]
+fn drop_database_then_drop_write_transaction() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    drop(db);
+    {
+        let mut table = write_txn.open_table(STR_TABLE).unwrap();
+        table.insert("hello", "world").unwrap();
+    }
+    // Dropping the transaction aborts it and performs the deferred close
+    drop(write_txn);
+
+    let db = Database::builder()
+        .set_repair_callback(|session| session.abort())
+        .open(tmpfile.path())
+        .unwrap();
+    let read_txn = db.begin_read().unwrap();
+    assert!(matches!(
+        read_txn.open_table(STR_TABLE),
+        Err(TableError::TableDoesNotExist(_))
+    ));
+}
+
+#[test]
+fn deferred_close_invalidates_read_transactions() {
+    let tmpfile = create_tempfile();
+    let db = Database::builder()
+        .set_cache_size(0)
+        .create(tmpfile.path())
+        .unwrap();
+    let setup_txn = db.begin_write().unwrap();
+    {
+        let mut table = setup_txn.open_table(STR_TABLE).unwrap();
+        table.insert("hello", "world").unwrap();
+    }
+    setup_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    let read_txn = db.begin_read().unwrap();
+    drop(db);
+    // The database is still open, so the read transaction remains usable
+    assert!(read_txn.list_tables().is_ok());
+    write_txn.commit().unwrap();
+    // The write transaction's completion closed the database
+    assert!(matches!(
+        read_txn.list_tables().err().unwrap(),
+        StorageError::DatabaseClosed
+    ));
+}
+
+// Regression test for https://github.com/cberner/redb/issues/1072
+#[test]
+fn return_write_transaction_from_function() {
+    fn make_txn(path: &std::path::Path) -> WriteTransaction {
+        let db = Database::create(path).unwrap();
+        db.begin_write().unwrap()
+    }
+
+    let tmpfile = create_tempfile();
+    let txn = make_txn(tmpfile.path());
+    txn.commit().unwrap();
+    Database::open(tmpfile.path()).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1072

`Database::drop` writes the allocator state table, which begins a write transaction. That blocked until the live write transaction ended, so dropping a `Database` while one of its `WriteTransaction`s was still alive deadlocked — in the single-threaded case (e.g. returning a transaction from the function that owns the `Database`) it hung forever.

## Semantics

A live `WriteTransaction` now keeps the database open:

- `Database::drop` with a live write transaction logs a warning and returns without blocking; the transaction remains fully usable.
- When the transaction ends — commit, abort, or drop — it performs the deferred close: the allocator state table commit (so the next open does not require a repair) and the backend close, which releases the file lock.
- Until then the file stays locked, so re-opening fails with `DatabaseAlreadyOpen`; once the transaction completes, re-opening succeeds without repair.
- Read transactions are unchanged: they are invalidated when the database closes, now possibly at the deferred point.

## Implementation

The handoff lives in `TransactionTracker` under the same mutex that guards the write-transaction slot: `Database::drop` calls `defer_close_if_write_transaction_live()`, and `end_write_transaction()` returns the deferred close for `TransactionGuard::drop` to perform. The shared lock makes the close exactly-once under any thread interleaving, and by the time the transaction ends no `Database` handle exists, so the shutdown's own write transaction cannot block. The shutdown logic (`begin_write_with_allocation_policy`, `ensure_allocator_state_table_and_trim`, `close_database`) moved from `Database` methods to free functions shared by both paths.

## Testing

- Four new integration tests: the transaction staying usable after `drop(db)`, with `DatabaseAlreadyOpen` while it is live and a repair-free reopen after commit; the abort-on-drop path; reads surviving `drop(db)` until the deferred close, then failing with `DatabaseClosed`; and the exact issue repro (returning a `WriteTransaction` from the function that owns the `Database`).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features`, the full `cargo test --all-features` suite, `cargo deny check licenses advisories`, the CI non-ASCII check, and a 60s `fuzz_redb` smoke run (41k runs, no crashes) all pass. `just test` could not run verbatim in this environment (no podman), so the underlying gates were run directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2kvWcqSHXiEX6ADUWyWUW

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2kvWcqSHXiEX6ADUWyWUW)_