### PR TITLE
Fix stats() walking stale table roots while a table is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## 4.2.0 - 2026-XX-XX
 * Fix `WriteTransaction::stats()` reading pages that had been freed and reallocated when called
-  while a table handle was open, if that table had already been modified and closed earlier in
-  the transaction. This returned garbage statistics, or panicked with debug assertions enabled.
-  A table that is currently open is now reported as of the start of the transaction.
+  while a table handle was open, if that table had already been modified and closed (and possibly
+  renamed) earlier in the transaction. This returned garbage statistics, or panicked with debug
+  assertions enabled. A table that is currently open is now reported as of the start of the
+  transaction.
 * Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. A live
   `WriteTransaction` now keeps the database open: the transaction remains usable after the
   `Database` is dropped, and the database closes when the transaction commits, aborts, or is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,85 +2,126 @@
 
 ## 4.2.0 - 2026-XX-XX
 * Fix `WriteTransaction::stats()` returning garbage statistics, or panicking when debug assertions
-  are enabled, if a table modified earlier in the transaction was still open. Open tables are now
-  reported as of the start of the transaction.
-* Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. The transaction
-  now keeps the database open until it commits, aborts, or is dropped.
-* Fix a panic after `check_integrity()` returned an error. Such a database now returns
-  `StorageError::Corrupted` from write transactions until it is reopened.
-* Refuse to begin new write transactions after an error or panic part way through
-  `WriteTransaction::commit()`, instead of risking corruption. Reopening the database repairs it.
-* `check_integrity()` now repairs stored table counts that disagree with the trees. Such a file
-  previously passed the check and later panicked.
-* Add `ReadOnlyTable::get_owned()` and `range_owned()`, and the multimap equivalents, which return
-  the new `OwnedAccessGuard`, `OwnedRange`, `OwnedMultimapValue`, and `OwnedMultimapRange` types.
-  These keep the read transaction alive until they are dropped.
+  are enabled, when called while a table is open and modified in the same transaction.
+* Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. A live
+  `WriteTransaction` now keeps the database open: the transaction remains usable after the
+  `Database` is dropped, and the database closes when the transaction commits, aborts, or is
+  dropped.
+* Fix a panic, including one raised while dropping a `Database`, after `check_integrity()` returned
+  an error. Such a database now refuses to begin a write transaction or to re-run the check,
+  returning `StorageError::Corrupted`, and is no longer recorded as cleanly shut down.
+* Harden against errors and panics raised part way through `WriteTransaction::commit()`: the
+  database now refuses further write transactions until it is closed and reopened (which
+  repairs it), instead of risking corruption from continued use after the failed commit.
+* `check_integrity()` now recomputes the table counts stored alongside the data and system roots,
+  repairing a file whose counts disagree with its trees. Such a file previously passed the check
+  and then panicked, including from `Database::drop`.
+* Add `ReadOnlyTable::get_owned()`, `ReadOnlyTable::range_owned()`,
+  `ReadOnlyMultimapTable::get_owned()`, and `ReadOnlyMultimapTable::range_owned()`, which
+  return the new `OwnedAccessGuard`, `OwnedRange`, `OwnedMultimapValue`, and
+  `OwnedMultimapRange` types. These keep the read transaction alive until they are dropped,
+  including the guards yielded by the iterators, which may outlive the iterator that produced
+  them.
 * Fix a crash during a transaction that grows the database file leaving the database permanently
   unopenable afterward.
-* Fix a potential deadlock when a multimap value-set shrinks from a subtree back to inline storage
-  while another table in the same write transaction is used from a different thread.
-* Avoid write amplification when removing a value that is not present from a multimap table.
+* Fix a potential deadlock when removing a value from a multimap table causes its value-set to
+  shrink from a subtree back to inline storage, while another table of the same write transaction
+  is used concurrently from a different thread.
+* Avoid unnecessary write amplification when removing a value that is not present from a multimap
+  table. Such a removal is now a no-op.
 * Fix a crash during a commit that resizes the database file leaving the database permanently
-  unopenable.
-* Optimize `Table::retain()` and `Table::retain_in()`. 30-100x faster on some large-table
-  benchmarks.
-* Optimize `Table::extract_if()` and `Table::extract_from_if()`. 18-65x faster on some benchmarks.
-* After the extract iterator returns an error, later calls keep returning an error.
-* Add `Table::entry()` and the associated `Entry`, `OccupiedEntry`, and `VacantEntry` types,
-  mirroring `std::collections::BTreeMap::entry`.
+  unopenable, and reporting corruption on subsequent opens, even though every committed transaction
+  was intact and fully recoverable.
+* Optimize `Table::retain()` and `Table::retain_in()`. Some benchmarks on large tables show a
+  30-100x speedup, depending on the fraction of entries retained.
+* Optimize `Table::extract_if()` and `Table::extract_from_if()`. Benchmarks on large tables show
+  an 18-65x speedup, depending on the fraction of entries extracted, and iterating the extract
+  iterator from both ends no longer degrades the removal batching.
+* After the extract iterator returns an error, later calls keep returning an error instead of
+  continuing.
+* Add `Table::entry()` and the associated `Entry`, `OccupiedEntry`, and `VacantEntry`
+  types, mirroring `std::collections::BTreeMap::entry`. Supports `or_insert`,
+  `or_insert_with`, `or_insert_with_key`, `and_modify`, and the usual `OccupiedEntry`
+  / `VacantEntry` accessors.
 * `Table::retain()`, `Table::retain_in()`, `Table::extract_if()`, and `Table::extract_from_if()`
-  now poison the write transaction if their predicate panics or removals cannot be applied, causing
-  `WriteTransaction::commit()` to return `CommitError::TransactionPoisoned`.
-* Add `ExtractIf::close()` to finalize an extract iterator without removing unread entries.
+  now poison the write transaction if their predicate panics, causing `WriteTransaction::commit()`
+  to return `CommitError::TransactionPoisoned`. They also poison the
+  transaction if an internal error prevents removals from being applied.
+* Add `ExtractIf::close()` to explicitly finalize an extract iterator without removing unread
+  entries.
 * Optimize `Table::pop_first()` and `Table::pop_last()` to be about 2x faster.
 * Enable file space reclamation during non-durable transactions performed while a savepoint exists.
