### PR TITLE
Tag user-defined field types in the derived TypeName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,19 @@
   instead of splitting it evenly when an insert past the leaf's last key forces a split. This
   reduces free space left behind when loading data in ascending key order, at the cost of
   leaves needing to split again to accept a later key that falls inside them.
+### redb-derive (unreleased)
+* Fix the derived implementations calling inherent methods named `fixed_width`, `from_bytes`,
+  `as_bytes`, or `type_name` on field types, instead of the `Value` trait methods. The
+  generated code now uses fully qualified paths, and no longer requires the `Value` and `Key`
+  traits to be in scope at the derive site.
+* Add `#[redb(crate = "...")]` to name the crate the implementations are generated for, when
+  redb is renamed or present in several versions. Structs with fields require redb 3.0+.
+* Fix derived structs producing the same `TypeName` when two field types with different
+  definitions share a name, such as a user-defined type named `String` and the built-in
+  `String`. User-defined field types (including the `chrono` types redb provides) are now
+  tagged in the derived `TypeName`, so structs containing them change type identity: their
+  existing tables report `TableTypeMismatch` and must be migrated. Structs whose fields are
+  all built-in types are unaffected.
 
 ### Python bindings
 * Add `Database.create(path)` for creating or opening a database file.

--- a/crates/redb-derive/Cargo.toml
+++ b/crates/redb-derive/Cargo.toml
@@ -21,5 +21,7 @@ syn = { version = "2.0", features = ["full"] }
 redb = { path = "../..", features = ["uuid"] }
 tempfile = "3.5.0"
 uuid = { version = "1.17.0", features = ["v4"] }
-# An old version of the redb package, for the tests that derive against two versions at once
+# Old versions of the redb package, for the tests that derive against two versions at once.
+# 3.0.0 is the oldest whose public API supports deriving for a struct with fields.
 redb2_6 = { package = "redb", version = "=2.6.0" }
+redb3_0 = { package = "redb", version = "=3.0.0" }

