### PR TITLE
Add InsertWithHint fuzz operation

### DIFF
--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -112,6 +112,10 @@ pub(crate) enum FuzzOperation {
         key: BoundedU64<KEY_SPACE>,
         value_size: BinomialDifferenceBoundedUSize<MAX_VALUE_SIZE>,
     },
+    InsertWithHint {
+        key: BoundedU64<KEY_SPACE>,
+        value_size: BinomialDifferenceBoundedUSize<MAX_VALUE_SIZE>,
+    },
     InsertReserve {
         key: BoundedU64<KEY_SPACE>,
         value_size: BinomialDifferenceBoundedUSize<MAX_VALUE_SIZE>,

--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use redb::{
-    AccessGuard, Database, Durability, Error, MultimapTable, MultimapTableDefinition,
+    AccessGuard, Database, Durability, Error, InsertHint, MultimapTable, MultimapTableDefinition,
     MultimapValue, ReadableDatabase, ReadableMultimapTable, ReadableTable, ReadableTableMetadata, Savepoint,
     StorageBackend, Table, TableDefinition, WriteTransaction,
 };
@@ -328,6 +328,9 @@ fn handle_multimap_table_op(
         FuzzOperation::GetMut { .. } => {
             // no-op. Multimap tables don't support get_mut
         }
+        FuzzOperation::InsertWithHint { .. } => {
+            // no-op. Multimap tables don't support insert hints
+        }
         FuzzOperation::Insert { key, value_size } => {
             let key = key.value;
             let value_size = value_size.value as usize;
@@ -511,6 +514,15 @@ fn handle_table_op(
             let value_size = value_size.value as usize;
             let value = vec![0xFF; value_size];
             table.insert(&key, value.as_slice())?;
+            reference.insert(key, value_size);
+        }
+        FuzzOperation::InsertWithHint { key, value_size } => {
+            let key = key.value;
+            let value_size = value_size.value as usize;
+            let value = vec![0xFF; value_size];
+            // The hint is advisory: it must never change the stored data, whether or
+            // not this key actually is greater than every existing one
+            table.insert_with_hint(&key, value.as_slice(), InsertHint::Append)?;
             reference.insert(key, value_size);
         }
         FuzzOperation::InsertReserve { key, value_size } => {


### PR DESCRIPTION
## Summary

Adds `FuzzOperation::InsertWithHint` so the fuzz target exercises `Table::insert_with_hint`. Nothing currently reaches it.

The hint is advisory: it changes how a leaf is split but never what is stored, and a caller may be wrong about the order without any consequence. That property is what wants adversarial coverage, since the fuzzer will freely emit hinted inserts for keys that are not greater than everything already present, interleaved with plain inserts, removals and the rest.

The operation records the same expectation in the reference model as a plain insert, so any divergence in stored data fails the existing comparison. Multimap tables have no insert hints, so it is a no-op there.

## Testing

`cargo fuzz run --sanitizer=none fuzz_redb -- -max_len=10000 -max_total_time=600`: 275255 runs, no crashes.