-* Reuse pages freed by a durable write transaction in the next write transaction, one transaction
-  earlier than before.
-* Fix a bug where `compact()` could cause the file to grow rather than shrink.
-* Fix a bug where the file could grow instead of reusing freed space, and `compact()` could stop
-  before fully shrinking the file.
+* Reuse pages freed by a durable write transaction in the next write transaction when no
+  live read transaction or savepoint still needs them. Previously, pages were not reused for one
+  additional transaction.
+* Fix a bug where calling `compact()` on a database could cause the file to grow
+  rather than shrink in some cases.
+* Fix a bug where the database file could grow unnecessarily instead of reusing freed space, and
+  where `compact()` could stop before fully shrinking the file.
 * Enforce the maximum value size limit when replacing a value in place via `Table::get_mut()`
-  or `Entry::and_modify()`.
-* Fix a panic in `insert()` when a single leaf page accumulated 65536 entries via in-place appends.
+  or `Entry::and_modify()`. Previously these paths could bypass the limit that `Table::insert()`
+  and the `entry()` accessors enforce, returning `StorageError::ValueTooLarge` only inconsistently.
+* Fix a panic in `insert()` when a single leaf page accumulated 65536 entries via in-place
+  appends, e.g. by inserting a large value and then many small values in ascending key order
+  within the same transaction.
 * `StorageBackend::close()` is now called when the `Database` is dropped even if an I/O error
-  occurs during shutdown.
+  occurs during shutdown. Previously a shutdown I/O error could skip the `close()` call, leaking
+  any resources the backend releases there.
 * `compact()` now returns `CompactionError::PersistentSavepointExists` or
   `CompactionError::EphemeralSavepointExists` instead of the misleading
   `CompactionError::TransactionInProgress` when a savepoint blocks compaction.
-* Fix `check_integrity()` incorrectly reporting a healthy database as corrupted after a persistent
-  savepoint was deleted or restored.
-* Fix `check_integrity()` incorrectly reporting a healthy database as corrupted when an ephemeral
-  `Savepoint` was dropped from another thread during a commit.
-* Fix a leak of database space when an ephemeral `Savepoint`, created while the same write
-  transaction was first accessing a table from another thread, was later restored.
-* Fix a panic when opening a database file that was externally extended to an invalid size;
-  `StorageError::Corrupted` is now returned instead.
-* Fix a hang on Windows when opening a truncated or corrupt database file.
+* Fix `check_integrity()` incorrectly reporting a healthy database as corrupted (and panicking
+  in debug builds) after a persistent savepoint was deleted or restored.
+* Fix `check_integrity()` incorrectly reporting a healthy database as corrupted (and panicking
+  in debug builds) when an ephemeral `Savepoint` was dropped from another thread while the same
+  write transaction was committing.
+* Fix a leak of database space when an ephemeral `Savepoint` was created from one thread while the
+  same write transaction was first accessing a table from another thread, and that savepoint was
+  later restored. The leaked space was only reclaimed by a full repair.
+* Fix a panic when opening a database file that was externally extended to an invalid size; such
+  files are now rejected with `StorageError::Corrupted`.
+* Fix a hang on Windows when opening a truncated or corrupt database file. Reads past the end of the
+  file now return an error instead of looping forever.
 * `check_integrity()` now returns `DatabaseError::TransactionInProgress` when an ephemeral
-  `Savepoint` is still alive, instead of invalidating the pages it references.
-* Fix `check_integrity()` silently rolling back transactions committed with `Durability::None`
-  that were not yet durable; a passing check now makes them durable.
-* Fix a bug that could roll back or corrupt durably committed transactions if a crash occurred
-  during the repair from an earlier crash. Two-phase commit was not affected.
-* Fix composite types (`Option`, `Vec`, tuples, and arrays) of a user-defined type sharing a type
-  identity with the same composite of a built-in type with the same name. The mismatch is now
-  reported as `TableError::TableTypeMismatch`; existing databases remain readable.
-* Add `Table::insert_with_hint()` and `InsertHint`. `InsertHint::Append` packs a leaf fully when
-  an append forces a split, reducing free space when loading data in ascending key order.
+  `Savepoint` is still alive. Previously the check could invalidate the pages such a savepoint
+  referenced while leaving it marked valid, so restoring it afterward could corrupt the database.
+* Fix `Database::check_integrity()` silently discarding transactions committed with
+  `Durability::None` that had not yet been made durable by a later commit; a passing check now
+  preserves them (making them durable) instead of rolling them back.
+* Fix a bug that could silently roll back or corrupt durably committed transactions if a crash
+  occurred while recovering from an earlier crash. Triggering it required two crashes -- one
+  interrupting a commit and another during the subsequent repair on the next open -- and it did
+  not affect transactions committed with two-phase commit.
+* Fix new composite types (`Option`, `Vec`, tuples, and arrays) of a user-defined type sharing a
+  type identity with the same composite of a built-in type when the two happened to have the same
+  name. A table using such a composite of a user type can no longer be silently opened under the
+  built-in composite (and vice versa); the mismatch is now reported as `TableError::TableTypeMismatch`.
+  Existing databases created by older versions remain readable. If an older database already used
+  such a colliding composite name, its stored type identity remains ambiguous and may still open
+  under either spelling.
+* Add `Table::insert_with_hint()` and `InsertHint`. `InsertHint::Append` packs a leaf fully
+  instead of splitting it evenly when an insert past the leaf's last key forces a split. This
+  reduces free space left behind when loading data in ascending key order, at the cost of
+  leaves needing to split again to accept a later key that falls inside them.
 ### redb-derive (unreleased)
 * Fix the derived implementations calling inherent methods named `fixed_width`, `from_bytes`,
