### PR TITLE
Add an experimental cursor API for bulk loading sorted data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # redb - Changelog
 
 ## 4.2.0 - 2026-XX-XX
+* Add an experimental cursor API, behind the `experimental_cursor` feature flag:
+  `Table::lower_bound_mut()` and `Table::upper_bound_mut()` return a `CursorMut` pointing at a gap
+  between entries, modeled on the standard library's `BTreeMap` cursors. Its `insert_before()`
+  method makes bulk loading sorted data much faster than `insert()`. The feature is unstable and
+  may change incompatibly, or be removed, in any release.
 * Fix `WriteTransaction::stats()` returning garbage statistics, or panicking when debug assertions
   are enabled, when called while a table is open and modified in the same transaction.
 * Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. A live

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ redb-derive = { path = "./crates/redb-derive" }
 logging = ["dep:log"]
 # Enable cache hit metrics
 cache_metrics = []
+# Unstable cursor API. May change incompatibly, or be removed, in any release
+experimental_cursor = []
 
 [profile.bench]
 debug = true

--- a/crates/redb-bench/Cargo.toml
+++ b/crates/redb-bench/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 
 # Common test/bench dependencies
 [dev-dependencies]
-redb = { path = "../.." }
+redb = { path = "../..", features = ["experimental_cursor"] }
 rand = "0.10.1"
 tempfile = "3.5.0"
 walkdir = "2.5.0"

--- a/crates/redb-bench/benches/common.rs
+++ b/crates/redb-bench/benches/common.rs
@@ -1,5 +1,5 @@
 use fjall::Readable as _;
-use heed::{CompactionOption, EnvFlags, EnvInfo, FlagSetMode};
+use heed::{CompactionOption, EnvFlags, EnvInfo, FlagSetMode, PutFlags};
 use redb::{
     AccessGuard, Durability, ReadableDatabase, ReadableTable, ReadableTableMetadata,
     TableDefinition,
@@ -20,6 +20,7 @@ const X: TableDefinition<&[u8], &[u8]> = TableDefinition::new("x");
 
 const READ_ITERATIONS: usize = 2;
 const BULK_ELEMENTS: usize = 5_000_000;
+const SORTED_ELEMENTS: usize = 1_000_000;
 const INDIVIDUAL_WRITES: usize = 1_000;
 const NOSYNC_WRITES: usize = 50_000;
 const BATCH_WRITES: usize = 100;
@@ -550,6 +551,42 @@ pub fn benchmark<T: BenchDatabase + Send + Sync>(
         results.push(("compacted size".to_string(), ResultType::NA));
     }
 
+    // Sorted inserts: pairs whose keys ascend, all past every existing key, loaded
+    // through the fastest sorted-insert path the database offers. The keys extend the
+    // largest possible random key by a suffix so they sort past every existing entry,
+    // and the pairs are precomputed so the timing covers only the load. Runs after the
+    // size measurements so those stay comparable with historical results.
+    let sorted_pairs: Vec<([u8; KEY_SIZE + 8], Vec<u8>)> = (0..SORTED_ELEMENTS as u64)
+        .map(|i| {
+            let mut key = [0xFFu8; KEY_SIZE + 8];
+            key[KEY_SIZE..].copy_from_slice(&i.to_be_bytes());
+            let mut value = vec![0u8; VALUE_SIZE];
+            rng.fill(&mut value);
+            (key, value)
+        })
+        .collect();
+    let connection = db.connect();
+    let start = Instant::now();
+    let mut txn = connection.write_transaction();
+    let mut inserter = txn.get_inserter();
+    inserter
+        .insert_sorted(
+            sorted_pairs
+                .iter()
+                .map(|(key, value)| (key.as_slice(), value.as_slice())),
+        )
+        .unwrap();
+    drop(inserter);
+    txn.commit().unwrap();
+    let duration = start.elapsed();
+    println!(
+        "{}: Loaded {} sorted items in {}ms",
+        T::db_type_name(),
+        SORTED_ELEMENTS,
+        duration.as_millis()
+    );
+    results.push(("sorted inserts".to_string(), ResultType::Duration(duration)));
+
     results
 }
 
@@ -649,6 +686,20 @@ pub trait BenchInserter {
 
     #[allow(clippy::result_unit_err)]
     fn insert(&mut self, key: &[u8], value: &[u8]) -> Result<(), ()>;
+
+    // Inserts pairs whose keys are strictly ascending and greater than every key
+    // already in the table, through the fastest sorted-insert path the database
+    // offers. Databases without one fall back to ordinary inserts.
+    #[allow(clippy::result_unit_err)]
+    fn insert_sorted<'i>(
+        &mut self,
+        pairs: impl Iterator<Item = (&'i [u8], &'i [u8])>,
+    ) -> Result<(), ()> {
+        for (key, value) in pairs {
+            self.insert(key, value)?;
+        }
+        Ok(())
+    }
 
     #[allow(clippy::result_unit_err)]
     fn remove(&mut self, key: &[u8]) -> Result<(), ()>;
@@ -941,6 +992,22 @@ impl BenchInserter for RedbBenchInserter<'_> {
         self.table.insert(key, value).map(|_| ()).map_err(|_| ())
     }
 
+    fn insert_sorted<'i>(
+        &mut self,
+        pairs: impl Iterator<Item = (&'i [u8], &'i [u8])>,
+    ) -> Result<(), ()> {
+        // redb's appending cursor: buffers the inserts and splices packed leaves into
+        // the tree, instead of descending it for each pair
+        let mut cursor = self
+            .table
+            .upper_bound_mut(Bound::<&[u8]>::Unbounded)
+            .map_err(|_| ())?;
+        for (key, value) in pairs {
+            cursor.insert_before(key, value).map_err(|_| ())?;
+        }
+        cursor.close().map_err(|_| ())
+    }
+
     fn remove(&mut self, key: &[u8]) -> Result<(), ()> {
         self.table.remove(key).map(|_| ()).map_err(|_| ())
     }
