### PR TITLE
Poison the database when a commit fails part way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Fix a panic, including one raised while dropping a `Database`, after `check_integrity()` returned
   an error. Such a database now refuses to begin a write transaction or to re-run the check,
   returning `StorageError::Corrupted`, and is no longer recorded as cleanly shut down.
+* Harden against errors and panics raised part way through `WriteTransaction::commit()`: the
+  database now refuses further write transactions until it is closed and reopened (which
+  repairs it), instead of risking corruption from continued use after the failed commit.
 * `check_integrity()` now recomputes the table counts stored alongside the data and system roots,
   repairing a file whose counts disagree with its trees. Such a file previously passed the check
   and then panicked, including from `Database::drop`.

--- a/src/db.rs
+++ b/src/db.rs
@@ -624,11 +624,13 @@ impl Database {
             return Err(DatabaseError::TransactionInProgress);
         }
 
-        // Rebuilding the allocator state is what this does, so there is nothing to retry once a
-        // previous call has failed at it
+        // Report a latched I/O failure as such, not as the discarded allocator state it also causes
+        self.mem.check_io_errors()?;
+        // Once the allocator state has been discarded (by a failed commit or integrity check),
+        // the database must be reopened to rebuild it; this check requires one to compare against
         if !self.mem.allocator_state_loaded() {
             return Err(StorageError::Corrupted(
-                "Allocator state was discarded by a failed integrity check".to_string(),
+                "Allocator state was discarded by a failed integrity check or commit; reopen the database to repair it".to_string(),
             )
             .into());
         }