-  `as_bytes`, or `type_name` on field types, instead of the `Value` trait methods. The `Value` and
-  `Key` traits no longer need to be in scope at the derive site.
-* Add `#[redb(crate = "...")]` to name the redb crate when it is renamed or present in several
-  versions. Structs with fields require redb 3.0+.
-* Fix derived structs producing the same `TypeName` when two field types with different definitions
-  share a name. Structs containing user-defined field types (including redb's `chrono` types)
-  change type identity: their existing tables report `TableTypeMismatch` and must be migrated.
+  `as_bytes`, or `type_name` on field types, instead of the `Value` trait methods. The
+  generated code now uses fully qualified paths, and no longer requires the `Value` and `Key`
+  traits to be in scope at the derive site.
+* Add `#[redb(crate = "...")]` to name the crate the implementations are generated for, when
+  redb is renamed or present in several versions. Structs with fields require redb 3.0+.
+* Fix derived structs producing the same `TypeName` when two field types with different
+  definitions share a name, such as a user-defined type named `String` and the built-in
+  `String`. User-defined field types (including the `chrono` types redb provides) are now
+  tagged in the derived `TypeName`, so structs containing them change type identity: their
+  existing tables report `TableTypeMismatch` and must be migrated. Structs whose fields are
+  all built-in types are unaffected.
 
 ### Python bindings
 * Add `Database.create(path)` for creating or opening a database file.
-* Add `Database.begin_write()`, which returns a `WriteTransaction` context manager that commits
-  on success and aborts if an exception propagates out of the `with` block.
+* Add `Database.begin_write()`, which returns a `WriteTransaction`
+  context manager. Exiting the `with` block commits the transaction on success
+  and aborts it if an exception propagates out of the block.
 * The minimum supported Python version is now 3.8 (Python 3.7 is end-of-life).
 
 ## 4.1.0 - 2026-04-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # redb - Changelog
 
 ## 4.2.0 - 2026-XX-XX
+* Fix `WriteTransaction::stats()` reading pages that had been freed and reallocated when called
+  while a table handle was open, if that table had already been modified and closed earlier in
+  the transaction. This returned garbage statistics, or panicked with debug assertions enabled.
+  A table that is currently open is now reported as of the start of the transaction.
 * Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. A live
   `WriteTransaction` now keeps the database open: the transaction remains usable after the
   `Database` is dropped, and the database closes when the transaction commits, aborts, or is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,130 +1,86 @@
 # redb - Changelog
 
 ## 4.2.0 - 2026-XX-XX
-* Fix `WriteTransaction::stats()` reading pages that had been freed and reallocated when called
-  while a table handle was open, if that table had already been modified and closed (and possibly
-  renamed) earlier in the transaction. This returned garbage statistics, or panicked with debug
-  assertions enabled. A table that is currently open is now reported as of the start of the
-  transaction.
-* Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. A live
-  `WriteTransaction` now keeps the database open: the transaction remains usable after the
-  `Database` is dropped, and the database closes when the transaction commits, aborts, or is
-  dropped.
-* Fix a panic, including one raised while dropping a `Database`, after `check_integrity()` returned
-  an error. Such a database now refuses to begin a write transaction or to re-run the check,
-  returning `StorageError::Corrupted`, and is no longer recorded as cleanly shut down.
-* Harden against errors and panics raised part way through `WriteTransaction::commit()`: the
-  database now refuses further write transactions until it is closed and reopened (which
-  repairs it), instead of risking corruption from continued use after the failed commit.
-* `check_integrity()` now recomputes the table counts stored alongside the data and system roots,
-  repairing a file whose counts disagree with its trees. Such a file previously passed the check
-  and then panicked, including from `Database::drop`.
-* Add `ReadOnlyTable::get_owned()`, `ReadOnlyTable::range_owned()`,
-  `ReadOnlyMultimapTable::get_owned()`, and `ReadOnlyMultimapTable::range_owned()`, which
-  return the new `OwnedAccessGuard`, `OwnedRange`, `OwnedMultimapValue`, and
-  `OwnedMultimapRange` types. These keep the read transaction alive until they are dropped,
-  including the guards yielded by the iterators, which may outlive the iterator that produced
-  them.
+* Fix `WriteTransaction::stats()` returning garbage statistics, or panicking when debug assertions
+  are enabled, if a table modified earlier in the transaction was still open. Open tables are now
+  reported as of the start of the transaction.
+* Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. The transaction
+  now keeps the database open until it commits, aborts, or is dropped.
+* Fix a panic after `check_integrity()` returned an error. Such a database now returns
+  `StorageError::Corrupted` from write transactions until it is reopened.
+* Refuse to begin new write transactions after an error or panic part way through
+  `WriteTransaction::commit()`, instead of risking corruption. Reopening the database repairs it.
+* `check_integrity()` now repairs stored table counts that disagree with the trees. Such a file
+  previously passed the check and later panicked.
+* Add `ReadOnlyTable::get_owned()` and `range_owned()`, and the multimap equivalents, which return
+  the new `OwnedAccessGuard`, `OwnedRange`, `OwnedMultimapValue`, and `OwnedMultimapRange` types.
+  These keep the read transaction alive until they are dropped.
 * Fix a crash during a transaction that grows the database file leaving the database permanently
   unopenable afterward.
-* Fix a potential deadlock when removing a value from a multimap table causes its value-set to
-  shrink from a subtree back to inline storage, while another table of the same write transaction
-  is used concurrently from a different thread.
-* Avoid unnecessary write amplification when removing a value that is not present from a multimap
-  table. Such a removal is now a no-op.
+* Fix a potential deadlock when a multimap value-set shrinks from a subtree back to inline storage
+  while another table in the same write transaction is used from a different thread.
+* Avoid write amplification when removing a value that is not present from a multimap table.
 * Fix a crash during a commit that resizes the database file leaving the database permanently
-  unopenable, and reporting corruption on subsequent opens, even though every committed transaction
-  was intact and fully recoverable.
-* Optimize `Table::retain()` and `Table::retain_in()`. Some benchmarks on large tables show a
-  30-100x speedup, depending on the fraction of entries retained.
-* Optimize `Table::extract_if()` and `Table::extract_from_if()`. Benchmarks on large tables show
-  an 18-65x speedup, depending on the fraction of entries extracted, and iterating the extract
-  iterator from both ends no longer degrades the removal batching.
-* After the extract iterator returns an error, later calls keep returning an error instead of
-  continuing.
-* Add `Table::entry()` and the associated `Entry`, `OccupiedEntry`, and `VacantEntry`
-  types, mirroring `std::collections::BTreeMap::entry`. Supports `or_insert`,
-  `or_insert_with`, `or_insert_with_key`, `and_modify`, and the usual `OccupiedEntry`
-  / `VacantEntry` accessors.
+  unopenable.
+* Optimize `Table::retain()` and `Table::retain_in()`. 30-100x faster on some large-table
+  benchmarks.
+* Optimize `Table::extract_if()` and `Table::extract_from_if()`. 18-65x faster on some benchmarks.
+* After the extract iterator returns an error, later calls keep returning an error.
+* Add `Table::entry()` and the associated `Entry`, `OccupiedEntry`, and `VacantEntry` types,
+  mirroring `std::collections::BTreeMap::entry`.
 * `Table::retain()`, `Table::retain_in()`, `Table::extract_if()`, and `Table::extract_from_if()`
-  now poison the write transaction if their predicate panics, causing `WriteTransaction::commit()`
-  to return `CommitError::TransactionPoisoned`. They also poison the
-  transaction if an internal error prevents removals from being applied.
-* Add `ExtractIf::close()` to explicitly finalize an extract iterator without removing unread
-  entries.
+  now poison the write transaction if their predicate panics or removals cannot be applied, causing
+  `WriteTransaction::commit()` to return `CommitError::TransactionPoisoned`.
+* Add `ExtractIf::close()` to finalize an extract iterator without removing unread entries.
 * Optimize `Table::pop_first()` and `Table::pop_last()` to be about 2x faster.
 * Enable file space reclamation during non-durable transactions performed while a savepoint exists.
-* Reuse pages freed by a durable write transaction in the next write transaction when no
-  live read transaction or savepoint still needs them. Previously, pages were not reused for one
-  additional transaction.
-* Fix a bug where calling `compact()` on a database could cause the file to grow
-  rather than shrink in some cases.
-* Fix a bug where the database file could grow unnecessarily instead of reusing freed space, and
-  where `compact()` could stop before fully shrinking the file.
+* Reuse pages freed by a durable write transaction in the next write transaction, one transaction
+  earlier than before.
+* Fix a bug where `compact()` could cause the file to grow rather than shrink.
+* Fix a bug where the file could grow instead of reusing freed space, and `compact()` could stop
+  before fully shrinking the file.
 * Enforce the maximum value size limit when replacing a value in place via `Table::get_mut()`
-  or `Entry::and_modify()`. Previously these paths could bypass the limit that `Table::insert()`
-  and the `entry()` accessors enforce, returning `StorageError::ValueTooLarge` only inconsistently.
-* Fix a panic in `insert()` when a single leaf page accumulated 65536 entries via in-place
-  appends, e.g. by inserting a large value and then many small values in ascending key order
-  within the same transaction.
+  or `Entry::and_modify()`.
+* Fix a panic in `insert()` when a single leaf page accumulated 65536 entries via in-place appends.
 * `StorageBackend::close()` is now called when the `Database` is dropped even if an I/O error
-  occurs during shutdown. Previously a shutdown I/O error could skip the `close()` call, leaking
-  any resources the backend releases there.
+  occurs during shutdown.
 * `compact()` now returns `CompactionError::PersistentSavepointExists` or
   `CompactionError::EphemeralSavepointExists` instead of the misleading
   `CompactionError::TransactionInProgress` when a savepoint blocks compaction.
-* Fix `check_integrity()` incorrectly reporting a healthy database as corrupted (and panicking
-  in debug builds) after a persistent savepoint was deleted or restored.
-* Fix `check_integrity()` incorrectly reporting a healthy database as corrupted (and panicking
-  in debug builds) when an ephemeral `Savepoint` was dropped from another thread while the same
-  write transaction was committing.
-* Fix a leak of database space when an ephemeral `Savepoint` was created from one thread while the
-  same write transaction was first accessing a table from another thread, and that savepoint was
-  later restored. The leaked space was only reclaimed by a full repair.
-* Fix a panic when opening a database file that was externally extended to an invalid size; such
-  files are now rejected with `StorageError::Corrupted`.
-* Fix a hang on Windows when opening a truncated or corrupt database file. Reads past the end of the
-  file now return an error instead of looping forever.
+* Fix `check_integrity()` incorrectly reporting a healthy database as corrupted after a persistent
+  savepoint was deleted or restored.
+* Fix `check_integrity()` incorrectly reporting a healthy database as corrupted when an ephemeral
+  `Savepoint` was dropped from another thread during a commit.
+* Fix a leak of database space when an ephemeral `Savepoint`, created while the same write
+  transaction was first accessing a table from another thread, was later restored.
+* Fix a panic when opening a database file that was externally extended to an invalid size;
+  `StorageError::Corrupted` is now returned instead.
+* Fix a hang on Windows when opening a truncated or corrupt database file.
 * `check_integrity()` now returns `DatabaseError::TransactionInProgress` when an ephemeral
-  `Savepoint` is still alive. Previously the check could invalidate the pages such a savepoint
-  referenced while leaving it marked valid, so restoring it afterward could corrupt the database.
-* Fix `Database::check_integrity()` silently discarding transactions committed with
-  `Durability::None` that had not yet been made durable by a later commit; a passing check now
-  preserves them (making them durable) instead of rolling them back.
-* Fix a bug that could silently roll back or corrupt durably committed transactions if a crash
-  occurred while recovering from an earlier crash. Triggering it required two crashes -- one
-  interrupting a commit and another during the subsequent repair on the next open -- and it did
-  not affect transactions committed with two-phase commit.
-* Fix new composite types (`Option`, `Vec`, tuples, and arrays) of a user-defined type sharing a
-  type identity with the same composite of a built-in type when the two happened to have the same
-  name. A table using such a composite of a user type can no longer be silently opened under the
-  built-in composite (and vice versa); the mismatch is now reported as `TableError::TableTypeMismatch`.
-  Existing databases created by older versions remain readable. If an older database already used
-  such a colliding composite name, its stored type identity remains ambiguous and may still open
-  under either spelling.
-* Add `Table::insert_with_hint()` and `InsertHint`. `InsertHint::Append` packs a leaf fully
-  instead of splitting it evenly when an insert past the leaf's last key forces a split. This
-  reduces free space left behind when loading data in ascending key order, at the cost of
-  leaves needing to split again to accept a later key that falls inside them.
+  `Savepoint` is still alive, instead of invalidating the pages it references.
+* Fix `check_integrity()` silently rolling back transactions committed with `Durability::None`
+  that were not yet durable; a passing check now makes them durable.
+* Fix a bug that could roll back or corrupt durably committed transactions if a crash occurred
+  during the repair from an earlier crash. Two-phase commit was not affected.
+* Fix composite types (`Option`, `Vec`, tuples, and arrays) of a user-defined type sharing a type
+  identity with the same composite of a built-in type with the same name. The mismatch is now
+  reported as `TableError::TableTypeMismatch`; existing databases remain readable.
+* Add `Table::insert_with_hint()` and `InsertHint`. `InsertHint::Append` packs a leaf fully when
+  an append forces a split, reducing free space when loading data in ascending key order.
 ### redb-derive (unreleased)
 * Fix the derived implementations calling inherent methods named `fixed_width`, `from_bytes`,
-  `as_bytes`, or `type_name` on field types, instead of the `Value` trait methods. The
-  generated code now uses fully qualified paths, and no longer requires the `Value` and `Key`
-  traits to be in scope at the derive site.
-* Add `#[redb(crate = "...")]` to name the crate the implementations are generated for, when
-  redb is renamed or present in several versions. Structs with fields require redb 3.0+.
-* Fix derived structs producing the same `TypeName` when two field types with different
-  definitions share a name, such as a user-defined type named `String` and the built-in
-  `String`. User-defined field types (including the `chrono` types redb provides) are now
-  tagged in the derived `TypeName`, so structs containing them change type identity: their
-  existing tables report `TableTypeMismatch` and must be migrated. Structs whose fields are
-  all built-in types are unaffected.
+  `as_bytes`, or `type_name` on field types, instead of the `Value` trait methods. The `Value` and
+  `Key` traits no longer need to be in scope at the derive site.
+* Add `#[redb(crate = "...")]` to name the redb crate when it is renamed or present in several
+  versions. Structs with fields require redb 3.0+.
+* Fix derived structs producing the same `TypeName` when two field types with different definitions
+  share a name. Structs containing user-defined field types (including redb's `chrono` types)
+  change type identity: their existing tables report `TableTypeMismatch` and must be migrated.
 
 ### Python bindings
 * Add `Database.create(path)` for creating or opening a database file.
-* Add `Database.begin_write()`, which returns a `WriteTransaction`
-  context manager. Exiting the `with` block commits the transaction on success
-  and aborts it if an exception propagates out of the block.
+* Add `Database.begin_write()`, which returns a `WriteTransaction` context manager that commits
+  on success and aborts if an exception propagates out of the `with` block.
 * The minimum supported Python version is now 3.8 (Python 3.7 is end-of-life).
 
 ## 4.1.0 - 2026-04-19

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2413,14 +2413,23 @@ impl WriteTransaction {
     }
 
     /// Retrieves information about storage usage in the database
+    ///
+    /// Tables that are currently open in this transaction are reported as of the start of
+    /// the transaction: modifications made through an open table handle are not reflected
+    /// until the handle is dropped. Tables that were modified and then closed are reported
+    /// with their in-progress contents.
     pub fn stats(&self) -> Result<DatabaseStats> {
         let tables = self.tables.lock().unwrap();
-        let table_tree = &tables.table_tree;
-        let data_tree_stats = table_tree.stats()?;
+        let tables = &*tables;
+        let data_tree_stats = tables
+            .table_tree
+            .stats(|name| tables.open_tables.contains_key(name))?;
 
         let system_tables = self.system_tables.lock().unwrap();
         let system_table_tree = &system_tables.table_tree;
-        let system_tree_stats = system_table_tree.stats()?;
+        // System tables are only open while redb's own methods hold the system_tables lock,
+        // so none can be open here
+        let system_tree_stats = system_table_tree.stats(|_| false)?;
 
         let total_metadata_bytes = data_tree_stats.metadata_bytes()
             + system_tree_stats.metadata_bytes

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2418,15 +2418,12 @@ impl WriteTransaction {
     /// transaction; their modifications are reflected once the handle is dropped.
     pub fn stats(&self) -> Result<DatabaseStats> {
         let tables = self.tables.lock().unwrap();
-        let tables = &*tables;
-        let data_tree_stats = tables
-            .table_tree
-            .stats(|name| tables.open_tables.contains_key(name))?;
+        let table_tree = &tables.table_tree;
+        let data_tree_stats = table_tree.stats()?;
 
         let system_tables = self.system_tables.lock().unwrap();
         let system_table_tree = &system_tables.table_tree;
-        // No system table can be open here, since they hold this lock while open
-        let system_tree_stats = system_table_tree.stats(|_| false)?;
+        let system_tree_stats = system_table_tree.stats()?;
 
         let total_metadata_bytes = data_tree_stats.metadata_bytes()
             + system_tree_stats.metadata_bytes

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -551,6 +551,8 @@ impl SystemNamespace {
             .map_err(|e| {
                 e.into_storage_error_or_corrupted("Internal error. System table is corrupted")
             })?;
+        self.table_tree
+            .clear_pending_table_update(definition.name());
         transaction.dirty.store(true, Ordering::Release);
 
         let page_allocator = self.table_tree.page_allocator().clone();
@@ -650,6 +652,7 @@ impl TableNamespace {
         let root = self
             .table_tree
             .get_or_create_table::<K, V>(name, table_type)?;
+        self.table_tree.clear_pending_table_update(name);
         self.open_tables
             .insert(name.to_string(), panic::Location::caller());
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2414,10 +2414,8 @@ impl WriteTransaction {
 
     /// Retrieves information about storage usage in the database
     ///
-    /// Tables that are currently open in this transaction are reported as of the start of
-    /// the transaction: modifications made through an open table handle are not reflected
-    /// until the handle is dropped. Tables that were modified and then closed are reported
-    /// with their in-progress contents.
+    /// Tables currently open in this transaction are reported as of the start of the
+    /// transaction; their modifications are reflected once the handle is dropped.
     pub fn stats(&self) -> Result<DatabaseStats> {
         let tables = self.tables.lock().unwrap();
         let tables = &*tables;
@@ -2427,8 +2425,7 @@ impl WriteTransaction {
 
         let system_tables = self.system_tables.lock().unwrap();
         let system_table_tree = &system_tables.table_tree;
-        // System tables are only open while redb's own methods hold the system_tables lock,
-        // so none can be open here
+        // No system table can be open here, since they hold this lock while open
         let system_tree_stats = system_table_tree.stats(|_| false)?;
 
         let total_metadata_bytes = data_tree_stats.metadata_bytes()

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -549,10 +549,8 @@ impl TableTreeMut {
         new_name: &str,
         table_type: TableType,
     ) -> Result<(), TableError> {
-        // Move the definition as stored in the tree, without applying pending_table_updates:
-        // a root staged by a table close must stay out of the master tree until commit,
-        // because reopening the table can free that root's pages. stats() relies on the
-        // staged roots of open tables living only in pending_table_updates, which it skips.
+        // Move the definition as stored, not the pending update: staged roots must stay out
+        // of the master tree, since reopening the table can free their pages (see stats())
         let stored_definition = if let Some(guard) = self.tree.get(&name)? {
             let definition = guard.value();
             definition.check_match_untyped(table_type, name)?;
@@ -706,14 +704,8 @@ impl TableTreeMut {
         Ok(())
     }
 
-    // `is_open` must return true for tables that are currently open in this transaction.
-    // An open table may have staged a root here on a previous close, and then freed pages
-    // reachable from that root: pages allocated by this transaction are returned to the
-    // allocator immediately when freed, so they may already have been reallocated and
-    // rewritten with unrelated data. Walking such a root reads garbage. The committed root
-    // is always safe to walk, because pages allocated by previous transactions are only
-    // queued for freeing at commit, so for open tables we ignore the staged root and report
-    // the table as of the start of the transaction.
+    // Staged roots of tables that are currently open (per `is_open`) may reference recycled
+    // pages, so those tables are reported from their stored root: as of the transaction start.
     pub fn stats(&self, is_open: impl Fn(&str) -> bool) -> Result<DatabaseStats> {
         let master_tree_stats = self.tree.stats()?;
         let mut max_subtree_height = 0;

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -549,7 +549,21 @@ impl TableTreeMut {
         new_name: &str,
         table_type: TableType,
     ) -> Result<(), TableError> {
-        if let Some(definition) = self.get_table_untyped(name, table_type)? {
+        // Move the definition as stored in the tree, without applying pending_table_updates:
+        // a root staged by a table close must stay out of the master tree until commit,
+        // because reopening the table can free that root's pages. stats() relies on the
+        // staged roots of open tables living only in pending_table_updates, which it skips.
+        let stored_definition = {
+            // Scoped so its cached pages are released before the mutations below free them
+            let stored_tree = TableTree::new(
+                self.tree.get_root(),
+                PageHint::None,
+                self.guard.clone(),
+                self.page_allocator.resolver(),
+            )?;
+            stored_tree.get_table_untyped(name, table_type)?
+        };
+        if let Some(definition) = stored_definition {
             if self.get_table_untyped(new_name, table_type)?.is_some() {
                 return Err(TableError::TableExists(new_name.to_string()));
             }

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -226,6 +226,8 @@ pub(crate) struct TableTreeMut {
     page_allocator: PageAllocator,
     // Cached updates from tables that have been closed. These must be flushed to the btree.
     // The bool indicates whether the root has dirty (DEFERRED) checksums that need finalization.
+    // Never contains an entry for an open table -- the update is taken out on open and re-staged
+    // on close -- so entries cannot reference pages that an open handle frees.
     pending_table_updates: HashMap<String, (Option<BtreeHeader>, u64, bool)>,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
     allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
@@ -623,6 +625,9 @@ impl TableTreeMut {
             table
         };
 
+        // Take the staged update: while the table is open its root lives in the handle
+        self.pending_table_updates.remove(name);
+
         match table {
             InternalTableDefinition::Normal {
                 table_root,
@@ -704,9 +709,7 @@ impl TableTreeMut {
         Ok(())
     }
 
-    // Staged roots of tables that are currently open (per `is_open`) may reference recycled
-    // pages, so those tables are reported from their stored root: as of the transaction start.
-    pub fn stats(&self, is_open: impl Fn(&str) -> bool) -> Result<DatabaseStats> {
+    pub fn stats(&self) -> Result<DatabaseStats> {
         let master_tree_stats = self.tree.stats()?;
         let mut max_subtree_height = 0;
         let mut total_stored_bytes = 0;
@@ -722,9 +725,7 @@ impl TableTreeMut {
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;
             let mut definition = entry.value();
-            if !is_open(entry.key())
-                && let Some((updated_root, length, _)) = self.pending_table_updates.get(entry.key())
-            {
+            if let Some((updated_root, length, _)) = self.pending_table_updates.get(entry.key()) {
                 definition.set_header(*updated_root, *length);
             }
             match definition {

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -553,15 +553,12 @@ impl TableTreeMut {
         // a root staged by a table close must stay out of the master tree until commit,
         // because reopening the table can free that root's pages. stats() relies on the
         // staged roots of open tables living only in pending_table_updates, which it skips.
-        let stored_definition = {
-            // Scoped so its cached pages are released before the mutations below free them
-            let stored_tree = TableTree::new(
-                self.tree.get_root(),
-                PageHint::None,
-                self.guard.clone(),
-                self.page_allocator.resolver(),
-            )?;
-            stored_tree.get_table_untyped(name, table_type)?
+        let stored_definition = if let Some(guard) = self.tree.get(&name)? {
+            let definition = guard.value();
+            definition.check_match_untyped(table_type, name)?;
+            Some(definition)
+        } else {
+            None
         };
         if let Some(definition) = stored_definition {
             if self.get_table_untyped(new_name, table_type)?.is_some() {

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -612,6 +612,12 @@ impl TableTreeMut {
         Ok(false)
     }
 
+    // Takes the staged update for `name`. Called when the table is opened: while it is open
+    // the live root is in the handle, and it is re-staged on close
+    pub(crate) fn clear_pending_table_update(&mut self, name: &str) {
+        self.pending_table_updates.remove(name);
+    }
+
     pub(crate) fn get_or_create_table<K: Key, V: Value>(
         &mut self,
         name: &str,
@@ -624,9 +630,6 @@ impl TableTreeMut {
             self.tree.insert(&name, &table)?;
             table
         };
-
-        // Take the staged update: while the table is open its root lives in the handle
-        self.pending_table_updates.remove(name);
 
         match table {
             InternalTableDefinition::Normal {

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -695,7 +695,15 @@ impl TableTreeMut {
         Ok(())
     }
 
-    pub fn stats(&self) -> Result<DatabaseStats> {
+    // `is_open` must return true for tables that are currently open in this transaction.
+    // An open table may have staged a root here on a previous close, and then freed pages
+    // reachable from that root: pages allocated by this transaction are returned to the
+    // allocator immediately when freed, so they may already have been reallocated and
+    // rewritten with unrelated data. Walking such a root reads garbage. The committed root
+    // is always safe to walk, because pages allocated by previous transactions are only
+    // queued for freeing at commit, so for open tables we ignore the staged root and report
+    // the table as of the start of the transaction.
+    pub fn stats(&self, is_open: impl Fn(&str) -> bool) -> Result<DatabaseStats> {
         let master_tree_stats = self.tree.stats()?;
         let mut max_subtree_height = 0;
         let mut total_stored_bytes = 0;
@@ -711,7 +719,9 @@ impl TableTreeMut {
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;
             let mut definition = entry.value();
-            if let Some((updated_root, length, _)) = self.pending_table_updates.get(entry.key()) {
+            if !is_open(entry.key())
+                && let Some((updated_root, length, _)) = self.pending_table_updates.get(entry.key())
+            {
                 definition.set_header(*updated_root, *length);
             }
             match definition {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -658,6 +658,73 @@ fn stats_with_open_table() {
     txn.abort().unwrap();
 }
 
+// Same as stats_with_open_table, but the staged root travels through a rename before the
+// table is reopened. rename_table() used to write the staged root into the master tree
+// entry for the new name, so stats() would walk it even though it skips staged roots of
+// open tables.
+#[test]
+fn stats_with_renamed_open_table() {
+    const RENAMED_TABLE: TableDefinition<u64, u64> = TableDefinition::new("renamed");
+    const BIG_TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("big");
+    const BIG_ELEMENTS: u64 = 2000;
+    const BIG_VALUE_LEN: usize = 16000;
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    const COMMITTED_ELEMENTS: u64 = 5000;
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in 0..COMMITTED_ELEMENTS {
+            table.insert(i, i).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    // Stage a root made of this transaction's pages, and move it through a rename
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in COMMITTED_ELEMENTS..2 * COMMITTED_ELEMENTS {
+            table.insert(i, i).unwrap();
+        }
+    }
+    txn.rename_table(U64_TABLE, RENAMED_TABLE).unwrap();
+    // Reopen the renamed table and free the pages of the staged root, keeping the handle open
+    let table = {
+        let mut table = txn.open_table(RENAMED_TABLE).unwrap();
+        for i in 0..2 * COMMITTED_ELEMENTS {
+            table.remove(i).unwrap();
+        }
+        table
+    };
+    // Reallocate the freed pages with unrelated contents
+    {
+        let mut big = txn.open_table(BIG_TABLE).unwrap();
+        let value = vec![0xEE; BIG_VALUE_LEN];
+        for i in 0..BIG_ELEMENTS {
+            big.insert(i, value.as_slice()).unwrap();
+        }
+    }
+
+    let element_stored = 2 * u64::fixed_width().unwrap() as u64;
+    let big_stored = BIG_ELEMENTS * (u64::fixed_width().unwrap() as u64 + BIG_VALUE_LEN as u64);
+    // The open table is reported as of the start of the transaction
+    let stats = txn.stats().unwrap();
+    assert_eq!(
+        stats.stored_bytes(),
+        big_stored + COMMITTED_ELEMENTS * element_stored
+    );
+
+    // Once the table is closed, its staged contents are reported
+    drop(table);
+    let stats = txn.stats().unwrap();
+    assert_eq!(stats.stored_bytes(), big_stored);
+
+    txn.abort().unwrap();
+}
+
 fn begin_page_reuse_write(db: &Database, quick_repair: bool) -> WriteTransaction {
     let mut txn = db.begin_write().unwrap();
     txn.set_quick_repair(quick_repair);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -720,6 +720,27 @@ fn stats_with_renamed_open_table() {
     txn.abort().unwrap();
 }
 
+// A failed reopen must not discard the update staged when the table was closed
+#[test]
+fn failed_reopen_preserves_staged_table() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in 0..100 {
+            table.insert(i, i).unwrap();
+        }
+    }
+    let wrong_type: TableDefinition<&str, &str> = TableDefinition::new("u64");
+    assert!(txn.open_table(wrong_type).is_err());
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    assert_eq!(txn.open_table(U64_TABLE).unwrap().len().unwrap(), 100);
+}
+
 fn begin_page_reuse_write(db: &Database, quick_repair: bool) -> WriteTransaction {
     let mut txn = db.begin_write().unwrap();
     txn.set_quick_repair(quick_repair);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -603,10 +603,8 @@ fn page_reuse_after_unclean_reopen() {
     test_page_reuse_after_unclean_reopen(true);
 }
 
-// stats() used to walk the root staged when an open table was last closed. Pages reachable
-// from that root may have been freed by modifications through the reopened handle and
-// reallocated to other tables, so the walk read unrelated pages: an assertion failure with
-// debug_assertions on, garbage statistics otherwise.
+// stats() used to walk an open table's staged root, whose pages the reopened handle may
+// have freed for reuse: garbage statistics, or an assertion failure with debug_assertions
 #[test]
 fn stats_with_open_table() {
     const BIG_TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("big");
@@ -623,8 +621,7 @@ fn stats_with_open_table() {
             table.insert(i, i).unwrap();
         }
     }
-    // Reopen the table and free the pages of the root staged by the close above, keeping
-    // the handle open so that root stays staged
+    // Reopen the table and free the staged root's pages, keeping the handle open
     let mut table = {
         let mut table = txn.open_table(U64_TABLE).unwrap();
         for i in 0..5000 {
@@ -642,7 +639,7 @@ fn stats_with_open_table() {
     }
 
     let big_stored = BIG_ELEMENTS * (u64::fixed_width().unwrap() as u64 + BIG_VALUE_LEN as u64);
-    // The open table is reported as of the start of the transaction, when it did not exist
+    // The open table is reported as of the transaction start, when it did not exist
     let stats = txn.stats().unwrap();
     assert_eq!(stats.stored_bytes(), big_stored);
 
@@ -658,10 +655,8 @@ fn stats_with_open_table() {
     txn.abort().unwrap();
 }
 
-// Same as stats_with_open_table, but the staged root travels through a rename before the
-// table is reopened. rename_table() used to write the staged root into the master tree
-// entry for the new name, so stats() would walk it even though it skips staged roots of
-// open tables.
+// Same as stats_with_open_table, but the staged root travels through a rename, which used
+// to write it into the master tree entry where the open-table skip could not help.
 #[test]
 fn stats_with_renamed_open_table() {
     const RENAMED_TABLE: TableDefinition<u64, u64> = TableDefinition::new("renamed");
@@ -691,7 +686,7 @@ fn stats_with_renamed_open_table() {
         }
     }
     txn.rename_table(U64_TABLE, RENAMED_TABLE).unwrap();
-    // Reopen the renamed table and free the pages of the staged root, keeping the handle open
+    // Reopen the renamed table and free the staged root's pages, keeping the handle open
     let table = {
         let mut table = txn.open_table(RENAMED_TABLE).unwrap();
         for i in 0..2 * COMMITTED_ELEMENTS {
@@ -710,7 +705,7 @@ fn stats_with_renamed_open_table() {
 
     let element_stored = 2 * u64::fixed_width().unwrap() as u64;
     let big_stored = BIG_ELEMENTS * (u64::fixed_width().unwrap() as u64 + BIG_VALUE_LEN as u64);
-    // The open table is reported as of the start of the transaction
+    // The open table is reported as of the transaction start
     let stats = txn.stats().unwrap();
     assert_eq!(
         stats.stored_bytes(),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -603,6 +603,61 @@ fn page_reuse_after_unclean_reopen() {
     test_page_reuse_after_unclean_reopen(true);
 }
 
+// stats() used to walk the root staged when an open table was last closed. Pages reachable
+// from that root may have been freed by modifications through the reopened handle and
+// reallocated to other tables, so the walk read unrelated pages: an assertion failure with
+// debug_assertions on, garbage statistics otherwise.
+#[test]
+fn stats_with_open_table() {
+    const BIG_TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("big");
+    const BIG_ELEMENTS: u64 = 2000;
+    const BIG_VALUE_LEN: usize = 16000;
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in 0..5000 {
+            table.insert(i, i).unwrap();
+        }
+    }
+    // Reopen the table and free the pages of the root staged by the close above, keeping
+    // the handle open so that root stays staged
+    let mut table = {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in 0..5000 {
+            table.remove(i).unwrap();
+        }
+        table
+    };
+    // Reallocate the freed pages with unrelated contents
+    {
+        let mut big = txn.open_table(BIG_TABLE).unwrap();
+        let value = vec![0xEE; BIG_VALUE_LEN];
+        for i in 0..BIG_ELEMENTS {
+            big.insert(i, value.as_slice()).unwrap();
+        }
+    }
+
+    let big_stored = BIG_ELEMENTS * (u64::fixed_width().unwrap() as u64 + BIG_VALUE_LEN as u64);
+    // The open table is reported as of the start of the transaction, when it did not exist
+    let stats = txn.stats().unwrap();
+    assert_eq!(stats.stored_bytes(), big_stored);
+
+    // Once the table is closed, its staged contents are reported
+    table.insert(0, 0).unwrap();
+    drop(table);
+    let stats = txn.stats().unwrap();
+    assert_eq!(
+        stats.stored_bytes(),
+        big_stored + 2 * u64::fixed_width().unwrap() as u64
+    );
+
+    txn.abort().unwrap();
+}
+
 fn begin_page_reuse_write(db: &Database, quick_repair: bool) -> WriteTransaction {
     let mut txn = db.begin_write().unwrap();
     txn.set_quick_repair(quick_repair);


### PR DESCRIPTION
## The bug

A write transaction only learns a table's root when the table handle is closed: `Table::drop` stages it in `pending_table_updates`, where it waits until commit. While a handle is open, the live root exists only inside that handle, so the staged entry is the root from the table's *previous* close.

That staleness is dangerous because of how freeing works mid-transaction: pages allocated by **this** transaction are returned to the allocator immediately when freed (nothing committed can reference them), so they are eligible for reuse right away. A root staged on close is built of exactly such pages. Reopening the table and modifying it frees those pages, and the allocator may recycle them for unrelated tables — while the staged entry still points at them.

`WriteTransaction::stats()` preferred the staged root unconditionally. Calling it in that window walked recycled pages:

1. Open table X, insert 5000 rows, drop the handle → staged root R1, made of this-transaction pages
2. Reopen X, delete all rows, **keep the handle open** → R1's pages are freed immediately; the map still says R1
3. Open table X2, insert 2000 × 16KB values → the allocator recycles R1's pages for X2's leaves
4. `txn.stats()` walks R1 and parses X2's data as X's btree nodes

**Release builds** returned `Ok` with garbage numbers (the repro reported a phantom 16,008-byte row read out of a recycled page). **Debug builds** abort the process: the walk trips an internal assertion (`cached_file.rs` buffer-length check or a btree parse assert, depending on what landed in the page) while `stats()` holds the `tables` mutex; the unwind poisons the mutex, the still-open `Table`'s destructor then panics on the poisoned lock, and a panic inside a destructor during unwinding is fatal.

## The fix

`stats()` now takes the set of currently-open tables into account (the transaction already tracks them to reject double-opens): for an open table it skips the staged root and walks the **committed** root, which cannot be recycled during the transaction — pages from previous transactions are only queued for freeing at commit. The semantics are documented on the method: a table currently open for writing is reported as of the start of the transaction; tables that were modified and closed are reported with their in-progress contents, as before.

The sibling pending-update walkers (compaction's `relocate_tables` and `highest_index_pages`) only run without open tables, so `stats()` was the sole exposed path. Reporting the live root instead was considered and rejected: it would require every open table to publish root updates into shared locked state on every mutation, taxing the write hot path for a diagnostics call.

## Testing

- New regression test `stats_with_open_table` reproduces the full recycle dance and asserts exact `stored_bytes` both while the table is open (committed view) and after it closes (staged view). Without the fix it aborts under debug assertions.
- Standalone repro confirms debug and release now agree on the exact byte count where release previously reported garbage and debug aborted.
- Full test suite passes; clippy and rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuLGiEERgJR51vhJNtYwRA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuLGiEERgJR51vhJNtYwRA)_