--- a/crates/redb-derive/src/lib.rs
+++ b/crates/redb-derive/src/lib.rs
@@ -45,7 +45,12 @@ fn redb_crate_path_for(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStr
 /// The generated implementation refers to the redb crate as `::redb`. When it should be
 /// generated for a crate under another name -- a renamed dependency
 /// (`my_redb = { package = "redb" }`), or one of several versions of redb -- name that crate
-/// with `#[redb(crate = "my_redb")]`.
+/// with `#[redb(crate = "my_redb")]`. For a struct with fields, the generated implementation
+/// uses `TypeName` API that redb makes public from 3.0 on; a unit struct works with older
+/// versions as well. The tagging of user-defined field types in the composed type name follows
+/// the named version's classification: redb 4.1 and older classify composites (`Option`,
+/// `Vec`, tuples, arrays) of user-defined types as built-in, so such composite fields render
+/// untagged there, and their names collide exactly where that version's own type names do.
 #[proc_macro_derive(Key, attributes(redb))]
 pub fn derive_key(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -88,7 +93,12 @@ fn generate_key_impl(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStrea
 /// The generated implementation refers to the redb crate as `::redb`. When it should be
 /// generated for a crate under another name -- a renamed dependency
 /// (`my_redb = { package = "redb" }`), or one of several versions of redb -- name that crate
-/// with `#[redb(crate = "my_redb")]`.
+/// with `#[redb(crate = "my_redb")]`. For a struct with fields, the generated implementation
+/// uses `TypeName` API that redb makes public from 3.0 on; a unit struct works with older
+/// versions as well. The tagging of user-defined field types in the composed type name follows
+/// the named version's classification: redb 4.1 and older classify composites (`Option`,
+/// `Vec`, tuples, arrays) of user-defined types as built-in, so such composite fields render
+/// untagged there, and their names collide exactly where that version's own type names do.
 #[proc_macro_derive(Value, attributes(redb))]
 pub fn derive_value(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -183,6 +193,40 @@ fn generate_self_type(
     }
 }
 
+// Renders the name of one field's type for embedding in the struct's `TypeName`. A user-defined
+// type may share its name string with a built-in type (e.g. a user type named "String"), and only
+// the classification of its `TypeName` tells the two apart, so user-defined field types are
+// tagged to keep the composed names distinct. Built-in field types render as the bare name,
+// which keeps the `TypeName` of structs made only of built-in types unchanged.
+//
+// The classification is read by rebuilding the `TypeName` through `TypeName::new` -- the
+// user-defined constructor -- and comparing: `TypeName` equality is exactly (classification,
+// name), so the rebuilt name is equal iff the field's classification is user-defined. redb's
+// `TypeName::is_user_defined()` would say the same, but it is crate-private, and `new`,
+// `name()`, and `PartialEq` reach back to redb 3.0, which `#[redb(crate = "...")]` may name
+// (`name()` is private before that, so field-bearing structs already floor there).
+//
+// The classification is whatever the named redb reports: 4.1 and older classify composites of
+// user-defined types (`Option<UserType>`, say) as built-in, so those fields render untagged
+// and collide exactly where that version's own type names do. Recursing into the field's type
+// syntax instead would misrender aliases (`type A = Option<UserType>`) and change composed
+// names between redb versions, breaking existing tables on upgrade.
+fn render_field_type_name(
+    field_type: &syn::Type,
+    redb: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    quote! {
+        {
+            let type_name = <#field_type as #redb::Value>::type_name();
+            if type_name == #redb::TypeName::new(type_name.name()) {
+                ::std::format!("{}#user", type_name.name())
+            } else {
+                ::std::borrow::ToOwned::to_owned(type_name.name())
+            }
+        }
+    }
+}
+
 fn generate_type_name(
     struct_name: &Ident,
     fields: &Fields,
@@ -195,13 +239,9 @@ fn generate_type_name(
                 .iter()
                 .map(|field| {
                     let field_name = field.ident.as_ref().unwrap();
-                    let field_type = &field.ty;
+                    let rendered_type = render_field_type_name(&field.ty, redb);
                     quote! {
-                        ::std::format!(
-                            "{}: {}",
-                            ::std::stringify!(#field_name),
-                            <#field_type as #redb::Value>::type_name().name(),
-                        )
+                        ::std::format!("{}: {}", ::std::stringify!(#field_name), #rendered_type)
                     }
                 })
                 .collect();
@@ -225,12 +265,7 @@ fn generate_type_name(
             let field_strings: Vec<_> = fields_unnamed
                 .unnamed
                 .iter()
-                .map(|field| {
-                    let field_type = &field.ty;
-                    quote! {
-                        <#field_type as #redb::Value>::type_name().name()
-                    }
-                })
+                .map(|field| render_field_type_name(&field.ty, redb))
                 .collect();
 
             if field_strings.is_empty() {

--- a/crates/redb-derive/tests/crate_attr_tests.rs
+++ b/crates/redb-derive/tests/crate_attr_tests.rs
@@ -2,8 +2,10 @@
 //! for when it is not reachable as `::redb`, such as deriving against two versions of redb
 //! from the same crate.
 //!
-//! redb 2.6 keeps `TypeName::name()` private, which the composed type name of a struct with
-//! fields needs, so the old-version struct here is a unit struct.
+//! The composed type name of a struct with fields reads the field types' `TypeName`s only
+//! through `TypeName::new`, `name()`, and `PartialEq`, so that it compiles against every redb
+//! version exposing those -- redb 3.0 on. redb 2.6 keeps `name()` private, so the 2.6 struct
+//! here is a unit struct, the most that version can derive.
 
 mod old {
     use redb_derive::{Key, Value};
@@ -11,6 +13,30 @@ mod old {
     #[derive(Value, Key, Debug, PartialEq, Eq, PartialOrd, Ord)]
     #[redb(crate = "redb2_6")]
     pub struct OldValue;
+}
+
+mod old3 {
+    use redb_derive::{Key, Value};
+
+    // A user-defined field type, so the tagging in the composed type name runs against the old
+    // version too.
+    #[derive(Value, Key, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    #[redb(crate = "redb3_0")]
+    pub struct Old3Inner {
+        pub tag: u16,
+    }
+
+    #[derive(Value, Key, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    #[redb(crate = "redb3_0")]
+    pub struct Old3Value {
+        pub id: u32,
+        pub inner: Old3Inner,
+        // redb 3.0 classifies composites of user-defined types as built-in (the classification
+        // bubbling is new in 4.2), so this field renders untagged, matching 3.0's own type
+        // names -- which collide for such composites -- rather than 4.2's.
+        pub maybe: Option<Old3Inner>,
+        pub name: String,
+    }
 }
 
 mod new {
@@ -26,7 +52,9 @@ mod new {
 
 use new::NewValue;
 use old::OldValue;
+use old3::{Old3Inner, Old3Value};
 use redb::ReadableDatabase;
+use redb3_0::ReadableDatabase as _;
 
 fn create_tempfile() -> tempfile::NamedTempFile {
     if cfg!(target_os = "wasi") {
@@ -37,6 +65,7 @@ fn create_tempfile() -> tempfile::NamedTempFile {
 }
 
 const OLD_TABLE: redb2_6::TableDefinition<u32, OldValue> = redb2_6::TableDefinition::new("old");
+const OLD3_TABLE: redb3_0::TableDefinition<u32, Old3Value> = redb3_0::TableDefinition::new("old3");
 const NEW_TABLE: redb::TableDefinition<u32, NewValue> = redb::TableDefinition::new("new");
 
 #[test]
@@ -52,6 +81,29 @@ fn derives_for_both_redb_versions() {
     let read_txn = old_db.begin_read().unwrap();
     let table = read_txn.open_table(OLD_TABLE).unwrap();
     assert_eq!(table.get(1).unwrap().unwrap().value(), OldValue);
+
+    let old3_value = Old3Value {
+        id: 7,
+        inner: Old3Inner { tag: 3 },
+        maybe: Some(Old3Inner { tag: 5 }),
+        name: "old3".to_string(),
+    };
+    assert_eq!(
+        <Old3Value as redb3_0::Value>::type_name().name(),
+        "Old3Value {id: u32, inner: Old3Inner {tag: u16}#user, \
+         maybe: Option<Old3Inner {tag: u16}>, name: String}"
+    );
+    let old3_file = create_tempfile();
+    let old3_db = redb3_0::Database::create(old3_file.path()).unwrap();
+    let write_txn = old3_db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(OLD3_TABLE).unwrap();
+        table.insert(1, &old3_value).unwrap();
+    }
+    write_txn.commit().unwrap();
+    let read_txn = old3_db.begin_read().unwrap();
+    let table = read_txn.open_table(OLD3_TABLE).unwrap();
+    assert_eq!(table.get(1).unwrap().unwrap().value(), old3_value);
 
     let new_file = create_tempfile();
     let new_db = redb::Database::create(new_file.path()).unwrap();

--- a/crates/redb-derive/tests/derive_tests.rs
+++ b/crates/redb-derive/tests/derive_tests.rs
@@ -1,4 +1,4 @@
-use redb::{Database, Key, ReadableDatabase, TableDefinition, TypeName, Value};
+use redb::{Database, Key, ReadableDatabase, TableDefinition, TableError, TypeName, Value};
 use redb_derive::{Key, Value};
 use std::fmt::Debug;
 use tempfile::NamedTempFile;
@@ -287,7 +287,7 @@ fn test_inherent_methods_do_not_shadow_trait_methods() {
     // The inherent `type_name` returns "bogus"
     assert_eq!(
         InherentHolder::type_name().name(),
-        "InherentHolder {a: Inherent, b: u64}"
+        "InherentHolder {a: Inherent#user, b: u64}"
     );
 
     test_key_helper::<InherentHolder>(&original);
@@ -380,7 +380,7 @@ fn test_field_with_conflicting_inherent_signatures() {
     assert_eq!(decoded, original);
     assert_eq!(
         UuidHolder::type_name().name(),
-        "UuidHolder {id: FakeUuid, tag: String}"
+        "UuidHolder {id: FakeUuid#user, tag: String}"
     );
 }
 
@@ -401,7 +401,7 @@ fn test_uuid_field() {
     assert_eq!(decoded, original);
     assert_eq!(
         RealUuidHolder::type_name().name(),
-        "RealUuidHolder {id: uuid::Uuid, tag: String}"
+        "RealUuidHolder {id: uuid::Uuid#user, tag: String}"
     );
     test_key_helper::<RealUuidHolder>(&original);
 }
@@ -525,6 +525,139 @@ fn test_no_prelude_at_derive_site() {
         c: vec![4, 5],
     };
     test_key_helper::<no_prelude::Bare>(&original);
+}
+
+mod name_collision {
+    use redb::TypeName;
+
+    // A user-defined type that shares its name with the built-in `String`, with an incompatible
+    // serialized representation
+    #[derive(Debug, PartialEq)]
+    pub struct String {
+        pub inner: u64,
+    }
+
+    impl redb::Value for String {
+        type SelfType<'a> = String;
+        type AsBytes<'a> = [u8; 8];
+
+        fn fixed_width() -> Option<usize> {
+            Some(8)
+        }
+
+        fn from_bytes<'a>(data: &'a [u8]) -> String
+        where
+            Self: 'a,
+        {
+            String {
+                inner: u64::from_le_bytes(data.try_into().unwrap()),
+            }
+        }
+
+        fn as_bytes<'a, 'b: 'a>(value: &'a String) -> [u8; 8]
+        where
+            Self: 'b,
+        {
+            value.inner.to_le_bytes()
+        }
+
+        fn type_name() -> TypeName {
+            TypeName::new("String")
+        }
+    }
+}
+
+#[derive(Value, Debug)]
+struct BuiltinField {
+    s: String,
+}
+
+mod user_field {
+    use redb_derive::Value;
+
+    #[derive(Value, Debug)]
+    pub struct BuiltinField {
+        pub s: super::name_collision::String,
+    }
+}
+
+#[test]
+fn test_user_defined_field_type_name_does_not_collide() {
+    // Structs made only of built-in field types keep the exact pre-0.2 type identity, so their
+    // existing tables still open
+    assert_eq!(
+        BuiltinField::type_name(),
+        TypeName::new("BuiltinField {s: String}")
+    );
+    // A user-defined field type with a colliding name yields a distinct identity
+    assert_eq!(
+        user_field::BuiltinField::type_name().name(),
+        "BuiltinField {s: String#user}"
+    );
+    assert_ne!(
+        BuiltinField::type_name(),
+        user_field::BuiltinField::type_name()
+    );
+}
+
+#[test]
+fn test_colliding_types_do_not_open_each_others_tables() {
+    let file = create_tempfile();
+    let db = Database::create(file.path()).unwrap();
+
+    let def: TableDefinition<u32, BuiltinField> = TableDefinition::new("test");
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(def).unwrap();
+        table
+            .insert(
+                1,
+                BuiltinField {
+                    s: "hello".to_string(),
+                },
+            )
+            .unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let colliding_def: TableDefinition<u32, user_field::BuiltinField> =
+        TableDefinition::new("test");
+    assert!(matches!(
+        read_txn.open_table(colliding_def),
+        Err(TableError::TableTypeMismatch { .. })
+    ));
+}
+
+#[derive(Value, Debug)]
+struct Nested {
+    inner: SingleField,
+}
+
+#[derive(Value, Debug)]
+struct WrappedUser {
+    v: Vec<SingleField>,
+    w: Vec<u32>,
+}
+
+#[derive(Value, Debug)]
+struct TupleNested(SingleField, u32);
+
+#[test]
+fn test_nested_user_types_are_marked() {
+    assert_eq!(
+        Nested::type_name().name(),
+        "Nested {inner: SingleField {value: i32}#user}"
+    );
+    // Composites wrapping a user type are user-defined; composites of built-ins are not
+    assert_eq!(
+        WrappedUser::type_name().name(),
+        "WrappedUser {v: Vec<SingleField {value: i32}>#user, w: Vec<u32>}"
+    );
+    assert_eq!(
+        TupleNested::type_name().name(),
+        "TupleNested(SingleField {value: i32}#user, u32)"
+    );
 }
 
 #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -728,6 +728,30 @@ le_value!(f64);
 mod tests {
     use super::*;
 
+    #[test]
+    fn classification_is_readable_through_reconstruction() {
+        // The derive macro reads a field type's classification by rebuilding its `TypeName`
+        // through `TypeName::new` and comparing, because the generated code has to compile
+        // against older redb versions that lack `is_user_defined()` (see `#[redb(crate)]` in
+        // redb-derive). Equality must keep agreeing with `is_user_defined()` for every
+        // classification.
+        let samples = [
+            TypeName::new("Plain"),
+            TypeName::internal("Plain"),
+            TypeName::internal2("Plain"),
+            TypeName::internal("Composite").into_composite(true),
+            TypeName::internal("Composite").into_composite(false),
+            TypeName::internal2("Composite").into_composite(true),
+            TypeName::internal2("Composite").into_composite(false),
+        ];
+        for type_name in samples {
+            assert_eq!(
+                type_name.is_user_defined(),
+                type_name == TypeName::new(type_name.name())
+            );
+        }
+    }
+
     // A user-defined type whose name deliberately collides with the built-in `u32`, and whose
     // fixed width matches it. Before composite classifications bubbled up, `Option<FakeU32>` and
     // `Option<u32>` produced byte-identical `TypeName`s, letting one silently open as the other.


### PR DESCRIPTION
Last in the redb-derive stack (#1314 → #1311 → this). Both predecessors have merged; this PR is rebased onto master and is the only one remaining. It carries the changelog for the whole stack, under a `redb-derive (unreleased)` heading (no version changes in the stack; versioning happens at release).

## The bug

Derived `type_name()` composed the struct's `TypeName` from only the *name strings* of its field types, discarding the user-defined vs built-in classification. A user type named `String` and the built-in `String` produced byte-identical `TypeName`s for their containing structs, so a table written with one opened as the other without error and silently misread the stored bytes.

## The fix

This is the derive-side analog of the composite-type collision fixed in 4388342/27160a5, but bubbling the classification up cannot work here: a derived struct is itself always user-defined, so the outer classification carries no signal. Instead, user-defined field types are tagged in the composed name (`Holder {id: Inherent#user}`); `#` cannot appear in any built-in type name, so tagged and untagged renderings cannot collide.

The generated code reads the classification by rebuilding the field's `TypeName` through `TypeName::new` and comparing — `TypeName` equality is exactly (classification, name) — rather than calling `is_user_defined()`. That keeps it compiling when `#[redb(crate = "...")]` names an older redb: `new`, `name()`, and `PartialEq` are public back to redb 3.0, which was already the floor for field-bearing derives (`name()` is private in ≤2.6). `TypeName::is_user_defined()` stays `pub(crate)` — nothing outside the crate needs it (per review).

## Compatibility

- Derived structs whose fields are **all built-in types** (including tuples, arrays, `Option`/`Vec` of built-ins) keep a byte-identical `TypeName` — their existing tables still open. The pre-existing tests pin this: all expected name strings are unchanged.
- Structs containing **user-defined field types** change identity; their derive-0.1 tables report `TableTypeMismatch` and need migration. Per review, this includes the `chrono` types whose `Value` implementations redb provides under the `chrono_v0_4` feature — those are classified user-defined (`TypeName::new`) and, unlike `uuid::Uuid` (which never compiled under 0.1, see #1311), chrono fields did compile, so such tables can exist. The changelog calls this out.
- The `#[redb(crate = "...")]` multi-version use case keeps working (per review): field-bearing derives compile against redb 3.0+, pinned by a new `redb3_0 = "=3.0.0"` dev-dependency.

## Tests

- User type named `String` vs built-in `String` → distinct `TypeName`s, and an end-to-end `open_table` mismatch error.
- Nested derived structs, and `Vec`/tuple composites wrapping user types → tagged; composites of built-ins → untagged.
- Equality pin that built-in-only structs keep the exact pre-change identity.
- A field-bearing struct with a user-defined field derives against redb 3.0.0 via `#[redb(crate = "redb3_0")]`, asserts its tagged name, and round-trips through a 3.0 database; a `types.rs` unit test keeps the reconstruction agreeing with `is_user_defined()` for every classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuLGiEERgJR51vhJNtYwRA