@@ -1263,17 +1265,21 @@ fn begin_write_with_allocation_policy(
 ) -> Result<WriteTransaction, TransactionError> {
     // Fail early if there has been an I/O error -- nothing can be committed in that case
     mem.check_io_errors()?;
-    // Every durable commit allocates and frees pages, which requires an allocator state
-    if !mem.allocator_state_loaded() {
-        return Err(StorageError::Corrupted(
-            "Allocator state was discarded by a failed integrity check".to_string(),
-        )
-        .into());
-    }
     let guard = TransactionGuard::new_write(
         transaction_tracker.start_write_transaction(),
         transaction_tracker.clone(),
     );
+    // Re-checked after acquiring the write slot: the writer this call blocked on can fail its
+    // commit, latching an I/O error and discarding the allocator state. The I/O check comes
+    // first so a backend failure is not misreported as corruption. Returning drops the guard,
+    // releasing the slot.
+    mem.check_io_errors()?;
+    if !mem.allocator_state_loaded() {
+        return Err(StorageError::Corrupted(
+            "Allocator state was discarded by a failed integrity check or commit; reopen the database to repair it".to_string(),
+        )
+        .into());
+    }
     WriteTransaction::new(
         guard,
         transaction_tracker.clone(),

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -856,6 +856,32 @@ impl SavepointTransactionState {
     }
 }
 
+// Discards the in-memory allocator state on drop, unless disarmed. An incomplete commit may
+// have returned pages to the allocator that the durable roots still reference through the
+// freed tables; such an allocator state must never be used, or persisted by a clean
+// shutdown, again.
+struct AllocatorStateLatch {
+    mem: Option<Arc<TransactionalMemory>>,
+}
+
+impl AllocatorStateLatch {
+    fn arm(mem: Arc<TransactionalMemory>) -> Self {
+        Self { mem: Some(mem) }
+    }
+
+    fn disarm(mut self) {
+        self.mem = None;
+    }
+}
+
+impl Drop for AllocatorStateLatch {
+    fn drop(&mut self) {
+        if let Some(mem) = self.mem.take() {
+            mem.invalidate_allocator_state();
+        }
+    }
+}
+
 /// A read/write transaction
 ///
 /// Only a single [`WriteTransaction`] may exist at a time
@@ -1583,7 +1609,13 @@ impl WriteTransaction {
     /// durable as consistent with the [`Durability`] level set by [`Self::set_durability`]
     ///
     /// Returns [`CommitError::TransactionPoisoned`] if a previous operation panicked and left the
-    /// transaction unable to commit.
+    /// transaction unable to commit. In that case the transaction is rolled back and the database
+    /// remains usable.
+    ///
+    /// On any other error the commit did not complete cleanly: the transaction's changes are
+    /// applied atomically -- fully or not at all -- but may already have become durable, so they
+    /// must not be assumed rolled back. The database refuses further write transactions; closing
+    /// and reopening it repairs any internal state left by the failed commit.
     pub fn commit(mut self) -> Result<(), CommitError> {
         // Set completed flag first, so that we don't go through the abort() path on drop, if this fails
         self.completed = true;
@@ -1595,6 +1627,17 @@ impl WriteTransaction {
     }
 
     fn commit_inner(&mut self) -> Result<(), CommitError> {
+        // Covers both the error and the panic-unwind path. Without an allocator state,
+        // begin_write() refuses new write transactions and the next open repairs.
+        let latch = AllocatorStateLatch::arm(self.mem.clone());
+        let result = self.commit_inner_helper();
+        if result.is_ok() {
+            latch.disarm();
+        }
+        result
+    }
+
+    fn commit_inner_helper(&mut self) -> Result<(), CommitError> {
         // Quick-repair requires 2-phase commit
         if self.quick_repair {
             self.two_phase_commit = true;
@@ -2630,10 +2673,77 @@ impl Debug for ReadTransaction {
 
 #[cfg(test)]
 mod test {
-    use crate::{Database, TableDefinition};
+    use crate::{Database, ReadableDatabase, StorageError, TableDefinition, TransactionError};
 
     const X: TableDefinition<&str, &str> = TableDefinition::new("x");
     const BIG_VALUE: TableDefinition<u64, &[u8]> = TableDefinition::new("big_value");
+
+    // A commit that stops part way may leave pages returned to the allocator while the durable
+    // freed tables still reference them, so commit_inner() discards the allocator state unless
+    // it completes. Verify the resulting contract: writes are refused, reads keep working, the
+    // shutdown is not recorded as clean, and reopening repairs the database.
+    #[test]
+    fn discarded_allocator_state_poisons_database() {
+        let tmpfile = crate::create_tempfile();
+        let db = Database::create(tmpfile.path()).unwrap();
+
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(X).unwrap();
+            for i in 0..100u32 {
+                table.insert(format!("key{i}").as_str(), "value").unwrap();
+            }
+        }
+        txn.commit().unwrap();
+
+        // Leave freed-table entries pending, so the repair below must handle them
+        let mut txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(X).unwrap();
+            for i in 0..50u32 {
+                table.remove(format!("key{i}").as_str()).unwrap();
+            }
+        }
+        txn.disable_post_commit_free();
+        txn.commit().unwrap();
+
+        // The state a failed commit leaves behind
+        db.get_memory().invalidate_allocator_state();
+
+        // Twice: a refused attempt must release the write slot
+        for _ in 0..2 {
+            match db.begin_write() {
+                Err(TransactionError::Storage(StorageError::Corrupted(_))) => {}
+                Err(err) => panic!("unexpected error: {err}"),
+                Ok(_) => panic!("begin_write() must fail"),
+            }
+        }
+
+        // Reads still work and see the last committed state
+        {
+            let read_txn = db.begin_read().unwrap();
+            let table = read_txn.open_table(X).unwrap();
+            assert!(table.get("key0").unwrap().is_none());
+            assert_eq!(table.get("key99").unwrap().unwrap().value(), "value");
+        }
+
+        // Closing must not record a clean shutdown, so reopening repairs the database
+        drop(db);
+        let mut db = Database::open(tmpfile.path()).unwrap();
+        assert!(db.check_integrity().unwrap());
+        {
+            let read_txn = db.begin_read().unwrap();
+            let table = read_txn.open_table(X).unwrap();
+            assert_eq!(table.get("key99").unwrap().unwrap().value(), "value");
+        }
+
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(X).unwrap();
+            table.insert("after-repair", "value").unwrap();
+        }
+        txn.commit().unwrap();
+    }
 
     #[test]
     fn transaction_id_persistence() {

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -605,11 +605,20 @@ impl TransactionalMemory {
 
     // Discards an allocator state that no longer describes the file. Callers that allocate or free
     // must check for one first, since those paths have no way to work without it.
+    //
+    // Runs during panic unwinding, so it must tolerate poisoned locks rather than double-panic.
+    // The poison is deliberately left set: subsequent lock users fail rather than trusting state
+    // touched by a panicking thread.
     pub(crate) fn invalidate_allocator_state(&self) {
-        let mut state = self.state.lock().unwrap();
-        state.allocators = None;
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .allocators = None;
         #[cfg(debug_assertions)]
-        self.allocated_pages.lock().unwrap().clear();
+        self.allocated_pages
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clear();
     }
 
     pub(crate) fn allocator_state_loaded(&self) -> bool {
@@ -1448,6 +1457,39 @@ mod test {
 
         let mut db = Database::open(tmpfile).unwrap();
         assert!(db.check_integrity().unwrap());
+    }
+
+    // A panic raised while the state mutex is held (e.g. an allocator assertion) poisons it.
+    // invalidate_allocator_state() runs while unwinding from such a panic, so it must recover
+    // the lock rather than double-panic; the poison itself is left set.
+    #[test]
+    #[cfg(panic = "unwind")]
+    fn invalidate_allocator_state_tolerates_poison() {
+        use super::TransactionalMemory;
+        use crate::tree_store::InMemoryBackend;
+
+        let mem =
+            TransactionalMemory::new(Box::new(InMemoryBackend::new()), true, 4096, None, 0, false)
+                .unwrap();
+        mem.reset_allocator_state().unwrap();
+
+        std::thread::scope(|s| {
+            let result = s
+                .spawn(|| {
+                    let _guard = mem.state.lock().unwrap();
+                    panic!("poison the state mutex");
+                })
+                .join();
+            assert!(result.is_err());
+        });
+        assert!(mem.state.is_poisoned());
+
+        // Must not panic, despite the poisoned lock
+        mem.invalidate_allocator_state();
+
+        // The poison stays set, so later accesses fail rather than trust the state
+        assert!(mem.state.is_poisoned());
+        assert!(mem.get_last_committed_transaction_id().is_err());
     }
 
     // Freeing pages that buddy-merge into a higher order must re-mark the region tracker at the


### PR DESCRIPTION
Fixes the highest-priority finding from the codebase audit: a `WriteTransaction::commit()` that fails part way with a non-I/O error leaves the in-memory page allocator inconsistent with the durable state, and continuing to use the database can then corrupt committed data.

## The bug

During a durable commit, `process_freed_pages()` returns pending-free pages to the shared allocator and drains the corresponding freed-table entries from the in-memory CoW system tree **before** `TransactionalMemory::commit()` installs the new roots. If any later step of the commit fails, the in-memory roots remain at the previous durable state — whose freed tables still name the pages that were just returned to the allocator.

Backend I/O errors are already latched by `CheckedBackend`, so they were safe. But a non-I/O error (e.g. a `StorageError::Corrupted` raised while reading a page mid-commit, or a poisoned lock) escaped with no latch: `begin_write()` only checked `io_failed` and that an allocator state was loaded, so the next write transaction proceeded, re-processed the same freed-table entries from the old system root, and freed the same pages a second time. `BuddyAllocator::free()` on an already-free page mis-merges buddies, and `free_helper()` cancels pending writes for a page the new transaction may have re-allocated and written — one page ends up with two owners, silently corrupting committed data. A clean shutdown would then persist the inconsistent allocator state into the allocator-state table, making the corruption durable. The realistic trigger is a second-order failure: latent on-disk corruption surfacing mid-commit (undetected across clean shutdowns, since those skip full verification) followed by an application-level retry, or a panic during commit caught by the application.

## The fix

Discard the in-memory allocator state whenever `commit_inner()` does not complete — via a drop guard, so both the error path and a panic unwinding through the commit are covered:

* subsequent `begin_write()` calls fail with `StorageError::Corrupted` instead of corrupting the database; the check runs after the write-slot wait (a waiter can be woken by the failing commit itself), preceded by an I/O-latch re-check so backend failures keep reporting as `PreviousIo`
* reads remain available on non-I/O failures and see the last committed state
* the shutdown path can no longer record a clean shutdown or persist the stale allocator state, so the next open rebuilds a consistent allocator via the normal repair path
* `invalidate_allocator_state()` tolerates poisoned locks (it runs during unwinding, where a second panic would abort) but deliberately leaves the poison set, so accesses after a caught panic stay fail-stop

The successful-commit path is unchanged apart from disarming the guard. The `TransactionPoisoned` path is intentionally not latched: it aborts cleanly via `rollback_all()` and the database remains usable.

## Testing

* `discarded_allocator_state_poisons_database` drives the post-failure state (via the crate-internal `invalidate_allocator_state()`, no test hooks in production code paths) and verifies the contract end to end: `begin_write()` refuses with `Corrupted` and releases the write slot, reads still serve the last committed state, close does not record a clean shutdown, and reopening repairs the database (`check_integrity()` passes) with committed data intact and writes working again.
* `invalidate_allocator_state_tolerates_poison` verifies the no-double-panic guarantee on a poisoned state mutex, and that the poison is left in place.
* `cargo fmt --check`, `cargo clippy --all-targets --all-features` with `--deny warnings`, and `RUST_BACKTRACE=1 cargo test --all-features` all pass (336 tests, 0 failures). Podman is unavailable in this environment, so the checks were run directly rather than through the `just test` sandbox wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuLGiEERgJR51vhJNtYwRA