### PR TITLE
Add Table::insert_with_hint() and InsertHint::Append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@
   Existing databases created by older versions remain readable. If an older database already used
   such a colliding composite name, its stored type identity remains ambiguous and may still open
   under either spelling.
+* Add `Table::insert_with_hint()` and `InsertHint`. `InsertHint::Append` packs a leaf fully
+  instead of splitting it evenly when an insert past the leaf's last key forces a split. This
+  reduces free space left behind when loading data in ascending key order, at the cost of
+  leaves needing to split again to accept a later key that falls inside them.
 
 ### Python bindings
 * Add `Database.create(path)` for creating or opening a database file.

--- a/crates/redb-bench/Cargo.toml
+++ b/crates/redb-bench/Cargo.toml
@@ -64,3 +64,7 @@ harness = false
 [[bench]]
 name = "syscall_benchmark"
 harness = false
+
+[[bench]]
+name = "insert_hint_benchmark"
+harness = false

--- a/crates/redb-bench/benches/insert_hint_benchmark.rs
+++ b/crates/redb-bench/benches/insert_hint_benchmark.rs
@@ -1,0 +1,101 @@
+#![allow(dead_code)]
+
+use tempfile::NamedTempFile;
+
+mod benchmark_dir;
+use benchmark_dir::benchmark_dir;
+
+use rand::RngExt;
+use redb::{
+    Database, InsertHint, ReadableDatabase, ReadableTableMetadata, TableDefinition, TableStats,
+};
+use std::time::{Duration, Instant};
+
+const TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("x");
+
+const ELEMENTS: usize = 1_000_000;
+const KEY_SIZE: usize = 24;
+const VALUE_SIZE: usize = 150;
+
+struct Timing {
+    load: Duration,
+    stats: TableStats,
+    size: u64,
+}
+
+fn random_keys() -> Vec<[u8; KEY_SIZE]> {
+    let mut rng = rand::rng();
+    (0..ELEMENTS)
+        .map(|_| {
+            let mut key = [0u8; KEY_SIZE];
+            rng.fill(&mut key[..]);
+            key
+        })
+        .collect()
+}
+
+fn benchmark(keys: &[[u8; KEY_SIZE]], hint: Option<InsertHint>) -> Timing {
+    let tmpfile: NamedTempFile = NamedTempFile::new_in(benchmark_dir()).unwrap();
+    let db = Database::builder().create(tmpfile.path()).unwrap();
+    let value = vec![0u8; VALUE_SIZE];
+
+    let start = Instant::now();
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        for key in keys {
+            match hint {
+                Some(hint) => table
+                    .insert_with_hint(key.as_slice(), value.as_slice(), hint)
+                    .unwrap(),
+                None => table.insert(key.as_slice(), value.as_slice()).unwrap(),
+            };
+        }
+    }
+    txn.commit().unwrap();
+    let load = start.elapsed();
+
+    let txn = db.begin_read().unwrap();
+    let stats = txn.open_table(TABLE).unwrap().stats().unwrap();
+    let size = tmpfile.as_file().metadata().unwrap().len();
+
+    Timing { load, stats, size }
+}
+
+// Share of the table's bytes that hold user data, rather than padding left
+// behind by splitting
+fn data_percent(stats: &TableStats) -> f64 {
+    let total = stats.stored_bytes() + stats.metadata_bytes() + stats.fragmented_bytes();
+    100.0 * stats.stored_bytes() as f64 / total as f64
+}
+
+fn main() {
+    let random = random_keys();
+    let mut ascending = random.clone();
+    ascending.sort_unstable();
+
+    let mut table = comfy_table::Table::new();
+    table.set_width(100);
+    table.set_header(["", "load", "leaf pages", "data", "DB size"]);
+    for (name, keys, hint) in [
+        ("random order", &random, None),
+        ("ascending order", &ascending, None),
+        (
+            "ascending order, Append hint",
+            &ascending,
+            Some(InsertHint::Append),
+        ),
+    ] {
+        let timing = benchmark(keys, hint);
+        table.add_row(vec![
+            name.to_string(),
+            format!("{}ms", timing.load.as_millis()),
+            format!("{}", timing.stats.leaf_pages()),
+            format!("{:.1}%", data_percent(&timing.stats)),
+            format!("{}MiB", timing.size / 1024 / 1024),
+        ]);
+    }
+
+    println!();
+    println!("{table}");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,9 @@ pub use multimap_table::{
     ReadOnlyMultimapTable, ReadOnlyUntypedMultimapTable, ReadableMultimapTable,
 };
 pub use table::{
-    Entry, ExtractIf, OccupiedEntry, OwnedAccessGuard, OwnedRange, Range, ReadOnlyTable,
-    ReadOnlyUntypedTable, ReadableTable, ReadableTableMetadata, Table, TableStats, VacantEntry,
+    Entry, ExtractIf, InsertHint, OccupiedEntry, OwnedAccessGuard, OwnedRange, Range,
+    ReadOnlyTable, ReadOnlyUntypedTable, ReadableTable, ReadableTableMetadata, Table, TableStats,
+    VacantEntry,
 };
 pub use transactions::{DatabaseStats, Durability, ReadTransaction, WriteTransaction};
 pub use tree_store::{AccessGuard, AccessGuardMut, AccessGuardMutInPlace, Savepoint};

--- a/src/table.rs
+++ b/src/table.rs
@@ -59,6 +59,15 @@ impl TableStats {
     }
 }
 
