### PR TITLE
Add the experimental CursorMut API for bulk loading sorted data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 4.2.0 - 2026-XX-XX
 * Fix a panic when opening a database containing a corrupted persistent savepoint record;
   `StorageError::Corrupted` is now returned instead.
+* Add an experimental cursor API, behind the `experimental_cursor` feature flag:
+  `Table::lower_bound_mut()` and `Table::upper_bound_mut()` return a `CursorMut` pointing at a gap
+  between entries, modeled on the standard library's `BTreeMap` cursors. Its `insert_before()`
+  method makes bulk loading sorted data much faster than `insert()`. The feature is unstable and
+  may change incompatibly, or be removed, in any release.
 * Fix `WriteTransaction::stats()` returning garbage statistics, or panicking when debug assertions
   are enabled, when called while a table is open and modified in the same transaction.
 * Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. A live

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,6 +17,7 @@ rand_distr = "0.6"
 
 [dependencies.redb]
 path = ".."
+features = ["experimental_cursor"]
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -9,7 +9,7 @@ const MAX_CRASH_OPS: u64 = 20;
 const MAX_CACHE_SIZE: usize = 100_000_000;
 // Limit values to 100KiB
 const MAX_VALUE_SIZE: usize = 100_000;
-const KEY_SPACE: u64 = 1_000_000;
+pub(crate) const KEY_SPACE: u64 = 1_000_000;
 pub const MAX_SAVEPOINTS: usize = 6;
 
 #[derive(Debug, Clone)]