@@ -1189,6 +1256,20 @@ impl BenchInserter for HeedBenchInserter<'_, '_> {
 
     fn insert(&mut self, key: &[u8], value: &[u8]) -> Result<(), ()> {
         self.db.put(self.txn, key, value).map_err(|_| ())
+    }
+
+    fn insert_sorted<'i>(
+        &mut self,
+        pairs: impl Iterator<Item = (&'i [u8], &'i [u8])>,
+    ) -> Result<(), ()> {
+        // LMDB's append mode: writes at the cursor without searching the tree, and
+        // requires each key to be greater than every key already in the table
+        for (key, value) in pairs {
+            self.db
+                .put_with_flags(self.txn, PutFlags::APPEND, key, value)
+                .map_err(|_| ())?;
+        }
+        Ok(())
     }
 
     fn remove(&mut self, key: &[u8]) -> Result<(), ()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,9 @@ pub enum StorageError {
     Corrupted(String),
     /// The value being inserted exceeds the maximum of 3GiB
     ValueTooLarge(usize),
+    /// The key does not sort strictly between the entries adjacent to the cursor
+    #[cfg(feature = "experimental_cursor")]
+    UnorderedKey,
     Io(io::Error),
     PreviousIo,
     DatabaseClosed,
@@ -35,6 +38,8 @@ impl From<StorageError> for Error {
         match err {
             StorageError::Corrupted(msg) => Error::Corrupted(msg),
             StorageError::ValueTooLarge(x) => Error::ValueTooLarge(x),
+            #[cfg(feature = "experimental_cursor")]
+            StorageError::UnorderedKey => Error::UnorderedKey,
             StorageError::Io(x) => Error::Io(x),
             StorageError::PreviousIo => Error::PreviousIo,
             StorageError::DatabaseClosed => Error::DatabaseClosed,
@@ -54,6 +59,13 @@ impl Display for StorageError {
                     f,
                     "The value (length={len}) being inserted exceeds the maximum of {}GiB",
                     MAX_VALUE_LENGTH / 1024 / 1024 / 1024
+                )
+            }
+            #[cfg(feature = "experimental_cursor")]
+            StorageError::UnorderedKey => {
+                write!(
+                    f,
+                    "The key does not sort strictly between the entries adjacent to the cursor"
                 )
             }
             StorageError::Io(err) => {
@@ -540,6 +552,9 @@ pub enum Error {
     UpgradeRequired(u8),
     /// The value being inserted exceeds the maximum of 3GiB
     ValueTooLarge(usize),
+    /// The key does not sort strictly between the entries adjacent to the cursor
+    #[cfg(feature = "experimental_cursor")]
+    UnorderedKey,
     /// Table types didn't match.
     TableTypeMismatch {
         table: String,
@@ -600,6 +615,13 @@ impl Display for Error {
                     f,
                     "The value (length={len}) being inserted exceeds the maximum of {}GiB",
                     MAX_VALUE_LENGTH / 1024 / 1024 / 1024
+                )
+            }
+            #[cfg(feature = "experimental_cursor")]
+            Error::UnorderedKey => {
+                write!(
+                    f,
+                    "The key does not sort strictly between the entries adjacent to the cursor"
                 )
             }
             Error::TypeDefinitionChanged {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,8 @@ pub use multimap_table::{
     MultimapRange, MultimapTable, MultimapValue, OwnedMultimapRange, OwnedMultimapValue,
     ReadOnlyMultimapTable, ReadOnlyUntypedMultimapTable, ReadableMultimapTable,
 };
+#[cfg(feature = "experimental_cursor")]
+pub use table::CursorMut;
 pub use table::{
     Entry, ExtractIf, OccupiedEntry, OwnedAccessGuard, OwnedRange, Range, ReadOnlyTable,
     ReadOnlyUntypedTable, ReadableTable, ReadableTableMetadata, Table, TableStats, VacantEntry,

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,5 +1,7 @@
 use crate::db::TransactionGuard;
 use crate::sealed::Sealed;
+#[cfg(feature = "experimental_cursor")]
+use crate::tree_store::BtreeCursorMut;
 use crate::tree_store::{
     AccessGuardMutInPlace, Btree, BtreeCursorRange, BtreeExtractIf, BtreeHeader, BtreeMut,
     MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PageAllocator, PageHint, PageNumber, PageResolver,
@@ -11,6 +13,8 @@ use crate::{Result, TableHandle};
 use std::borrow::Borrow;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
+#[cfg(feature = "experimental_cursor")]
+use std::ops::Bound;
 use std::ops::RangeBounds;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -268,6 +272,86 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         key: impl Borrow<K::SelfType<'a>>,
     ) -> Result<Option<AccessGuard<'_, V>>> {
         self.tree.remove(key.borrow())
+    }
+
+    /// Returns a [`CursorMut`] pointing at the gap before the smallest key
+    /// greater than the given bound.
+    ///
+    /// Passing `Bound::Included(x)` will return a cursor pointing to the gap
+    /// before the smallest key greater than or equal to `x`.
+    ///
+    /// Passing `Bound::Excluded(x)` will return a cursor pointing to the gap
+    /// before the smallest key greater than `x`.
+    ///
+    /// Passing `Bound::Unbounded` will return a cursor pointing to the gap
+    /// before the smallest key in the table.
+    ///
+    /// This is analogous to [`std::collections::BTreeMap::lower_bound_mut`].
+    #[cfg(feature = "experimental_cursor")]
+    pub fn lower_bound_mut<'a>(
+        &mut self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<CursorMut<'_, K, V>> {
+        let bound = bound_to_bytes::<K, _>(&bound);
+        let mut inner = self.tree.cursor_mut();
+        inner.seek_lower_bound(bound.as_ref().map(|bytes| bytes.as_slice()))?;
+        Ok(CursorMut::new(inner, self.transaction))
+    }
+
+    /// Returns a [`CursorMut`] pointing at the gap after the greatest key
+    /// smaller than the given bound.
+    ///
+    /// Passing `Bound::Included(x)` will return a cursor pointing to the gap
+    /// after the greatest key smaller than or equal to `x`.
+    ///
+    /// Passing `Bound::Excluded(x)` will return a cursor pointing to the gap
+    /// after the greatest key smaller than `x`.
+    ///
+    /// Passing `Bound::Unbounded` will return a cursor pointing to the gap
+    /// after the greatest key in the table.
+    ///
+    /// This is analogous to [`std::collections::BTreeMap::upper_bound_mut`].
+    ///
+    /// # Examples
+    ///
+    /// Bulk loading a table from a stream of ascending keys:
+    ///
+    /// ```rust
+    /// use std::ops::Bound;
+    /// use redb::{Database, Error, ReadableTableMetadata, TableDefinition};
+    /// # use tempfile::NamedTempFile;
+    /// const TABLE: TableDefinition<u64, u64> = TableDefinition::new("my_data");
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// # #[cfg(not(target_os = "wasi"))]
+    /// # let tmpfile = NamedTempFile::new().unwrap();
+    /// # #[cfg(target_os = "wasi")]
+    /// # let tmpfile = NamedTempFile::new_in("/tmp").unwrap();
+    /// # let filename = tmpfile.path();
+    /// let db = Database::create(filename)?;
+    /// let write_txn = db.begin_write()?;
+    /// {
+    ///     let mut table = write_txn.open_table(TABLE)?;
+    ///     let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded)?;
+    ///     for key in 0..1000 {
+    ///         cursor.insert_before(key, &(key * 2))?;
+    ///     }
+    ///     cursor.close()?;
+    ///     assert_eq!(table.len()?, 1000);
+    /// }
+    /// write_txn.commit()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "experimental_cursor")]
+    pub fn upper_bound_mut<'a>(
+        &mut self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<CursorMut<'_, K, V>> {
+        let bound = bound_to_bytes::<K, _>(&bound);
+        let mut inner = self.tree.cursor_mut();
+        inner.seek_upper_bound(bound.as_ref().map(|bytes| bytes.as_slice()))?;
+        Ok(CursorMut::new(inner, self.transaction))
     }
 
     /// Gets the given key's corresponding entry in the table for in-place manipulation.
@@ -1071,5 +1155,187 @@ impl<'a, K: Key + 'static, V: Value + 'static> VacantEntry<'a, K, V> {
                 "inserted entry not found after VacantEntry::insert".to_string(),
             )
         })
+    }
+}
+
+#[cfg(feature = "experimental_cursor")]
+fn bound_to_bytes<'a, K: Key + 'a, KR: Borrow<K::SelfType<'a>>>(
+    bound: &Bound<KR>,
+) -> Bound<Vec<u8>> {
+    match bound {
+        Bound::Included(key) => Bound::Included(K::as_bytes(key.borrow()).as_ref().to_vec()),
+        Bound::Excluded(key) => Bound::Excluded(K::as_bytes(key.borrow()).as_ref().to_vec()),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+/// A cursor over a [`Table`], pointing at a gap between two entries, with
+/// support for inserting new entries into that gap.
+///
+/// Cursors are constructed with [`Table::lower_bound_mut`] and
+/// [`Table::upper_bound_mut`], and mirror the nightly
+/// [`std::collections::btree_map::CursorMut`] as closely as the redb data
+/// model allows: values are stored serialized, so inspecting the entries
+/// around the gap returns [`AccessGuard`]s instead of references, and every
+/// operation can report a storage error.
+///
+/// A cursor makes it cheap to insert a run of keys that arrive in sorted
+/// order, such as when bulk loading a table: inserting through the gap skips
+/// the per-key descent from the root that [`Table::insert`] performs, and
+/// packs finished leaves densely. Pending inserts may be buffered internally.
+/// They are visible through the cursor's own [`peek_prev`](Self::peek_prev)
+/// and [`peek_next`](Self::peek_next), and are spliced into the table when
+/// the buffer fills and when the cursor is closed or dropped. Call
+/// [`close`](Self::close) to observe errors from the final splice: if the
+/// cursor is dropped instead and the splice fails, the write transaction is
+/// poisoned so the loss cannot be committed, and
+/// [`crate::WriteTransaction::commit`] will return
+/// [`crate::CommitError::TransactionPoisoned`].
+///
+/// The cursor mutably borrows the [`Table`]: the table cannot be used while
+/// a cursor into it exists.
+#[cfg(feature = "experimental_cursor")]
+pub struct CursorMut<'a, K: Key + 'static, V: Value + 'static> {
+    inner: BtreeCursorMut<'a, K, V>,
+    transaction: &'a WriteTransaction,
+    // An I/O error leaves the cursor position unreliable, so later operations
+    // re-raise instead of continuing. Pending inserts are still flushed (or
+    // the transaction poisoned) on close: an error never latches while both
+    // pending inserts and a damaged position exist.
+    errored: bool,
+    closed: bool,
+}
+
+#[cfg(feature = "experimental_cursor")]
+impl<'a, K: Key + 'static, V: Value + 'static> CursorMut<'a, K, V> {
+    pub(crate) fn new(inner: BtreeCursorMut<'a, K, V>, transaction: &'a WriteTransaction) -> Self {
+        Self {
+            inner,
+            transaction,
+            errored: false,
+            closed: false,
+        }
+    }
+
+    /// Returns the entry after the cursor's gap without moving the cursor.
+    ///
+    /// Returns `None` if the gap is at the end of the table.
+    #[allow(clippy::type_complexity)]
+    pub fn peek_next(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.check_usable()?;
+        match self.inner.peek_next() {
+            Ok(entry) => Ok(entry),
+            Err(err) => {
+                // Peeking never consumes pending inserts, so unlike a failed
+                // splice this cannot lose reported inserts; the position is
+                // merely unreliable.
+                self.errored = true;
+                Err(err)
+            }
+        }
+    }
+
+    /// Returns the entry before the cursor's gap without moving the cursor.
+    ///
+    /// Returns `None` if the gap is at the start of the table.
+    #[allow(clippy::type_complexity)]
+    pub fn peek_prev(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.check_usable()?;
+        match self.inner.peek_prev() {
+            Ok(entry) => Ok(entry),
+            Err(err) => {
+                self.errored = true;
+                Err(err)
+            }
+        }
+    }
+
+    /// Inserts a new entry into the gap that the cursor is pointing at. After
+    /// the insertion, the cursor points at the gap after the newly inserted
+    /// entry.
+    ///
+    /// If the key does not sort strictly greater than the entry before the
+    /// gap and strictly smaller than the entry after it,
+    /// [`StorageError::UnorderedKey`] is returned and the table, the pending
+    /// inserts, and the cursor are unchanged. Unlike [`Table::insert`], an
+    /// existing key is never overwritten: inserting a key equal to either
+    /// neighbor is unordered.
+    ///
+    /// This is analogous to the nightly
+    /// [`std::collections::btree_map::CursorMut::insert_before`].
+    pub fn insert_before<'k, 'v>(
+        &mut self,
+        key: impl Borrow<K::SelfType<'k>>,
+        value: impl Borrow<V::SelfType<'v>>,
+    ) -> Result<()> {
+        self.check_usable()?;
+        let key_bytes = K::as_bytes(key.borrow());
+        let value_bytes = V::as_bytes(value.borrow());
+        let key_len = key_bytes.as_ref().len();
+        let value_len = value_bytes.as_ref().len();
+        if value_len > MAX_VALUE_LENGTH {
+            return Err(StorageError::ValueTooLarge(value_len));
+        }
+        if key_len > MAX_VALUE_LENGTH {
+            return Err(StorageError::ValueTooLarge(key_len));
+        }
+        if value_len + key_len > MAX_PAIR_LENGTH {
+            return Err(StorageError::ValueTooLarge(value_len + key_len));
+        }
+        match self
+            .inner
+            .insert_before(key_bytes.as_ref(), value_bytes.as_ref())
+        {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(StorageError::UnorderedKey),
+            Err(err) => Err(self.latch_error(err)),
+        }
+    }
+
+    /// Closes the cursor, splicing any pending inserts into the table.
+    ///
+    /// Dropping the cursor also closes it, but this method returns any error
+    /// encountered while splicing. `Ok` means every reported insert is in the
+    /// table.
+    pub fn close(mut self) -> Result {
+        self.closed = true;
+        self.finish()
+    }
+
+    fn check_usable(&self) -> Result {
+        if self.errored {
+            return Err(StorageError::PreviousIo);
+        }
+        Ok(())
+    }
+
+    fn latch_error(&mut self, err: StorageError) -> StorageError {
+        self.errored = true;
+        if self.inner.poisoned() {
+            // Inserts already reported as applied were lost; the transaction
+            // must not commit without them.
+            self.transaction.poison();
+        }
+        err
+    }
+
+    fn finish(&mut self) -> Result {
+        let result = self.inner.finish();
+        if result.is_err() || self.inner.poisoned() {
+            self.transaction.poison();
+        }
+        result
+    }
+}
+
+#[cfg(feature = "experimental_cursor")]
+impl<K: Key + 'static, V: Value + 'static> Drop for CursorMut<'_, K, V> {
+    fn drop(&mut self) {
+        if self.closed {
+            return;
+        }
+        // Drop cannot surface a splice failure; finish() poisons the
+        // transaction instead, so the loss cannot be committed.
+        let _ = self.finish();
     }
 }

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -3,6 +3,8 @@ use crate::tree_store::btree_base::{
     AccessGuardMut, BRANCH, BranchAccessor, BranchMutator, BtreeHeader, Checksum, DEFERRED, LEAF,
     LeafAccessor, LeafPageMut, branch_checksum, leaf_checksum,
 };
