### PR TITLE
Fix derived Value and Key impls resolving inherent methods on field types

### DIFF
--- a/crates/redb-derive-rename-test/tests/rename_test.rs
+++ b/crates/redb-derive-rename-test/tests/rename_test.rs
@@ -2,7 +2,6 @@
 // through `#[redb(crate = "...")]`, and any stray `redb` path in the generated code fails to
 // compile here.
 use redb_derive::{Key, Value};
-use renamed_redb::Value as _;
 
 #[derive(Key, Value, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[redb(crate = "renamed_redb")]

--- a/crates/redb-derive/Cargo.toml
+++ b/crates/redb-derive/Cargo.toml
@@ -18,7 +18,8 @@ quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]
-redb = { path = "../.." }
+redb = { path = "../..", features = ["uuid"] }
 tempfile = "3.5.0"
+uuid = { version = "1.17.0", features = ["v4"] }
 # An old version of the redb package, for the tests that derive against two versions at once
 redb2_6 = { package = "redb", version = "=2.6.0" }

--- a/crates/redb-derive/src/lib.rs
+++ b/crates/redb-derive/src/lib.rs
@@ -10,6 +10,13 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput, Fields, GenericParam, Ident, parse_macro_input};
 
+// All paths in the generated code must be fully qualified (`::std::...`, `#redb::...`, and
+// `<T as #redb::Value>::...` for trait methods, where `#redb` is the path returned by
+// `redb_crate_path_for()`). Method-call syntax and bare paths resolve inherent items before
+// trait items, so a field type with an inherent `from_bytes` or `as_bytes` (e.g. `uuid::Uuid`)
+// would otherwise hijack the generated encoding, and names shadowed at the derive site would
+// change what the code means.
+
 // The path of the redb crate in generated code: `::redb`, unless an explicit
 // `#[redb(crate = "path")]` on the deriving struct names it otherwise, as when the dependency
 // is renamed (`my_redb = { package = "redb" }`) or the implementations are derived against one
@@ -64,10 +71,13 @@ fn generate_key_impl(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStrea
 
     Ok(quote! {
         impl #impl_generics #redb::Key for #name #ty_generics #where_clause {
-            fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
-                let value1 = #name::from_bytes(data1);
-                let value2 = #name::from_bytes(data2);
-                Ord::cmp(&value1, &value2)
+            fn compare(
+                data1: &[::std::primitive::u8],
+                data2: &[::std::primitive::u8],
+            ) -> ::std::cmp::Ordering {
+                let value1 = <Self as #redb::Value>::from_bytes(data1);
+                let value2 = <Self as #redb::Value>::from_bytes(data2);
+                ::std::cmp::Ord::cmp(&value1, &value2)
             }
         }
     })