@@ -114,6 +114,15 @@ pub(crate) enum FuzzOperation {
     },
     InsertReserve {
         key: BoundedU64<KEY_SPACE>,
+        value_size: BinomialDifferenceBoundedUSize<MAX_VALUE_SIZE>,
+    },
+    // Keys are derived from the gap around start_key in the reference model,
+    // since the cursor rejects keys that do not sort into its gap; rejection
+    // itself is covered by unit tests.
+    CursorInsert {
+        start_key: BoundedU64<KEY_SPACE>,
+        count: U64Between<0, 64>,
+        stride: U64Between<1, 8>,
         value_size: BinomialDifferenceBoundedUSize<MAX_VALUE_SIZE>,
     },
     Remove {

--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -3,13 +3,14 @@
 use libfuzzer_sys::fuzz_target;
 use redb::{
     AccessGuard, Database, Durability, Error, MultimapTable, MultimapTableDefinition,
-    MultimapValue, ReadableDatabase, ReadableMultimapTable, ReadableTable, ReadableTableMetadata, Savepoint,
-    StorageBackend, Table, TableDefinition, WriteTransaction,
+    MultimapValue, ReadableDatabase, ReadableMultimapTable, ReadableTable, ReadableTableMetadata,
+    Savepoint, StorageBackend, Table, TableDefinition, WriteTransaction,
 };
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::fs::{File, OpenOptions};
 use std::io::{ErrorKind, Read, Seek, SeekFrom};
+use std::ops::Bound;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tempfile::NamedTempFile;
@@ -337,6 +338,9 @@ fn handle_multimap_table_op(
         FuzzOperation::InsertReserve { .. } => {
             // no-op. Multimap tables don't support insert_reserve
         }
+        FuzzOperation::CursorInsert { .. } => {
+            // no-op. Multimap tables don't support cursors
+        }
         FuzzOperation::Remove { key } => {
             let key = key.value;
             let entry = reference.remove(&key);
@@ -519,6 +523,39 @@ fn handle_table_op(
             let mut value = table.insert_reserve(&key, value_size)?;
             value.as_mut().fill(0xFF);
             reference.insert(key, value_size);
+        }
+        FuzzOperation::CursorInsert {
+            start_key,
+            count,
+            stride,
+            value_size,
+        } => {
+            let start = start_key.value;
+            let stride = stride.value;
+            let value_size = value_size.value as usize;
+            let value = vec![0xFF; value_size];
+            // The gap before the smallest key >= start: its neighbors in the
+            // reference bound the keys the cursor accepts.
+            let successor = reference.range(start..).next().map(|(k, _)| *k);
+            let predecessor = reference.range(..start).next_back().map(|(k, _)| *k);
+            let keys: Vec<u64> = (0..count.value)
+                .map(|i| start + i * stride)
+                .take_while(|k| *k < KEY_SPACE && successor.is_none_or(|s| *k < s))
+                .collect();
+            let mut cursor = table.lower_bound_mut(Bound::Included(&start))?;
+            assert_eq!(cursor.peek_prev()?.map(|(k, _)| k.value()), predecessor);
+            assert_eq!(cursor.peek_next()?.map(|(k, _)| k.value()), successor);
+            for key in &keys {
+                cursor.insert_before(key, value.as_slice())?;
+            }
+            // Peeks observe pending inserts without splicing them
+            let last = keys.last().copied().or(predecessor);
+            assert_eq!(cursor.peek_prev()?.map(|(k, _)| k.value()), last);
+            assert_eq!(cursor.peek_next()?.map(|(k, _)| k.value()), successor);
+            cursor.close()?;
+            for key in keys {
+                reference.insert(key, value_size);
+            }
         }
         FuzzOperation::Remove { key } | FuzzOperation::RemoveOne { key, .. } => {
             let key = key.value;

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,9 @@ pub enum StorageError {
     Corrupted(String),
     /// The value being inserted exceeds the maximum of 3GiB
     ValueTooLarge(usize),
+    /// The key does not sort strictly between the entries adjacent to the cursor
+    #[cfg(feature = "experimental_cursor")]
+    UnorderedKey,
     Io(io::Error),
     PreviousIo,
     DatabaseClosed,
@@ -35,6 +38,8 @@ impl From<StorageError> for Error {
         match err {
             StorageError::Corrupted(msg) => Error::Corrupted(msg),
             StorageError::ValueTooLarge(x) => Error::ValueTooLarge(x),
+            #[cfg(feature = "experimental_cursor")]
+            StorageError::UnorderedKey => Error::UnorderedKey,
             StorageError::Io(x) => Error::Io(x),
             StorageError::PreviousIo => Error::PreviousIo,
             StorageError::DatabaseClosed => Error::DatabaseClosed,
@@ -54,6 +59,13 @@ impl Display for StorageError {
                     f,
                     "The value (length={len}) being inserted exceeds the maximum of {}GiB",
                     MAX_VALUE_LENGTH / 1024 / 1024 / 1024
+                )
+            }
+            #[cfg(feature = "experimental_cursor")]
+            StorageError::UnorderedKey => {
+                write!(
+                    f,
+                    "The key does not sort strictly between the entries adjacent to the cursor"
                 )
             }
             StorageError::Io(err) => {
@@ -540,6 +552,9 @@ pub enum Error {
     UpgradeRequired(u8),
     /// The value being inserted exceeds the maximum of 3GiB
     ValueTooLarge(usize),
+    /// The key does not sort strictly between the entries adjacent to the cursor
+    #[cfg(feature = "experimental_cursor")]
+    UnorderedKey,
     /// Table types didn't match.
     TableTypeMismatch {
         table: String,
@@ -600,6 +615,13 @@ impl Display for Error {
                     f,
                     "The value (length={len}) being inserted exceeds the maximum of {}GiB",
                     MAX_VALUE_LENGTH / 1024 / 1024 / 1024
+                )
+            }
+            #[cfg(feature = "experimental_cursor")]
+            Error::UnorderedKey => {
+                write!(
+                    f,
+                    "The key does not sort strictly between the entries adjacent to the cursor"
                 )
             }
             Error::TypeDefinitionChanged {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,8 @@ pub use multimap_table::{
     MultimapRange, MultimapTable, MultimapValue, OwnedMultimapRange, OwnedMultimapValue,
     ReadOnlyMultimapTable, ReadOnlyUntypedMultimapTable, ReadableMultimapTable,
 };
+#[cfg(feature = "experimental_cursor")]
+pub use table::CursorMut;
 pub use table::{
     Entry, ExtractIf, OccupiedEntry, OwnedAccessGuard, OwnedRange, Range, ReadOnlyTable,
     ReadOnlyUntypedTable, ReadableTable, ReadableTableMetadata, Table, TableStats, VacantEntry,

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,5 +1,7 @@
 use crate::db::TransactionGuard;
 use crate::sealed::Sealed;
+#[cfg(feature = "experimental_cursor")]
+use crate::tree_store::BtreeCursorMut;
 use crate::tree_store::{
     AccessGuardMutInPlace, Btree, BtreeCursorRange, BtreeExtractIf, BtreeHeader, BtreeMut,
     MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PageAllocator, PageHint, PageNumber, PageResolver,
@@ -11,6 +13,8 @@ use crate::{Result, TableHandle};
 use std::borrow::Borrow;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
+#[cfg(feature = "experimental_cursor")]
+use std::ops::Bound;
 use std::ops::RangeBounds;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -268,6 +272,87 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         key: impl Borrow<K::SelfType<'a>>,
     ) -> Result<Option<AccessGuard<'_, V>>> {
         self.tree.remove(key.borrow())
+    }
+
+    /// Returns a [`CursorMut`] pointing at the gap before the smallest key
+    /// greater than the given bound.
+    ///
+    /// Passing `Bound::Included(x)` will return a cursor pointing to the gap
+    /// before the smallest key greater than or equal to `x`.
+    ///
+    /// Passing `Bound::Excluded(x)` will return a cursor pointing to the gap
+    /// before the smallest key greater than `x`.
+    ///
+    /// Passing `Bound::Unbounded` will return a cursor pointing to the gap
+    /// before the smallest key in the table.
+    ///
+    /// This is analogous to [`std::collections::BTreeMap::lower_bound_mut`].
+    #[cfg(feature = "experimental_cursor")]
+    pub fn lower_bound_mut<'a>(
+        &mut self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<CursorMut<'_, K, V>> {
+        let bound = bound_to_bytes::<K, _>(&bound);
+        let mut inner = self.tree.cursor_mut();
+        inner.seek_lower_bound(bound.as_ref().map(|bytes| bytes.as_slice()))?;
+        Ok(CursorMut::new(inner, self.transaction))
+    }
+
+    /// Returns a [`CursorMut`] pointing at the gap after the greatest key
+    /// smaller than the given bound.
+    ///
+    /// Passing `Bound::Included(x)` will return a cursor pointing to the gap
+    /// after the greatest key smaller than or equal to `x`.
+    ///
+    /// Passing `Bound::Excluded(x)` will return a cursor pointing to the gap
+    /// after the greatest key smaller than `x`.
+    ///
+    /// Passing `Bound::Unbounded` will return a cursor pointing to the gap
+    /// after the greatest key in the table.
+    ///
+    /// This is analogous to [`std::collections::BTreeMap::upper_bound_mut`].
+    ///
+    /// # Examples
+    ///
+    /// Inserting a stream of ascending keys through the gap at the end of
+    /// the table:
+    ///
+    /// ```rust
+    /// use std::ops::Bound;
+    /// use redb::{Database, Error, ReadableTableMetadata, TableDefinition};
+    /// # use tempfile::NamedTempFile;
+    /// const TABLE: TableDefinition<u64, u64> = TableDefinition::new("my_data");
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// # #[cfg(not(target_os = "wasi"))]
+    /// # let tmpfile = NamedTempFile::new().unwrap();
+    /// # #[cfg(target_os = "wasi")]
+    /// # let tmpfile = NamedTempFile::new_in("/tmp").unwrap();
+    /// # let filename = tmpfile.path();
+    /// let db = Database::create(filename)?;
+    /// let write_txn = db.begin_write()?;
+    /// {
+    ///     let mut table = write_txn.open_table(TABLE)?;
+    ///     let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded)?;
+    ///     for key in 0..1000 {
+    ///         cursor.insert_before(key, &(key * 2))?;
+    ///     }
+    ///     cursor.close()?;
+    ///     assert_eq!(table.len()?, 1000);
+    /// }
+    /// write_txn.commit()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "experimental_cursor")]
+    pub fn upper_bound_mut<'a>(
+        &mut self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<CursorMut<'_, K, V>> {
+        let bound = bound_to_bytes::<K, _>(&bound);
+        let mut inner = self.tree.cursor_mut();
+        inner.seek_upper_bound(bound.as_ref().map(|bytes| bytes.as_slice()))?;
+        Ok(CursorMut::new(inner, self.transaction))
     }
 
     /// Gets the given key's corresponding entry in the table for in-place manipulation.
@@ -1071,5 +1156,180 @@ impl<'a, K: Key + 'static, V: Value + 'static> VacantEntry<'a, K, V> {
                 "inserted entry not found after VacantEntry::insert".to_string(),
             )
         })
+    }
+}
+
+#[cfg(feature = "experimental_cursor")]
+fn bound_to_bytes<'a, K: Key + 'a, KR: Borrow<K::SelfType<'a>>>(
+    bound: &Bound<KR>,
+) -> Bound<Vec<u8>> {
+    match bound {
+        Bound::Included(key) => Bound::Included(K::as_bytes(key.borrow()).as_ref().to_vec()),
+        Bound::Excluded(key) => Bound::Excluded(K::as_bytes(key.borrow()).as_ref().to_vec()),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+/// A cursor over a [`Table`], pointing at a gap between two entries, with
+/// support for inserting new entries into that gap.
+///
+/// Cursors are constructed with [`Table::lower_bound_mut`] and
+/// [`Table::upper_bound_mut`], and mirror the nightly
+/// [`std::collections::btree_map::CursorMut`] as closely as the redb data
+/// model allows: values are stored serialized, so inspecting the entries
+/// around the gap returns [`AccessGuard`]s instead of references, and every
+/// operation can report a storage error.
+///
+/// Call [`close`](Self::close) when finished with the cursor: errors from
+/// applying its inserts can be deferred, and only `close` reports them.
+///
+/// The cursor mutably borrows the [`Table`]: the table cannot be used while
+/// a cursor into it exists.
+#[cfg(feature = "experimental_cursor")]
+pub struct CursorMut<'a, K: Key + 'static, V: Value + 'static> {
+    inner: BtreeCursorMut<'a, K, V>,
+    transaction: &'a WriteTransaction,
+    // An I/O error leaves the cursor position unreliable, so later operations
+    // re-raise instead of continuing. Pending inserts are still flushed (or
+    // the transaction poisoned) on close: an error never latches while both
+    // pending inserts and a damaged position exist.
+    errored: bool,
+    closed: bool,
+}
+
+#[cfg(feature = "experimental_cursor")]
+impl<'a, K: Key + 'static, V: Value + 'static> CursorMut<'a, K, V> {
+    pub(crate) fn new(inner: BtreeCursorMut<'a, K, V>, transaction: &'a WriteTransaction) -> Self {
+        Self {
+            inner,
+            transaction,
+            errored: false,
+            closed: false,
+        }
+    }
+
+    /// Returns the entry after the cursor's gap without moving the cursor.
+    ///
+    /// Returns `None` if the gap is at the end of the table.
+    #[allow(clippy::type_complexity)]
+    pub fn peek_next(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.check_usable()?;
+        match self.inner.peek_next() {
+            Ok(entry) => Ok(entry),
+            Err(err) => {
+                // Peeking never consumes pending inserts, so unlike a failed
+                // splice this cannot lose reported inserts; the position is
+                // merely unreliable.
+                self.errored = true;
+                Err(err)
+            }
+        }
+    }
+
+    /// Returns the entry before the cursor's gap without moving the cursor.
+    ///
+    /// Returns `None` if the gap is at the start of the table.
+    #[allow(clippy::type_complexity)]
+    pub fn peek_prev(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.check_usable()?;
+        match self.inner.peek_prev() {
+            Ok(entry) => Ok(entry),
+            Err(err) => {
+                self.errored = true;
+                Err(err)
+            }
+        }
+    }
+
+    /// Inserts a new entry into the gap that the cursor is pointing at. After
+    /// the insertion, the cursor points at the gap after the newly inserted
+    /// entry.
+    ///
+    /// If the key does not sort strictly greater than the entry before the
+    /// gap and strictly smaller than the entry after it,
+    /// [`StorageError::UnorderedKey`] is returned and nothing is changed.
+    /// Unlike [`Table::insert`], an existing key is never overwritten:
+    /// inserting a key equal to either neighbor is unordered.
+    ///
+    /// This is analogous to the nightly
+    /// [`std::collections::btree_map::CursorMut::insert_before`].
+    pub fn insert_before<'k, 'v>(
+        &mut self,
+        key: impl Borrow<K::SelfType<'k>>,
+        value: impl Borrow<V::SelfType<'v>>,
+    ) -> Result<()> {
+        self.check_usable()?;
+        let key_bytes = K::as_bytes(key.borrow());
+        let value_bytes = V::as_bytes(value.borrow());
+        let key_len = key_bytes.as_ref().len();
+        let value_len = value_bytes.as_ref().len();
+        if value_len > MAX_VALUE_LENGTH {
+            return Err(StorageError::ValueTooLarge(value_len));
+        }
+        if key_len > MAX_VALUE_LENGTH {
+            return Err(StorageError::ValueTooLarge(key_len));
+        }
+        if value_len + key_len > MAX_PAIR_LENGTH {
+            return Err(StorageError::ValueTooLarge(value_len + key_len));
+        }
+        match self
+            .inner
+            .insert_before(key_bytes.as_ref(), value_bytes.as_ref())
+        {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(StorageError::UnorderedKey),
+            Err(err) => Err(self.latch_error(err)),
+        }
+    }
+
+    /// Closes the cursor, applying any of its inserts that have not yet
+    /// reached the table.
+    ///
+    /// `Ok` means every insert this cursor accepted is in the table. Dropping
+    /// the cursor closes it too, but cannot report errors; if applying the
+    /// inserts fails then, the write transaction is poisoned and
+    /// [`crate::WriteTransaction::commit`] will return
+    /// [`crate::CommitError::TransactionPoisoned`], so the loss cannot be
+    /// committed.
+    pub fn close(mut self) -> Result {
+        self.closed = true;
+        self.finish()
+    }
+
+    fn check_usable(&self) -> Result {
+        if self.errored {
+            return Err(StorageError::PreviousIo);
+        }
+        Ok(())
+    }
+
+    fn latch_error(&mut self, err: StorageError) -> StorageError {
+        self.errored = true;
+        if self.inner.poisoned() {
+            // Inserts already reported as applied were lost; the transaction
+            // must not commit without them.
+            self.transaction.poison();
+        }
+        err
+    }
+
+    fn finish(&mut self) -> Result {
+        let result = self.inner.finish();
+        if result.is_err() || self.inner.poisoned() {
+            self.transaction.poison();
+        }
+        result
+    }
+}
+
+#[cfg(feature = "experimental_cursor")]
+impl<K: Key + 'static, V: Value + 'static> Drop for CursorMut<'_, K, V> {
+    fn drop(&mut self) {
+        if self.closed {
+            return;
+        }
+        // Drop cannot surface a splice failure; finish() poisons the
+        // transaction instead, so the loss cannot be committed.
+        let _ = self.finish();
     }
 }

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -3,6 +3,8 @@ use crate::tree_store::btree_base::{
     AccessGuardMut, BRANCH, BranchAccessor, BranchMutator, BtreeHeader, Checksum, DEFERRED, LEAF,
     LeafAccessor, LeafPageMut, branch_checksum, leaf_checksum,
 };
+#[cfg(feature = "experimental_cursor")]
+use crate::tree_store::btree_cursor::BtreeCursorMut;
 use crate::tree_store::btree_cursor::{CursorMut, Position};
 use crate::tree_store::btree_iters::range_is_empty;
 use crate::tree_store::btree_mutator::MutateHelper;
@@ -700,6 +702,18 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         );
 
         Ok(result)
+    }
+
+    // The tree-level cursor behind the public `CursorMut`. The caller
+    // positions it with its seek methods before use.
+    #[cfg(feature = "experimental_cursor")]
+    pub(crate) fn cursor_mut(&mut self) -> BtreeCursorMut<'_, K, V> {
+        BtreeCursorMut::new(
+            &mut self.root,
+            self.page_allocator.clone(),
+            self.freed_pages.clone(),
+            self.allocated_pages.clone(),
+        )
     }
 
     // Sets `poisoned` if an error left entries in the tree that the

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -719,8 +719,6 @@ impl OwnedEntryBuffer {
     }
 
     // Appends one pair, which must be greater than every buffered entry.
