### PR TITLE
Add Table::append_sorted()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # redb - Changelog
 
 ## 4.2.0 - 2026-XX-XX
+* Add `Table::append_sorted()`, which loads pairs whose keys are greater than everything already
+  in the table without descending the tree for each one. Keys must be strictly increasing, and
+  `StorageError::KeysNotAscending` is returned if they are not.
 * Fix `WriteTransaction::stats()` returning garbage statistics, or panicking when debug assertions
   are enabled, when called while a table is open and modified in the same transaction.
 * Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. A live

--- a/crates/redb-bench/Cargo.toml
+++ b/crates/redb-bench/Cargo.toml
@@ -64,3 +64,7 @@ harness = false
 [[bench]]
 name = "syscall_benchmark"
 harness = false
+
+[[bench]]
+name = "graph_load_benchmark"
+harness = false

--- a/crates/redb-bench/benches/common.rs
+++ b/crates/redb-bench/benches/common.rs
@@ -553,7 +553,7 @@ pub fn benchmark<T: BenchDatabase + Send + Sync>(
     results
 }
 
-fn database_size(path: &Path) -> u64 {
+pub fn database_size(path: &Path) -> u64 {
     let mut size = 0u64;
     for result in walkdir::WalkDir::new(path) {
         let entry = result.unwrap();

--- a/crates/redb-bench/benches/graph_load_benchmark.rs
+++ b/crates/redb-bench/benches/graph_load_benchmark.rs
@@ -1,0 +1,218 @@
+#![allow(dead_code)]
+
+use std::time::{Duration, Instant};
+
+use redb::{
+    Database, ReadableDatabase, ReadableTableMetadata, TableDefinition, TableStats,
+    WriteTransaction,
+};
+use tempfile::NamedTempFile;
+
+mod benchmark_dir;
+use benchmark_dir::benchmark_dir;
+
+mod common;
+use common::*;
+
+const VERTICES: u64 = 1_000_000;
+const EDGES: usize = 8_000_000;
+const RNG_SEED: u64 = 3;
+
+// Mirrors a graph bulk load: a vertex table plus forward and reverse adjacency
+// tables, all built in one transaction. Edge keys are (src, dst) big endian, so
+// key order is adjacency order.
+const NODES: TableDefinition<&[u8], u64> = TableDefinition::new("nodes");
+const FORWARD: TableDefinition<&[u8], u64> = TableDefinition::new("forward");
+const REVERSE: TableDefinition<&[u8], u64> = TableDefinition::new("reverse");
+
+fn edge_key(src: u64, dst: u64) -> [u8; 16] {
+    let mut key = [0u8; 16];
+    key[..8].copy_from_slice(&src.to_be_bytes());
+    key[8..].copy_from_slice(&dst.to_be_bytes());
+    key
+}
+
+fn node_key(id: u64) -> [u8; 8] {
+    id.to_be_bytes()
+}
+
+// Deduplicated so every arm writes the same set of keys. The insert path would
+// silently overwrite a repeated edge, while an appending cursor requires each
+// key to be greater than the last.
+fn generate_edges() -> Vec<(u64, u64)> {
+    let mut rng = fastrand::Rng::with_seed(RNG_SEED);
+    let mut edges: Vec<(u64, u64)> = (0..EDGES)
+        .map(|_| (rng.u64(0..VERTICES), rng.u64(0..VERTICES)))
+        .collect();
+    edges.sort_unstable();
+    edges.dedup();
+    edges
+}
+
+struct Arm {
+    load: Duration,
+    size: u64,
+    compacted: u64,
+    nodes: TableStats,
+    forward: TableStats,
+    reverse: TableStats,
+}
+
+fn write_stream<F>(txn: &WriteTransaction, table: TableDefinition<&[u8], u64>, mut fill: F)
+where
+    F: FnMut(&mut dyn FnMut(&[u8], u64)),
+{
+    let mut table = txn.open_table(table).unwrap();
+    fill(&mut |key, value| {
+        table.insert(key, value).unwrap();
+    });
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Mode {
+    // Insert in arrival order, as an unsorted producer would
+    Arrival,
+    // Sort first, then insert through the normal write path
+    Sorted,
+    // Sort first, then append each table through a buffering cursor
+    Cursor,
+}
+
+fn run(edges: &[(u64, u64)], mode: Mode) -> Arm {
+    let sorted = mode != Mode::Arrival;
+    let mut forward: Vec<[u8; 16]> = edges.iter().map(|(s, d)| edge_key(*s, *d)).collect();
+    let mut reverse: Vec<[u8; 16]> = edges.iter().map(|(s, d)| edge_key(*d, *s)).collect();
+    let mut nodes: Vec<u64> = (0..VERTICES).collect();
+
+    if sorted {
+        forward.sort_unstable();
+        reverse.sort_unstable();
+    } else {
+        // Same data, arrival order instead of key order.
+        let mut rng = fastrand::Rng::with_seed(RNG_SEED + 1);
+        rng.shuffle(&mut forward);
+        rng.shuffle(&mut reverse);
+        rng.shuffle(&mut nodes);
+    }
+
+    let file: NamedTempFile = NamedTempFile::new_in(benchmark_dir()).unwrap();
+    let mut db = Database::builder()
+        .set_cache_size(CACHE_SIZE)
+        .create(file.path())
+        .unwrap();
+
+    let start = Instant::now();
+    let txn = db.begin_write().unwrap();
+    if mode == Mode::Cursor {
+        // append_sorted borrows its keys, so these cannot be built inline
+        let node_keys: Vec<([u8; 8], u64)> = nodes.iter().map(|id| (node_key(*id), *id)).collect();
+        let mut table = txn.open_table(NODES).unwrap();
+        table
+            .append_sorted(node_keys.iter().map(|(key, id)| (key.as_slice(), *id)))
+            .unwrap();
+        drop(table);
+        for (definition, keys) in [(FORWARD, &forward), (REVERSE, &reverse)] {
+            let mut table = txn.open_table(definition).unwrap();
+            table
+                .append_sorted(keys.iter().map(|key| (key.as_slice(), 1u64)))
+                .unwrap();
+        }
+    } else {
+        write_stream(&txn, NODES, |insert| {
+            for id in &nodes {
+                insert(node_key(*id).as_slice(), *id);
+            }
+        });
+        write_stream(&txn, FORWARD, |insert| {
+            for key in &forward {
+                insert(key.as_slice(), 1);
+            }
+        });
+        write_stream(&txn, REVERSE, |insert| {
+            for key in &reverse {
+                insert(key.as_slice(), 1);
+            }
+        });
+    }
+    txn.commit().unwrap();
+    let load = start.elapsed();
+
+    let size = database_size(file.path());
+    let read = db.begin_read().unwrap();
+    let stats = (
+        read.open_table(NODES).unwrap().stats().unwrap(),
+        read.open_table(FORWARD).unwrap().stats().unwrap(),
+        read.open_table(REVERSE).unwrap().stats().unwrap(),
+    );
+    drop(read);
+
+    db.compact().unwrap();
+    let compacted = database_size(file.path());
+
+    Arm {
+        load,
+        size,
+        compacted,
+        nodes: stats.0,
+        forward: stats.1,
+        reverse: stats.2,
+    }
+}
+
+// Share of the table's bytes that hold user data, which stays comparable across
+// arms that produce different numbers of leaf pages.
+fn fill_percent(stats: &TableStats) -> f64 {
+    let total = stats.stored_bytes() + stats.metadata_bytes() + stats.fragmented_bytes();
+    if total == 0 {
+        return 0.0;
+    }
+    100.0 * stats.stored_bytes() as f64 / total as f64
+}
+
+fn describe(label: &str, arm: &Arm) {
+    println!(
+        "{label}: {}ms, {} uncompacted, {} compacted",
+        arm.load.as_millis(),
+        mib(arm.size),
+        mib(arm.compacted)
+    );
+    for (name, stats) in [
+        ("nodes", &arm.nodes),
+        ("forward", &arm.forward),
+        ("reverse", &arm.reverse),
+    ] {
+        println!(
+            "    {name:>8}: {:>9} leaf pages, {:>5.1}% data, {} fragmented",
+            stats.leaf_pages(),
+            fill_percent(stats),
+            mib(stats.fragmented_bytes())
+        );
+    }
+}
+
+fn mib(bytes: u64) -> String {
+    format!("{:.2} MiB", bytes as f64 / 1024.0 / 1024.0)
+}
+
+fn main() {
+    let _ = env_logger::try_init();
+    let edges = generate_edges();
+    println!(
+        "{VERTICES} vertices, {} unique edges, forward + reverse adjacency",
+        edges.len()
+    );
+    let arrival = run(&edges, Mode::Arrival);
+    describe("        arrival order", &arrival);
+    let sorted = run(&edges, Mode::Sorted);
+    describe("         sorted order", &sorted);
+    let cursor = run(&edges, Mode::Cursor);
+    describe("       cursor append", &cursor);
+
+    for (label, arm) in [("sorted", &sorted), ("cursor", &cursor)] {
+        println!(
+            "{label} vs arrival: {:.3}x size, {:.3}x load",
+            arm.compacted as f64 / arrival.compacted as f64,
+            arm.load.as_secs_f64() / arrival.load.as_secs_f64(),
+        );
+    }
+}

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -9,7 +9,7 @@ const MAX_CRASH_OPS: u64 = 20;
 const MAX_CACHE_SIZE: usize = 100_000_000;
 // Limit values to 100KiB
 const MAX_VALUE_SIZE: usize = 100_000;
-const KEY_SPACE: u64 = 1_000_000;
+pub(crate) const KEY_SPACE: u64 = 1_000_000;
 pub const MAX_SAVEPOINTS: usize = 6;
 
 #[derive(Debug, Clone)]
@@ -110,6 +110,14 @@ pub(crate) enum FuzzOperation {
     },
     Insert {
         key: BoundedU64<KEY_SPACE>,
+        value_size: BinomialDifferenceBoundedUSize<MAX_VALUE_SIZE>,
+    },
+    // Keys are derived from the table's current maximum, since append_sorted
+    // only accepts a strictly ascending stream. Rejection of everything else is
+    // covered by unit tests.
+    AppendSorted {
+        count: BoundedUSize<64>,
+        stride: U64Between<1, 8>,
         value_size: BinomialDifferenceBoundedUSize<MAX_VALUE_SIZE>,
     },
     InsertReserve {

--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -337,6 +337,9 @@ fn handle_multimap_table_op(
         FuzzOperation::InsertReserve { .. } => {
             // no-op. Multimap tables don't support insert_reserve
         }
+        FuzzOperation::AppendSorted { .. } => {
+            // no-op. Multimap tables don't support append_sorted
+        }
         FuzzOperation::Remove { key } => {
             let key = key.value;
             let entry = reference.remove(&key);
@@ -505,6 +508,32 @@ fn handle_table_op(
                 v.insert(value.as_slice())?;
             }
             reference.get_mut(&key).map(|x| *x = value_size);
+        }
+        FuzzOperation::AppendSorted {
+            count,
+            stride,
+            value_size,
+        } => {
+            let value_size = value_size.value as usize;
+            let value = vec![0xFF; value_size];
+            let stride = stride.value;
+            let start = reference
+                .keys()
+                .next_back()
+                .map_or(0, |max| max.saturating_add(stride));
+            let keys: Vec<u64> = (0..count.value as u64)
+                .map(|i| start.saturating_add(i.saturating_mul(stride)))
+                .take_while(|key| *key < KEY_SPACE)
+                .collect();
+            // saturating_add can repeat a key at the top of the space, which
+            // append_sorted rejects rather than silently overwrites.
+            let ascending = keys.windows(2).all(|pair| pair[0] < pair[1]);
+            if ascending && keys.first().is_none_or(|first| !reference.contains_key(first)) {
+                table.append_sorted(keys.iter().map(|key| (*key, value.as_slice())))?;
+                for key in keys {
+                    reference.insert(key, value_size);
+                }
+            }
         }
         FuzzOperation::Insert { key, value_size } => {
             let key = key.value;

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,9 @@ pub enum StorageError {
     Corrupted(String),
     /// The value being inserted exceeds the maximum of 3GiB
     ValueTooLarge(usize),
+    /// Keys given to [`crate::Table::append_sorted`] were not strictly greater than
+    /// every key already in the table
+    KeysNotAscending,
     Io(io::Error),
     PreviousIo,
     DatabaseClosed,
@@ -38,6 +41,7 @@ impl From<StorageError> for Error {
             StorageError::Io(x) => Error::Io(x),
             StorageError::PreviousIo => Error::PreviousIo,
             StorageError::DatabaseClosed => Error::DatabaseClosed,
+            StorageError::KeysNotAscending => Error::KeysNotAscending,
             StorageError::LockPoisoned(location) => Error::LockPoisoned(location),
         }
     }
@@ -54,6 +58,12 @@ impl Display for StorageError {
                     f,
                     "The value (length={len}) being inserted exceeds the maximum of {}GiB",
                     MAX_VALUE_LENGTH / 1024 / 1024 / 1024
+                )
+            }
+            StorageError::KeysNotAscending => {
+                write!(
+                    f,
+                    "Keys appended to a table must be strictly greater than every key it already contains"
                 )
             }
             StorageError::Io(err) => {
@@ -540,6 +550,9 @@ pub enum Error {
     UpgradeRequired(u8),
     /// The value being inserted exceeds the maximum of 3GiB
     ValueTooLarge(usize),
+    /// Keys given to [`crate::Table::append_sorted`] were not strictly greater than
+    /// every key already in the table
+    KeysNotAscending,
     /// Table types didn't match.
     TableTypeMismatch {
         table: String,
@@ -600,6 +613,12 @@ impl Display for Error {
                     f,
                     "The value (length={len}) being inserted exceeds the maximum of {}GiB",
                     MAX_VALUE_LENGTH / 1024 / 1024 / 1024
+                )
+            }
+            Error::KeysNotAscending => {
+                write!(
+                    f,
+                    "Keys appended to a table must be strictly greater than every key it already contains"
                 )
             }
             Error::TypeDefinitionChanged {

--- a/src/table.rs
+++ b/src/table.rs
@@ -9,6 +9,7 @@ use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, AccessGuardMut, StorageError, WriteTransaction};
 use crate::{Result, TableHandle};
 use std::borrow::Borrow;
+use std::cmp::max;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
 use std::ops::RangeBounds;
@@ -258,6 +259,33 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
             return Err(StorageError::ValueTooLarge(value_len + key_len));
         }
         self.tree.insert(key.borrow(), value.borrow())
+    }
+
+    /// Appends pairs in ascending key order, past every key already in the table
+    ///
+    /// Buffers them and writes packed leaves once enough have accumulated, rather
+    /// than descending the tree for each one
+    ///
+    /// Each key must be greater than the last, and greater than every key already
+    /// in the table; otherwise [`StorageError::KeysNotAscending`] is returned. The
+    /// pairs accepted before that point are kept, as they would be by [`Table::insert`]
+    /// in a loop, so abort the transaction to discard them
+    pub fn append_sorted<'k, 'v, I>(&mut self, pairs: I) -> Result
+    where
+        I: IntoIterator<Item = (K::SelfType<'k>, V::SelfType<'v>)>,
+    {
+        self.tree
+            .append_sorted(pairs.into_iter().map(|(key, value)| {
+                let key_len = K::as_bytes(&key).as_ref().len();
+                let value_len = V::as_bytes(&value).as_ref().len();
+                if key_len > MAX_VALUE_LENGTH || value_len > MAX_VALUE_LENGTH {
+                    return Err(StorageError::ValueTooLarge(max(key_len, value_len)));
+                }
+                if key_len + value_len > MAX_PAIR_LENGTH {
+                    return Err(StorageError::ValueTooLarge(key_len + value_len));
+                }
+                Ok((key, value))
+            }))
     }
 
     /// Removes the given key

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -511,6 +511,26 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         cursor.remove_next()
     }
 
+    // Appends pairs in ascending key order through a cursor, buffering them and
+    // splicing packed leaves into the tree once enough have accumulated.
+    pub(crate) fn append_sorted<'k, 'v, I>(&mut self, pairs: I) -> Result
+    where
+        I: IntoIterator<Item = Result<(K::SelfType<'k>, V::SelfType<'v>)>>,
+    {
+        let mut freed_pages = self.freed_pages.lock().unwrap();
+        let mut cursor: CursorMut<'_, '_, K, V> = CursorMut::new(
+            &mut self.root,
+            &self.page_allocator,
+            freed_pages.as_mut(),
+            &self.allocated_pages,
+        );
+        for pair in pairs {
+            let (key, value) = pair?;
+            cursor.append_sorted(K::as_bytes(&key).as_ref(), V::as_bytes(&value).as_ref())?;
+        }
+        cursor.flush_sorted()
+    }
+
     // Removes and returns the rightmost entry in the tree, if any, in a single tree descent.
     pub(crate) fn pop_last(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
         let mut freed_pages = self.freed_pages.lock().unwrap();

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -718,6 +718,11 @@ impl OwnedEntryBuffer {
         }
     }
 
+    pub(super) fn push(&mut self, key: &[u8], value: &[u8]) {
+        let pair = self.store(key, value);
+        self.pairs.push_back(pair);
+    }
+
     pub(super) fn num_pairs(&self) -> usize {
         self.pairs.len()
     }

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -1,7 +1,7 @@
 use crate::AccessGuard;
 use crate::tree_store::btree_base::{
-    BRANCH, BranchAccessor, LEAF, LeafAccessor, OwnedEntryBuffer, leaf_below_merge_threshold,
-    leaf_fits_one_page, retained_after_removals,
+    BRANCH, BranchAccessor, LEAF, LeafAccessor, OwnedEntryBuffer, is_single_large_value,
+    leaf_below_merge_threshold, leaf_fits_one_page, retained_after_removals,
 };
 use crate::tree_store::btree_iters::EntryGuard;
 use crate::tree_store::btree_mutator::MutateHelper;
@@ -15,6 +15,11 @@ use std::collections::Bound::{Excluded, Included, Unbounded};
 use std::marker::PhantomData;
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
+
+// Bytes buffered by append_sorted before packed leaves are spliced in. Each
+// splice rewrites the parent chain, so what costs is the number of splices, not
+// the buffer; the gain flattens out above this.
+const APPEND_BUFFER_BYTES: usize = 1024 * 1024;
 
 #[derive(Clone)]
 struct Branch {
@@ -269,6 +274,7 @@ struct LeafRunRewrite {
     // bounded by fanout x page_size.
     entries: OwnedEntryBuffer,
     removed_pairs: u64,
+    added_pairs: u64,
 }
 
 impl LeafRunRewrite {
@@ -284,7 +290,15 @@ impl LeafRunRewrite {
             replaced_children,
             entries: OwnedEntryBuffer::default(),
             removed_pairs: 0,
+            added_pairs: 0,
         }
+    }
+
+    // Buffers a pair that is not yet in the tree. Callers must keep the run in
+    // ascending key order, so this is only valid past every key it already holds.
+    fn push_entry(&mut self, key: &[u8], value: &[u8]) {
+        self.entries.push(key, value);
+        self.added_pairs += 1;
     }
 
     fn append_entries_from<K: Key, V: Value>(
@@ -505,6 +519,10 @@ pub(super) struct CursorState {
     // so it may outlive the position; it is spliced before the tree is
     // observed.
     leaf_run_rewrite: Option<LeafRunRewrite>,
+    // Highest key appended so far, against which the next append is checked.
+    // Seeded from the tree on the first append, since the run buffer is emptied
+    // by every splice.
+    appended_last_key: Option<Vec<u8>>,
 }
 
 enum LeafCloseOutcome {
@@ -1095,6 +1113,79 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         run.append_entries_from::<K, V>(page, child_index, removed_indexes);
     }
 
+    // Buffers a pair past every key in the tree, splicing packed leaves into the
+    // parent once the buffer is large enough to fill several of them. The tail
+    // leaf is absorbed on open so the run rewrites it rather than leaving it
+    // short.
+    pub(super) fn append_sorted(&mut self, key: &[u8], value: &[u8]) -> Result {
+        if let Some(last) = self.state.appended_last_key.as_deref()
+            && K::compare(key, last) != Ordering::Greater
+        {
+            return Err(StorageError::KeysNotAscending);
+        }
+        if self.state.leaf_run_rewrite.is_none() {
+            self.seek_to(Position::End)?;
+            // Checked against the tree only on the first append, since after that
+            // the highest key is one this call wrote.
+            if self.state.appended_last_key.is_none()
+                && let Some(position) = self.state.position.as_ref()
+            {
+                let accessor = LeafAccessor::new(
+                    position.leaf.page.memory(),
+                    K::fixed_width(),
+                    V::fixed_width(),
+                );
+                if accessor.num_pairs() > 0
+                    && K::compare(key, accessor.last_entry().key()) != Ordering::Greater
+                {
+                    return Err(StorageError::KeysNotAscending);
+                }
+            }
+            // Opening a run absorbs the tail leaf, so a leaf holding one large
+            // value would be copied through the buffer whole. Ordinary insert
+            // gives that pair a leaf of its own, and the next call absorbs that
+            // one instead.
+            let tail_is_large_value = self.state.position.as_ref().is_some_and(|position| {
+                let accessor = LeafAccessor::new(
+                    position.leaf.page.memory(),
+                    K::fixed_width(),
+                    V::fixed_width(),
+                );
+                is_single_large_value(&accessor, self.page_allocator.get_page_size())
+            });
+            let has_parent = self
+                .state
+                .position
+                .as_ref()
+                .is_some_and(|position| !position.path.is_empty());
+            if !has_parent || tail_is_large_value {
+                // Without a parent there is nothing to splice into either: the root
+                // is still a leaf, and ordinary inserts grow the tree until there is one.
+                self.state.position = None;
+                self.mutate_helper()
+                    .insert(&K::from_bytes(key), &V::from_bytes(value))?;
+                self.state.appended_last_key = Some(key.to_vec());
+                return Ok(());
+            }
+            self.append_leaf_to_run(Direction::Next, &[]);
+        }
+
+        let run = self.state.leaf_run_rewrite.as_mut().unwrap();
+        run.push_entry(key, value);
+        if run.entries.total_bytes() >= APPEND_BUFFER_BYTES {
+            self.splice_open_run()?;
+        }
+        self.state.appended_last_key = Some(key.to_vec());
+        Ok(())
+    }
+
+    pub(super) fn flush_sorted(&mut self) -> Result {
+        if self.state.leaf_run_rewrite.is_some() {
+            self.splice_open_run()?;
+        }
+        Ok(())
+    }
+
     // Replaces the run's children in the parent with packed leaves built from
     // the buffered entries, while the cursor path is still valid. The cursor
     // position is consumed; callers reseek from the run's boundary key. On
@@ -1135,6 +1226,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
             run.replaced_children,
             run.entries,
             run.removed_pairs,
+            run.added_pairs,
         )
     }
 

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -4,7 +4,7 @@ use crate::tree_store::btree_base::{
     leaf_split_required, retained_after_removals,
 };
 use crate::tree_store::btree_mutator::DeletionResult::{
-    DeletedBranch, DeletedSubtree, PartialBranch, PartialLeaf, Subtree,
+    DeletedBranch, DeletedSubtree, PartialBranch, PartialLeaf, SplitBranch, Subtree,
 };
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
@@ -41,6 +41,13 @@ enum DeletionResult {
     // Indicates that the branch node was deleted, and includes the only remaining child.
     // Checksum is retained for the same reason as `PartialBranch`.
     DeletedBranch(PageNumber, Checksum),
+    // A branch outgrew a page and was split in two, so its parent gains a child.
+    // Only the appending splice path reaches this: deletions only ever shrink a branch.
+    SplitBranch {
+        left: PageNumber,
+        key: Vec<u8>,
+        right: PageNumber,
+    },
 }
 
 #[derive(Debug)]
@@ -153,6 +160,20 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         let new_root = match deletion_result {
             Subtree(page) => Some(BtreeHeader::new(page, DEFERRED, new_length)),
             DeletedSubtree => None,
+            // The split reached the top, so the tree gains a level.
+            SplitBranch { left, key, right } => {
+                let mut builder =
+                    BranchBuilder::new(&self.page_allocator, &self.allocated, 2, K::fixed_width());
+                builder.push_child(left, DEFERRED);
+                builder.push_key(&key);
+                builder.push_child(right, DEFERRED);
+                let page = builder.build()?;
+                Some(BtreeHeader::new(
+                    page.get_page_number(),
+                    DEFERRED,
+                    new_length,
+                ))
+            }
             PartialLeaf {
                 page,
                 deleted_pairs,
@@ -254,6 +275,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         mut replaced_children: Range<usize>,
         mut entries: OwnedEntryBuffer,
         removed_pairs: u64,
+        added_pairs: u64,
     ) -> Result {
         assert!(!replaced_children.is_empty());
         let length = self.root.expect("replace requires a root").length;
@@ -361,7 +383,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
 
         let new_length = length
             .checked_sub(removed_pairs)
-            .expect("cursor removed more entries than the tree contains");
+            .expect("cursor removed more entries than the tree contains")
+            + added_pairs;
         self.finish_deletion(result, new_length)?;
         // Freed only after every fallible step, so an error never leaves the
         // surviving root referencing a freed page.
@@ -1143,6 +1166,15 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     ) -> Result<DeletionResult> {
         let result = if let Some((only_child, checksum)) = builder.to_single_child() {
             DeletedBranch(only_child, checksum)
+        } else if builder.should_split() {
+            // Splicing appended leaves in grows a branch, unlike every other
+            // caller here, so this is the one path that can outgrow a page.
+            let (left, key, right) = builder.build_split()?;
+            SplitBranch {
+                left: left.get_page_number(),
+                key: key.to_vec(),
+                right: right.get_page_number(),
+            }
         } else if builder.required_bytes() < page_size / 3 {
             // Merge when less than 33% full. Splits occur when a page is full and produce two 50%
             // full pages, so we use 33% instead of 50% to avoid oscillating.
@@ -1222,6 +1254,38 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             return Ok(Subtree(result_page));
         }
 
+        // The child split, so this branch gains one: rebuild it with both halves
+        // in place of the original child, splitting again if that overflows.
+        if let SplitBranch { left, key, right } = result {
+            let children = accessor.count_children();
+            let mut builder = BranchBuilder::new(
+                &self.page_allocator,
+                &self.allocated,
+                children + 1,
+                K::fixed_width(),
+            );
+            for i in 0..children {
+                if i == child_index {
+                    builder.push_child(left, DEFERRED);
+                    builder.push_key(&key);
+                    builder.push_child(right, DEFERRED);
+                } else {
+                    builder.push_child(
+                        accessor.child_page(i).unwrap(),
+                        accessor.child_checksum(i).unwrap(),
+                    );
+                }
+                if i + 1 < children {
+                    builder.push_key(accessor.key(i).unwrap());
+                }
+            }
+            let result =
+                Self::finalize_branch_builder(builder, self.page_allocator.get_page_size())?;
+            drop(page);
+            self.conditional_free(original_page_number);
+            return Ok(result);
+        }
+
         // Child is requesting to be merged with a sibling
         let mut builder = BranchBuilder::new(
             &self.page_allocator,
@@ -1231,8 +1295,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         );
 
         let final_result = match result {
-            Subtree(_) => {
-                // Handled in the if above
+            Subtree(_) | SplitBranch { .. } => {
+                // Both are handled in the ifs above
                 unreachable!();
             }
             DeletedSubtree => {

--- a/tests/append_sorted_tests.rs
+++ b/tests/append_sorted_tests.rs
@@ -1,0 +1,265 @@
+use redb::{
+    Database, ReadableDatabase, ReadableTable, ReadableTableMetadata, StorageError, TableDefinition,
+};
+
+const TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("x");
+
+fn create_tempfile() -> tempfile::NamedTempFile {
+    if cfg!(target_os = "wasi") {
+        tempfile::NamedTempFile::new_in("/tmp").unwrap()
+    } else {
+        tempfile::NamedTempFile::new().unwrap()
+    }
+}
+
+fn key(i: u64) -> String {
+    format!("{i:016}")
+}
+
+// Spans a root that is still a leaf, and enough pairs to grow the tree several
+// levels. These stay inside one buffer; splicing is covered separately.
+const COUNTS: [u64; 5] = [1, 2, 100, 5_000, 50_000];
+
+#[test]
+fn append_sorted_reads_back() {
+    for count in COUNTS {
+        let tmpfile = create_tempfile();
+        let mut db = Database::create(tmpfile.path()).unwrap();
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            let owned: Vec<String> = (0..count).map(key).collect();
+            let pairs = owned.iter().map(|k| (k.as_bytes(), b"v".as_slice()));
+            table.append_sorted(pairs).unwrap();
+        }
+        txn.commit().unwrap();
+
+        let txn = db.begin_read().unwrap();
+        let table = txn.open_table(TABLE).unwrap();
+        assert_eq!(table.len().unwrap(), count, "count={count}");
+        let mut expected = 0u64;
+        for entry in table.iter().unwrap() {
+            let (k, v) = entry.unwrap();
+            assert_eq!(k.value(), key(expected).as_bytes(), "count={count}");
+            assert_eq!(v.value(), b"v");
+            expected += 1;
+        }
+        assert_eq!(expected, count, "count={count}");
+        drop(table);
+        drop(txn);
+        db.check_integrity().unwrap();
+    }
+}
+
+#[test]
+fn append_sorted_extends_a_populated_table() {
+    for (existing, appended) in [(1u64, 1u64), (5, 5_000), (20_000, 20_000)] {
+        let tmpfile = create_tempfile();
+        let mut db = Database::create(tmpfile.path()).unwrap();
+        let label = format!("{existing}+{appended}");
+
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            for i in 0..existing {
+                table.insert(key(i).as_bytes(), b"v".as_slice()).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            let owned: Vec<String> = (existing..existing + appended).map(key).collect();
+            let pairs = owned.iter().map(|k| (k.as_bytes(), b"v".as_slice()));
+            table.append_sorted(pairs).unwrap();
+        }
+        txn.commit().unwrap();
+
+        let txn = db.begin_read().unwrap();
+        let table = txn.open_table(TABLE).unwrap();
+        let total = existing + appended;
+        assert_eq!(table.len().unwrap(), total, "{label}");
+        let mut expected = 0u64;
+        for entry in table.iter().unwrap() {
+            let (k, v) = entry.unwrap();
+            assert_eq!(k.value(), key(expected).as_bytes(), "{label}");
+            assert_eq!(v.value(), b"v", "{label}");
+            expected += 1;
+        }
+        assert_eq!(expected, total, "{label}");
+        drop(table);
+        drop(txn);
+        db.check_integrity().unwrap();
+    }
+}
+
+#[test]
+fn append_sorted_accepts_an_empty_stream() {
+    let tmpfile = create_tempfile();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        table
+            .append_sorted(std::iter::empty::<(&[u8], &[u8])>())
+            .unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    assert_eq!(txn.open_table(TABLE).unwrap().len().unwrap(), 0);
+    drop(txn);
+    db.check_integrity().unwrap();
+}
+
+// Out of order within one call, at a batch size that stays inside the buffer and
+// at one that spans several splices.
+#[test]
+fn append_sorted_rejects_keys_that_do_not_ascend() {
+    for (label, keys) in [
+        ("descending", vec![key(5), key(3)]),
+        ("duplicate", vec![key(5), key(5)]),
+        ("dip after a run", {
+            let mut keys: Vec<String> = (0..20_000).map(key).collect();
+            keys.push(key(1));
+            keys
+        }),
+    ] {
+        let tmpfile = create_tempfile();
+        let mut db = Database::create(tmpfile.path()).unwrap();
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            let pairs = keys.iter().map(|k| (k.as_bytes(), b"v".as_slice()));
+            let error = table.append_sorted(pairs).unwrap_err();
+            assert!(matches!(error, StorageError::KeysNotAscending), "{label}");
+            assert!(error.to_string().contains("strictly greater"), "{label}");
+            let converted: redb::Error = error.into();
+            assert!(
+                matches!(converted, redb::Error::KeysNotAscending),
+                "{label}"
+            );
+            assert!(
+                converted.to_string().contains("strictly greater"),
+                "{label}"
+            );
+        }
+        drop(txn);
+        db.check_integrity().unwrap();
+    }
+}
+
+// The first key of a call is checked against what the table already holds, not
+// just against the keys the call has seen.
+#[test]
+fn append_sorted_rejects_keys_below_an_existing_table() {
+    for offset in [0u64, 1, 500] {
+        let tmpfile = create_tempfile();
+        let mut db = Database::create(tmpfile.path()).unwrap();
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            for i in 0..1_000u64 {
+                table.insert(key(i).as_bytes(), b"v".as_slice()).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            // 999 is the highest key present, so none of these are an append.
+            let clashing = [key(999 - offset)];
+            let pairs = clashing.iter().map(|k| (k.as_bytes(), b"v".as_slice()));
+            assert!(table.append_sorted(pairs).is_err(), "offset={offset}");
+        }
+        drop(txn);
+        db.check_integrity().unwrap();
+    }
+}
+
+// Values large enough that the append buffer fills several times, which is the
+// only way to reach the splice path partway through a stream rather than once
+// at the end.
+#[test]
+fn append_sorted_splices_partway_through() {
+    let tmpfile = create_tempfile();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+    let value = vec![0xABu8; 512];
+    let count = 8_000u64;
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        let owned: Vec<String> = (0..count).map(key).collect();
+        table
+            .append_sorted(owned.iter().map(|k| (k.as_bytes(), value.as_slice())))
+            .unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), count);
+    let mut expected = 0u64;
+    for entry in table.iter().unwrap() {
+        let (k, v) = entry.unwrap();
+        assert_eq!(k.value(), key(expected).as_bytes());
+        assert_eq!(v.value(), value.as_slice());
+        expected += 1;
+    }
+    assert_eq!(expected, count);
+
+    // Splicing hands the parent branch a batch of leaves at a time, so it has to
+    // split like any other branch. Left to grow instead it stays one page deep,
+    // and eventually exceeds the u16 key count a branch can store.
+    let stats = table.stats().unwrap();
+    assert!(stats.tree_height() >= 3, "{stats:?}");
+    assert!(stats.branch_pages() > 1, "{stats:?}");
+
+    drop(table);
+    drop(txn);
+    db.check_integrity().unwrap();
+}
+
+// A leaf holding one value larger than a page must not be pulled through the
+// append buffer, which would copy the whole value to add one pair after it.
+#[test]
+fn append_sorted_past_a_large_value() {
+    let tmpfile = create_tempfile();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+    let large = vec![0xCDu8; 8 * 1024 * 1024];
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        table.insert(key(0).as_bytes(), large.as_slice()).unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        let owned: Vec<String> = (1..500u64).map(key).collect();
+        table
+            .append_sorted(owned.iter().map(|k| (k.as_bytes(), b"v".as_slice())))
+            .unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 500);
+    assert_eq!(
+        table.get(key(0).as_bytes()).unwrap().unwrap().value(),
+        large.as_slice()
+    );
+    assert_eq!(
+        table.get(key(499).as_bytes()).unwrap().unwrap().value(),
+        b"v"
+    );
+    drop(table);
+    drop(txn);
+    db.check_integrity().unwrap();
+}


### PR DESCRIPTION
Adds `Table::append_sorted`, per the discussion in #1317.

Stacked on #1321 so the diff shows only the new work — retarget to master once that lands.

## What it does

Appending a stream of ascending keys through `insert()` descends the tree once per pair. This seeks to the end once, buffers into the existing `LeafRunRewrite`, and splices packed leaves in through `replace_leaf_children` when the buffer fills, which is the machinery `retain()` already uses.

```rust
let mut table = txn.open_table(TABLE)?;
table.append_sorted(sorted_pairs)?;
```

Keys must be strictly greater than every key already in the table. It works on a table that already holds data, not only an empty one.

## Numbers

Same benchmark as #1317, 1M vertices and 8M edges as 17M pairs across three tables in one transaction, on top of #1321:

| | load | compacted | forward leaf pages | data |
|---|---|---|---|---|
| arrival order `insert()` | 25.0s | 651.55 MiB | 78713 | 58.8% |
| sorted `insert()` | 10.3s | 456.88 MiB | 54795 | 83.7% |
| `append_sorted` | 1.7s | 453.84 MiB | 54862 | 84.3% |

Load times move with anything else running on the machine; the leaf page counts and compacted sizes are identical run to run.

## Splitting the parent branch

`replace_leaf_children` was written for `retain()` and `extract_if()`, where a branch only ever loses children, so `finalize_branch_builder` handles merging and collapsing but never splitting. Appending inverts that: each splice hands the parent a batch of leaves in place of one, so the branch grew without bound and the tree stayed two levels deep. A large enough load then panicked in `RawBranchBuilder::new`, which stores the key count as a `u16` — 500k pairs of 512 bytes was enough.

`BranchBuilder::should_split()` already existed and already accounted for that `u16` limit; the splice path simply never called it. `finalize_branch_builder` now does, returning a `SplitBranch` that the ancestor path applies like any other result, growing a new root if it reaches the top. Deletions never make a branch grow, so the new arm is unreachable for the existing callers.

Tree shape for an ascending load of 512 byte values, before and after:

| pairs | leaves | branches | height |
|---|---|---|---|
| 60,000 | 8572 | 1 → 33 | 2 → 3 |
| 500,000 | 71429 | panic → 260 | panic → 4 |

Leaf counts are unchanged, so packing is unaffected. Dropping the oversized branch pages is also where the compacted size above improves against a plain sorted load.

## Out-of-order keys

`append_sorted` originally corrupted the tree when given keys that did not ascend, since nothing checked. It now returns `StorageError::KeysNotAscending`, checked against both the previous key of the call and the table's existing maximum. Both error enums are `#[non_exhaustive]`, so the new variant is not a breaking change.

Pairs accepted before the rejected one are kept, as they would be by `insert()` in a loop. That is documented on the method rather than made atomic, since the iterator is consumed lazily and a caller wanting all-or-nothing can abort the transaction.

## Large values

A leaf holding a single value larger than a page is not absorbed into the buffer, which would copy the whole value to add one pair after it. Those fall back to an ordinary insert, matching what `replace_leaf_children` already does for the neighbouring-leaf case.

## Buffer size

`APPEND_BUFFER_BYTES` is an internal constant rather than a parameter. The cost is per splice — each one rewrites the parent chain — so what matters is the flush count, not the buffer. At 64 KiB it is 4x slower than at 1 MiB, and flat from 1 MiB out to 16 MiB.

## Testing

`cargo fmt --check`, `cargo clippy --all --all-targets -- -Dwarnings`, and `cargo test` all pass.

`tests/append_sorted_tests.rs` covers read-back at five sizes, extending a table that already has data, an empty stream, keys that do not ascend within one call, keys at or below an existing table's maximum, a stream long enough to splice several times (asserting the tree actually gained a level and more than one branch), and appending past a leaf holding an 8 MiB value. All call `check_integrity()`.

`FuzzOperation::AppendSorted` appends a run derived from the reference model's current maximum, so the fuzzer exercises the splice path against the model. `cargo fuzz run fuzz_redb -- -max_len=10000 -max_total_time=600` ran 217,725 inputs with no crashes.
