### PR TITLE
Add #[redb(crate = "...")] to name the redb crate in derived code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 authors.workspace = true
 
 [workspace]
-members = [".", "crates/redb-bench", "crates/redb-derive", "crates/redb-python"]
-default-members = [".", "crates/redb-derive", "crates/redb-python"]
+members = [".", "crates/redb-bench", "crates/redb-derive", "crates/redb-derive-rename-test", "crates/redb-python"]
+default-members = [".", "crates/redb-derive", "crates/redb-derive-rename-test", "crates/redb-python"]
 
 [workspace.package]
 edition = "2024"

--- a/crates/redb-derive-rename-test/Cargo.toml
+++ b/crates/redb-derive-rename-test/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "redb-derive-rename-test"
+description = "Tests that redb-derive works when the redb dependency is renamed"
+version = "0.0.0"
+publish = false
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dev-dependencies]
+renamed_redb = { package = "redb", path = "../.." }
+redb-derive = { path = "../redb-derive" }

--- a/crates/redb-derive-rename-test/src/lib.rs
+++ b/crates/redb-derive-rename-test/src/lib.rs
@@ -1,0 +1,2 @@
+// Intentionally empty: this package exists for the integration test in tests/, which must live
+// in a package whose only redb dependency is under a renamed key.

--- a/crates/redb-derive-rename-test/tests/rename_test.rs
+++ b/crates/redb-derive-rename-test/tests/rename_test.rs
@@ -1,0 +1,40 @@
+// This package depends on redb only under the name `renamed_redb`, so the derives work only
+// through `#[redb(crate = "...")]`, and any stray `redb` path in the generated code fails to
+// compile here.
+use redb_derive::{Key, Value};
+use renamed_redb::Value as _;
+
+#[derive(Key, Value, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[redb(crate = "renamed_redb")]
+struct Composite {
+    a: u32,
+    b: String,
+}
+
+#[test]
+fn derive_with_renamed_redb_dependency() {
+    let original = Composite {
+        a: 7,
+        b: "hello".to_string(),
+    };
+    let bytes = <Composite as renamed_redb::Value>::as_bytes(&original);
+    let decoded = <Composite as renamed_redb::Value>::from_bytes(&bytes);
+    assert_eq!(decoded, original);
+    assert_eq!(
+        <Composite as renamed_redb::Value>::type_name().name(),
+        "Composite {a: u32, b: String}"
+    );
+
+    let small = <Composite as renamed_redb::Value>::as_bytes(&Composite {
+        a: 1,
+        b: "x".to_string(),
+    });
+    let large = <Composite as renamed_redb::Value>::as_bytes(&Composite {
+        a: 2,
+        b: "x".to_string(),
+    });
+    assert_eq!(
+        <Composite as renamed_redb::Key>::compare(&small, &large),
+        std::cmp::Ordering::Less
+    );
+}

--- a/crates/redb-derive/Cargo.toml
+++ b/crates/redb-derive/Cargo.toml
@@ -20,3 +20,5 @@ syn = { version = "2.0", features = ["full"] }
 [dev-dependencies]
 redb = { path = "../.." }
 tempfile = "3.5.0"
+# An old version of the redb package, for the tests that derive against two versions at once
+redb2_6 = { package = "redb", version = "=2.6.0" }

--- a/crates/redb-derive/src/lib.rs
+++ b/crates/redb-derive/src/lib.rs
@@ -10,7 +10,36 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput, Fields, GenericParam, Ident, parse_macro_input};
 
