### PR TITLE
Add buffered insertion through a gap cursor, behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ redb-derive = { path = "./crates/redb-derive" }
 logging = ["dep:log"]
 # Enable cache hit metrics
 cache_metrics = []
+# Unstable cursor API. May change incompatibly, or be removed, in any release
+experimental_cursor = []
 
 [profile.bench]
 debug = true

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -718,6 +718,34 @@ impl OwnedEntryBuffer {
         }
     }
 
+    // Appends one pair, which must be greater than every buffered entry.
+    // Reachable only from the unit tests until the public cursor API lands.
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn push(&mut self, key: &[u8], value: &[u8]) {
+        let pair = self.store(key, value);
+        self.pairs.push_back(pair);
+    }
+
+    // Copies `range` of the leaf's pairs to the back of the buffer. The pairs
+    // must all be greater than the buffered entries.
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn extend_from_leaf_range(
+        &mut self,
+        accessor: &LeafAccessor<'_>,
+        range: Range<usize>,
+    ) {
+        self.pairs.reserve(range.len());
+        self.data
+            .reserve(accessor.length_of_pairs(range.start, range.end));
+        for index in range {
+            let entry = accessor.entry(index).unwrap();
+            let pair = self.store(entry.key(), entry.value());
+            self.pairs.push_back(pair);
+        }
+    }
+
     pub(super) fn num_pairs(&self) -> usize {
         self.pairs.len()
     }

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -336,6 +336,56 @@ impl LeafRunRewrite {
     }
 }
 
+// The threshold at which a cursor's pending inserts are spliced into the
+// tree. The splice cost is dominated by rebuilding the ancestor path, so what
+// matters is the flush count; measurements flatten out around 1MiB.
+// Reachable only from the unit tests until the public cursor API lands.
+#[cfg_attr(not(test), allow(dead_code))]
+#[cfg(feature = "experimental_cursor")]
+const INSERT_FLUSH_BYTES: usize = 1024 * 1024;
+
+// Pending inserts at the cursor's gap. The buffer holds the current leaf's
+// entries before the gap followed by the inserts, in ascending key order, so
+// the splice packs it (plus the rest of the leaf) into full leaves in one
+// parent update per flush instead of descending the tree per insert.
+//
+// While a run is open the tree is never mutated and the cursor position never
+// moves, so the position's path stays valid until the splice.
+#[cfg_attr(not(test), allow(dead_code))]
+#[cfg(feature = "experimental_cursor")]
+struct InsertRun {
+    // Key of the entry after the gap when the run opened; None when the gap
+    // is at the end of the tree. Inserts must sort strictly below it.
+    upper_key: Option<Vec<u8>>,
+    // Greatest key at or before the gap: the last insert or, before any
+    // insert, the entry preceding the gap; None at the start of the tree.
+    // Inserts must sort strictly above it.
+    previous_key: Option<Vec<u8>>,
+    entries: OwnedEntryBuffer,
+    // Buffered pairs that are new inserts; the rest were copied from the
+    // current leaf.
+    inserted_pairs: u64,
+}
+
+#[cfg(feature = "experimental_cursor")]
+impl InsertRun {
+    // True unless `key` sorts strictly between the run's bounds.
+    #[cfg_attr(not(test), allow(dead_code))]
+    fn rejects<K: Key>(&self, key: &[u8]) -> bool {
+        if let Some(previous) = &self.previous_key
+            && K::compare(key, previous).is_le()
+        {
+            return true;
+        }
+        if let Some(upper) = &self.upper_key
+            && K::compare(key, upper).is_ge()
+        {
+            return true;
+        }
+        false
+    }
+}
+
 pub(super) struct EntryRef<'a, K: Key + 'static, V: Value + 'static> {
     page: &'a PageImpl,
     key_range: Range<usize>,