+/// A hint describing the workload an insert belongs to
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum InsertHint {
+    /// The key is expected to compare greater than all existing keys in the table,
+    /// and further appending insert calls are likely
+    Append,
+}
+
 /// A table containing key-value mappings
 pub struct Table<'txn, K: Key + 'static, V: Value + 'static> {
     name: String,
@@ -246,6 +255,28 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         key: impl Borrow<K::SelfType<'k>>,
         value: impl Borrow<V::SelfType<'v>>,
     ) -> Result<Option<AccessGuard<'_, V>>> {
+        self.insert_helper(key, value, None)
+    }
+
+    /// Identical to [`Table::insert`], but allows the caller to provide a workload hint
+    ///
+    /// A hint only changes how pages are laid out; it never changes the stored data. An
+    /// [`InsertHint::Append`] that does not turn out to be an append is ignored
+    pub fn insert_with_hint<'k, 'v>(
+        &mut self,
+        key: impl Borrow<K::SelfType<'k>>,
+        value: impl Borrow<V::SelfType<'v>>,
+        hint: InsertHint,
+    ) -> Result<Option<AccessGuard<'_, V>>> {
+        self.insert_helper(key, value, Some(hint))
+    }
+
+    fn insert_helper<'k, 'v>(
+        &mut self,
+        key: impl Borrow<K::SelfType<'k>>,
+        value: impl Borrow<V::SelfType<'v>>,
+        hint: Option<InsertHint>,
+    ) -> Result<Option<AccessGuard<'_, V>>> {
         let value_len = V::as_bytes(value.borrow()).as_ref().len();
         if value_len > MAX_VALUE_LENGTH {
             return Err(StorageError::ValueTooLarge(value_len));
@@ -257,7 +288,8 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         if value_len + key_len > MAX_PAIR_LENGTH {
             return Err(StorageError::ValueTooLarge(value_len + key_len));
         }
-        self.tree.insert(key.borrow(), value.borrow())
+        self.tree
+            .insert_with_hint(key.borrow(), value.borrow(), hint)
     }
 
     /// Removes the given key

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -1,4 +1,5 @@
 use crate::db::TransactionGuard;
+use crate::table::InsertHint;
 use crate::tree_store::btree_base::{
     AccessGuardMut, BRANCH, BranchAccessor, BranchMutator, BtreeHeader, Checksum, DEFERRED, LEAF,
     LeafAccessor, LeafPageMut, branch_checksum, leaf_checksum,
@@ -422,6 +423,15 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         key: &K::SelfType<'_>,
         value: &V::SelfType<'_>,
     ) -> Result<Option<AccessGuard<'_, V>>> {
+        self.insert_with_hint(key, value, None)
+    }
+
+    pub(crate) fn insert_with_hint(
+        &mut self,
+        key: &K::SelfType<'_>,
+        value: &V::SelfType<'_>,
+        hint: Option<InsertHint>,
+    ) -> Result<Option<AccessGuard<'_, V>>> {
         #[cfg(feature = "logging")]
         trace!(
             "Btree(root={:?}): Inserting {:?} with value of length {}",
@@ -438,7 +448,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
             freed_pages.as_mut(),
             self.allocated_pages.clone(),
         );