+#[cfg(feature = "experimental_cursor")]
+use crate::tree_store::btree_cursor::BtreeCursorMut;
 use crate::tree_store::btree_cursor::{CursorMut, Position};
 use crate::tree_store::btree_iters::range_is_empty;
 use crate::tree_store::btree_mutator::MutateHelper;
@@ -700,6 +702,18 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         );
 
         Ok(result)
+    }
+
+    // The tree-level cursor behind the public `CursorMut`. The caller
+    // positions it with its seek methods before use.
+    #[cfg(feature = "experimental_cursor")]
+    pub(crate) fn cursor_mut(&mut self) -> BtreeCursorMut<'_, K, V> {
+        BtreeCursorMut::new(
+            &mut self.root,
+            self.page_allocator.clone(),
+            self.freed_pages.clone(),
+            self.allocated_pages.clone(),
+        )
     }
 
     // Sets `poisoned` if an error left entries in the tree that the

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -718,12 +718,44 @@ impl OwnedEntryBuffer {
         }
     }
 
+    // Appends one pair, which must be greater than every buffered entry.
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn push(&mut self, key: &[u8], value: &[u8]) {
+        let pair = self.store(key, value);
+        self.pairs.push_back(pair);
+    }
+
+    // Copies `range` of the leaf's pairs to the back of the buffer. The pairs
+    // must all be greater than the buffered entries.
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn extend_from_leaf_range(
+        &mut self,
+        accessor: &LeafAccessor<'_>,
+        range: Range<usize>,
+    ) {
+        self.pairs.reserve(range.len());
+        self.data
+            .reserve(accessor.length_of_pairs(range.start, range.end));
+        for index in range {
+            let entry = accessor.entry(index).unwrap();
+            let pair = self.store(entry.key(), entry.value());
+            self.pairs.push_back(pair);
+        }
+    }
+
     pub(super) fn num_pairs(&self) -> usize {
         self.pairs.len()
     }
 
     pub(super) fn total_bytes(&self) -> usize {
         self.data.len()
+    }
+
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn back(&self) -> Option<(&[u8], &[u8])> {
+        self.pairs
+            .back()
+            .map(|(key, value)| (&self.data[key.clone()], &self.data[value.clone()]))
     }
 
     pub(super) fn entries(&self) -> impl Iterator<Item = (&[u8], &[u8])> {

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -63,6 +63,26 @@ pub(super) enum Position<'a> {
     After(&'a [u8]),
 }
 
+impl<'a> Position<'a> {
+    // The gap before the first key the bound admits.
+    pub(super) fn from_lower_bound(bound: Bound<&'a [u8]>) -> Self {
+        match bound {
+            Included(key) => Self::Before(key),
+            Excluded(key) => Self::After(key),
+            Unbounded => Self::Start,
+        }
+    }
+
+    // The gap after the last key the bound admits.
+    pub(super) fn from_upper_bound(bound: Bound<&'a [u8]>) -> Self {
+        match bound {
+            Included(key) => Self::After(key),
+            Excluded(key) => Self::Before(key),
+            Unbounded => Self::End,
+        }
+    }
+}
+
 #[derive(Copy, Clone, PartialEq)]
 enum Direction {
     Next,
@@ -316,6 +336,34 @@ impl LeafRunRewrite {
     }
 }
 
+// The threshold at which a cursor's pending inserts are spliced into the
+// tree. The splice cost is dominated by rebuilding the ancestor path, so what
+// matters is the flush count; measurements flatten out around 1MiB.
+#[cfg(feature = "experimental_cursor")]
+const INSERT_FLUSH_BYTES: usize = 1024 * 1024;
+
+// Pending inserts at the cursor's gap. The buffer holds the current leaf's
+// entries before the gap followed by the inserts, in ascending key order, so
+// the splice packs it (plus the rest of the leaf) into full leaves in one
+// parent update per flush instead of descending the tree per insert.
+//
+// While a run is open the tree is never mutated and the cursor position never
+// moves, so the position's path stays valid until the splice.
+#[cfg(feature = "experimental_cursor")]
+struct InsertRun {
+    // Key of the entry after the gap when the run opened; None when the gap
+    // is at the end of the tree. Inserts must sort strictly below it.
+    upper_key: Option<Vec<u8>>,
+    // Greatest key at or before the gap: the last insert or, before any
+    // insert, the entry preceding the gap; None at the start of the tree.
+    // Inserts must sort strictly above it.
+    previous_key: Option<Vec<u8>>,
+    entries: OwnedEntryBuffer,
+    // Buffered pairs that are new inserts; the rest were copied from the
+    // current leaf.
+    inserted_pairs: u64,
+}
+
 pub(super) struct EntryRef<'a, K: Key + 'static, V: Value + 'static> {
     page: &'a PageImpl,
     key_range: Range<usize>,
@@ -327,6 +375,17 @@ pub(super) struct EntryRef<'a, K: Key + 'static, V: Value + 'static> {
 impl<K: Key + 'static, V: Value + 'static> EntryRef<'_, K, V> {
     pub(super) fn key_bytes(&self) -> &[u8] {
         &self.page.memory()[self.key_range.clone()]
+    }
+
+    // Guards over the entry that outlive this borrow of the cursor. They stay
+    // valid as long as the tree is not mutated, which the compiler enforces
+    // once the caller ties them to a borrow of the cursor's owner.
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn to_guards<'g>(&self) -> (AccessGuard<'g, K>, AccessGuard<'g, V>) {
+        (
+            AccessGuard::with_page(self.page.clone(), self.key_range.clone()),
+            AccessGuard::with_page(self.page.clone(), self.value_range.clone()),
+        )
     }
 
     pub(super) fn key(&self) -> K::SelfType<'_> {