-    // Reachable only from the unit tests until the public cursor API lands.
-    #[cfg_attr(not(test), allow(dead_code))]
     #[cfg(feature = "experimental_cursor")]
     pub(super) fn push(&mut self, key: &[u8], value: &[u8]) {
         let pair = self.store(key, value);
@@ -729,7 +727,6 @@ impl OwnedEntryBuffer {
 
     // Copies `range` of the leaf's pairs to the back of the buffer. The pairs
     // must all be greater than the buffered entries.
-    #[cfg_attr(not(test), allow(dead_code))]
     #[cfg(feature = "experimental_cursor")]
     pub(super) fn extend_from_leaf_range(
         &mut self,
@@ -752,6 +749,13 @@ impl OwnedEntryBuffer {
 
     pub(super) fn total_bytes(&self) -> usize {
         self.data.len()
+    }
+
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn back(&self) -> Option<(&[u8], &[u8])> {
+        self.pairs
+            .back()
+            .map(|(key, value)| (&self.data[key.clone()], &self.data[value.clone()]))
     }
 
     pub(super) fn entries(&self) -> impl Iterator<Item = (&[u8], &[u8])> {

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -339,8 +339,6 @@ impl LeafRunRewrite {
 // The threshold at which a cursor's pending inserts are spliced into the
 // tree. The splice cost is dominated by rebuilding the ancestor path, so what
 // matters is the flush count; measurements flatten out around 1MiB.
-// Reachable only from the unit tests until the public cursor API lands.
-#[cfg_attr(not(test), allow(dead_code))]
 #[cfg(feature = "experimental_cursor")]
 const INSERT_FLUSH_BYTES: usize = 1024 * 1024;
 
@@ -351,7 +349,6 @@ const INSERT_FLUSH_BYTES: usize = 1024 * 1024;
 //
 // While a run is open the tree is never mutated and the cursor position never
 // moves, so the position's path stays valid until the splice.
-#[cfg_attr(not(test), allow(dead_code))]
 #[cfg(feature = "experimental_cursor")]
 struct InsertRun {
     // Key of the entry after the gap when the run opened; None when the gap
@@ -370,7 +367,6 @@ struct InsertRun {
 #[cfg(feature = "experimental_cursor")]
 impl InsertRun {
     // True unless `key` sorts strictly between the run's bounds.
-    #[cfg_attr(not(test), allow(dead_code))]
     fn rejects<K: Key>(&self, key: &[u8]) -> bool {
         if let Some(previous) = &self.previous_key
             && K::compare(key, previous).is_le()
@@ -397,6 +393,17 @@ pub(super) struct EntryRef<'a, K: Key + 'static, V: Value + 'static> {
 impl<K: Key + 'static, V: Value + 'static> EntryRef<'_, K, V> {
     pub(super) fn key_bytes(&self) -> &[u8] {
         &self.page.memory()[self.key_range.clone()]
+    }
+
+    // Guards over the entry that outlive this borrow of the cursor. They stay
+    // valid as long as the tree is not mutated, which the compiler enforces
+    // once the caller ties them to a borrow of the cursor's owner.
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn to_guards<'g>(&self) -> (AccessGuard<'g, K>, AccessGuard<'g, V>) {
+        (
+            AccessGuard::with_page(self.page.clone(), self.key_range.clone()),
+            AccessGuard::with_page(self.page.clone(), self.value_range.clone()),
+        )
     }
 
     pub(super) fn key(&self) -> K::SelfType<'_> {
@@ -1251,7 +1258,6 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     }
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 #[cfg(feature = "experimental_cursor")]
 impl<K: Key + 'static, V: Value + 'static> CursorMut<'_, '_, K, V> {
     /// Buffers `key`/`value` for insertion into the gap, leaving the gap
@@ -1423,6 +1429,122 @@ impl<'a, K: Key + 'static, V: Value + 'static> CursorTree<'a, K, V> {
                 master_free_list.push(page);
             }
         }
+    }
+}
+
+// The tree-level cursor behind the public `CursorMut`: one gap cursor that
+// owns its state across calls, in the style of `RangeMut` but with a single
+// end and buffered insertion instead of removal batching.
+#[cfg(feature = "experimental_cursor")]
+pub(crate) struct BtreeCursorMut<'a, K: Key + 'static, V: Value + 'static> {
+    tree: CursorTree<'a, K, V>,
+    state: CursorState,
+}
+
+#[cfg(feature = "experimental_cursor")]
+impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
+    pub(crate) fn new(
+        root: &'a mut Option<BtreeHeader>,
+        page_allocator: PageAllocator,
+        master_free_list: Arc<Mutex<Vec<PageNumber>>>,
+        allocated: Arc<Mutex<PageTrackerPolicy>>,
+    ) -> Self {
+        Self {
+            tree: CursorTree::new(root, page_allocator, master_free_list, allocated),
+            state: CursorState::default(),
+        }
+    }
+
+    /// Positions the cursor at the gap before the first key `bound` admits.
+    pub(crate) fn seek_lower_bound(&mut self, bound: Bound<&[u8]>) -> Result {
+        self.with_cursor(|cursor| cursor.seek_to(Position::from_lower_bound(bound)))
+    }
+
+    /// Positions the cursor at the gap after the last key `bound` admits.
+    pub(crate) fn seek_upper_bound(&mut self, bound: Bound<&[u8]>) -> Result {
+        self.with_cursor(|cursor| cursor.seek_to(Position::from_upper_bound(bound)))
+    }
+
+    /// The entry after the gap, including while inserts are pending: peeking
+    /// never splices them.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn peek_next(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        if let Some(run) = &self.state.insert_run {
+            // The position must not move while a run is open, so the entry
+            // after the gap (the run's captured upper bound, unchanged since
+            // the tree is not mutated during a run) is re-read with a
+            // detached read-only cursor.
+            let Some(upper_key) = &run.upper_key else {
+                return Ok(None);
+            };
+            let header = self
+                .tree
+                .root
+                .expect("a captured upper bound implies a root");
+            let mut cursor: Cursor<K, V> = Cursor::new(
+                header.root,
+                self.tree.page_allocator.resolver(),
+                PageHint::None,
+            );
+            cursor.seek_to(Position::Before(upper_key))?;
+            let entry = cursor
+                .next()?
+                .expect("the captured upper bound is in the tree");
+            let (page, key_range, value_range) = entry.into_raw();
+            return Ok(Some((
+                AccessGuard::with_page(page.clone(), key_range),
+                AccessGuard::with_page(page, value_range),
+            )));
+        }
+        self.with_cursor(|cursor| Ok(cursor.peek_next()?.map(|entry| entry.to_guards())))
+    }
+
+    /// The entry before the gap, including while inserts are pending: the
+    /// most recent insert is returned without splicing.
+    ///
+    /// While a run is open, its buffer holds every predecessor the gap has in
+    /// the current leaf (the normalizing peeks settled the position on the
+    /// earlier of two leaves sharing the gap), so an empty buffer means the
+    /// gap is at the start of the tree.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn peek_prev(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        if let Some(run) = &self.state.insert_run {
+            return Ok(run.entries.back().map(|(key, value)| {
+                (
+                    AccessGuard::with_owned_value(key.to_vec()),
+                    AccessGuard::with_owned_value(value.to_vec()),
+                )
+            }));
+        }
+        self.with_cursor(|cursor| Ok(cursor.peek_prev()?.map(|entry| entry.to_guards())))
+    }
+
+    /// See [`CursorMut::insert_before`].
+    pub(crate) fn insert_before(&mut self, key: &[u8], value: &[u8]) -> Result<bool> {
+        self.with_cursor(|cursor| cursor.insert_before(key, value))
+    }
+
+    /// Splices any pending inserts into the tree, consuming the position.
+    pub(crate) fn finish(&mut self) -> Result {
+        self.with_cursor(|cursor| cursor.flush_insert_run(false))
+    }
+
+    /// True if an error interrupted inserts that were already reported to the
+    /// caller: they may be missing from the tree, so the transaction must not
+    /// commit.
+    pub(crate) fn poisoned(&self) -> bool {
+        self.state.poisoned
+    }
+
+    fn with_cursor<R>(
+        &mut self,
+        operation: impl FnOnce(&mut CursorMut<'a, '_, K, V>) -> Result<R>,
+    ) -> Result<R> {
+        let mut cursor = self.tree.cursor(std::mem::take(&mut self.state));
+        let result = operation(&mut cursor);
+        self.state = cursor.into_state();
+        self.tree.drain_freed();
+        result
     }
 }
 

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -63,8 +63,6 @@ impl DeletedPairs {
 // A page produced while splicing an insert run into the tree, with its
 // subtree's greatest key. The key is None only for the node whose subtree
 // contains the tree's original last entry, which stays last at every level.
-// Reachable only from the unit tests until the public cursor API lands.
-#[cfg_attr(not(test), allow(dead_code))]
 #[cfg(feature = "experimental_cursor")]
 type SplicedNode = (PageNumber, Checksum, Option<Vec<u8>>);
 
@@ -475,7 +473,6 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     // greatest key. Ancestors above the level where the replacements collapse
     // back to a single node take the deletion path's child-pointer swap
     // instead of a rebuild.
-    #[cfg_attr(not(test), allow(dead_code))]
     #[cfg(feature = "experimental_cursor")]
     pub(super) fn splice_insert_run(
         &mut self,
@@ -549,7 +546,6 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     // Rebuilds one branch of the path, with `replacement` in place of
     // `child_index`. Returns the built pages, more than one if the level had
     // to split.
-    #[cfg_attr(not(test), allow(dead_code))]
     #[cfg(feature = "experimental_cursor")]
     fn rebuild_branch_level(
         &mut self,
@@ -591,7 +587,6 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     // Mirrors `build_replacement_leaves`: cut a page whenever the next child
     // would not fit, except that a page must keep at least two children, so
     // the tail is merged into its neighbor instead of rebalanced.
-    #[cfg_attr(not(test), allow(dead_code))]
     #[cfg(feature = "experimental_cursor")]
     fn build_branch_nodes(&mut self, children: &[SplicedNode]) -> Result<Vec<SplicedNode>> {
         fn separator(node: &SplicedNode) -> &[u8] {

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -14,6 +14,8 @@ pub(crate) use btree::{Btree, BtreeMut, BtreeStats, RawBtree};
 pub(crate) use btree_base::BtreeHeader;
 pub use btree_base::{AccessGuard, AccessGuardMut, AccessGuardMutInPlace};
 pub(crate) use btree_base::{BRANCH, LEAF, LeafAccessor, RawLeafBuilder};
+#[cfg(feature = "experimental_cursor")]
+pub(crate) use btree_cursor::BtreeCursorMut;
 pub(crate) use btree_cursor_range::BtreeCursorRange;
 pub(crate) use btree_iters::AllPageNumbersBtreeIter;
 pub(crate) use extract_if::BtreeExtractIf;

--- a/tests/cursor_tests.rs
+++ b/tests/cursor_tests.rs
@@ -1,0 +1,448 @@
+#![cfg(feature = "experimental_cursor")]
+
+use redb::{
+    Database, ReadableDatabase, ReadableTable, ReadableTableMetadata, StorageError, TableDefinition,
+};
+use std::ops::Bound;
+
+const U64_TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+const STR_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("x");
+
+fn create_tempfile() -> tempfile::NamedTempFile {
+    if cfg!(target_os = "wasi") {
+        tempfile::NamedTempFile::new_in("/tmp").unwrap()
+    } else {
+        tempfile::NamedTempFile::new().unwrap()
+    }
+}
+
+// Zero padded so that lexicographic order matches numeric order
+fn key(i: u64) -> String {
+    format!("{i:016}")
+}
+
+fn assert_u64_table_contents(db: &Database, expected: &[(u64, u64)]) {
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), expected.len() as u64);
+    let actual: Vec<(u64, u64)> = table
+        .iter()
+        .unwrap()
+        .map(|entry| {
+            let (key, value) = entry.unwrap();
+            (key.value(), value.value())
+        })
+        .collect();
+    assert_eq!(actual, expected);
+    for (key, value) in expected {
+        assert_eq!(table.get(key).unwrap().unwrap().value(), *value);
+    }
+}
+
+#[test]
+fn bulk_load_into_empty_table() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        for i in 0..10_000 {
+            cursor.insert_before(i, &(i * 7)).unwrap();
+        }
+        cursor.close().unwrap();
+        assert_eq!(table.len().unwrap(), 10_000);
+        assert_eq!(table.get(&5432).unwrap().unwrap().value(), 5432 * 7);
+    }
+    txn.commit().unwrap();
+
+    let expected: Vec<(u64, u64)> = (0..10_000).map(|i| (i, i * 7)).collect();
+    assert_u64_table_contents(&db, &expected);
+
+    // Also readable after reopening the database
+    drop(db);
+    let db = Database::open(tmpfile.path()).unwrap();
+    assert_u64_table_contents(&db, &expected);
+}
+
+// Enough data to cross the cursor's internal buffer threshold several times,
+// so mid-load splices and reseeks are exercised through the public API.
+#[test]
+fn bulk_load_crosses_flush_threshold() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(STR_TABLE).unwrap();
+        let mut cursor = table.upper_bound_mut(Bound::<&str>::Unbounded).unwrap();
+        for i in 0..600u64 {
+            // Varying sizes exercise the leaf packing decisions
+            let value = vec![i as u8; 2000 + (i as usize % 3000)];
+            cursor
+                .insert_before(key(i).as_str(), value.as_slice())
+                .unwrap();
+        }
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(STR_TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 600);
+    for (index, entry) in table.iter().unwrap().enumerate() {
+        let (k, v) = entry.unwrap();
+        let i = index as u64;
+        assert_eq!(k.value(), key(i));
+        assert_eq!(v.value(), vec![i as u8; 2000 + (index % 3000)]);
+    }
+}
+
+// A value that does not fit in a single page must get a page of its own,
+// like `Table::insert` gives it.
+#[test]
+fn bulk_load_large_values() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(STR_TABLE).unwrap();
+        let mut cursor = table.upper_bound_mut(Bound::<&str>::Unbounded).unwrap();
+        for i in 0..20u64 {
+            let size = if i % 4 == 0 { 100_000 } else { 10 };
+            let value = vec![i as u8; size];
+            cursor
+                .insert_before(key(i).as_str(), value.as_slice())
+                .unwrap();
+        }
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(STR_TABLE).unwrap();
+    for i in 0..20u64 {
+        let size = if i % 4 == 0 { 100_000 } else { 10 };
+        let value = table.get(key(i).as_str()).unwrap().unwrap();
+        assert_eq!(value.value(), vec![i as u8; size]);
+    }
+}
+
+// Dropping the cursor splices the pending inserts, like closing it does.
+#[test]
+fn append_to_existing_table() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in 0..1000 {
+            table.insert(i, i).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        {
+            let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 999);
+            for i in 1000..2000 {
+                cursor.insert_before(i, &i).unwrap();
+            }
+        }
+        assert_eq!(table.len().unwrap(), 2000);
+    }
+    txn.commit().unwrap();
+
+    let expected: Vec<(u64, u64)> = (0..2000).map(|i| (i, i)).collect();
+    assert_u64_table_contents(&db, &expected);
+}
+
+#[test]
+fn insert_into_middle_gap() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        // Even keys, leaving odd keys insertable in the gaps
+        for i in 0..1000 {
+            table.insert(i * 2, i * 2).unwrap();
+        }
+        let mut cursor = table.lower_bound_mut(Bound::Included(&500)).unwrap();
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 498);
+        assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 500);
+        cursor.insert_before(499, &499).unwrap();
+        // The gap now sits between the new entry and 500
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 499);
+        assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 500);
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    let mut expected: Vec<(u64, u64)> = (0..1000).map(|i| (i * 2, i * 2)).collect();
+    expected.push((499, 499));
+    expected.sort_unstable();
+    assert_u64_table_contents(&db, &expected);
+}
+
+// Middle inserts under a non-rightmost branch of a taller tree exercise the
+// separator bookkeeping of the ancestor rebuild.
+#[test]
+fn insert_into_middle_of_tall_tree() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        {
+            let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            for i in 0..100_000 {
+                cursor.insert_before(i * 2, &(i * 2)).unwrap();
+            }
+        }
+        for target in [101u64, 50_001, 100_001, 150_001, 199_001] {
+            let mut cursor = table.lower_bound_mut(Bound::Included(&target)).unwrap();
+            cursor.insert_before(target, &target).unwrap();
+            cursor.close().unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let mut expected: Vec<(u64, u64)> = (0..100_000).map(|i| (i * 2, i * 2)).collect();
+    expected.extend([101u64, 50_001, 100_001, 150_001, 199_001].map(|i| (i, i)));
+    expected.sort_unstable();
+    assert_u64_table_contents(&db, &expected);
+}
+
+#[test]
+fn unordered_keys_rejected() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 20, 30] {
+            table.insert(i, i).unwrap();
+        }
+        let mut cursor = table.upper_bound_mut(Bound::Included(&20)).unwrap();
+        // Equal to either neighbor, below the gap, and above the gap all fail
+        for bad in [10u64, 15, 20, 30, 35] {
+            assert!(matches!(
+                cursor.insert_before(bad, &bad),
+                Err(StorageError::UnorderedKey)
+            ));
+        }
+        // The cursor remains usable after rejections
+        cursor.insert_before(25, &25).unwrap();
+        // Later inserts must also stay above the pending insert
+        assert!(matches!(
+            cursor.insert_before(25, &25),
+            Err(StorageError::UnorderedKey)
+        ));
+        assert!(matches!(
+            cursor.insert_before(24, &24),
+            Err(StorageError::UnorderedKey)
+        ));
+        cursor.insert_before(26, &26).unwrap();
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    let expected: Vec<(u64, u64)> = [10, 20, 25, 26, 30].iter().map(|&i| (i, i)).collect();
+    assert_u64_table_contents(&db, &expected);
+}
+
+#[test]
+fn bound_positions() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 20, 30] {
+            table.insert(i, i).unwrap();
+        }
+
+        let peeked = |cursor: &mut redb::CursorMut<'_, u64, u64>| {
+            let prev = cursor.peek_prev().unwrap().map(|(k, _)| k.value());
+            let next = cursor.peek_next().unwrap().map(|(k, _)| k.value());
+            (prev, next)
+        };
+
+        let mut cursor = table.lower_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        assert_eq!(peeked(&mut cursor), (None, Some(10)));
+        drop(cursor);
+        let mut cursor = table.lower_bound_mut(Bound::Included(&20)).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(10), Some(20)));
+        drop(cursor);
+        let mut cursor = table.lower_bound_mut(Bound::Excluded(&20)).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(20), Some(30)));
+        drop(cursor);
+        let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(30), None));
+        drop(cursor);
+        let mut cursor = table.upper_bound_mut(Bound::Included(&20)).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(20), Some(30)));
+        drop(cursor);
+        let mut cursor = table.upper_bound_mut(Bound::Excluded(&20)).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(10), Some(20)));
+        drop(cursor);
+        // A bound between entries points into the same gap either way
+        let mut cursor = table.lower_bound_mut(Bound::Included(&25)).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(20), Some(30)));
+        drop(cursor);
+        let mut cursor = table.upper_bound_mut(Bound::Included(&25)).unwrap();
+        assert_eq!(peeked(&mut cursor), (Some(20), Some(30)));
+    }
+    txn.abort().unwrap();
+}
+
+// Peeks observe pending inserts without splicing them.
+#[test]
+fn peeks_during_pending_inserts() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 30] {
+            table.insert(i, i).unwrap();
+        }
+        let mut cursor = table.upper_bound_mut(Bound::Included(&10)).unwrap();
+        cursor.insert_before(20, &200).unwrap();
+        let (prev_key, prev_value) = cursor.peek_prev().unwrap().unwrap();
+        assert_eq!(prev_key.value(), 20);
+        assert_eq!(prev_value.value(), 200);
+        drop((prev_key, prev_value));
+        assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 30);
+        cursor.insert_before(21, &210).unwrap();
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 21);
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    let expected: Vec<(u64, u64)> = vec![(10, 10), (20, 200), (21, 210), (30, 30)];
+    assert_u64_table_contents(&db, &expected);
+}
+
+#[test]
+fn peeks_on_empty_table_and_at_start() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        {
+            let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            assert!(cursor.peek_prev().unwrap().is_none());
+            assert!(cursor.peek_next().unwrap().is_none());
+            cursor.insert_before(100, &100).unwrap();
+            assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 100);
+            assert!(cursor.peek_next().unwrap().is_none());
+            cursor.close().unwrap();
+        }
+        // At the start of a non-empty table, a pending insert becomes the
+        // predecessor while the old first entry stays the successor
+        {
+            let mut cursor = table.lower_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            assert!(cursor.peek_prev().unwrap().is_none());
+            assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 100);
+            cursor.insert_before(50, &50).unwrap();
+            assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 50);
+            assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 100);
+            cursor.close().unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    assert_u64_table_contents(&db, &[(50, 50), (100, 100)]);
+}
+
+// A cursor that inserts nothing, including one whose every insert was
+// rejected, leaves the table untouched.
+#[test]
+fn empty_and_rejected_only_cursors() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        table.insert(10, 10).unwrap();
+        let cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        cursor.close().unwrap();
+        let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        assert!(matches!(
+            cursor.insert_before(10, &10),
+            Err(StorageError::UnorderedKey)
+        ));
+        cursor.close().unwrap();
+        assert_eq!(table.len().unwrap(), 1);
+    }
+    txn.commit().unwrap();
+
+    assert_u64_table_contents(&db, &[(10, 10)]);
+}
+
+// Several transactions each appending a sorted batch through a cursor: the
+// day-two shape of a bulk load.
+#[test]
+fn incremental_appends_across_transactions() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    for batch in 0..5u64 {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(U64_TABLE).unwrap();
+            let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            for i in (batch * 1000)..((batch + 1) * 1000) {
+                cursor.insert_before(i, &i).unwrap();
+            }
+            cursor.close().unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    let expected: Vec<(u64, u64)> = (0..5000).map(|i| (i, i)).collect();
+    assert_u64_table_contents(&db, &expected);
+}
+
+// An aborted transaction discards inserts spliced through a cursor.
+#[test]
+fn abort_discards_cursor_inserts() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        table.insert(1, 1).unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        for i in 2..1000 {
+            cursor.insert_before(i, &i).unwrap();
+        }
+        cursor.close().unwrap();
+    }
+    txn.abort().unwrap();
+
+    assert_u64_table_contents(&db, &[(1, 1)]);
+}