-#[proc_macro_derive(Key)]
+// The path of the redb crate in generated code: `::redb`, unless an explicit
+// `#[redb(crate = "path")]` on the deriving struct names it otherwise, as when the dependency
+// is renamed (`my_redb = { package = "redb" }`) or the implementations are derived against one
+// of several versions of the redb package.
+fn redb_crate_path_for(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let mut path = None;
+    for attr in &input.attrs {
+        if !attr.path().is_ident("redb") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("crate") {
+                let value: syn::LitStr = meta.value()?.parse()?;
+                path = Some(value.parse::<syn::Path>()?);
+                Ok(())
+            } else {
+                Err(meta.error("expected `#[redb(crate = \"...\")]`"))
+            }
+        })?;
+    }
+    Ok(path.map_or_else(|| quote! { ::redb }, |path| quote! { #path }))
+}
+
+/// Derives `redb::Key` for a struct whose fields all implement `Key`.
+///
+/// The generated implementation refers to the redb crate as `::redb`. When it should be
+/// generated for a crate under another name -- a renamed dependency
+/// (`my_redb = { package = "redb" }`), or one of several versions of redb -- name that crate
+/// with `#[redb(crate = "my_redb")]`.
+#[proc_macro_derive(Key, attributes(redb))]
 pub fn derive_key(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
@@ -31,9 +60,10 @@ fn generate_key_impl(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStrea
     let name = &input.ident;
     let generics = &input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let redb = redb_crate_path_for(input)?;
 
     Ok(quote! {
-        impl #impl_generics redb::Key for #name #ty_generics #where_clause {
+        impl #impl_generics #redb::Key for #name #ty_generics #where_clause {
             fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
                 let value1 = #name::from_bytes(data1);
                 let value2 = #name::from_bytes(data2);
@@ -43,7 +73,13 @@ fn generate_key_impl(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStrea
     })
 }
 
-#[proc_macro_derive(Value)]
+/// Derives `redb::Value` for a struct whose fields all implement `Value`.
+///
+/// The generated implementation refers to the redb crate as `::redb`. When it should be
+/// generated for a crate under another name -- a renamed dependency
+/// (`my_redb = { package = "redb" }`), or one of several versions of redb -- name that crate
+/// with `#[redb(crate = "my_redb")]`.
+#[proc_macro_derive(Value, attributes(redb))]
 pub fn derive_value(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
@@ -66,14 +102,15 @@ fn generate_value_impl(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStr
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let self_type = generate_self_type(name, generics)?;
+    let redb = redb_crate_path_for(input)?;
 
-    let type_name_impl = generate_type_name(name, &data_struct.fields);
+    let type_name_impl = generate_type_name(name, &data_struct.fields, &redb);
     let as_bytes_impl = generate_as_bytes(&data_struct.fields);
     let from_bytes_impl = generate_from_bytes(name, &data_struct.fields);
     let fixed_width_impl = generate_fixed_width(&data_struct.fields);
 
     Ok(quote! {
-        impl #impl_generics redb::Value for #name #ty_generics #where_clause {
+        impl #impl_generics #redb::Value for #name #ty_generics #where_clause {
             type SelfType<'a> = #self_type
             where
                 Self: 'a;
@@ -99,7 +136,7 @@ fn generate_value_impl(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStr
                 #as_bytes_impl
             }
 
-            fn type_name() -> redb::TypeName {
+            fn type_name() -> #redb::TypeName {
                 #type_name_impl
             }
         }
@@ -136,7 +173,11 @@ fn generate_self_type(
     }
 }
 
-fn generate_type_name(struct_name: &Ident, fields: &Fields) -> proc_macro2::TokenStream {
+fn generate_type_name(
+    struct_name: &Ident,
+    fields: &Fields,
+    redb: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
     match fields {
         Fields::Named(fields_named) => {
             let field_strings: Vec<_> = fields_named
@@ -153,13 +194,13 @@ fn generate_type_name(struct_name: &Ident, fields: &Fields) -> proc_macro2::Toke
 
             if field_strings.is_empty() {
                 quote! {
-                    redb::TypeName::new(&format!("{} {{}}",
+                    #redb::TypeName::new(&format!("{} {{}}",
                         stringify!(#struct_name),
                     ))
                 }
             } else {
                 quote! {
-                    redb::TypeName::new(&format!("{} {{{}}}",
+                    #redb::TypeName::new(&format!("{} {{{}}}",
                         stringify!(#struct_name),
                         [#(#field_strings),*].join(", ")
                     ))
@@ -180,13 +221,13 @@ fn generate_type_name(struct_name: &Ident, fields: &Fields) -> proc_macro2::Toke
 
             if field_strings.is_empty() {
                 quote! {
-                    redb::TypeName::new(&format!("{}()",
+                    #redb::TypeName::new(&format!("{}()",
                         stringify!(#struct_name),
                     ))
                 }
             } else {
                 quote! {
-                    redb::TypeName::new(&format!("{}({})",
+                    #redb::TypeName::new(&format!("{}({})",
                         stringify!(#struct_name),
                         [#(#field_strings),*].join(", ")
                     ))
@@ -195,7 +236,7 @@ fn generate_type_name(struct_name: &Ident, fields: &Fields) -> proc_macro2::Toke
         }
         Fields::Unit => {
             quote! {
-                redb::TypeName::new(stringify!(#struct_name))
+                #redb::TypeName::new(stringify!(#struct_name))
             }
         }
     }

--- a/crates/redb-derive/tests/crate_attr_tests.rs
+++ b/crates/redb-derive/tests/crate_attr_tests.rs
@@ -1,0 +1,80 @@
+//! Tests for `#[redb(crate = "...")]`, which names the crate the implementations are generated
+//! for when it is not reachable as `::redb`, such as deriving against two versions of redb
+//! from the same crate.
+//!
+//! redb 2.6 keeps `TypeName::name()` private, which the composed type name of a struct with
+//! fields needs, so the old-version struct here is a unit struct.
+
+mod old {
+    use redb_derive::{Key, Value};
+    use redb2_6::Value as _;
+
+    #[derive(Value, Key, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    #[redb(crate = "redb2_6")]
+    pub struct OldValue;
+}
+
+mod new {
+    use redb::Value as _;
+    use redb_derive::{Key, Value};
+
+    #[derive(Value, Key, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    #[redb(crate = "::redb")]
+    pub struct NewValue {
+        pub id: u32,
+        pub name: String,
+    }
+}
+
+use new::NewValue;
+use old::OldValue;
+use redb::ReadableDatabase;
+
+fn create_tempfile() -> tempfile::NamedTempFile {
+    if cfg!(target_os = "wasi") {
+        tempfile::NamedTempFile::new_in("/tmp").unwrap()
+    } else {
+        tempfile::NamedTempFile::new().unwrap()
+    }
+}
+
+const OLD_TABLE: redb2_6::TableDefinition<u32, OldValue> = redb2_6::TableDefinition::new("old");
+const NEW_TABLE: redb::TableDefinition<u32, NewValue> = redb::TableDefinition::new("new");
+
+#[test]
+fn derives_for_both_redb_versions() {
+    let old_file = create_tempfile();
+    let old_db = redb2_6::Database::create(old_file.path()).unwrap();
+    let write_txn = old_db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(OLD_TABLE).unwrap();
+        table.insert(1, &OldValue).unwrap();
+    }
+    write_txn.commit().unwrap();
+    let read_txn = old_db.begin_read().unwrap();
+    let table = read_txn.open_table(OLD_TABLE).unwrap();
+    assert_eq!(table.get(1).unwrap().unwrap().value(), OldValue);
+
+    let new_file = create_tempfile();
+    let new_db = redb::Database::create(new_file.path()).unwrap();
+    let write_txn = new_db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(NEW_TABLE).unwrap();
+        let value = NewValue {
+            id: 1,
+            name: "new".to_string(),
+        };
+        table.insert(1, &value).unwrap();
+    }
+    write_txn.commit().unwrap();
+    let read_txn = new_db.begin_read().unwrap();
+    let table = read_txn.open_table(NEW_TABLE).unwrap();
+    let value = table.get(1).unwrap().unwrap().value();
+    assert_eq!(
+        value,
+        NewValue {
+            id: 1,
+            name: "new".to_string(),
+        }
+    );
+}


### PR DESCRIPTION
Prep PR for the redb-derive audit fixes — first of the stack (this → #1311 → #1313).

The code generated by `#[derive(Value)]` and `#[derive(Key)]` referenced the redb crate by the literal path `redb`, so the derives only worked when the dependency was named `redb` at the derive site. The generated code now references the crate as `::redb` by default, and a `#[redb(crate = "...")]` attribute on the deriving struct (same shape as `#[serde(crate = "...")]`) names the crate explicitly for the remaining cases: a renamed dependency (`my_redb = { package = "redb" }`), or deriving against one of several versions of the redb package from the same crate.

Automatic rename resolution through Cargo metadata (proc-macro-crate) was in an earlier version of this PR and was dropped as not worth the complexity: it took manifest parsing plus priority rules for manifests that name several versions of the redb package, all to save one attribute at the derive site.

Tests:
- `crate_attr_tests.rs` derives for redb 2.6 and redb 4 side by side (via the attribute) and round-trips through both database versions. (The 2.6 struct is a unit struct: composed type names of field-bearing structs need `TypeName::name()`, which 2.6 keeps `pub(crate)`.)
- The `redb-derive-rename-test` workspace member (publish = false), whose only dependency on redb is under the renamed key `renamed_redb`, pins that the attribute suffices with no dependency named `redb`, and that no stray `redb` path remains in the generated code. At this point in the stack it still needs `use renamed_redb::Value as _;` for the generated code's unqualified trait-method calls — #1311 removes that requirement.

No version changes anywhere in the stack; versioning happens at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuLGiEERgJR51vhJNtYwRA