@@ -505,6 +564,11 @@ pub(super) struct CursorState {
     // so it may outlive the position; it is spliced before the tree is
     // observed.
     leaf_run_rewrite: Option<LeafRunRewrite>,
+    // Pending inserts at the gap, spliced when the buffer fills or the cursor
+    // moves on. Never set by the removal-oriented cursor users. Boxed to keep
+    // the state small for those users.
+    #[cfg(feature = "experimental_cursor")]
+    insert_run: Option<Box<InsertRun>>,
 }
 
 enum LeafCloseOutcome {
@@ -604,6 +668,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         self.check_not_poisoned()?;
         assert!(self.state.leaf_run_rewrite.is_none());
         assert!(self.state.removed_indexes.is_empty());
+        #[cfg(feature = "experimental_cursor")]
+        assert!(self.state.insert_run.is_none());
         self.state.position = None;
         let Some(header) = *self.root else {
             return Ok(());
@@ -645,6 +711,10 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     // flushes its pending removals and reseeks past it in the updated tree.
     fn ensure_has_entry(&mut self, direction: Direction) -> Result<bool> {
         self.check_not_poisoned()?;
+        // Moving across a leaf edge here would invalidate an open insert
+        // run's captured position; its owner peeks the buffer instead.
+        #[cfg(feature = "experimental_cursor")]
+        assert!(self.state.insert_run.is_none());
         self.check_pending_removals(direction);
         loop {
             let Some(position) = self.state.position.as_ref() else {
@@ -931,6 +1001,10 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         self.state.position = None;
         self.state.removed_indexes.clear();
         self.state.leaf_run_rewrite = None;
+        #[cfg(feature = "experimental_cursor")]
+        {
+            self.state.insert_run = None;
+        }
     }
 
     fn check_not_poisoned(&self) -> Result {
@@ -1143,6 +1217,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     // violation would later splice through a stale path.
     fn mutate_helper<'c>(&'c mut self) -> MutateHelper<'a, 'c, K, V> {
         assert!(self.state.leaf_run_rewrite.is_none());
+        #[cfg(feature = "experimental_cursor")]
+        assert!(self.state.insert_run.is_none());
         MutateHelper::new(
             &mut *self.root,
             (*self.page_allocator).clone(),
@@ -1161,6 +1237,297 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         let path = path.into_iter().map(Branch::into_parts).collect();
         let entry = self.mutate_helper().pop_leaf_entry(leaf, path, index)?;
         Ok(Some(entry))
+    }
+}
+
+#[cfg(feature = "experimental_cursor")]
+impl<K: Key + 'static, V: Value + 'static> CursorMut<'_, '_, K, V> {
+    /// Buffers `key`/`value` for insertion into the gap, leaving the gap
+    /// after the new entry. Returns false, leaving the tree and any pending
+    /// inserts unchanged, unless `key` sorts strictly between the entries
+    /// adjacent to the gap.
+    pub(super) fn insert_before(&mut self, key: &[u8], value: &[u8]) -> Result<bool> {
+        self.check_not_poisoned()?;
+        assert!(self.state.removed_indexes.is_empty());
+        assert!(self.state.leaf_run_rewrite.is_none());
+        if self.state.insert_run.is_none() {
+            self.open_insert_run()?;
+        }
+        let run = self.state.insert_run.as_mut().unwrap();
+        if let Some(previous) = &run.previous_key
+            && K::compare(key, previous).is_le()
+        {
+            return Ok(false);
+        }
+        if let Some(upper) = &run.upper_key
+            && K::compare(key, upper).is_ge()
+        {
+            return Ok(false);
+        }
+        run.entries.push(key, value);
+        run.previous_key = Some(key.to_vec());
+        run.inserted_pairs += 1;
+        if run.entries.total_bytes() >= INSERT_FLUSH_BYTES {
+            self.flush_insert_run(true)?;
+        }
+        Ok(true)
+    }
+
+    // Captures the gap's neighbor keys and the current leaf's entries before
+    // the gap. The peeks first settle a gap at the edge of two leaves on the
+    // later leaf and then back on the earlier one, so afterward the gap's
+    // remaining predecessors all sit in the current leaf before `position`,
+    // and its successors are `position..` of the current leaf plus every
+    // later leaf.
+    fn open_insert_run(&mut self) -> Result {
+        assert!(self.state.insert_run.is_none());
+        let upper_key = self.peek_next()?.map(|entry| entry.key_bytes().to_vec());
+        let previous_key = self.peek_prev()?.map(|entry| entry.key_bytes().to_vec());
+        let mut entries = OwnedEntryBuffer::default();
+        if let Some(position) = &self.state.position {
+            let accessor = LeafAccessor::new(
+                position.leaf.page.memory(),
+                K::fixed_width(),
+                V::fixed_width(),
+            );
+            entries.extend_from_leaf_range(&accessor, 0..position.leaf.position);
+        }
+        self.state.insert_run = Some(Box::new(InsertRun {
+            upper_key,
+            previous_key,
+            entries,
+            inserted_pairs: 0,
+        }));
+        Ok(())
+    }
+
+    /// Splices the pending inserts into the tree. With `reseek` the cursor is
+    /// repositioned at the gap after the last insert; without it the position
+    /// is consumed and the cursor must not be used again.
+    ///
+    /// On error the cursor is poisoned: inserts already reported to the
+    /// caller were lost, so the transaction must not commit.
+    pub(super) fn flush_insert_run(&mut self, reseek: bool) -> Result {
+        self.check_not_poisoned()?;
+        let Some(run) = self.state.insert_run.take() else {
+            return Ok(());
+        };
+        if run.inserted_pairs == 0 {
+            // Every insert was rejected: the tree was never touched and the
+            // position remains valid.
+            return Ok(());
+        }
+        let resume_key = run
+            .previous_key
+            .expect("a run with inserts records the last inserted key");
+        let mut entries = run.entries;
+        let replaced = if let Some(position) = self.state.position.take() {
+            // The rest of the current leaf follows every pending insert.
+            let accessor = LeafAccessor::new(
+                position.leaf.page.memory(),
+                K::fixed_width(),
+                V::fixed_width(),
+            );
+            entries.extend_from_leaf_range(&accessor, position.leaf.position..position.leaf.len);
+            let CursorPosition { path, leaf } = position;
+            let replaced_leaf = leaf.page.get_page_number();
+            // The leaf is one of the pages the splice frees, so its page
+            // reference must be released first.
+            drop(leaf);
+            Some((
+                path.into_iter().map(Branch::into_parts).collect(),
+                replaced_leaf,
+            ))
+        } else {
+            None
+        };
+        let result = self
+            .mutate_helper()
+            .splice_insert_run(replaced, &entries, run.inserted_pairs);
+        if result.is_err() {
+            // The buffered inserts were consumed and can no longer be applied.
+            self.poison();
+        }
+        result?;
+        if reseek {
+            self.seek_to(Position::After(&resume_key))?;
+        }
+        Ok(())
+    }
+}
+
+// The tree borrows shared by every owner of detached cursor state: the root,
+// the plumbing needed to build `CursorMut`s over it, and the pages their
+// mutations free, drained after every operation so the master list's lock is
+// never held while control returns to the caller.
+pub(super) struct CursorTree<'a, K: Key + 'static, V: Value + 'static> {
+    root: &'a mut Option<BtreeHeader>,
+    page_allocator: PageAllocator,
+    allocated: Arc<Mutex<PageTrackerPolicy>>,
+    master_free_list: Arc<Mutex<Vec<PageNumber>>>,
+    freed: Vec<PageNumber>,
+    _key_type: PhantomData<K>,
+    _value_type: PhantomData<V>,
+}
+
+impl<'a, K: Key + 'static, V: Value + 'static> CursorTree<'a, K, V> {
+    fn new(
+        root: &'a mut Option<BtreeHeader>,
+        page_allocator: PageAllocator,
+        master_free_list: Arc<Mutex<Vec<PageNumber>>>,
+        allocated: Arc<Mutex<PageTrackerPolicy>>,
+    ) -> Self {
+        Self {
+            root,
+            page_allocator,
+            allocated,
+            master_free_list,
+            freed: vec![],
+            _key_type: PhantomData,
+            _value_type: PhantomData,
+        }
+    }
+
+    fn cursor(&mut self, state: CursorState) -> CursorMut<'a, '_, K, V> {
+        CursorMut::with_state(
+            &mut *self.root,
+            &self.page_allocator,
+            &mut self.freed,
+            &self.allocated,
+            state,
+        )
+    }
+
+    fn drain_freed(&mut self) {
+        if self.freed.is_empty() {
+            return;
+        }
+        let mut master_free_list = self.master_free_list.lock().unwrap();
+        let mut allocated = self.allocated.lock().unwrap();
+        for page in self.freed.drain(..) {
+            if !self
+                .page_allocator
+                .free_if_uncommitted(page, &mut allocated)
+            {
+                master_free_list.push(page);
+            }
+        }
+    }
+}
+
+// The tree-level cursor behind the public `CursorMut`: one gap cursor that
+// owns its state across calls, in the style of `RangeMut` but with a single
+// end and buffered insertion instead of removal batching.
+#[cfg(feature = "experimental_cursor")]
+pub(crate) struct BtreeCursorMut<'a, K: Key + 'static, V: Value + 'static> {
+    tree: CursorTree<'a, K, V>,
+    state: CursorState,
+}
+
+#[cfg(feature = "experimental_cursor")]
+impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
+    pub(crate) fn new(
+        root: &'a mut Option<BtreeHeader>,
+        page_allocator: PageAllocator,
+        master_free_list: Arc<Mutex<Vec<PageNumber>>>,
+        allocated: Arc<Mutex<PageTrackerPolicy>>,
+    ) -> Self {
+        Self {
+            tree: CursorTree::new(root, page_allocator, master_free_list, allocated),
+            state: CursorState::default(),
+        }
+    }
+
+    /// Positions the cursor at the gap before the first key `bound` admits.
+    pub(crate) fn seek_lower_bound(&mut self, bound: Bound<&[u8]>) -> Result {
+        self.with_cursor(|cursor| cursor.seek_to(Position::from_lower_bound(bound)))
+    }
+
+    /// Positions the cursor at the gap after the last key `bound` admits.
+    pub(crate) fn seek_upper_bound(&mut self, bound: Bound<&[u8]>) -> Result {
+        self.with_cursor(|cursor| cursor.seek_to(Position::from_upper_bound(bound)))
+    }
+
+    /// The entry after the gap, including while inserts are pending: peeking
+    /// never splices them.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn peek_next(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        if let Some(run) = &self.state.insert_run {
+            // The position must not move while a run is open, so the entry
+            // after the gap (the run's captured upper bound, unchanged since
+            // the tree is not mutated during a run) is re-read with a
+            // detached read-only cursor.
+            let Some(upper_key) = &run.upper_key else {
+                return Ok(None);
+            };
+            let header = self
+                .tree
+                .root
+                .expect("a captured upper bound implies a root");
+            let mut cursor: Cursor<K, V> = Cursor::new(
+                header.root,
+                self.tree.page_allocator.resolver(),
+                PageHint::None,
+            );
+            cursor.seek_to(Position::Before(upper_key))?;
+            let entry = cursor
+                .next()?
+                .expect("the captured upper bound is in the tree");
+            let (page, key_range, value_range) = entry.into_raw();
+            return Ok(Some((
+                AccessGuard::with_page(page.clone(), key_range),
+                AccessGuard::with_page(page, value_range),
+            )));
+        }
+        self.with_cursor(|cursor| Ok(cursor.peek_next()?.map(|entry| entry.to_guards())))
+    }
+
+    /// The entry before the gap, including while inserts are pending: the
+    /// most recent insert is returned without splicing.
+    ///
+    /// While a run is open, its buffer holds every predecessor the gap has in
+    /// the current leaf (the normalizing peeks settled the position on the
+    /// earlier of two leaves sharing the gap), so an empty buffer means the
+    /// gap is at the start of the tree.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn peek_prev(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        if let Some(run) = &self.state.insert_run {
+            return Ok(run.entries.back().map(|(key, value)| {
+                (
+                    AccessGuard::with_owned_value(key.to_vec()),
+                    AccessGuard::with_owned_value(value.to_vec()),
+                )
+            }));
+        }
+        self.with_cursor(|cursor| Ok(cursor.peek_prev()?.map(|entry| entry.to_guards())))
+    }
+
+    /// See [`CursorMut::insert_before`].
+    pub(crate) fn insert_before(&mut self, key: &[u8], value: &[u8]) -> Result<bool> {
+        self.with_cursor(|cursor| cursor.insert_before(key, value))
+    }
+
+    /// Splices any pending inserts into the tree, consuming the position.
+    pub(crate) fn finish(&mut self) -> Result {
+        self.with_cursor(|cursor| cursor.flush_insert_run(false))
+    }
+
+    /// True if an error interrupted inserts that were already reported to the
+    /// caller: they may be missing from the tree, so the transaction must not
+    /// commit.
+    pub(crate) fn poisoned(&self) -> bool {
+        self.state.poisoned
+    }
+
+    fn with_cursor<R>(
+        &mut self,
+        operation: impl FnOnce(&mut CursorMut<'a, '_, K, V>) -> Result<R>,
+    ) -> Result<R> {
+        let mut cursor = self.tree.cursor(std::mem::take(&mut self.state));
+        let result = operation(&mut cursor);
+        self.state = cursor.into_state();
+        self.tree.drain_freed();
+        result
     }
 }
 
@@ -1199,13 +1566,7 @@ struct ParkedBatch {
 // and flushed when the scan leaves the leaf, when the other end is activated,
 // or on close.
 pub(super) struct RangeMut<'a, K: Key + 'static, V: Value + 'static> {
-    root: &'a mut Option<BtreeHeader>,
-    page_allocator: PageAllocator,
-    allocated: Arc<Mutex<PageTrackerPolicy>>,
-    master_free_list: Arc<Mutex<Vec<PageNumber>>>,
-    // Pages freed by cursor mutations, drained after every operation so the
-    // master list's lock is never held while control returns to the caller.
-    freed: Vec<PageNumber>,
+    tree: CursorTree<'a, K, V>,
     front: EndState,
     back: EndState,
     // Which end, if any, is known to be live and positioned at an in-range
@@ -1215,8 +1576,6 @@ pub(super) struct RangeMut<'a, K: Key + 'static, V: Value + 'static> {
     // caller: they may remain in the tree, so the transaction must not
     // commit. Every range operation re-raises instead of touching the tree.
     poisoned: bool,
-    _key_type: PhantomData<K>,
-    _value_type: PhantomData<V>,
 }
 
 impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
