### PR TITLE
Return an error when opening a database with a corrupted savepoint record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # redb - Changelog
 
 ## 4.2.0 - 2026-XX-XX
+* Fix a panic when opening a database containing a corrupted persistent savepoint record;
+  `StorageError::Corrupted` is now returned instead.
 * Fix `WriteTransaction::stats()` returning garbage statistics, or panicking when debug assertions
   are enabled, when called while a table is open and modified in the same transaction.
 * Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. A live

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1163,7 +1163,9 @@ impl WriteTransaction {
     pub fn get_persistent_savepoint(&self, id: u64) -> Result<Savepoint, SavepointError> {
         let Some(value) = self.read_existing_system_table(SAVEPOINT_TABLE, |table| {
             let value = table.get(&SavepointId(id))?;
-            Ok(value.map(|x| x.value().to_savepoint(self.transaction_tracker.clone())))
+            value
+                .map(|x| x.value().to_savepoint(self.transaction_tracker.clone()))
+                .transpose()
         })?
         else {
             return Err(SavepointError::InvalidSavepoint);
@@ -1190,19 +1192,20 @@ impl WriteTransaction {
             return Ok(false);
         }
         let mut table = system_tables.open_system_table(self, SAVEPOINT_TABLE)?;
-        let savepoint = table.remove(SavepointId(id))?;
-        if let Some(serialized) = savepoint {
-            let savepoint = serialized
+        // Parse before removing, so that a corrupted record errors out without staging any change
+        let savepoint = if let Some(serialized) = table.get(SavepointId(id))? {
+            serialized
                 .value()
-                .to_savepoint(self.transaction_tracker.clone());
-            self.savepoint_state
-                .lock()
-                .unwrap()
-                .record_deleted(savepoint.get_id(), savepoint.get_transaction_id());
-            Ok(true)
+                .to_savepoint(self.transaction_tracker.clone())?
         } else {
-            Ok(false)
-        }
+            return Ok(false);
+        };
+        table.remove(SavepointId(id))?;
+        self.savepoint_state
+            .lock()
+            .unwrap()
+            .record_deleted(savepoint.get_id(), savepoint.get_transaction_id());
+        Ok(true)
     }
 
     /// List all persistent savepoints

--- a/src/tree_store/page_store/savepoint.rs
+++ b/src/tree_store/page_store/savepoint.rs
@@ -1,7 +1,7 @@
 use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker};
 use crate::tree_store::page_store::page_manager::FILE_FORMAT_VERSION3;
 use crate::tree_store::{BtreeHeader, TransactionalMemory};
-use crate::{TypeName, Value};
+use crate::{Result, StorageError, TypeName, Value};
 use std::fmt::Debug;
 use std::mem::size_of;
 use std::sync::Arc;
@@ -114,11 +114,25 @@ impl SerializedSavepoint<'_> {
         }
     }
 