### PR DESCRIPTION
Fourth slice of splitting up #1323. The machinery from #1326 has merged; this now targets master directly.

The public surface over #1326's machinery, behind the `experimental_cursor` feature flag:

```rust
let mut table = txn.open_table(TABLE)?;
let mut cursor = table.upper_bound_mut(Bound::Unbounded)?;
for (key, value) in sorted_stream {
    cursor.insert_before(key, &value)?;
}
cursor.close()?;
```

- `Table::lower_bound_mut()` / `Table::upper_bound_mut()` return a `CursorMut` pointing at a gap between entries, modeled on the standard library's nightly `BTreeMap` cursors as closely as redb's data model allows.
- `insert_before(key, value)` inserts into the gap and leaves the cursor after the new entry. A key that does not sort strictly between the gap's neighbors is rejected with the new `StorageError::UnorderedKey` and nothing changes, matching std's `UnorderedKeyError`; an existing key is never overwritten.
- `peek_prev()` / `peek_next()` return the gap's neighbors as `AccessGuard`s, including pending buffered inserts, without splicing them.
- `close()` splices any pending inserts and surfaces errors. Dropping the cursor also splices; a failed splice on either path poisons the write transaction, so inserts that were reported as applied can never be silently missing from a commit.

Loading 1M sorted 150-byte pairs is ~2x faster than `insert()` at the same leaf density and half the branch pages; on #1322's 17M-pair graph load the gap is ~6x. The changelog marks the feature unstable; `insert_after`, `remove_*`, and multimap coverage are future work.

Integration tests cover bulk loads crossing the buffer threshold, large values, appends across transactions, all six bound positions, peeks over pending inserts, unordered-key rejection, drop-flush, and abort. The fuzzer gains a `CursorInsert` operation that inserts runs derived from the gap around a random key and checks the peeks against the reference model.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ)_