@@ -1229,17 +1588,11 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
         allocated: Arc<Mutex<PageTrackerPolicy>>,
     ) -> Self {
         Self {
-            root,
-            page_allocator,
-            allocated,
-            master_free_list,
-            freed: vec![],
+            tree: CursorTree::new(root, page_allocator, master_free_list, allocated),
             front: EndState::Parked(lower_bound),
             back: EndState::Parked(upper_bound),
             settled: None,
             poisoned: false,
-            _key_type: PhantomData,
-            _value_type: PhantomData,
         }
     }
 
@@ -1422,19 +1775,12 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
             EndState::Pending(batch) => batch.bound.clone(),
             EndState::Live(_) => unreachable!("end must be parked"),
         };
+        let bound = bound.as_ref().map(Vec::as_slice);
         let target = match direction {
-            Direction::Next => match &bound {
-                Included(key) => Position::Before(key),
-                Excluded(key) => Position::After(key),
-                Unbounded => Position::Start,
-            },
-            Direction::Previous => match &bound {
-                Included(key) => Position::After(key),
-                Excluded(key) => Position::Before(key),
-                Unbounded => Position::End,
-            },
+            Direction::Next => Position::from_lower_bound(bound),
+            Direction::Previous => Position::from_upper_bound(bound),
         };
-        let mut cursor = self.cursor(CursorState::default());
+        let mut cursor = self.tree.cursor(CursorState::default());
         let result = cursor.seek_to(target);
         let state = cursor.into_state();
         // On error the end stays parked, preserving any pending batch for close().
@@ -1475,7 +1821,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
             Ok(())
         };
         *self.end_mut(direction) = parked;
-        self.drain_freed();
+        self.tree.drain_freed();
         result
     }
 
@@ -1508,16 +1854,16 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
                 .expect("snapshot entry must exist")
                 .key();
             let mut helper: MutateHelper<'_, '_, K, V> = MutateHelper::new(
-                &mut *self.root,
-                self.page_allocator.clone(),
-                &mut self.freed,
-                Arc::clone(&self.allocated),
+                &mut *self.tree.root,
+                self.tree.page_allocator.clone(),
+                &mut self.tree.freed,
+                Arc::clone(&self.tree.allocated),
             );
             // In-place deletion must be disabled: the other end's pending
             // snapshot and any deferred-removal guards handed to the caller
             // may share the buffer of the live leaf containing this key.
             let result = helper.delete_key(key, false);
-            self.drain_freed();
+            self.tree.drain_freed();
             match result {
                 Ok(removed) => debug_assert!(removed.is_some()),
                 Err(err) => {
@@ -1538,25 +1884,15 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
         let EndState::Live(state) = std::mem::replace(end, EndState::Parked(Unbounded)) else {
             unreachable!("end must be live");
         };
-        let mut cursor = self.cursor(state);
+        let mut cursor = self.tree.cursor(state);
         let result = operation(&mut cursor);
         let state = cursor.into_state();
         if state.poisoned {
             self.poisoned = true;
         }
         *self.end_mut(direction) = EndState::Live(state);
-        self.drain_freed();
+        self.tree.drain_freed();
         result
-    }
-
-    fn cursor(&mut self, state: CursorState) -> CursorMut<'a, '_, K, V> {
-        CursorMut::with_state(
-            &mut *self.root,
-            &self.page_allocator,
-            &mut self.freed,
-            &self.allocated,
-            state,
-        )
     }
 
     // Whether the live end's current entry is still inside the range bounded
@@ -1598,22 +1934,6 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
         match direction {
             Direction::Next => &mut self.front,
             Direction::Previous => &mut self.back,
-        }
-    }
-
-    fn drain_freed(&mut self) {
-        if self.freed.is_empty() {
-            return;
-        }
-        let mut master_free_list = self.master_free_list.lock().unwrap();
-        let mut allocated = self.allocated.lock().unwrap();
-        for page in self.freed.drain(..) {
-            if !self
-                .page_allocator
-                .free_if_uncommitted(page, &mut allocated)
-            {
-                master_free_list.push(page);
-            }
         }
     }
 }
@@ -1665,7 +1985,7 @@ mod tests {
         AllocationPolicy, InMemoryBackend, PAGE_SIZE, PageTrackerPolicy, TransactionalMemory,
     };
 