-        let (old_value, _) = operation.insert(key, value)?;
+        let (old_value, _) = operation.insert(key, value, hint)?;
         Ok(old_value)
     }
 
@@ -832,7 +842,7 @@ impl<K: Key + 'static, V: MutInPlaceValue + 'static> BtreeMut<K, V> {
             freed_pages.as_mut(),
             self.allocated_pages.clone(),
         );
-        let (_, guard) = operation.insert(key, &V::from_bytes(&value))?;
+        let (_, guard) = operation.insert(key, &V::from_bytes(&value), None)?;
         Ok(guard)
     }
 }

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -811,28 +811,41 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
     pub(super) fn build_split<'txn>(self) -> Result<(PageMut<'txn>, &'a [u8], PageMut<'txn>)> {
         let total_size = self.total_key_bytes + self.total_value_bytes;
         let mut division = 0;
-        let mut first_split_key_bytes = 0;
-        let mut first_split_value_bytes = 0;
+        let mut split_bytes = 0;
         for (key, value) in self.pairs.iter().take(self.pairs.len() - 1) {
-            first_split_key_bytes += key.len();
-            first_split_value_bytes += value.len();
+            split_bytes += key.len() + value.len();
             division += 1;
-            if first_split_key_bytes + first_split_value_bytes >= total_size / 2 {
+            if split_bytes >= total_size / 2 {
                 break;
             }
         }
+        self.build_split_at(division)
+    }
 
+    // Divides after the second to last pair, rather than evenly, so that the
+    // leading page stays full. An ascending insert splits the rightmost leaf and
+    // never returns to it, so an even division strands it at half capacity.
+    pub(super) fn build_split_appending<'txn>(
+        self,
+    ) -> Result<(PageMut<'txn>, &'a [u8], PageMut<'txn>)> {
+        let division = self.pairs.len() - 1;
+        self.build_split_at(division)
+    }
+
+    fn build_split_at<'txn>(
+        self,
+        division: usize,
+    ) -> Result<(PageMut<'txn>, &'a [u8], PageMut<'txn>)> {
         // num_pairs is stored as a u16, so neither half may exceed u16::MAX pairs. The
         // byte-based division above can be arbitrarily lopsided when pair sizes are skewed
         // (e.g. merging a leaf full of tiny pairs with one containing a huge value)
         let max_pairs = usize::from(u16::MAX);
         assert!(self.pairs.len() <= 2 * max_pairs);
-        let clamped = division.clamp(self.pairs.len().saturating_sub(max_pairs), max_pairs);
-        if clamped != division {
-            division = clamped;
-            first_split_key_bytes = self.pairs[..division].iter().map(|(k, _)| k.len()).sum();
-            first_split_value_bytes = self.pairs[..division].iter().map(|(_, v)| v.len()).sum();
-        }
+        let division = division.clamp(self.pairs.len().saturating_sub(max_pairs), max_pairs);
+        let first_split_key_bytes: usize =
+            self.pairs[..division].iter().map(|(k, _)| k.len()).sum();
+        let first_split_value_bytes: usize =
+            self.pairs[..division].iter().map(|(_, v)| v.len()).sum();
 
         let required_size =
             self.required_bytes(division, first_split_key_bytes + first_split_value_bytes);

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -1,3 +1,4 @@
+use crate::table::InsertHint;
 use crate::tree_store::btree_base::{
     BRANCH, BranchAccessor, BranchBuilder, BranchMutator, Checksum, DEFERRED, LEAF, LeafAccessor,
     LeafBuilder, LeafMutator, OwnedEntryBuffer, is_single_large_value, leaf_below_merge_threshold,
@@ -461,6 +462,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         &mut self,
         key: &K::SelfType<'_>,
         value: &V::SelfType<'_>,
+        hint: Option<InsertHint>,
     ) -> Result<(Option<AccessGuard<'a, V>>, AccessGuardMutInPlace<'a, V>)> {
         let (new_root, old_value, guard) = if let Some(BtreeHeader {
             root: p,
@@ -473,6 +475,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 checksum,
                 K::as_bytes(key).as_ref(),
                 V::as_bytes(value).as_ref(),
+                hint,
             )?;
 
             let new_length = if result.old_value.is_some() {
@@ -525,6 +528,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         page_checksum: Checksum,
         key: &[u8],
         value: &[u8],
+        hint: Option<InsertHint>,
     ) -> Result<InsertionResult<'a, V>> {
         let node_mem = page.memory();
         Ok(match node_mem[0] {
@@ -678,7 +682,14 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         old_value: existing_value,
                     }
                 } else {
-                    let (new_page1, split_key, new_page2) = builder.build_split()?;
+                    let appending = hint == Some(InsertHint::Append)
+                        && !found
+                        && position == accessor.num_pairs();
+                    let (new_page1, split_key, new_page2) = if appending {
+                        builder.build_split_appending()?
+                    } else {
+                        builder.build_split()?
+                    };
                     let split_key = split_key.to_vec();
                     let page_number = page.get_page_number();
                     let existing_value = if found {
@@ -740,6 +751,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     child_checksum,
                     key,
                     value,
+                    hint,
                 )?;
 
                 // Skip-path: if child page number and checksum haven't changed,

--- a/tests/insert_hint_tests.rs
+++ b/tests/insert_hint_tests.rs
@@ -1,0 +1,168 @@
+use redb::{
+    Database, InsertHint, ReadableDatabase, ReadableTable, ReadableTableMetadata, TableDefinition,
+};
+
+const TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("x");
+
+fn create_tempfile() -> tempfile::NamedTempFile {
+    tempfile::NamedTempFile::new().unwrap()
+}
+
+// Zero padded so that lexicographic order matches numeric order
+fn key(i: u64) -> String {
+    format!("{i:016}")
+}
+
+fn load(hint: Option<InsertHint>, keys: &[u64]) -> (u64, u64) {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let value = vec![0u8; 150];
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        for i in keys {
+            match hint {
+                Some(hint) => table
+                    .insert_with_hint(key(*i).as_bytes(), value.as_slice(), hint)
+                    .unwrap(),
+                None => table.insert(key(*i).as_bytes(), value.as_slice()).unwrap(),
+            };
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(TABLE).unwrap();
+    let stats = table.stats().unwrap();
+    (table.len().unwrap(), stats.leaf_pages())
+}
+
+#[test]
+fn append_hint_packs_fewer_leaves() {
+    let ascending: Vec<u64> = (0..20_000).collect();
+    let (plain_len, plain_pages) = load(None, &ascending);
+    let (hinted_len, hinted_pages) = load(Some(InsertHint::Append), &ascending);
+
+    assert_eq!(plain_len, hinted_len);
+    assert!(
+        hinted_pages < plain_pages,
+        "{hinted_pages} should be fewer than {plain_pages}"
+    );
+}
+
+#[test]
+fn append_hint_does_not_change_stored_data() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        for i in 0..5_000u64 {
+            table
+                .insert_with_hint(key(i).as_bytes(), b"v".as_slice(), InsertHint::Append)
+                .unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 5_000);
+    let mut expected = 0u64;
+    for entry in table.iter().unwrap() {
+        let (k, v) = entry.unwrap();
+        assert_eq!(k.value(), key(expected).as_bytes());
+        assert_eq!(v.value(), b"v");
+        expected += 1;
+    }
+    assert_eq!(expected, 5_000);
+}
+
+// The hint is advisory: a caller may be wrong about the order without corrupting anything.
+#[test]
+fn a_wrong_append_hint_is_harmless() {
+    let tmpfile = create_tempfile();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+
+    let mut descending: Vec<u64> = (0..5_000).collect();
+    descending.reverse();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        for i in &descending {
+            table
+                .insert_with_hint(key(*i).as_bytes(), b"v".as_slice(), InsertHint::Append)
+                .unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 5_000);
+    for i in 0..5_000u64 {
+        assert_eq!(table.get(key(i).as_bytes()).unwrap().unwrap().value(), b"v");
+    }
+    drop(table);
+    drop(txn);
+    db.check_integrity().unwrap();
+}
+
+#[test]
+fn append_hint_replaces_an_existing_key() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        table.insert(key(1).as_bytes(), b"old".as_slice()).unwrap();
+        let old = table
+            .insert_with_hint(key(1).as_bytes(), b"new".as_slice(), InsertHint::Append)
+            .unwrap();
+        assert_eq!(old.unwrap().value(), b"old");
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 1);
+    assert_eq!(
+        table.get(key(1).as_bytes()).unwrap().unwrap().value(),
+        b"new"
+    );
+}
+
+#[test]
+fn hinted_and_unhinted_inserts_interleave() {
+    let tmpfile = create_tempfile();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        for i in 0..10_000u64 {
+            if i % 3 == 0 {
+                table.insert(key(i).as_bytes(), b"v".as_slice()).unwrap();
+            } else {
+                table
+                    .insert_with_hint(key(i).as_bytes(), b"v".as_slice(), InsertHint::Append)
+                    .unwrap();
+            }
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 10_000);
+    for i in 0..10_000u64 {
+        assert!(table.get(key(i).as_bytes()).unwrap().is_some());
+    }
+    drop(table);
+    drop(txn);
+    db.check_integrity().unwrap();
+}

--- a/tests/insert_hint_tests.rs
+++ b/tests/insert_hint_tests.rs
@@ -5,7 +5,11 @@ use redb::{
 const TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("x");
 
 fn create_tempfile() -> tempfile::NamedTempFile {
-    tempfile::NamedTempFile::new().unwrap()
+    if cfg!(target_os = "wasi") {
+        tempfile::NamedTempFile::new_in("/tmp").unwrap()
+    } else {
+        tempfile::NamedTempFile::new().unwrap()
+    }
 }
 
 // Zero padded so that lexicographic order matches numeric order


### PR DESCRIPTION
## Problem

Inserting keys in ascending order leaves every leaf about half full. `LeafBuilder::build_split()` divides at the byte midpoint, and an ascending insert always splits the rightmost leaf, so the leading half is sealed at half capacity with nothing to refill it. Loading 1M pairs in ascending order costs 28.6% more leaf pages than loading the same pairs in random order, where later inserts land in the half-empty pages and fill them.

## Fix

Add `InsertHint` and `Table::insert_with_hint()`, as discussed in #1310:

```rust
#[non_exhaustive]
pub enum InsertHint {
    Append,
}

table.insert_with_hint(&key, &value, InsertHint::Append)?;
```

`InsertHint::Append` divides after the second to last pair instead of evenly, so the leading page stays full. The hint is threaded through `BtreeMut::insert_with_hint()` and `MutateHelper` to the split site; `insert()` is unchanged and passes `None`.

The hint is advisory and verified rather than trusted: the split site still checks that the insert actually landed past the leaf's last key, so a hint that turns out to be wrong is ignored rather than producing a malformed leaf. This differs from LMDB's `MDB_APPEND`, which rejects out-of-order keys with `KEYEXIST`. Happy to switch to rejecting if you would rather match LMDB.

Packing leaves fully does cost something: a later key falling inside a packed leaf has to split it again. Loading 1M pairs ascending and then inserting 200k random ones uses 90,129 leaf pages with the hint against 83,362 without, so this is a poor trade for a table that keeps taking scattered writes. That is why it is opt-in per insert rather than automatic.

## Testing

`cargo test --all-features` passes. New `tests/insert_hint_tests.rs` covers packing fewer leaves, stored data being unchanged, a wrong hint being harmless (5,000 descending keys inserted with the hint set, then `check_integrity()`), replacing an existing key, and hinted and unhinted inserts interleaved in one transaction.

New `insert_hint_benchmark`, 1M pairs of 24-byte keys and 150-byte values:

| | load | leaf pages | data | DB size |
|---|---|---|---|---|
| random order | 1794ms | 64799 | 64.5% | 514MiB |
| ascending order | 1233ms | 83333 | 49.7% | 514MiB |
| ascending order, Append hint | 910ms | 45455 | 91.1% | 257MiB |

The `data` column is the share of the table's bytes holding user data, rather than padding left behind by splitting.

On a larger load (1M vertices, 8M edges, a vertex table plus forward and reverse adjacency tables, 17M pairs in one transaction) the compacted database goes from 901.55 MiB to 456.88 MiB.