@@ -105,24 +115,24 @@ fn generate_value_impl(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStr
     let redb = redb_crate_path_for(input)?;
 
     let type_name_impl = generate_type_name(name, &data_struct.fields, &redb);
-    let as_bytes_impl = generate_as_bytes(&data_struct.fields);
-    let from_bytes_impl = generate_from_bytes(name, &data_struct.fields);
-    let fixed_width_impl = generate_fixed_width(&data_struct.fields);
+    let as_bytes_impl = generate_as_bytes(&data_struct.fields, &redb);
+    let from_bytes_impl = generate_from_bytes(name, &data_struct.fields, &redb);
+    let fixed_width_impl = generate_fixed_width(&data_struct.fields, &redb);
 
     Ok(quote! {
         impl #impl_generics #redb::Value for #name #ty_generics #where_clause {
             type SelfType<'a> = #self_type
             where
                 Self: 'a;
-            type AsBytes<'a> = Vec<u8>
+            type AsBytes<'a> = ::std::vec::Vec<::std::primitive::u8>
             where
                 Self: 'a;
 
-            fn fixed_width() -> Option<usize> {
+            fn fixed_width() -> ::std::option::Option<::std::primitive::usize> {
                 #fixed_width_impl
             }
 
-            fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+            fn from_bytes<'a>(data: &'a [::std::primitive::u8]) -> Self::SelfType<'a>
             where
                 Self: 'a,
             {
@@ -187,21 +197,25 @@ fn generate_type_name(
                     let field_name = field.ident.as_ref().unwrap();
                     let field_type = &field.ty;
                     quote! {
-                        format!("{}: {}", stringify!(#field_name), <#field_type>::type_name().name())
+                        ::std::format!(
+                            "{}: {}",
+                            ::std::stringify!(#field_name),
+                            <#field_type as #redb::Value>::type_name().name(),
+                        )
                     }
                 })
                 .collect();
 
             if field_strings.is_empty() {
                 quote! {
-                    #redb::TypeName::new(&format!("{} {{}}",
-                        stringify!(#struct_name),
+                    #redb::TypeName::new(&::std::format!("{} {{}}",
+                        ::std::stringify!(#struct_name),
                     ))
                 }
             } else {
                 quote! {
-                    #redb::TypeName::new(&format!("{} {{{}}}",
-                        stringify!(#struct_name),
+                    #redb::TypeName::new(&::std::format!("{} {{{}}}",
+                        ::std::stringify!(#struct_name),
                         [#(#field_strings),*].join(", ")
                     ))
                 }
@@ -214,21 +228,21 @@ fn generate_type_name(
                 .map(|field| {
                     let field_type = &field.ty;
                     quote! {
-                        <#field_type>::type_name().name()
+                        <#field_type as #redb::Value>::type_name().name()
                     }
                 })
                 .collect();
 
             if field_strings.is_empty() {
                 quote! {
-                    #redb::TypeName::new(&format!("{}()",
-                        stringify!(#struct_name),
+                    #redb::TypeName::new(&::std::format!("{}()",
+                        ::std::stringify!(#struct_name),
                     ))
                 }
             } else {
                 quote! {
-                    #redb::TypeName::new(&format!("{}({})",
-                        stringify!(#struct_name),
+                    #redb::TypeName::new(&::std::format!("{}({})",
+                        ::std::stringify!(#struct_name),
                         [#(#field_strings),*].join(", ")
                     ))
                 }
@@ -236,7 +250,7 @@ fn generate_type_name(
         }
         Fields::Unit => {
             quote! {
-                #redb::TypeName::new(stringify!(#struct_name))
+                #redb::TypeName::new(::std::stringify!(#struct_name))
             }
         }
     }
@@ -260,18 +274,21 @@ fn get_field_types(fields: &Fields) -> Vec<syn::Type> {
     }
 }
 
-fn generate_fixed_width(fields: &Fields) -> proc_macro2::TokenStream {
+fn generate_fixed_width(
+    fields: &Fields,
+    redb: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
     let field_types = get_field_types(fields);
     quote! {
         let mut total_width = 0usize;
         #(
-            total_width += <#field_types>::fixed_width()?;
+            total_width += <#field_types as #redb::Value>::fixed_width()?;
         )*
-        Some(total_width)
+        ::std::option::Option::Some(total_width)
     }
 }
 
-fn generate_as_bytes(fields: &Fields) -> proc_macro2::TokenStream {
+fn generate_as_bytes(fields: &Fields, redb: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let field_types = get_field_types(fields);
     let field_accessors = match fields {
         Fields::Named(fields_named) => fields_named
@@ -294,14 +311,15 @@ fn generate_as_bytes(fields: &Fields) -> proc_macro2::TokenStream {
     let num_fields = field_types.len();
 
     if num_fields == 0 {
-        quote! { Vec::new() }
+        quote! { ::std::vec::Vec::new() }
     } else if num_fields == 1 {
         let field_accessor = &field_accessors[0];
         let field_type = &field_types[0];
         quote! {
             {
-                let field_bytes = <#field_type>::as_bytes(&value.#field_accessor);
-                field_bytes.as_ref().to_vec()
+                let field_bytes = <#field_type as #redb::Value>::as_bytes(&value.#field_accessor);
+                let bytes: &[::std::primitive::u8] = ::std::convert::AsRef::as_ref(&field_bytes);
+                bytes.to_vec()
             }
         }
     } else {
@@ -310,20 +328,35 @@ fn generate_as_bytes(fields: &Fields) -> proc_macro2::TokenStream {
 
         quote! {
             {
-                let mut result = Vec::new();
+                let mut result = ::std::vec::Vec::new();
 
                 #(
-                    if <#field_types_except_last>::fixed_width().is_none() {
-                        let field_bytes = <#field_types_except_last>::as_bytes(&value.#field_accessors_except_last);
-                        let bytes: &[u8] = field_bytes.as_ref();
+                    if <#field_types_except_last as #redb::Value>::fixed_width().is_none() {
+                        let field_bytes = <#field_types_except_last as #redb::Value>::as_bytes(
+                            &value.#field_accessors_except_last,
+                        );
+                        let bytes: &[::std::primitive::u8] =
+                            ::std::convert::AsRef::as_ref(&field_bytes);
                         let len = bytes.len();
                         if len < 254 {
-                            result.push(len.try_into().unwrap());
-                        } else if let Ok(u16_len) = u16::try_from(len) {
+                            result.push(
+                                <::std::primitive::u8 as ::std::convert::TryFrom<
+                                    ::std::primitive::usize,
+                                >>::try_from(len)
+                                .unwrap(),
+                            );
+                        } else if let ::std::result::Result::Ok(u16_len) =
+                            <::std::primitive::u16 as ::std::convert::TryFrom<
+                                ::std::primitive::usize,
+                            >>::try_from(len)
+                        {
                             result.push(254u8);
                             result.extend_from_slice(&u16_len.to_le_bytes());
                         } else {
-                            let u32_len: u32 = len.try_into().unwrap();
+                            let u32_len = <::std::primitive::u32 as ::std::convert::TryFrom<
+                                ::std::primitive::usize,
+                            >>::try_from(len)
+                            .unwrap();
                             result.push(255u8);
                             result.extend_from_slice(&u32_len.to_le_bytes());
                         }
@@ -332,8 +365,12 @@ fn generate_as_bytes(fields: &Fields) -> proc_macro2::TokenStream {
 
                 #(
                     {
-                        let field_bytes = <#field_types>::as_bytes(&value.#field_accessors);
-                        result.extend_from_slice(field_bytes.as_ref());
+                        let field_bytes = <#field_types as #redb::Value>::as_bytes(
+                            &value.#field_accessors,
+                        );
+                        let bytes: &[::std::primitive::u8] =
+                            ::std::convert::AsRef::as_ref(&field_bytes);
+                        result.extend_from_slice(bytes);
                     }
                 )*
 
@@ -343,7 +380,11 @@ fn generate_as_bytes(fields: &Fields) -> proc_macro2::TokenStream {
     }
 }
 
-fn generate_from_bytes(name: &Ident, fields: &Fields) -> proc_macro2::TokenStream {
+fn generate_from_bytes(
+    name: &Ident,
+    fields: &Fields,
+    redb: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
     let field_types = get_field_types(fields);
     let field_vars: Vec<_> = (0..field_types.len())
         .map(|i| quote::format_ident!("field_{}", i))
@@ -356,7 +397,7 @@ fn generate_from_bytes(name: &Ident, fields: &Fields) -> proc_macro2::TokenStrea
         let field_var = &field_vars[0];
         let field_type = &field_types[0];
         quote! {
-            let #field_var = <#field_type>::from_bytes(data);
+            let #field_var = <#field_type as #redb::Value>::from_bytes(data);
         }
     } else {
         let field_types_except_last = &field_types[..num_fields - 1];
@@ -366,18 +407,26 @@ fn generate_from_bytes(name: &Ident, fields: &Fields) -> proc_macro2::TokenStrea
 
         quote! {
             let mut offset = 0usize;
-            let mut var_lengths = Vec::new();
+            let mut var_lengths = ::std::vec::Vec::new();
 
             #(
-                if <#field_types_except_last>::fixed_width().is_none() {
+                if <#field_types_except_last as #redb::Value>::fixed_width().is_none() {
                     let (len, bytes_read) = match data[offset] {
-                        0u8..=253u8 => (data[offset] as usize, 1usize),
+                        0u8..=253u8 => (data[offset] as ::std::primitive::usize, 1usize),
                         254u8 => (
-                            u16::from_le_bytes(data[offset + 1..offset + 3].try_into().unwrap()) as usize,
+                            ::std::primitive::u16::from_le_bytes([
+                                data[offset + 1],
+                                data[offset + 2],
+                            ]) as ::std::primitive::usize,
                             3usize,
                         ),
                         255u8 => (
-                            u32::from_le_bytes(data[offset + 1..offset + 5].try_into().unwrap()) as usize,
+                            ::std::primitive::u32::from_le_bytes([
+                                data[offset + 1],
+                                data[offset + 2],
+                                data[offset + 3],
+                                data[offset + 4],
+                            ]) as ::std::primitive::usize,
                             5usize,
                         ),
                     };
@@ -386,26 +435,30 @@ fn generate_from_bytes(name: &Ident, fields: &Fields) -> proc_macro2::TokenStrea
                 }
             )*
 
-            let mut var_index = 0;
+            let mut var_index = 0usize;
             #(
-                let #field_vars_except_last = if let Some(fixed_width) = <#field_types_except_last>::fixed_width() {
+                let #field_vars_except_last = if let ::std::option::Option::Some(fixed_width) =
+                    <#field_types_except_last as #redb::Value>::fixed_width()
+                {
                     let field_data = &data[offset..offset + fixed_width];
                     offset += fixed_width;
-                    <#field_types_except_last>::from_bytes(field_data)
+                    <#field_types_except_last as #redb::Value>::from_bytes(field_data)
                 } else {
                     let len = var_lengths[var_index];
                     let field_data = &data[offset..offset + len];
                     offset += len;
                     var_index += 1;
-                    <#field_types_except_last>::from_bytes(field_data)
+                    <#field_types_except_last as #redb::Value>::from_bytes(field_data)
                 };
             )*
 
-            let #last_field_var = if let Some(fixed_width) = <#last_field_type>::fixed_width() {
+            let #last_field_var = if let ::std::option::Option::Some(fixed_width) =
+                <#last_field_type as #redb::Value>::fixed_width()
+            {
                 let field_data = &data[offset..offset + fixed_width];
-                <#last_field_type>::from_bytes(field_data)
+                <#last_field_type as #redb::Value>::from_bytes(field_data)
             } else {
-                <#last_field_type>::from_bytes(&data[offset..])
+                <#last_field_type as #redb::Value>::from_bytes(&data[offset..])
             };
         }
     };

--- a/crates/redb-derive/tests/crate_attr_tests.rs
+++ b/crates/redb-derive/tests/crate_attr_tests.rs
@@ -7,7 +7,6 @@
 
 mod old {
     use redb_derive::{Key, Value};
-    use redb2_6::Value as _;
 
     #[derive(Value, Key, Debug, PartialEq, Eq, PartialOrd, Ord)]
     #[redb(crate = "redb2_6")]
@@ -15,7 +14,6 @@ mod old {
 }
 
 mod new {
-    use redb::Value as _;
     use redb_derive::{Key, Value};
 
     #[derive(Value, Key, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/redb-derive/tests/derive_tests.rs
+++ b/crates/redb-derive/tests/derive_tests.rs
@@ -1,4 +1,4 @@
-use redb::{Database, Key, ReadableDatabase, TableDefinition, Value};
+use redb::{Database, Key, ReadableDatabase, TableDefinition, TypeName, Value};
 use redb_derive::{Key, Value};
 use std::fmt::Debug;
 use tempfile::NamedTempFile;
@@ -203,6 +203,328 @@ fn test_single_field() {
     assert_eq!(value, original.value);
     test_key_helper::<SingleField>(&original);
     test_value_helper::<SingleField>(original, "SingleField {value: i32}");
+}
+
+// A field type whose inherent methods share names with the `Value` trait methods but lie.
+// The derived code must resolve the trait methods, never these.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Inherent(u32);
+
+#[allow(dead_code)]
+impl Inherent {
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes(_data: &[u8]) -> Inherent {
+        Inherent(u32::MAX)
+    }
+
+    fn as_bytes(&self) -> Vec<u8> {
+        vec![0xAB]
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::new("bogus")
+    }
+}
+
+impl Value for Inherent {
+    type SelfType<'a> = Inherent;
+    type AsBytes<'a> = [u8; 4];
+
+    fn fixed_width() -> Option<usize> {
+        Some(4)
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Inherent
+    where
+        Self: 'a,
+    {
+        Inherent(u32::from_le_bytes(data.try_into().unwrap()))
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Inherent) -> [u8; 4]
+    where
+        Self: 'b,
+    {
+        value.0.to_le_bytes()
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::new("Inherent")
+    }
+}
+
+impl Key for Inherent {
+    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+        <Inherent as Value>::from_bytes(data1).cmp(&<Inherent as Value>::from_bytes(data2))
+    }
+}
+
+#[derive(Key, Value, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct InherentHolder {
+    a: Inherent,
+    b: u64,
+}
+
+#[test]
+fn test_inherent_methods_do_not_shadow_trait_methods() {
+    // The inherent `fixed_width` claims variable width; the trait impl is 4 bytes fixed
+    assert_eq!(<InherentHolder as Value>::fixed_width(), Some(12));
+
+    let original = InherentHolder {
+        a: Inherent(7),
+        b: 9,
+    };
+    // Both fields are fixed width, so the encoding is the concatenation of the two fields with
+    // no length prefixes. The inherent `as_bytes`/`from_bytes` would produce something else.
+    let bytes = InherentHolder::as_bytes(&original);
+    assert_eq!(&bytes[..], &[7u8, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0][..]);
+    let decoded = InherentHolder::from_bytes(&bytes);
+    assert_eq!(decoded, original);
+
+    // The inherent `type_name` returns "bogus"
+    assert_eq!(
+        InherentHolder::type_name().name(),
+        "InherentHolder {a: Inherent, b: u64}"
+    );
+
+    test_key_helper::<InherentHolder>(&original);
+}
+
+// An inherent `from_bytes` on the derived struct itself must not be picked up by the derived
+// `Key::compare`
+#[derive(Key, Value, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct OwnFromBytes {
+    value: u32,
+}
+
+#[allow(dead_code)]
+impl OwnFromBytes {
+    fn from_bytes(_data: &[u8]) -> OwnFromBytes {
+        OwnFromBytes { value: 0 }
+    }
+}
+
+#[test]
+fn test_compare_uses_trait_from_bytes() {
+    let small = OwnFromBytes { value: 1 };
+    let large = OwnFromBytes { value: 2 };
+    let small_bytes = OwnFromBytes::as_bytes(&small);
+    let large_bytes = OwnFromBytes::as_bytes(&large);
+    // The inherent `from_bytes` decodes everything to the same value, which would compare Equal
+    assert_eq!(
+        OwnFromBytes::compare(&small_bytes, &large_bytes),
+        std::cmp::Ordering::Less
+    );
+}
+
+// Mirrors `uuid::Uuid`: inherent `from_bytes`/`as_bytes` whose signatures are incompatible with
+// the `Value` trait methods. Deriving on a struct with such a field used to fail to compile.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct FakeUuid([u8; 16]);
+
+#[allow(dead_code)]
+impl FakeUuid {
+    fn from_bytes(bytes: [u8; 16]) -> FakeUuid {
+        FakeUuid(bytes)
+    }
+
+    const fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+}
+
+impl Value for FakeUuid {
+    type SelfType<'a> = FakeUuid;
+    type AsBytes<'a> = &'a [u8; 16];
+
+    fn fixed_width() -> Option<usize> {
+        Some(16)
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> FakeUuid
+    where
+        Self: 'a,
+    {
+        FakeUuid(data.try_into().unwrap())
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a FakeUuid) -> &'a [u8; 16]
+    where
+        Self: 'b,
+    {
+        &value.0
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::new("FakeUuid")
+    }
+}
+
+#[derive(Value, Debug, PartialEq)]
+struct UuidHolder {
+    id: FakeUuid,
+    tag: String,
+}
+
+#[test]
+fn test_field_with_conflicting_inherent_signatures() {
+    let original = UuidHolder {
+        id: FakeUuid([3; 16]),
+        tag: "x".to_string(),
+    };
+    let bytes = UuidHolder::as_bytes(&original);
+    let decoded = UuidHolder::from_bytes(&bytes);
+    assert_eq!(decoded, original);
+    assert_eq!(
+        UuidHolder::type_name().name(),
+        "UuidHolder {id: FakeUuid, tag: String}"
+    );
+}
+
+#[derive(Key, Value, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct RealUuidHolder {
+    id: uuid::Uuid,
+    tag: String,
+}
+
+#[test]
+fn test_uuid_field() {
+    let original = RealUuidHolder {
+        id: uuid::Uuid::new_v4(),
+        tag: "x".to_string(),
+    };
+    let bytes = RealUuidHolder::as_bytes(&original);
+    let decoded = RealUuidHolder::from_bytes(&bytes);
+    assert_eq!(decoded, original);
+    assert_eq!(
+        RealUuidHolder::type_name().name(),
+        "RealUuidHolder {id: uuid::Uuid, tag: String}"
+    );
+    test_key_helper::<RealUuidHolder>(&original);
+}
+
+// The generated code must not resolve any name at the derive site: shadow everything it could
+// plausibly reference and check that it still compiles and round trips.
+#[allow(
+    non_camel_case_types,
+    dead_code,
+    unused_macros,
+    unused_imports,
+    missing_copy_implementations
+)]
+mod hostile {
+    use redb_derive::{Key, Value};
+
+    pub struct u8;
+    pub struct u16;
+    pub struct u32;
+    pub struct u64;
+    pub struct usize;
+    pub struct Vec;
+    pub struct String;
+    pub struct Option;
+    pub struct Some;
+    pub struct None;
+    pub struct Ok;
+    pub struct Err;
+    pub struct Result;
+    pub struct Ord;
+    pub struct Ordering;
+    pub struct AsRef;
+    pub struct TryFrom;
+    pub struct TryInto;
+    pub struct From;
+    pub struct Into;
+    pub mod std {}
+    pub mod redb {}
+
+    macro_rules! format {
+        () => {};
+    }
+    macro_rules! stringify {
+        () => {};
+    }
+    macro_rules! vec {
+        () => {};
+    }
+
+    #[derive(Key, Value, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Sneaky {
+        pub a: ::std::primitive::u16,
+        pub b: ::std::string::String,
+        pub c: ::std::vec::Vec<::std::primitive::u8>,
+    }
+}
+
+#[test]
+fn test_shadowed_names_at_derive_site() {
+    // Exercise all three length-prefix encodings of the variable width field b
+    for len in [0usize, 253, 254, 65535, 65536] {
+        let value = hostile::Sneaky {
+            a: 5,
+            b: "x".repeat(len),
+            c: vec![9, 2, 3],
+        };
+        let bytes = hostile::Sneaky::as_bytes(&value);
+        let decoded = hostile::Sneaky::from_bytes(&bytes);
+        assert_eq!(decoded, value);
+    }
+
+    let original = hostile::Sneaky {
+        a: 1,
+        b: "hello".to_string(),
+        c: vec![4, 5],
+    };
+    test_key_helper::<hostile::Sneaky>(&original);
+}
+
+// Shadowing cannot catch a reliance on trait methods the prelude brings into scope -- shadowing
+// the `TryFrom` *name* does not undo the prelude's trait import for method resolution. Dropping
+// the prelude entirely does, and also covers derive sites in crates of editions before 2021,
+// whose preludes lack `TryFrom`.
+#[no_implicit_prelude]
+mod no_prelude {
+    use ::redb_derive::{Key, Value};
+
+    #[derive(
+        Key,
+        Value,
+        ::std::fmt::Debug,
+        ::std::cmp::PartialEq,
+        ::std::cmp::Eq,
+        ::std::cmp::PartialOrd,
+        ::std::cmp::Ord,
+    )]
+    pub struct Bare {
+        pub a: ::std::primitive::u16,
+        pub b: ::std::string::String,
+        pub c: ::std::vec::Vec<::std::primitive::u8>,
+    }
+}
+
+#[test]
+fn test_no_prelude_at_derive_site() {
+    // Exercise all three length-prefix encodings of the variable width field b
+    for len in [0usize, 253, 254, 65535, 65536] {
+        let value = no_prelude::Bare {
+            a: 5,
+            b: "x".repeat(len),
+            c: vec![9, 2, 3],
+        };
+        let bytes = no_prelude::Bare::as_bytes(&value);
+        let decoded = no_prelude::Bare::from_bytes(&bytes);
+        assert_eq!(decoded, value);
+    }
+
+    let original = no_prelude::Bare {
+        a: 1,
+        b: "hello".to_string(),
+        c: vec![4, 5],
+    };
+    test_key_helper::<no_prelude::Bare>(&original);
 }
 
 #[test]

--- a/examples/derive_value_impl.rs
+++ b/examples/derive_value_impl.rs
@@ -1,4 +1,4 @@
-use redb::{Database, Error, ReadableDatabase, TableDefinition, Value};
+use redb::{Database, Error, ReadableDatabase, TableDefinition};
 
 use redb_derive::{Key, Value};
 


### PR DESCRIPTION
Second in the redb-derive stack (#1314 → this → #1313). #1314 has merged; this PR is now rebased onto master and is next to merge, with #1313 stacked on it.

## The bug

The generated code called trait methods through unqualified paths like `::from_bytes(...)`, which resolve inherent methods ahead of trait methods:

- A field type with an inherent method of **incompatible signature** failed to compile — e.g. `uuid::Uuid`, whose inherent `from_bytes` takes `[u8; 16]`, could not be used as a field at all.
- A field type with a **compatible signature** was silently hijacked: an inherent `as_bytes`, `from_bytes`, `fixed_width`, or `type_name` was called instead of the `Value` impl, producing encodings that don't round trip. An inherent `from_bytes` on the annotated struct itself was likewise picked up by the derived `Key::compare`, yielding orderings that disagree with `Ord`.

## The fix

Generated code now spells every path fully qualified (`::std::...`, and the redb crate through #1314's path — `::redb`, or the `#[redb(crate = "...")]` override), so neither inherent methods nor any names shadowed at the derive site can change its meaning. The `Value`/`Key` traits no longer need to be in scope at the derive site (the rename and crate-attribute tests drop their trait imports accordingly). Trait associated functions reached through a type path (the length encoding's `u8`/`u16`/`u32::try_from`) are spelled through the trait as well, since they otherwise resolve `TryFrom` from the prelude — which only carries it since the 2021 edition (from Codex review).

## Compatibility

- The derived `TypeName` strings are unchanged, so existing tables are unaffected. The pre-existing tests pin this: all expected name strings are untouched.
- No version change (versioning happens at release); the changelog for the stack is carried by #1313.

## Tests

- Field type with lying compatible-signature inherents → trait impls used (encoding, width, ordering, `type_name`).
- `uuid::Uuid`-signature inherents (and the real `uuid::Uuid`, via a new dev-dependency) → compiles and round trips.
- Inherent `from_bytes` on the derived struct → `Key::compare` agrees with `Ord`.
- A hostile module shadowing every practical prelude name, primitive, and macro the generated code touches → still compiles and round trips (fails to compile against the old derive).
- A `#[no_implicit_prelude]` module → catches reliance on prelude *trait imports*, which shadowing cannot (shadowing a trait's name doesn't undo its methods being in scope). Fails on the unfixed `try_from` calls, and covers derive sites in pre-2021-edition crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuLGiEERgJR51vhJNtYwRA