-    fn leaf_root_with_entries(entries: &[u64]) -> (PageAllocator, PageNumber) {
+    fn test_page_allocator() -> PageAllocator {
         let mem = TransactionalMemory::new(
             Box::new(InMemoryBackend::new()),
             true,
@@ -1676,9 +1996,16 @@ mod tests {
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();
-        let mem = Arc::new(mem);
-        let page_allocator = PageAllocator::new(mem, AllocationPolicy::Default);
-        let allocated_pages = Mutex::new(PageTrackerPolicy::new_tracking());
+        PageAllocator::new(Arc::new(mem), AllocationPolicy::Default)
+    }
+
+    // The returned tracker records the built page: mutations through a cursor
+    // must share it, so the pages they free are found tracked.
+    fn leaf_root_with_entries(
+        entries: &[u64],
+    ) -> (PageAllocator, PageNumber, Arc<Mutex<PageTrackerPolicy>>) {
+        let page_allocator = test_page_allocator();
+        let allocated_pages = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
         let keys_and_values: Vec<_> = entries
             .iter()
             .map(|entry| {
@@ -1702,11 +2029,11 @@ mod tests {
         let root = page.get_page_number();
         drop(page);
 
-        (page_allocator, root)
+        (page_allocator, root, allocated_pages)
     }
 
     fn cursor_with_entries(entries: &[u64]) -> Cursor<u64, u64> {
-        let (page_allocator, root) = leaf_root_with_entries(entries);
+        let (page_allocator, root, _) = leaf_root_with_entries(entries);
         let mut cursor = Cursor::<u64, u64>::new(root, page_allocator.resolver(), PageHint::None);
         cursor.seek_to(Position::Start).unwrap();
         cursor
@@ -1740,10 +2067,9 @@ mod tests {
     // unpositioned cursor would park as Unbounded, un-consuming the entries.
     #[test]
     fn cursor_mut_stays_parked_at_tree_edge() {
-        let (page_allocator, root_page) = leaf_root_with_entries(&[1, 2, 3]);
+        let (page_allocator, root_page, allocated) = leaf_root_with_entries(&[1, 2, 3]);
         let mut root = Some(BtreeHeader::new(root_page, DEFERRED, 3));
         let mut freed = vec![];
-        let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
         let mut cursor: CursorMut<'_, '_, u64, u64> =
             CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
 
@@ -1776,15 +2102,268 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "experimental_cursor")]
+    mod insert_tests {
+        use super::*;
+        use crate::tree_store::RawBtree;
+        use crate::tree_store::btree::UntypedBtreeMut;
+
+        fn insert(cursor: &mut CursorMut<'_, '_, u64, u64>, key: u64, value: u64) -> bool {
+            cursor
+                .insert_before(u64::as_bytes(&key).as_ref(), u64::as_bytes(&value).as_ref())
+                .unwrap()
+        }
+
+        fn scan(root: Option<BtreeHeader>, page_allocator: &PageAllocator) -> Vec<(u64, u64)> {
+            let Some(header) = root else {
+                return vec![];
+            };
+            let mut cursor =
+                Cursor::<u64, u64>::new(header.root, page_allocator.resolver(), PageHint::None);
+            cursor.seek_to(Position::Start).unwrap();
+            let mut entries = vec![];
+            while let Some(entry) = cursor.next().unwrap() {
+                entries.push((entry.key(), entry.value()));
+            }
+            entries
+        }
+
+        // Full validation of a spliced tree: contents and order via a scan,
+        // stored length, per-key branch routing (which depends on the
+        // separators the splice wrote), and checksum-tree consistency.
+        fn assert_tree(
+            root: Option<BtreeHeader>,
+            page_allocator: &PageAllocator,
+            expected: &[(u64, u64)],
+        ) {
+            assert_eq!(scan(root, page_allocator), expected);
+            assert_eq!(
+                root.map_or(0, |header| header.length),
+                expected.len() as u64
+            );
+            for (key, value) in expected {
+                let mut cursor = Cursor::<u64, u64>::new(
+                    root.unwrap().root,
+                    page_allocator.resolver(),
+                    PageHint::None,
+                );
+                cursor
+                    .seek_to(Position::Before(u64::as_bytes(key).as_ref()))
+                    .unwrap();
+                let entry = cursor.next().unwrap().expect("key must route to its leaf");
+                assert_eq!(entry.key(), *key);
+                assert_eq!(entry.value(), *value);
+            }
+            let mut untyped = UntypedBtreeMut::new(
+                root,
+                page_allocator.clone(),
+                Arc::new(Mutex::new(vec![])),
+                u64::fixed_width(),
+                u64::fixed_width(),
+            );
+            let finalized = untyped.finalize_dirty_checksums().unwrap();
+            let raw = RawBtree::new(
+                finalized,
+                u64::fixed_width(),
+                u64::fixed_width(),
+                page_allocator.resolver(),
+                PageHint::None,
+            );
+            assert!(raw.verify_checksum().unwrap());
+        }
+
+        #[test]
+        fn insert_run_builds_tree_from_empty() {
+            for flush_every in [1, 3, 64] {
+                let page_allocator = test_page_allocator();
+                let mut root = None;
+                let mut freed = vec![];
+                let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+                let mut cursor: CursorMut<'_, '_, u64, u64> =
+                    CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+                cursor.seek_to(Position::End).unwrap();
+                for key in 0..2000 {
+                    assert!(insert(&mut cursor, key, key * 3));
+                    if key % flush_every == 0 {
+                        cursor.flush_insert_run(true).unwrap();
+                    }
+                }
+                cursor.flush_insert_run(true).unwrap();
+                drop(cursor);
+
+                let expected: Vec<_> = (0..2000).map(|key| (key, key * 3)).collect();
+                assert_tree(root, &page_allocator, &expected);
+            }
+        }
+
+        #[test]
+        fn insert_run_grows_multiple_levels() {
+            let page_allocator = test_page_allocator();
+            let mut root = None;
+            let mut freed = vec![];
+            let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor.seek_to(Position::End).unwrap();
+            for key in 0..60_000 {
+                assert!(insert(&mut cursor, key, key));
+                if key % 1000 == 999 {
+                    cursor.flush_insert_run(true).unwrap();
+                }
+            }
+            cursor.flush_insert_run(false).unwrap();
+            drop(cursor);
+
+            let stats = crate::tree_store::btree::btree_stats(
+                root.map(|header| header.root),
+                &page_allocator.resolver(),
+                u64::fixed_width(),
+                u64::fixed_width(),
+                PageHint::None,
+            )
+            .unwrap();
+            assert!(stats.tree_height >= 3, "height {}", stats.tree_height);
+
+            let expected: Vec<_> = (0..60_000).map(|key| (key, key)).collect();
+            assert_tree(root, &page_allocator, &expected);
+        }
+
+        #[test]
+        fn insert_run_into_leaf_middle() {
+            let existing: Vec<u64> = (0..100).map(|i| i * 10).collect();
+            let (page_allocator, root_page, allocated) = leaf_root_with_entries(&existing);
+            let mut root = Some(BtreeHeader::new(root_page, DEFERRED, existing.len() as u64));
+            let mut freed = vec![];
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor
+                .seek_to(Position::Before(u64::as_bytes(&500).as_ref()))
+                .unwrap();
+            for key in 491..500 {
+                assert!(insert(&mut cursor, key, key));
+            }
+            cursor.flush_insert_run(false).unwrap();
+            drop(cursor);
+
+            let mut expected: Vec<_> = existing.iter().map(|&key| (key, key)).collect();
+            expected.extend((491..500).map(|key| (key, key)));
+            expected.sort_unstable();
+            assert_tree(root, &page_allocator, &expected);
+        }
+
+        // Splicing many entries into a single-leaf root exercises replacing
+        // the root leaf itself and growing new levels above the replacements.
+        #[test]
+        fn insert_run_splits_root_leaf() {
+            let (page_allocator, root_page, allocated) = leaf_root_with_entries(&[0, 1_000_000]);
+            let mut root = Some(BtreeHeader::new(root_page, DEFERRED, 2));
+            let mut freed = vec![];
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor
+                .seek_to(Position::After(u64::as_bytes(&0).as_ref()))
+                .unwrap();
+            for key in 1..=10_000 {
+                assert!(insert(&mut cursor, key, key));
+            }
+            cursor.flush_insert_run(false).unwrap();
+            drop(cursor);
+
+            let mut expected = vec![(0, 0), (1_000_000, 1_000_000)];
+            expected.extend((1..=10_000).map(|key| (key, key)));
+            expected.sort_unstable();
+            assert_tree(root, &page_allocator, &expected);
+        }
+
+        // A splice under a non-rightmost branch of a height-3 tree: the
+        // rebuilt branch is not its parent's last child, so its subtree's
+        // unchanged greatest key must be recovered from the parent's
+        // separator rather than propagated as unknown.
+        #[test]
+        fn insert_run_into_middle_of_tall_tree() {
+            let page_allocator = test_page_allocator();
+            let mut root = None;
+            let mut freed = vec![];
+            let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor.seek_to(Position::End).unwrap();
+            // Even keys, leaving gaps to insert into; enough for three levels
+            for key in 0..60_000 {
+                assert!(insert(&mut cursor, key * 2, key * 2));
+                if key % 1000 == 999 {
+                    cursor.flush_insert_run(true).unwrap();
+                }
+            }
+            cursor.flush_insert_run(false).unwrap();
+            drop(cursor);
+            let stats = crate::tree_store::btree::btree_stats(
+                root.map(|header| header.root),
+                &page_allocator.resolver(),
+                u64::fixed_width(),
+                u64::fixed_width(),
+                PageHint::None,
+            )
+            .unwrap();
+            assert!(stats.tree_height >= 3, "height {}", stats.tree_height);
+
+            // Gaps chosen to land under leaves in the interior of the tree
+            let mut expected: Vec<(u64, u64)> = (0..60_000).map(|key| (key * 2, key * 2)).collect();
+            for target in [1001u64, 30_001, 60_001, 90_001, 119_001] {
+                let mut cursor: CursorMut<'_, '_, u64, u64> =
+                    CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+                cursor
+                    .seek_to(Position::Before(u64::as_bytes(&target).as_ref()))
+                    .unwrap();
+                assert!(insert(&mut cursor, target, target));
+                cursor.flush_insert_run(false).unwrap();
+                drop(cursor);
+                expected.push((target, target));
+            }
+            expected.sort_unstable();
+            assert_tree(root, &page_allocator, &expected);
+        }
+
+        #[test]
+        fn insert_run_rejects_unordered_keys() {
+            let (page_allocator, root_page, allocated) = leaf_root_with_entries(&[10, 20, 30]);
+            let mut root = Some(BtreeHeader::new(root_page, DEFERRED, 3));
+            let mut freed = vec![];
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor
+                .seek_to(Position::After(u64::as_bytes(&20).as_ref()))
+                .unwrap();
+            // Equal to the previous entry, below it, equal to the next entry,
+            // and above it are all rejected.
+            assert!(!insert(&mut cursor, 20, 20));
+            assert!(!insert(&mut cursor, 15, 15));
+            assert!(!insert(&mut cursor, 30, 30));
+            assert!(!insert(&mut cursor, 35, 35));
+            // A run whose every insert was rejected leaves the tree untouched
+            // and the cursor usable.
+            cursor.flush_insert_run(true).unwrap();
+            assert!(insert(&mut cursor, 25, 25));
+            // Inserts must also stay above the pending insert.
+            assert!(!insert(&mut cursor, 25, 25));
+            assert!(!insert(&mut cursor, 24, 24));
+            assert!(insert(&mut cursor, 26, 26));
+            cursor.flush_insert_run(false).unwrap();
+            drop(cursor);
+
+            let expected = [10, 20, 25, 26, 30].map(|key| (key, key));
+            assert_tree(root, &page_allocator, &expected);
+        }
+    }
+
     // Once poisoned, every cursor operation re-raises instead of touching the
     // tree, so removals stranded by the original error can never be observed
     // as applied.
     #[test]
     fn poisoned_cursor_mut_re_raises() {
-        let (page_allocator, root_page) = leaf_root_with_entries(&[1, 2, 3]);
+        let (page_allocator, root_page, allocated) = leaf_root_with_entries(&[1, 2, 3]);
         let mut root = Some(BtreeHeader::new(root_page, DEFERRED, 3));
         let mut freed = vec![];
-        let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
         let mut cursor: CursorMut<'_, '_, u64, u64> =
             CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
 

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "experimental_cursor")]
+use crate::tree_store::btree_base::RawBranchBuilder;
 use crate::tree_store::btree_base::{
     BRANCH, BranchAccessor, BranchBuilder, BranchMutator, Checksum, DEFERRED, LEAF, LeafAccessor,
     LeafBuilder, LeafMutator, OwnedEntryBuffer, is_single_large_value, leaf_below_merge_threshold,
@@ -57,6 +59,12 @@ impl DeletedPairs {
         }
     }
 }
+
+// A page produced while splicing an insert run into the tree, with its
+// subtree's greatest key. The key is None only for the node whose subtree
+// contains the tree's original last entry, which stays last at every level.
+#[cfg(feature = "experimental_cursor")]
+type SplicedNode = (PageNumber, Checksum, Option<Vec<u8>>);
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum LeafDeleteDisposition {
@@ -454,6 +462,158 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             leaves.push((page2.get_page_number(), entries[range.end - 1].0.to_vec()));
         }
         Ok(leaves)
+    }
+
+    // Replaces the leaf at the end of `path` (all of the tree when `replaced`
+    // is None) with packed leaves built from `entries`, rebuilding the
+    // ancestor branches bottom-up. Unlike `replace_leaf_children`, the
+    // replacements can outnumber what they replace, so branches split on the
+    // way up and the root grows new levels; the separator for the replaced
+    // slot is refreshed at every level, since inserting can raise a subtree's
+    // greatest key.
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn splice_insert_run(
+        &mut self,
+        replaced: Option<(Vec<(PageImpl, usize)>, PageNumber)>,
+        entries: &OwnedEntryBuffer,
+        inserted_pairs: u64,
+    ) -> Result {
+        assert!(entries.num_pairs() > 0);
+        assert_eq!(replaced.is_some(), self.root.is_some());
+        let length = self.root.map_or(0, |header| header.length);
+        let leaves = self.build_replacement_leaves(entries)?;
+        let mut nodes: Vec<SplicedNode> = leaves
+            .into_iter()
+            .map(|(page, greatest_key)| (page, DEFERRED, Some(greatest_key)))
+            .collect();
+        // Freed only after every fallible step, so an error never leaves the
+        // surviving root referencing a freed page.
+        let mut removed_pages = vec![];
+        if let Some((path, replaced_leaf)) = replaced {
+            removed_pages.push(replaced_leaf);
+            for (page, child_index) in path.into_iter().rev() {
+                nodes = self.rebuild_branch_level(&page, child_index, nodes)?;
+                removed_pages.push(page.get_page_number());
+                drop(page);
+            }
+        }
+        while nodes.len() > 1 {
+            nodes = self.build_branch_nodes(&nodes)?;
+        }
+        let (root, _, _) = nodes.pop().unwrap();
+        *self.root = Some(BtreeHeader::new(root, DEFERRED, length + inserted_pairs));
+        for page_number in removed_pages {
+            self.conditional_free(page_number);
+        }
+        Ok(())
+    }
+
+    // Rebuilds one branch of the path, with `replacement` in place of
+    // `child_index`. Returns the built pages, more than one if the level had
+    // to split.
+    #[cfg(feature = "experimental_cursor")]
+    fn rebuild_branch_level(
+        &mut self,
+        parent: &PageImpl,
+        child_index: usize,
+        mut replacement: Vec<SplicedNode>,
+    ) -> Result<Vec<SplicedNode>> {
+        let accessor = BranchAccessor::new(parent, K::fixed_width());
+        let count = accessor.count_children();
+        assert!(child_index < count);
+        // A replacement ending in None kept the replaced subtree's original
+        // last entry, whose key the lower level does not store: this level's
+        // separator for the slot is exactly that unchanged bound. It stays
+        // None only for the parent's own last child, so after this, None
+        // appears only at the end of the level.
+        if let Some(last) = replacement.last_mut()
+            && last.2.is_none()
+        {
+            last.2 = accessor.key(child_index).map(<[u8]>::to_vec);
+        }
+        // Preserved children keep their checksum, and reuse the original
+        // separator as their greatest key; only the original last child's is
+        // unknown (None), and it stays last through every rebuild above.
+        let preserved = |i: usize| {
+            (
+                accessor.child_page(i).unwrap(),
+                accessor.child_checksum(i).unwrap(),
+                accessor.key(i).map(<[u8]>::to_vec),
+            )
+        };
+        let mut children = Vec::with_capacity(count - 1 + replacement.len());
+        children.extend((0..child_index).map(preserved));
+        children.extend(replacement);
+        children.extend(((child_index + 1)..count).map(preserved));
+        self.build_branch_nodes(&children)
+    }
+
+    // Packs `children` into as many branch pages as they require, in order.
+    // Mirrors `build_replacement_leaves`: cut a page whenever the next child
+    // would not fit, except that a page must keep at least two children, so
+    // the tail is merged into its neighbor instead of rebalanced.
+    #[cfg(feature = "experimental_cursor")]
+    fn build_branch_nodes(&mut self, children: &[SplicedNode]) -> Result<Vec<SplicedNode>> {
+        fn separator(node: &SplicedNode) -> &[u8] {
+            node.2
+                .as_deref()
+                .expect("only the last child of a level may lack a separator")
+        }
+
+        assert!(children.len() >= 2);
+        let page_size = self.page_allocator.get_page_size();
+
+        let mut plan: Vec<Range<usize>> = vec![];
+        let mut start = 0;
+        let mut key_bytes = 0;
+        for index in 1..children.len() {
+            // Extending the page to `children[index]` stores the separator of
+            // the previously-last child.
+            let separator_bytes = separator(&children[index - 1]).len();
+            let required = RawBranchBuilder::required_bytes(
+                index - start,
+                key_bytes + separator_bytes,
+                K::fixed_width(),
+            );
+            if required > page_size && index - start >= 2 {
+                plan.push(start..index);
+                start = index;
+                key_bytes = 0;
+            } else {
+                key_bytes += separator_bytes;
+            }
+        }
+        plan.push(start..children.len());
+        // A single child cannot form a branch page; put it back with its
+        // neighbor, slightly overfilling that page.
+        if plan.last().unwrap().len() == 1 && plan.len() >= 2 {
+            let last = plan.pop().unwrap();
+            plan.last_mut().unwrap().end = last.end;
+        }
+
+        let mut nodes = Vec::with_capacity(plan.len());
+        for range in plan {
+            let chunk = &children[range];
+            let mut builder = BranchBuilder::new(
+                &self.page_allocator,
+                &self.allocated,
+                chunk.len(),
+                K::fixed_width(),
+            );
+            for (page, checksum, _) in chunk {
+                builder.push_child(*page, *checksum);
+            }
+            for node in &chunk[..chunk.len() - 1] {
+                builder.push_key(separator(node));
+            }
+            let page = builder.build()?;
+            nodes.push((
+                page.get_page_number(),
+                DEFERRED,
+                chunk.last().unwrap().2.clone(),
+            ));
+        }
+        Ok(nodes)
     }
 
     #[allow(clippy::type_complexity)]

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -14,6 +14,8 @@ pub(crate) use btree::{Btree, BtreeMut, BtreeStats, RawBtree};
 pub(crate) use btree_base::BtreeHeader;
 pub use btree_base::{AccessGuard, AccessGuardMut, AccessGuardMutInPlace};
 pub(crate) use btree_base::{BRANCH, LEAF, LeafAccessor, RawLeafBuilder};
+#[cfg(feature = "experimental_cursor")]
+pub(crate) use btree_cursor::BtreeCursorMut;
 pub(crate) use btree_cursor_range::BtreeCursorRange;
 pub(crate) use btree_iters::AllPageNumbersBtreeIter;
 pub(crate) use extract_if::BtreeExtractIf;

--- a/tests/cursor_tests.rs
+++ b/tests/cursor_tests.rs
@@ -1,0 +1,448 @@
+#![cfg(feature = "experimental_cursor")]
+
+use redb::{
+    Database, ReadableDatabase, ReadableTable, ReadableTableMetadata, StorageError, TableDefinition,
+};
+use std::ops::Bound;
+
+const U64_TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+const STR_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("x");
+
+fn create_tempfile() -> tempfile::NamedTempFile {
+    if cfg!(target_os = "wasi") {
+        tempfile::NamedTempFile::new_in("/tmp").unwrap()
+    } else {
+        tempfile::NamedTempFile::new().unwrap()
+    }
+}
+
+// Zero padded so that lexicographic order matches numeric order
+fn key(i: u64) -> String {
+    format!("{i:016}")
+}
+
+fn assert_u64_table_contents(db: &Database, expected: &[(u64, u64)]) {
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), expected.len() as u64);
+    let actual: Vec<(u64, u64)> = table
+        .iter()
+        .unwrap()
+        .map(|entry| {
+            let (key, value) = entry.unwrap();
+            (key.value(), value.value())
+        })
+        .collect();
+    assert_eq!(actual, expected);
+    for (key, value) in expected {
+        assert_eq!(table.get(key).unwrap().unwrap().value(), *value);
+    }
+}
+
+#[test]
+fn bulk_load_into_empty_table() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        for i in 0..10_000 {
+            cursor.insert_before(i, &(i * 7)).unwrap();
+        }
+        cursor.close().unwrap();
+        assert_eq!(table.len().unwrap(), 10_000);
+        assert_eq!(table.get(&5432).unwrap().unwrap().value(), 5432 * 7);
+    }
+    txn.commit().unwrap();
+
+    let expected: Vec<(u64, u64)> = (0..10_000).map(|i| (i, i * 7)).collect();
+    assert_u64_table_contents(&db, &expected);
+
+    // Also readable after reopening the database
+    drop(db);
+    let db = Database::open(tmpfile.path()).unwrap();
+    assert_u64_table_contents(&db, &expected);
+}
+
+// Enough data to cross the cursor's internal buffer threshold several times,
+// so mid-load splices and reseeks are exercised through the public API.
+#[test]
+fn bulk_load_crosses_flush_threshold() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(STR_TABLE).unwrap();
+        let mut cursor = table.upper_bound_mut(Bound::<&str>::Unbounded).unwrap();
+        for i in 0..600u64 {
+            // Varying sizes exercise the leaf packing decisions
+            let value = vec![i as u8; 2000 + (i as usize % 3000)];
+            cursor
+                .insert_before(key(i).as_str(), value.as_slice())
+                .unwrap();
+        }
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(STR_TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 600);
+    for (index, entry) in table.iter().unwrap().enumerate() {
+        let (k, v) = entry.unwrap();
+        let i = index as u64;
+        assert_eq!(k.value(), key(i));
+        assert_eq!(v.value(), vec![i as u8; 2000 + (index % 3000)]);
+    }
+}
+
+// A value that does not fit in a single page must get a page of its own,
+// like `Table::insert` gives it.
+#[test]
+fn bulk_load_large_values() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(STR_TABLE).unwrap();
+        let mut cursor = table.upper_bound_mut(Bound::<&str>::Unbounded).unwrap();
+        for i in 0..20u64 {
+            let size = if i % 4 == 0 { 100_000 } else { 10 };
+            let value = vec![i as u8; size];
+            cursor
+                .insert_before(key(i).as_str(), value.as_slice())
+                .unwrap();
+        }
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(STR_TABLE).unwrap();
+    for i in 0..20u64 {
+        let size = if i % 4 == 0 { 100_000 } else { 10 };
+        let value = table.get(key(i).as_str()).unwrap().unwrap();
+        assert_eq!(value.value(), vec![i as u8; size]);
+    }
+}
+
+// Dropping the cursor splices the pending inserts, like closing it does.
+#[test]
+fn append_to_existing_table() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in 0..1000 {
+            table.insert(i, i).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        {
+            let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 999);
+            for i in 1000..2000 {
+                cursor.insert_before(i, &i).unwrap();
+            }
+        }
+        assert_eq!(table.len().unwrap(), 2000);
+    }
+    txn.commit().unwrap();
+
+    let expected: Vec<(u64, u64)> = (0..2000).map(|i| (i, i)).collect();
+    assert_u64_table_contents(&db, &expected);
+}
+
+#[test]
+fn insert_into_middle_gap() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        // Even keys, leaving odd keys insertable in the gaps
+        for i in 0..1000 {
+            table.insert(i * 2, i * 2).unwrap();
+        }
+        let mut cursor = table.lower_bound_mut(Bound::Included(&500)).unwrap();
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 498);
+        assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 500);
+        cursor.insert_before(499, &499).unwrap();
+        // The gap now sits between the new entry and 500
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 499);
+        assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 500);
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    let mut expected: Vec<(u64, u64)> = (0..1000).map(|i| (i * 2, i * 2)).collect();
+    expected.push((499, 499));
+    expected.sort_unstable();
+    assert_u64_table_contents(&db, &expected);
+}
+
+// Middle inserts under a non-rightmost branch of a taller tree exercise the
+// separator bookkeeping of the ancestor rebuild.
+#[test]
+fn insert_into_middle_of_tall_tree() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        {
+            let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            for i in 0..100_000 {
+                cursor.insert_before(i * 2, &(i * 2)).unwrap();
+            }
+        }
+        for target in [101u64, 50_001, 100_001, 150_001, 199_001] {
+            let mut cursor = table.lower_bound_mut(Bound::Included(&target)).unwrap();
+            cursor.insert_before(target, &target).unwrap();
+            cursor.close().unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let mut expected: Vec<(u64, u64)> = (0..100_000).map(|i| (i * 2, i * 2)).collect();
+    expected.extend([101u64, 50_001, 100_001, 150_001, 199_001].map(|i| (i, i)));
+    expected.sort_unstable();
+    assert_u64_table_contents(&db, &expected);
+}
+
+#[test]
+fn unordered_keys_rejected() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 20, 30] {
+            table.insert(i, i).unwrap();
+        }
+        let mut cursor = table.upper_bound_mut(Bound::Included(&20)).unwrap();
+        // Equal to either neighbor, below the gap, and above the gap all fail
+        for bad in [10u64, 15, 20, 30, 35] {
+            assert!(matches!(
+                cursor.insert_before(bad, &bad),
+                Err(StorageError::UnorderedKey)
+            ));
+        }
+        // The cursor remains usable after rejections
+        cursor.insert_before(25, &25).unwrap();
+        // Later inserts must also stay above the pending insert
+        assert!(matches!(
+            cursor.insert_before(25, &25),
+            Err(StorageError::UnorderedKey)
+        ));
+        assert!(matches!(
+            cursor.insert_before(24, &24),
+            Err(StorageError::UnorderedKey)
+        ));
+        cursor.insert_before(26, &26).unwrap();
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    let expected: Vec<(u64, u64)> = [10, 20, 25, 26, 30].iter().map(|&i| (i, i)).collect();
+    assert_u64_table_contents(&db, &expected);
+}
+
+#[test]
+fn bound_positions() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 20, 30] {
+            table.insert(i, i).unwrap();
+        }
+
+        let peeked = |cursor: &mut redb::CursorMut<'_, u64, u64>| {
+            let prev = cursor.peek_prev().unwrap().map(|(k, _)| k.value());
+            let next = cursor.peek_next().unwrap().map(|(k, _)| k.value());
+            (prev, next)
+        };
+
+        let mut cursor = table.lower_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        assert_eq!(peeked(&mut cursor), (None, Some(10)));
+        drop(cursor);
+        let mut cursor = table.lower_bound_mut(Bound::Included(&20)).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(10), Some(20)));
+        drop(cursor);
+        let mut cursor = table.lower_bound_mut(Bound::Excluded(&20)).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(20), Some(30)));
+        drop(cursor);
+        let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(30), None));
+        drop(cursor);
+        let mut cursor = table.upper_bound_mut(Bound::Included(&20)).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(20), Some(30)));
+        drop(cursor);
+        let mut cursor = table.upper_bound_mut(Bound::Excluded(&20)).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(10), Some(20)));
+        drop(cursor);
+        // A bound between entries points into the same gap either way
+        let mut cursor = table.lower_bound_mut(Bound::Included(&25)).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(20), Some(30)));
+        drop(cursor);
+        let mut cursor = table.upper_bound_mut(Bound::Included(&25)).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(20), Some(30)));
+    }
+    txn.abort().unwrap();
+}
+
+// Peeks observe pending inserts without splicing them.
+#[test]
+fn peeks_during_pending_inserts() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 30] {
+            table.insert(i, i).unwrap();
+        }
+        let mut cursor = table.upper_bound_mut(Bound::Included(&10)).unwrap();
+        cursor.insert_before(20, &200).unwrap();
+        let (prev_key, prev_value) = cursor.peek_prev().unwrap().unwrap();
+        assert_eq!(prev_key.value(), 20);
+        assert_eq!(prev_value.value(), 200);
+        drop((prev_key, prev_value));
+        assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 30);
+        cursor.insert_before(21, &210).unwrap();
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 21);
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    let expected: Vec<(u64, u64)> = vec![(10, 10), (20, 200), (21, 210), (30, 30)];
+    assert_u64_table_contents(&db, &expected);
+}
+
+#[test]
+fn peeks_on_empty_table_and_at_start() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        {
+            let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            assert!(cursor.peek_prev().unwrap().is_none());
+            assert!(cursor.peek_next().unwrap().is_none());
+            cursor.insert_before(100, &100).unwrap();
+            assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 100);
+            assert!(cursor.peek_next().unwrap().is_none());
+            cursor.close().unwrap();
+        }
+        // At the start of a non-empty table, a pending insert becomes the
+        // predecessor while the old first entry stays the successor
+        {
+            let mut cursor = table.lower_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            assert!(cursor.peek_prev().unwrap().is_none());
+            assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 100);
+            cursor.insert_before(50, &50).unwrap();
+            assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 50);
+            assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 100);
+            cursor.close().unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    assert_u64_table_contents(&db, &[(50, 50), (100, 100)]);
+}
+
+// A cursor that inserts nothing, including one whose every insert was
+// rejected, leaves the table untouched.
+#[test]
+fn empty_and_rejected_only_cursors() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        table.insert(10, 10).unwrap();
+        let cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        cursor.close().unwrap();
+        let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        assert!(matches!(
+            cursor.insert_before(10, &10),
+            Err(StorageError::UnorderedKey)
+        ));
+        cursor.close().unwrap();
+        assert_eq!(table.len().unwrap(), 1);
+    }
+    txn.commit().unwrap();
+
+    assert_u64_table_contents(&db, &[(10, 10)]);
+}
+
+// Several transactions each appending a sorted batch through a cursor: the
+// day-two shape of a bulk load.
+#[test]
+fn incremental_appends_across_transactions() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    for batch in 0..5u64 {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(U64_TABLE).unwrap();
+            let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            for i in (batch * 1000)..((batch + 1) * 1000) {
+                cursor.insert_before(i, &i).unwrap();
+            }
+            cursor.close().unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    let expected: Vec<(u64, u64)> = (0..5000).map(|i| (i, i)).collect();
+    assert_u64_table_contents(&db, &expected);
+}
+
+// An aborted transaction discards inserts spliced through a cursor.
+#[test]
+fn abort_discards_cursor_inserts() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        table.insert(1, 1).unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        for i in 2..1000 {
+            cursor.insert_before(i, &i).unwrap();
+        }
+        cursor.close().unwrap();
+    }
+    txn.abort().unwrap();
+
+    assert_u64_table_contents(&db, &[(1, 1)]);
+}