@@ -525,6 +575,11 @@ pub(super) struct CursorState {
     // so it may outlive the position; it is spliced before the tree is
     // observed.
     leaf_run_rewrite: Option<LeafRunRewrite>,
+    // Pending inserts at the gap, spliced when the buffer fills or the cursor
+    // moves on. Never set by the removal-oriented cursor users. Boxed to keep
+    // the state small for those users.
+    #[cfg(feature = "experimental_cursor")]
+    insert_run: Option<Box<InsertRun>>,
 }
 
 enum LeafCloseOutcome {
@@ -624,6 +679,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         self.check_not_poisoned()?;
         assert!(self.state.leaf_run_rewrite.is_none());
         assert!(self.state.removed_indexes.is_empty());
+        #[cfg(feature = "experimental_cursor")]
+        assert!(self.state.insert_run.is_none());
         self.state.position = None;
         let Some(header) = *self.root else {
             return Ok(());
@@ -665,6 +722,10 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     // flushes its pending removals and reseeks past it in the updated tree.
     fn ensure_has_entry(&mut self, direction: Direction) -> Result<bool> {
         self.check_not_poisoned()?;
+        // Moving across a leaf edge here would invalidate an open insert
+        // run's captured position; its owner peeks the buffer instead.
+        #[cfg(feature = "experimental_cursor")]
+        assert!(self.state.insert_run.is_none());
         self.check_pending_removals(direction);
         loop {
             let Some(position) = self.state.position.as_ref() else {
@@ -951,6 +1012,10 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         self.state.position = None;
         self.state.removed_indexes.clear();
         self.state.leaf_run_rewrite = None;
+        #[cfg(feature = "experimental_cursor")]
+        {
+            self.state.insert_run = None;
+        }
     }
 
     fn check_not_poisoned(&self) -> Result {
@@ -1163,6 +1228,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     // violation would later splice through a stale path.
     fn mutate_helper<'c>(&'c mut self) -> MutateHelper<'a, 'c, K, V> {
         assert!(self.state.leaf_run_rewrite.is_none());
+        #[cfg(feature = "experimental_cursor")]
+        assert!(self.state.insert_run.is_none());
         MutateHelper::new(
             &mut *self.root,
             (*self.page_allocator).clone(),
@@ -1181,6 +1248,122 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         let path = path.into_iter().map(Branch::into_parts).collect();
         let entry = self.mutate_helper().pop_leaf_entry(leaf, path, index)?;
         Ok(Some(entry))
+    }
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[cfg(feature = "experimental_cursor")]
+impl<K: Key + 'static, V: Value + 'static> CursorMut<'_, '_, K, V> {
+    /// Buffers `key`/`value` for insertion into the gap, leaving the gap
+    /// after the new entry. Returns false, leaving the tree and any pending
+    /// inserts unchanged, unless `key` sorts strictly between the entries
+    /// adjacent to the gap.
+    pub(super) fn insert_before(&mut self, key: &[u8], value: &[u8]) -> Result<bool> {
+        self.check_not_poisoned()?;
+        assert!(self.state.removed_indexes.is_empty());
+        assert!(self.state.leaf_run_rewrite.is_none());
+        if self.state.insert_run.is_none() {
+            self.open_insert_run()?;
+        }
+        let run = self.state.insert_run.as_mut().unwrap();
+        if run.rejects::<K>(key) {
+            // A run opened just for a rejected key holds nothing; drop it
+            // again, so rejection never leaves an open run behind to trip
+            // operations that require no pending inserts.
+            if run.inserted_pairs == 0 {
+                self.state.insert_run = None;
+            }
+            return Ok(false);
+        }
+        run.entries.push(key, value);
+        run.previous_key = Some(key.to_vec());
+        run.inserted_pairs += 1;
+        if run.entries.total_bytes() >= INSERT_FLUSH_BYTES {
+            self.flush_insert_run(true)?;
+        }
+        Ok(true)
+    }
+
+    // Captures the gap's neighbor keys and the current leaf's entries before
+    // the gap. The peeks first settle a gap at the edge of two leaves on the
+    // later leaf and then back on the earlier one, so afterward the gap's
+    // remaining predecessors all sit in the current leaf before `position`,
+    // and its successors are `position..` of the current leaf plus every
+    // later leaf.
+    fn open_insert_run(&mut self) -> Result {
+        assert!(self.state.insert_run.is_none());
+        let upper_key = self.peek_next()?.map(|entry| entry.key_bytes().to_vec());
+        let previous_key = self.peek_prev()?.map(|entry| entry.key_bytes().to_vec());
+        let mut entries = OwnedEntryBuffer::default();
+        if let Some(position) = &self.state.position {
+            let accessor = LeafAccessor::new(
+                position.leaf.page.memory(),
+                K::fixed_width(),
+                V::fixed_width(),
+            );
+            entries.extend_from_leaf_range(&accessor, 0..position.leaf.position);
+        }
+        self.state.insert_run = Some(Box::new(InsertRun {
+            upper_key,
+            previous_key,
+            entries,
+            inserted_pairs: 0,
+        }));
+        Ok(())
+    }
+
+    /// Splices the pending inserts into the tree. With `reseek` the cursor is
+    /// repositioned at the gap after the last insert; without it the position
+    /// is consumed and the cursor must not be used again.
+    ///
+    /// On error the cursor is poisoned: inserts already reported to the
+    /// caller were lost, so the transaction must not commit.
+    pub(super) fn flush_insert_run(&mut self, reseek: bool) -> Result {
+        self.check_not_poisoned()?;
+        let Some(run) = self.state.insert_run.take() else {
+            return Ok(());
+        };
+        if run.inserted_pairs == 0 {
+            // No pending inserts: the tree is untouched and the position
+            // remains valid.
+            return Ok(());
+        }
+        let resume_key = run
+            .previous_key
+            .expect("a run with inserts records the last inserted key");
+        let mut entries = run.entries;
+        let replaced = if let Some(position) = self.state.position.take() {
+            // The rest of the current leaf follows every pending insert.
+            let accessor = LeafAccessor::new(
+                position.leaf.page.memory(),
+                K::fixed_width(),
+                V::fixed_width(),
+            );
+            entries.extend_from_leaf_range(&accessor, position.leaf.position..position.leaf.len);
+            let CursorPosition { path, leaf } = position;
+            let replaced_leaf = leaf.page.get_page_number();
+            // The leaf is one of the pages the splice frees, so its page
+            // reference must be released first.
+            drop(leaf);
+            Some((
+                path.into_iter().map(Branch::into_parts).collect(),
+                replaced_leaf,
+            ))
+        } else {
+            None
+        };
+        let result = self
+            .mutate_helper()
+            .splice_insert_run(replaced, &entries, run.inserted_pairs);
+        if result.is_err() {
+            // The buffered inserts were consumed and can no longer be applied.
+            self.poison();
+        }
+        result?;
+        if reseek {
+            self.seek_to(Position::After(&resume_key))?;
+        }
+        Ok(())
     }
 }
 
@@ -1697,7 +1880,7 @@ mod tests {
         AllocationPolicy, InMemoryBackend, PAGE_SIZE, PageTrackerPolicy, TransactionalMemory,
     };
 
-    fn leaf_root_with_entries(entries: &[u64]) -> (PageAllocator, PageNumber) {
+    fn test_page_allocator() -> PageAllocator {
         let mem = TransactionalMemory::new(
             Box::new(InMemoryBackend::new()),
             true,
@@ -1708,9 +1891,16 @@ mod tests {
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();
-        let mem = Arc::new(mem);
-        let page_allocator = PageAllocator::new(mem, AllocationPolicy::Default);
-        let allocated_pages = Mutex::new(PageTrackerPolicy::new_tracking());
+        PageAllocator::new(Arc::new(mem), AllocationPolicy::Default)
+    }
+
+    // The returned tracker records the built page: mutations through a cursor
+    // must share it, so the pages they free are found tracked.
+    fn leaf_root_with_entries(
+        entries: &[u64],
+    ) -> (PageAllocator, PageNumber, Arc<Mutex<PageTrackerPolicy>>) {
+        let page_allocator = test_page_allocator();
+        let allocated_pages = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
         let keys_and_values: Vec<_> = entries
             .iter()
             .map(|entry| {
@@ -1734,11 +1924,11 @@ mod tests {
         let root = page.get_page_number();
         drop(page);
 
-        (page_allocator, root)
+        (page_allocator, root, allocated_pages)
     }
 
     fn cursor_with_entries(entries: &[u64]) -> Cursor<u64, u64> {
-        let (page_allocator, root) = leaf_root_with_entries(entries);
+        let (page_allocator, root, _) = leaf_root_with_entries(entries);
         let mut cursor = Cursor::<u64, u64>::new(root, page_allocator.resolver(), PageHint::None);
         cursor.seek_to(Position::Start).unwrap();
         cursor
@@ -1772,10 +1962,9 @@ mod tests {
     // unpositioned cursor would park as Unbounded, un-consuming the entries.
     #[test]
     fn cursor_mut_stays_parked_at_tree_edge() {
-        let (page_allocator, root_page) = leaf_root_with_entries(&[1, 2, 3]);
+        let (page_allocator, root_page, allocated) = leaf_root_with_entries(&[1, 2, 3]);
         let mut root = Some(BtreeHeader::new(root_page, DEFERRED, 3));
         let mut freed = vec![];
-        let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
         let mut cursor: CursorMut<'_, '_, u64, u64> =
             CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
 
@@ -1808,15 +1997,333 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "experimental_cursor")]
+    mod insert_tests {
+        use super::*;
+        use crate::tree_store::RawBtree;
+        use crate::tree_store::btree::UntypedBtreeMut;
+
+        fn insert(cursor: &mut CursorMut<'_, '_, u64, u64>, key: u64, value: u64) -> bool {
+            cursor
+                .insert_before(u64::as_bytes(&key).as_ref(), u64::as_bytes(&value).as_ref())
+                .unwrap()
+        }
+
+        fn scan(root: Option<BtreeHeader>, page_allocator: &PageAllocator) -> Vec<(u64, u64)> {
+            let Some(header) = root else {
+                return vec![];
+            };
+            let mut cursor =
+                Cursor::<u64, u64>::new(header.root, page_allocator.resolver(), PageHint::None);
+            cursor.seek_to(Position::Start).unwrap();
+            let mut entries = vec![];
+            while let Some(entry) = cursor.next().unwrap() {
+                entries.push((entry.key(), entry.value()));
+            }
+            entries
+        }
+
+        // Full validation of a spliced tree: contents and order via a scan,
+        // stored length, per-key branch routing (which depends on the
+        // separators the splice wrote), and checksum-tree consistency.
+        fn assert_tree(
+            root: Option<BtreeHeader>,
+            page_allocator: &PageAllocator,
+            expected: &[(u64, u64)],
+        ) {
+            assert_eq!(scan(root, page_allocator), expected);
+            assert_eq!(
+                root.map_or(0, |header| header.length),
+                expected.len() as u64
+            );
+            for (key, value) in expected {
+                let mut cursor = Cursor::<u64, u64>::new(
+                    root.unwrap().root,
+                    page_allocator.resolver(),
+                    PageHint::None,
+                );
+                cursor
+                    .seek_to(Position::Before(u64::as_bytes(key).as_ref()))
+                    .unwrap();
+                let entry = cursor.next().unwrap().expect("key must route to its leaf");
+                assert_eq!(entry.key(), *key);
+                assert_eq!(entry.value(), *value);
+            }
+            let mut untyped = UntypedBtreeMut::new(
+                root,
+                page_allocator.clone(),
+                Arc::new(Mutex::new(vec![])),
+                u64::fixed_width(),
+                u64::fixed_width(),
+            );
+            let finalized = untyped.finalize_dirty_checksums().unwrap();
+            let raw = RawBtree::new(
+                finalized,
+                u64::fixed_width(),
+                u64::fixed_width(),
+                page_allocator.resolver(),
+                PageHint::None,
+            );
+            assert!(raw.verify_checksum().unwrap());
+        }
+
+        #[test]
+        fn insert_run_builds_tree_from_empty() {
+            for flush_every in [1, 3, 64] {
+                let page_allocator = test_page_allocator();
+                let mut root = None;
+                let mut freed = vec![];
+                let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+                let mut cursor: CursorMut<'_, '_, u64, u64> =
+                    CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+                cursor.seek_to(Position::End).unwrap();
+                for key in 0..2000 {
+                    assert!(insert(&mut cursor, key, key * 3));
+                    if key % flush_every == 0 {
+                        cursor.flush_insert_run(true).unwrap();
+                    }
+                }
+                cursor.flush_insert_run(true).unwrap();
+                drop(cursor);
+
+                let expected: Vec<_> = (0..2000).map(|key| (key, key * 3)).collect();
+                assert_tree(root, &page_allocator, &expected);
+            }
+        }
+
+        #[test]
+        fn insert_run_grows_multiple_levels() {
+            let page_allocator = test_page_allocator();
+            let mut root = None;
+            let mut freed = vec![];
+            let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor.seek_to(Position::End).unwrap();
+            for key in 0..60_000 {
+                assert!(insert(&mut cursor, key, key));
+                if key % 1000 == 999 {
+                    cursor.flush_insert_run(true).unwrap();
+                }
+            }
+            cursor.flush_insert_run(false).unwrap();
+            drop(cursor);
+
+            let stats = crate::tree_store::btree::btree_stats(
+                root.map(|header| header.root),
+                &page_allocator.resolver(),
+                u64::fixed_width(),
+                u64::fixed_width(),
+                PageHint::None,
+            )
+            .unwrap();
+            assert!(stats.tree_height >= 3, "height {}", stats.tree_height);
+
+            let expected: Vec<_> = (0..60_000).map(|key| (key, key)).collect();
+            assert_tree(root, &page_allocator, &expected);
+        }
+
+        #[test]
+        fn insert_run_into_leaf_middle() {
+            let existing: Vec<u64> = (0..100).map(|i| i * 10).collect();
+            let (page_allocator, root_page, allocated) = leaf_root_with_entries(&existing);
+            let mut root = Some(BtreeHeader::new(root_page, DEFERRED, existing.len() as u64));
+            let mut freed = vec![];
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor
+                .seek_to(Position::Before(u64::as_bytes(&500).as_ref()))
+                .unwrap();
+            for key in 491..500 {
+                assert!(insert(&mut cursor, key, key));
+            }
+            cursor.flush_insert_run(false).unwrap();
+            drop(cursor);
+
+            let mut expected: Vec<_> = existing.iter().map(|&key| (key, key)).collect();
+            expected.extend((491..500).map(|key| (key, key)));
+            expected.sort_unstable();
+            assert_tree(root, &page_allocator, &expected);
+        }
+
+        // Splicing many entries into a single-leaf root exercises replacing
+        // the root leaf itself and growing new levels above the replacements.
+        #[test]
+        fn insert_run_splits_root_leaf() {
+            let (page_allocator, root_page, allocated) = leaf_root_with_entries(&[0, 1_000_000]);
+            let mut root = Some(BtreeHeader::new(root_page, DEFERRED, 2));
+            let mut freed = vec![];
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor
+                .seek_to(Position::After(u64::as_bytes(&0).as_ref()))
+                .unwrap();
+            for key in 1..=10_000 {
+                assert!(insert(&mut cursor, key, key));
+            }
+            cursor.flush_insert_run(false).unwrap();
+            drop(cursor);
+
+            let mut expected = vec![(0, 0), (1_000_000, 1_000_000)];
+            expected.extend((1..=10_000).map(|key| (key, key)));
+            expected.sort_unstable();
+            assert_tree(root, &page_allocator, &expected);
+        }
+
+        // A splice under a non-rightmost branch of a height-3 tree: the
+        // rebuilt branch is not its parent's last child, so its subtree's
+        // unchanged greatest key must be recovered from the parent's
+        // separator rather than propagated as unknown.
+        #[test]
+        fn insert_run_into_middle_of_tall_tree() {
+            let page_allocator = test_page_allocator();
+            let mut root = None;
+            let mut freed = vec![];
+            let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor.seek_to(Position::End).unwrap();
+            // Even keys, leaving gaps to insert into; enough for three levels
+            for key in 0..60_000 {
+                assert!(insert(&mut cursor, key * 2, key * 2));
+                if key % 1000 == 999 {
+                    cursor.flush_insert_run(true).unwrap();
+                }
+            }
+            cursor.flush_insert_run(false).unwrap();
+            drop(cursor);
+            let stats = crate::tree_store::btree::btree_stats(
+                root.map(|header| header.root),
+                &page_allocator.resolver(),
+                u64::fixed_width(),
+                u64::fixed_width(),
+                PageHint::None,
+            )
+            .unwrap();
+            assert!(stats.tree_height >= 3, "height {}", stats.tree_height);
+
+            // Gaps chosen to land under leaves in the interior of the tree
+            let mut expected: Vec<(u64, u64)> = (0..60_000).map(|key| (key * 2, key * 2)).collect();
+            for target in [1001u64, 30_001, 60_001, 90_001, 119_001] {
+                let mut cursor: CursorMut<'_, '_, u64, u64> =
+                    CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+                cursor
+                    .seek_to(Position::Before(u64::as_bytes(&target).as_ref()))
+                    .unwrap();
+                assert!(insert(&mut cursor, target, target));
+                cursor.flush_insert_run(false).unwrap();
+                drop(cursor);
+                expected.push((target, target));
+            }
+            expected.sort_unstable();
+            assert_tree(root, &page_allocator, &expected);
+        }
+
+        // Once a splice's replacement collapses to a single node, the
+        // ancestors take the deletion path's child-pointer swap, writing
+        // uncommitted pages in place instead of rebuilding the spine. The
+        // second splice below lands in a leaf rebalanced by the first, so it
+        // replaces one leaf with one leaf and must leave the root page --
+        // and everything else above the leaf's parent -- untouched.
+        #[test]
+        fn insert_run_swaps_ancestors_in_place() {
+            let page_allocator = test_page_allocator();
+            let mut root = None;
+            let mut freed = vec![];
+            let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor.seek_to(Position::End).unwrap();
+            // Even keys, leaving gaps to insert into; enough for three levels
+            for key in 0..60_000 {
+                assert!(insert(&mut cursor, key * 2, key * 2));
+                if key % 1000 == 999 {
+                    cursor.flush_insert_run(true).unwrap();
+                }
+            }
+            cursor.flush_insert_run(false).unwrap();
+            drop(cursor);
+            let stats = crate::tree_store::btree::btree_stats(
+                root.map(|header| header.root),
+                &page_allocator.resolver(),
+                u64::fixed_width(),
+                u64::fixed_width(),
+                PageHint::None,
+            )
+            .unwrap();
+            assert!(stats.tree_height >= 3, "height {}", stats.tree_height);
+
+            // The first splice splits a packed-full leaf, rebalancing the
+            // pieces; root stability is not guaranteed here, since the
+            // parent may split as well.
+            for target in [30_001u64, 30_003] {
+                let root_before = root.map(|header| header.root);
+                let mut cursor: CursorMut<'_, '_, u64, u64> =
+                    CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+                cursor
+                    .seek_to(Position::Before(u64::as_bytes(&target).as_ref()))
+                    .unwrap();
+                assert!(insert(&mut cursor, target, target));
+                cursor.flush_insert_run(false).unwrap();
+                drop(cursor);
+                if target == 30_003 {
+                    assert_eq!(root.map(|header| header.root), root_before);
+                }
+            }
+
+            let mut expected: Vec<(u64, u64)> = (0..60_000).map(|key| (key * 2, key * 2)).collect();
+            expected.push((30_001, 30_001));
+            expected.push((30_003, 30_003));
+            expected.sort_unstable();
+            assert_tree(root, &page_allocator, &expected);
+        }
+
+        #[test]
+        fn insert_run_rejects_unordered_keys() {
+            let (page_allocator, root_page, allocated) = leaf_root_with_entries(&[10, 20, 30]);
+            let mut root = Some(BtreeHeader::new(root_page, DEFERRED, 3));
+            let mut freed = vec![];
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor
+                .seek_to(Position::After(u64::as_bytes(&20).as_ref()))
+                .unwrap();
+            // Equal to the previous entry, below it, equal to the next entry,
+            // and above it are all rejected.
+            assert!(!insert(&mut cursor, 20, 20));
+            assert!(!insert(&mut cursor, 15, 15));
+            assert!(!insert(&mut cursor, 30, 30));
+            assert!(!insert(&mut cursor, 35, 35));
+            // Rejections that leave no pending inserts also drop the run they
+            // opened, keeping operations that require no pending inserts
+            // available; seek_to asserts exactly that.
+            assert!(cursor.state.insert_run.is_none());
+            cursor
+                .seek_to(Position::After(u64::as_bytes(&20).as_ref()))
+                .unwrap();
+            assert!(insert(&mut cursor, 25, 25));
+            // Inserts must also stay above the pending insert.
+            assert!(!insert(&mut cursor, 25, 25));
+            assert!(!insert(&mut cursor, 24, 24));
+            // A rejection with inserts pending must keep the run open.
+            assert!(cursor.state.insert_run.is_some());
+            assert!(insert(&mut cursor, 26, 26));
+            cursor.flush_insert_run(false).unwrap();
+            drop(cursor);
+
+            let expected = [10, 20, 25, 26, 30].map(|key| (key, key));
+            assert_tree(root, &page_allocator, &expected);
+        }
+    }
+
     // Once poisoned, every cursor operation re-raises instead of touching the
     // tree, so removals stranded by the original error can never be observed
     // as applied.
     #[test]
     fn poisoned_cursor_mut_re_raises() {
-        let (page_allocator, root_page) = leaf_root_with_entries(&[1, 2, 3]);
+        let (page_allocator, root_page, allocated) = leaf_root_with_entries(&[1, 2, 3]);
         let mut root = Some(BtreeHeader::new(root_page, DEFERRED, 3));
         let mut freed = vec![];
-        let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
         let mut cursor: CursorMut<'_, '_, u64, u64> =
             CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
 

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "experimental_cursor")]
+use crate::tree_store::btree_base::RawBranchBuilder;
 use crate::tree_store::btree_base::{
     BRANCH, BranchAccessor, BranchBuilder, BranchMutator, Checksum, DEFERRED, LEAF, LeafAccessor,
     LeafBuilder, LeafMutator, OwnedEntryBuffer, is_single_large_value, leaf_below_merge_threshold,
@@ -57,6 +59,14 @@ impl DeletedPairs {
         }
     }
 }
+
+// A page produced while splicing an insert run into the tree, with its
+// subtree's greatest key. The key is None only for the node whose subtree
+// contains the tree's original last entry, which stays last at every level.
+// Reachable only from the unit tests until the public cursor API lands.
+#[cfg_attr(not(test), allow(dead_code))]
+#[cfg(feature = "experimental_cursor")]
+type SplicedNode = (PageNumber, Checksum, Option<Vec<u8>>);
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum LeafDeleteDisposition {
@@ -454,6 +464,210 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             leaves.push((page2.get_page_number(), entries[range.end - 1].0.to_vec()));
         }
         Ok(leaves)
+    }
+
+    // Replaces the leaf at the end of `path` (all of the tree when `replaced`
+    // is None) with packed leaves built from `entries`, rebuilding the
+    // ancestor branches bottom-up. Unlike `replace_leaf_children`, the
+    // replacements can outnumber what they replace, so branches split on the
+    // way up and the root grows new levels; the separator for the replaced
+    // slot is refreshed at every level, since inserting can raise a subtree's
+    // greatest key. Ancestors above the level where the replacements collapse
+    // back to a single node take the deletion path's child-pointer swap
+    // instead of a rebuild.
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn splice_insert_run(
+        &mut self,
+        replaced: Option<(Vec<(PageImpl, usize)>, PageNumber)>,
+        entries: &OwnedEntryBuffer,
+        inserted_pairs: u64,
+    ) -> Result {
+        assert!(entries.num_pairs() > 0);
+        assert_eq!(replaced.is_some(), self.root.is_some());
+        let length = self.root.map_or(0, |header| header.length);
+        let leaves = self.build_replacement_leaves(entries)?;
+        let mut nodes: Vec<SplicedNode> = leaves
+            .into_iter()
+            .map(|(page, greatest_key)| (page, DEFERRED, Some(greatest_key)))
+            .collect();
+        // Freed only after every fallible step, so an error never leaves the
+        // surviving root referencing a freed page.
+        let mut removed_pages = vec![];
+        if let Some((path, replaced_leaf)) = replaced {
+            removed_pages.push(replaced_leaf);
+            for (page, child_index) in path.into_iter().rev() {
+                // Once the replacement has collapsed to a single node whose
+                // stored separator is still exact, the remaining ancestors
+                // need only their child pointer replaced. This shares the
+                // deletion path's pointer swap, whose in-place write for
+                // uncommitted pages keeps repeated flushes from rebuilding
+                // the whole spine.
+                if nodes.len() == 1 {
+                    let accessor = BranchAccessor::new(&page, K::fixed_width());
+                    let stored = accessor.key(child_index);
+                    let separator = nodes[0].2.as_deref();
+                    // Exact when the node kept its subtree's original bound
+                    // (None), when the stored separator already equals the
+                    // new bound, or when the slot is the branch's last child
+                    // and stores no separator at all.
+                    if separator.is_none() || stored.is_none() || stored == separator {
+                        // With no stored separator, a raised bound must keep
+                        // propagating; a matching stored separator proves the
+                        // bound unchanged, which None expresses upward.
+                        let carried = if stored.is_none() {
+                            std::mem::take(&mut nodes[0].2)
+                        } else {
+                            None
+                        };
+                        let original = page.get_page_number();
+                        let (new_page, replaced_page) =
+                            self.replace_branch_child(page, child_index, nodes[0].0)?;
+                        if replaced_page {
+                            removed_pages.push(original);
+                        }
+                        nodes[0] = (new_page, DEFERRED, carried);
+                        continue;
+                    }
+                }
+                nodes = self.rebuild_branch_level(&page, child_index, nodes)?;
+                removed_pages.push(page.get_page_number());
+                drop(page);
+            }
+        }
+        while nodes.len() > 1 {
+            nodes = self.build_branch_nodes(&nodes)?;
+        }
+        let (root, _, _) = nodes.pop().unwrap();
+        *self.root = Some(BtreeHeader::new(root, DEFERRED, length + inserted_pairs));
+        for page_number in removed_pages {
+            self.conditional_free(page_number);
+        }
+        Ok(())
+    }
+
+    // Rebuilds one branch of the path, with `replacement` in place of
+    // `child_index`. Returns the built pages, more than one if the level had
+    // to split.
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(feature = "experimental_cursor")]
+    fn rebuild_branch_level(
+        &mut self,
+        parent: &PageImpl,
+        child_index: usize,
+        mut replacement: Vec<SplicedNode>,
+    ) -> Result<Vec<SplicedNode>> {
+        let accessor = BranchAccessor::new(parent, K::fixed_width());
+        let count = accessor.count_children();
+        assert!(child_index < count);
+        // A replacement ending in None kept the replaced subtree's original
+        // last entry, whose key the lower level does not store: this level's
+        // separator for the slot is exactly that unchanged bound. It stays
+        // None only for the parent's own last child, so after this, None
+        // appears only at the end of the level.
+        if let Some(last) = replacement.last_mut()
+            && last.2.is_none()
+        {
+            last.2 = accessor.key(child_index).map(<[u8]>::to_vec);
+        }
+        // Preserved children keep their checksum, and reuse the original
+        // separator as their greatest key; only the original last child's is
+        // unknown (None), and it stays last through every rebuild above.
+        let preserved = |i: usize| {
+            (
+                accessor.child_page(i).unwrap(),
+                accessor.child_checksum(i).unwrap(),
+                accessor.key(i).map(<[u8]>::to_vec),
+            )
+        };
+        let mut children = Vec::with_capacity(count - 1 + replacement.len());
+        children.extend((0..child_index).map(preserved));
+        children.extend(replacement);
+        children.extend(((child_index + 1)..count).map(preserved));
+        self.build_branch_nodes(&children)
+    }
+
+    // Packs `children` into as many branch pages as they require, in order.
+    // Mirrors `build_replacement_leaves`: cut a page whenever the next child
+    // would not fit, except that a page must keep at least two children, so
+    // the tail is merged into its neighbor instead of rebalanced.
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(feature = "experimental_cursor")]
+    fn build_branch_nodes(&mut self, children: &[SplicedNode]) -> Result<Vec<SplicedNode>> {
+        fn separator(node: &SplicedNode) -> &[u8] {
+            node.2
+                .as_deref()
+                .expect("only the last child of a level may lack a separator")
+        }
+
+        assert!(children.len() >= 2);
+        let page_size = self.page_allocator.get_page_size();
+
+        let mut plan: Vec<Range<usize>> = vec![];
+        let mut start = 0;
+        let mut key_bytes = 0;
+        for index in 1..children.len() {
+            // Extending the page to `children[index]` stores the separator of
+            // the previously-last child.
+            let separator_bytes = separator(&children[index - 1]).len();
+            let required = RawBranchBuilder::required_bytes(
+                index - start,
+                key_bytes + separator_bytes,
+                K::fixed_width(),
+            );
+            // num_keys is stored as a u16, so the page must also be cut before
+            // it would exceed u16::MAX keys, even when the bytes still fit
+            // (possible with large pages); otherwise build() would panic in
+            // RawBranchBuilder::new.
+            let too_many_keys = index - start > usize::from(u16::MAX);
+            if (required > page_size || too_many_keys) && index - start >= 2 {
+                plan.push(start..index);
+                start = index;
+                key_bytes = 0;
+            } else {
+                key_bytes += separator_bytes;
+            }
+        }
+        plan.push(start..children.len());
+        // A single child cannot form a branch page; put it back with its
+        // neighbor, slightly overfilling that page. If the neighbor is at the
+        // u16::MAX key limit, take its last child instead, so both pages stay
+        // within the limit.
+        if plan.last().unwrap().len() == 1 && plan.len() >= 2 {
+            let last = plan.pop().unwrap();
+            let previous = plan.last_mut().unwrap();
+            if previous.len() > usize::from(u16::MAX) {
+                previous.end -= 1;
+                let tail = previous.end..last.end;
+                plan.push(tail);
+            } else {
+                previous.end = last.end;
+            }
+        }
+
+        let mut nodes = Vec::with_capacity(plan.len());
+        for range in plan {
+            let chunk = &children[range];
+            let mut builder = BranchBuilder::new(
+                &self.page_allocator,
+                &self.allocated,
+                chunk.len(),
+                K::fixed_width(),
+            );
+            for (page, checksum, _) in chunk {
+                builder.push_child(*page, *checksum);
+            }
+            for node in &chunk[..chunk.len() - 1] {
+                builder.push_key(separator(node));
+            }
+            let page = builder.build()?;
+            nodes.push((
+                page.get_page_number(),
+                DEFERRED,
+                chunk.last().unwrap().2.clone(),
+            ));
+        }
+        Ok(nodes)
     }
 
     #[allow(clippy::type_complexity)]
@@ -1181,47 +1395,67 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         Ok((final_result, found))
     }
 
+    // Replaces the child pointer at `child_index` with `new_child` (checksum
+    // DEFERRED), leaving every other entry -- including the slot's separator
+    // key -- untouched; the caller must know the stored separator is still
+    // exact. Writes in place when the branch page is uncommitted. Returns the
+    // branch's resulting page number, and whether it is a new page whose
+    // predecessor the caller must free.
+    fn replace_branch_child(
+        &mut self,
+        page: PageImpl,
+        child_index: usize,
+        new_child: PageNumber,
+    ) -> Result<(PageNumber, bool)> {
+        let accessor = BranchAccessor::new(&page, K::fixed_width());
+        let original_page_number = page.get_page_number();
+        let child_page_number = accessor.child_page(child_index).unwrap();
+        let child_checksum = accessor.child_checksum(child_index).unwrap();
+        // Skip-path: the child's in-parent entry is already (child_page_number, DEFERRED)
+        // and the mutated child kept its page number, so no write to this branch is needed.
+        // This preserves the optimization from f8ccc39 without carrying a checksum on
+        // `Subtree` (a modified `Subtree` always has checksum DEFERRED).
+        if new_child == child_page_number && child_checksum == DEFERRED {
+            return Ok((original_page_number, false));
+        }
+
+        if self.page_allocator.uncommitted(original_page_number) {
+            drop(page);
+            let mut mutpage = self.page_allocator.get_page_mut(original_page_number)?;
+            let mut mutator = BranchMutator::new(mutpage.memory_mut());
+            mutator.write_child_page(child_index, new_child, DEFERRED);
+            Ok((original_page_number, false))
+        } else {
+            let mut builder = BranchBuilder::new(
+                &self.page_allocator,
+                &self.allocated,
+                accessor.count_children(),
+                K::fixed_width(),
+            );
+            builder.push_all(&accessor);
+            builder.replace_child(child_index, new_child, DEFERRED);
+            let new_page = builder.build()?;
+            Ok((new_page.get_page_number(), true))
+        }
+    }
+
     fn apply_child_deletion_result(
         &mut self,
         page: PageImpl,
         child_index: usize,
         result: DeletionResult,
     ) -> Result<DeletionResult> {
-        let accessor = BranchAccessor::new(&page, K::fixed_width());
         let original_page_number = page.get_page_number();
-        let child_page_number = accessor.child_page(child_index).unwrap();
-        let child_checksum = accessor.child_checksum(child_index).unwrap();
         if let Subtree(new_child) = result {
-            // Skip-path: the child's in-parent entry is already (child_page_number, DEFERRED)
-            // and the mutated child kept its page number, so no write to this branch is needed.
-            // This preserves the optimization from f8ccc39 without carrying a checksum on
-            // `Subtree` (a modified `Subtree` always has checksum DEFERRED).
-            if new_child == child_page_number && child_checksum == DEFERRED {
-                return Ok(Subtree(original_page_number));
-            }
-
-            let result_page = if self.page_allocator.uncommitted(original_page_number) {
-                drop(page);
-                let mut mutpage = self.page_allocator.get_page_mut(original_page_number)?;
-                let mut mutator = BranchMutator::new(mutpage.memory_mut());
-                mutator.write_child_page(child_index, new_child, DEFERRED);
-                original_page_number
-            } else {
-                let mut builder = BranchBuilder::new(
-                    &self.page_allocator,
-                    &self.allocated,
-                    accessor.count_children(),
-                    K::fixed_width(),
-                );
-                builder.push_all(&accessor);
-                builder.replace_child(child_index, new_child, DEFERRED);
-                let new_page = builder.build()?;
+            let (result_page, replaced) =
+                self.replace_branch_child(page, child_index, new_child)?;
+            if replaced {
                 self.conditional_free(original_page_number);
-                new_page.get_page_number()
-            };
+            }
             return Ok(Subtree(result_page));
         }
 
+        let accessor = BranchAccessor::new(&page, K::fixed_width());
         // Child is requesting to be merged with a sibling
         let mut builder = BranchBuilder::new(
             &self.page_allocator,
@@ -1523,5 +1757,101 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             BRANCH => self.delete_branch_helper(page, key, allow_in_place),
             _ => unreachable!(),
         }
+    }
+}
+
+#[cfg(all(test, feature = "experimental_cursor"))]
+mod tests {
+    use super::*;
+    use crate::tree_store::{AllocationPolicy, InMemoryBackend, TransactionalMemory};
+
+    const MAX_KEYS: usize = u16::MAX as usize;
+
+    // Large enough that MAX_KEYS + 2 children with 8-byte keys fit in one
+    // page by bytes, so only the key count can force a cut.
+    const HUGE_PAGE: usize = 4 * 1024 * 1024;
+
+    fn make_allocator_with_page_size(page_size: usize) -> PageAllocator {
+        let mem = TransactionalMemory::new(
+            Box::new(InMemoryBackend::new()),
+            true,
+            page_size,
+            None,
+            0,
+            false,
+        )
+        .unwrap();
+        mem.reset_allocator_state().unwrap();
+        PageAllocator::new(Arc::new(mem), AllocationPolicy::Default)
+    }
+
+    // Children as build_branch_nodes receives them: ascending separators,
+    // with only the level's last child lacking one.
+    fn synthetic_children(count: u32) -> Vec<SplicedNode> {
+        (0..count)
+            .map(|i| {
+                let separator = (i != count - 1).then(|| u64::from(i).to_le_bytes().to_vec());
+                (PageNumber::new(0, i, 0), DEFERRED, separator)
+            })
+            .collect()
+    }
+
+    fn pack_branches(children: &[SplicedNode], page_allocator: &PageAllocator) -> Vec<SplicedNode> {
+        let mut root = None;
+        let mut freed = vec![];
+        let mut helper: MutateHelper<'_, '_, u64, u64> = MutateHelper::new(
+            &mut root,
+            page_allocator.clone(),
+            &mut freed,
+            Arc::new(Mutex::new(PageTrackerPolicy::new_tracking())),
+        );
+        helper.build_branch_nodes(children).unwrap()
+    }
+
+    fn count_children(page_allocator: &PageAllocator, node: &SplicedNode) -> usize {
+        let page = page_allocator.get_page(node.0, PageHint::None).unwrap();
+        BranchAccessor::new(&page, u64::fixed_width()).count_children()
+    }
+
+    // num_keys is stored as a u16. With a page large enough that the byte
+    // condition never cuts, the packer must cut on the key count instead of
+    // building a branch that RawBranchBuilder::new cannot represent. The cut
+    // leaves a single-child tail here, whose neighbor is already at the
+    // limit: merging would overflow it, so the tail takes the neighbor's
+    // last child instead.
+    #[test]
+    fn branch_packing_splits_at_max_keys() {
+        let page_allocator = make_allocator_with_page_size(HUGE_PAGE);
+        let children = synthetic_children(u32::try_from(MAX_KEYS).unwrap() + 2);
+        let nodes = pack_branches(&children, &page_allocator);
+
+        assert_eq!(nodes.len(), 2);
+        let first = count_children(&page_allocator, &nodes[0]);
+        let second = count_children(&page_allocator, &nodes[1]);
+        assert_eq!(first, MAX_KEYS);
+        assert_eq!(second, 2);
+        // Each node's separator is its last child's; the level's last child
+        // keeps None.
+        assert_eq!(nodes[0].2, children[first - 1].2);
+        assert!(nodes[1].2.is_none());
+        // The second page holds the stolen child and the orphan, with the
+        // stolen child's separator between them.
+        let page = page_allocator.get_page(nodes[1].0, PageHint::None).unwrap();
+        let accessor = BranchAccessor::new(&page, u64::fixed_width());
+        assert_eq!(accessor.child_page(0).unwrap(), children[first].0);
+        assert_eq!(accessor.child_page(1).unwrap(), children[first + 1].0);
+        assert_eq!(accessor.key(0), children[first].2.as_deref());
+    }
+
+    // The boundary case: exactly u16::MAX keys still packs into one page.
+    #[test]
+    fn branch_packing_fills_page_to_max_keys() {
+        let page_allocator = make_allocator_with_page_size(HUGE_PAGE);
+        let children = synthetic_children(u32::try_from(MAX_KEYS).unwrap() + 1);
+        let nodes = pack_branches(&children, &page_allocator);
+
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(count_children(&page_allocator, &nodes[0]), children.len());
+        assert!(nodes[0].2.is_none());
     }
 }


### PR DESCRIPTION
Third slice of splitting up #1323, now targeting master.

The machinery for the cursor API discussed in #1317, gated behind a new `experimental_cursor` feature flag, without the public surface yet. This is the slice that deserves the most careful review:

- The internal `CursorMut::insert_before()` buffers pairs that sort into its gap (checked against the gap's captured neighbors), opening a run that copies the current leaf's entries before the gap. While a run is open the tree is never mutated and the position never moves -- the invariant `LeafRunRewrite` already relies on -- so the captured path stays valid for the splice.
- At 1MiB the run is spliced by a new growth-shaped `splice_insert_run`: the buffer (current leaf included) is packed into full leaves by the existing `build_replacement_leaves`, and ancestor branches are rebuilt bottom-up, splitting levels and growing the root as needed. Each level refreshes the replaced slot's separator, since inserting can raise a subtree's greatest key; a slot whose subtree kept its original greatest entry recovers the bound from the parent's stored separator (the case Codex flagged on #1323, with its regression tests included here).
- A failed splice poisons the cursor: inserts already reported to the caller were lost, so the transaction must not commit.
- The splice stays separate from `replace_leaf_children`: that one shrinks (parents never split, underfull results merge upward) while this one grows, and unifying them would mean teaching each the other's rebalancing.

Until the public API lands in #1327 the machinery is reachable only from its unit tests (temporary `cfg_attr(not(test), allow(dead_code))` markers, removed there). The tests cover flush cadences, splices into leaf middles and under non-rightmost branches of taller trees, root-leaf splits, multi-level growth, and out-of-order rejection, verifying contents, stored length, per-key routing through the rebuilt separators, and checksum-tree consistency.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