-    pub(crate) fn to_savepoint(&self, transaction_tracker: Arc<TransactionTracker>) -> Savepoint {
+    pub(crate) fn to_savepoint(
+        &self,
+        transaction_tracker: Arc<TransactionTracker>,
+    ) -> Result<Savepoint> {
         let data = self.data();
+        let serialized_len =
+            2 * size_of::<u8>() + 2 * size_of::<u64>() + BtreeHeader::serialized_size();
+        if data.len() != serialized_len {
+            return Err(StorageError::Corrupted(
+                "Corrupted savepoint record".to_string(),
+            ));
+        }
         let mut offset = 0;
         let version = data[offset];
-        assert_eq!(version, FILE_FORMAT_VERSION3);
+        if version != FILE_FORMAT_VERSION3 {
+            return Err(StorageError::Corrupted(format!(
+                "Unsupported savepoint version: {version}"
+            )));
+        }
         offset += size_of::<u8>();
 
         let id = u64::from_le_bytes(
@@ -136,7 +150,11 @@ impl SerializedSavepoint<'_> {
         offset += size_of::<u64>();
 
         let not_null = data[offset];
-        assert!(not_null == 0 || not_null == 1);
+        if not_null > 1 {
+            return Err(StorageError::Corrupted(
+                "Corrupted savepoint record".to_string(),
+            ));
+        }
         offset += 1;
         let user_root = if not_null == 1 {
             Some(BtreeHeader::from_le_bytes(
@@ -148,16 +166,16 @@ impl SerializedSavepoint<'_> {
             None
         };
         offset += BtreeHeader::serialized_size();
-        assert_eq!(offset, data.len());
+        debug_assert_eq!(offset, data.len());
 
-        Savepoint {
+        Ok(Savepoint {
             version,
             id: SavepointId(id),
             transaction_id: TransactionId::new(transaction_id),
             user_root,
             transaction_tracker,
             ephemeral: false,
-        }
+        })
     }
 }
 
@@ -191,5 +209,48 @@ impl Value for SerializedSavepoint<'_> {
 
     fn type_name() -> TypeName {
         TypeName::internal("redb::SerializedSavepoint")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::transaction_tracker::{TransactionId, TransactionTracker};
+    use std::sync::Arc;
+
+    #[test]
+    fn corrupted_record_errors() {
+        let tracker = Arc::new(TransactionTracker::new(TransactionId::new(1)));
+
+        let mut record = vec![FILE_FORMAT_VERSION3];
+        record.extend(1u64.to_le_bytes());
+        record.extend(1u64.to_le_bytes());
+        record.push(0);
+        record.extend([0; BtreeHeader::serialized_size()]);
+        assert!(
+            SerializedSavepoint::Ref(&record)
+                .to_savepoint(tracker.clone())
+                .is_ok()
+        );
+
+        let truncated = &record[..record.len() - 1];
+        assert!(matches!(
+            SerializedSavepoint::Ref(truncated).to_savepoint(tracker.clone()),
+            Err(StorageError::Corrupted(_))
+        ));
+
+        let mut bad_version = record.clone();
+        bad_version[0] = 9;
+        assert!(matches!(
+            SerializedSavepoint::Ref(&bad_version).to_savepoint(tracker.clone()),
+            Err(StorageError::Corrupted(_))
+        ));
+
+        let mut bad_null_marker = record.clone();
+        bad_null_marker[17] = 2;
+        assert!(matches!(
+            SerializedSavepoint::Ref(&bad_null_marker).to_savepoint(tracker),
+            Err(StorageError::Corrupted(_))
+        ));
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -720,6 +720,52 @@ fn stats_with_renamed_open_table() {
     txn.abort().unwrap();
 }
 
+// Opening a database containing a corrupted persistent savepoint record must error, not panic
+#[test]
+fn corrupted_persistent_savepoint_record() {
+    let tmpfile = create_tempfile();
+    let path = tmpfile.path();
+    let savepoint_id = {
+        let db = Database::create(path).unwrap();
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(U64_TABLE).unwrap();
+            table.insert(0, 0).unwrap();
+        }
+        txn.commit().unwrap();
+        let txn = db.begin_write().unwrap();
+        let id = txn.persistent_savepoint().unwrap();
+        txn.commit().unwrap();
+        id
+    };
+
+    // Find the serialized savepoint record: version 3, the savepoint id, a plausible
+    // transaction id, and a non-null user root
+    let mut data = fs::read(path).unwrap();
+    let mut offsets = vec![];
+    for i in 0..data.len() - 18 {
+        let transaction_id = u64::from_le_bytes(data[i + 9..i + 17].try_into().unwrap());
+        if data[i] == 3
+            && u64::from_le_bytes(data[i + 1..i + 9].try_into().unwrap()) == savepoint_id
+            && transaction_id > 0
+            && transaction_id < 100
+            && data[i + 17] == 1
+        {
+            offsets.push(i);
+        }
+    }
+    assert_eq!(offsets.len(), 1);
+    // Corrupt the version byte
+    data[offsets[0]] = 9;
+    fs::write(path, &data).unwrap();
+
+    let result = Database::open(path);
+    assert!(matches!(
+        result,
+        Err(DatabaseError::Storage(StorageError::Corrupted(_)))
+    ));
+}
+
 // A failed reopen must not discard the update staged when the table was closed
 #[test]
 fn failed_reopen_preserves_staged_table() {
@@ -2140,6 +2186,7 @@ fn check_integrity_after_persistent_savepoint_restore_and_delete() {
 
     let txn = db.begin_write().unwrap();
     assert!(txn.delete_persistent_savepoint(id).unwrap());
+    assert!(!txn.delete_persistent_savepoint(id).unwrap());
     txn.commit().unwrap();
 
     // Must not panic


### PR DESCRIPTION
`Database::open()` panicked on a database file whose persistent savepoint table contained a corrupted record: deserialization asserted on the version byte, the user-root null marker, and the record length, and indexed past the end of short records. `WriteTransaction::get_persistent_savepoint()` and `delete_persistent_savepoint()` shared the same paths.

`SerializedSavepoint::to_savepoint()` now validates the record and returns `StorageError::Corrupted`, which propagates out of `open()` and the savepoint methods.

Testing: new regression test `corrupted_persistent_savepoint_record` creates a persistent savepoint, corrupts the record's version byte in the file, and asserts `open()` returns `Corrupted`. It panics without the fix. Full suite, clippy, and fmt pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuLGiEERgJR51vhJNtYwRA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuLGiEERgJR51vhJNtYwRA)_