### PR DESCRIPTION
Implements the `CursorMut` direction from #1317, behind a new `experimental_cursor` feature flag. Rebased on master, so the numbers below are measured against the reverted-hint + rightmost-insert-optimization base.

## API

`Table::lower_bound_mut()` and `Table::upper_bound_mut()` return a `CursorMut` pointing at a gap between entries, modeled on the standard library's nightly `BTreeMap` cursors as closely as redb's data model allows:

```rust
let mut table = txn.open_table(TABLE)?;
let mut cursor = table.upper_bound_mut(Bound::Unbounded)?;
for (key, value) in sorted_stream {
    cursor.insert_before(key, &value)?;
}
cursor.close()?;
```

- `insert_before(key, value)` inserts into the gap and leaves the cursor after the new entry. A key that does not sort strictly between the gap's neighbors is rejected with the new `StorageError::UnorderedKey` and nothing changes, matching std's `UnorderedKeyError`; an existing key is never overwritten.
- `peek_prev()` / `peek_next()` return the gap's neighbors as `AccessGuard`s, including pending buffered inserts, without splicing them.
- `close()` splices any pending inserts and surfaces errors. Dropping the cursor also splices; a failed splice on either path poisons the write transaction, so inserts that were reported as applied can never be silently missing from a commit.

## How it works

Inserts buffer inside the cursor and are spliced into the tree a megabyte at a time: the current leaf plus the buffered inserts are packed into full leaves by the existing `build_replacement_leaves`, and the ancestor branches are rebuilt bottom-up by a new growth-shaped splice that splits branch levels and grows the root as needed, refreshing the replaced slot's separator at each level (appending raises a subtree's greatest key). While a run is open the tree is never mutated and the position never moves, the same invariant `LeafRunRewrite` relies on.

The cursor plumbing is shared with the existing removal cursors: `RangeMut` and the new `BtreeCursorMut` sit on a common `CursorTree` (root, allocator, free-list draining), the bound-to-gap conversions are shared `Position` constructors used by both, and the leaf packer is the one `retain()` already uses. The splice itself stays separate from `replace_leaf_children`: that one shrinks (parents never split, underfull results merge upward) while this one grows, and unifying them would mean teaching each the other's rebalancing.

## Numbers

1M sorted 150-byte pairs, one table, on this base (4-core machine). With the rightmost-insert optimization, plain sorted `insert()` already packs leaves densely; the cursor's remaining win is skipping the per-key descent and packing branch levels:

| | load | file | leaf pages | branch pages |
|---|---|---|---|---|
| `insert()` | 1.82s | 257 MiB | 43,479 | 945 |
| cursor | 0.89s | 257 MiB | 43,479 | 475 |

On #1322's graph benchmark (1M vertices, 8M edges as ~17M pairs across three tables in one transaction), sorted `insert()` ran 20.9-22.8s and the cursor arm 3.55-3.70s, against `append_sorted`'s 3.98-4.06s, across two runs each on the same machine -- identical leaf counts (54,862 per edge table) and 452.64 vs 456.04 MiB compacted, since the level-packed branch rebuild roughly halves branch pages and fragmentation. Timing gaps of the cursor-vs-`append_sorted` size move with the machine; the page counts and sizes are deterministic.

The benchmark suites gain a `sorted inserts` phase that loads ascending keys through the fastest sorted path each engine offers: this cursor for redb (1M pairs in ~1.0s at the end of the full `redb_benchmark` suite), `MDB_APPEND` for lmdb, ordinary inserts for the rest.

## Testing

- Unit tests on the splice machinery verify contents, stored length, per-key routing through the rebuilt separators, and checksum-tree consistency, across flush cadences, mid-leaf splices, root-leaf splits, and multi-level growth.
- Integration tests cover bulk loads crossing the buffer threshold, large values, appends across transactions, all six bound positions, peeks over pending inserts, unordered-key rejection, drop-flush, and abort.
- `cargo fmt --check`, `cargo clippy --all --all-targets` both with and without `--all-features`, `cargo test --all --all-features`, `cargo doc`, and the wasm32 `--all-features` check pass under `--deny warnings`. The lmdb append path was verified standalone against heed 0.22 (appends land in order; a non-append key errors). `cargo-fuzz` wasn't available in this environment; the harness doesn't exercise the cursor yet, so a `FuzzOperation` for it would be good follow-up.

The feature is gated because the surface is expected to evolve (`insert_after`, `remove_*`, and multimap coverage are future work); the changelog marks it unstable.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