### PR TITLE
Seal ReadableDatabase behind experimental-api-5

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::{io, thread};
 
 use crate::error::TransactionError;
-use crate::sealed::Sealed;
+use crate::sealed::{Sealed, SealedInApi5};
 use crate::transactions::{
     ALLOCATOR_STATE_TABLE_NAME, AllocatorStateKey, AllocatorStateTree, DATA_ALLOCATED_TABLE,
     DATA_FREED_TABLE, PageList, SYSTEM_FREED_TABLE, SystemTableDefinition,
@@ -354,7 +354,7 @@ impl Drop for TransactionGuard {
     }
 }
 
-pub trait ReadableDatabase {
+pub trait ReadableDatabase: SealedInApi5 {
     /// Begins a read transaction
     ///
     /// Captures a snapshot of the database, so that only data committed before calling this method
@@ -414,6 +414,8 @@ pub struct ReadOnlyDatabase {
     mem: Arc<TransactionalMemory>,
     transaction_tracker: Arc<TransactionTracker>,
 }
+
+impl Sealed for ReadOnlyDatabase {}
 
 impl ReadableDatabase for ReadOnlyDatabase {
     fn begin_read(&self) -> Result<ReadTransaction, TransactionError> {
@@ -529,6 +531,8 @@ pub struct Database {
     mem: Arc<TransactionalMemory>,
     transaction_tracker: Arc<TransactionTracker>,
 }
+
+impl Sealed for Database {}
 
 impl ReadableDatabase for Database {
     fn begin_read(&self) -> Result<ReadTransaction, TransactionError> {

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -1,1 +1,13 @@
 pub trait Sealed {}
+
+// Seals a trait only when the redb 5 API preview is enabled. `cfg` cannot be applied to a
+// supertrait bound directly, so the bound itself is swapped: with the feature off it resolves to a
+// blanket-implemented marker, leaving the trait implementable outside redb for the rest of 4.x.
+#[cfg(feature = "experimental-api-5")]
+pub use self::Sealed as SealedInApi5;
+
+#[cfg(not(feature = "experimental-api-5"))]
+pub trait SealedInApi5 {}
+
+#[cfg(not(feature = "experimental-api-5"))]
+impl<T: ?Sized> SealedInApi5 for T {}


### PR DESCRIPTION
Seals `ReadableDatabase`, gated on `experimental-api-5`. Rebased onto master (79614c5); one commit, two files, no changelog entry.

`ReadableDatabase` is implemented only by `Database` and `ReadOnlyDatabase`, so sealing it keeps the implementation set closed and lets methods be added without breaking callers — matching `TableHandle` and `MultimapTableHandle`.

Sealing it outright would be a source break: a wrapper outside redb can implement the trait today by delegating, even though it cannot construct a `ReadTransaction` or `CacheStats` itself. Gating it on `experimental-api-5` means 4.x keeps compiling for those wrappers, and the seal previews what redb 5 will do.

`cfg` can't be applied to a supertrait bound, so the bound itself is swapped in `sealed.rs`:

```rust
#[cfg(feature = "experimental-api-5")]
pub use self::Sealed as SealedInApi5;

#[cfg(not(feature = "experimental-api-5"))]
pub trait SealedInApi5 {}
#[cfg(not(feature = "experimental-api-5"))]
impl<T: ?Sized> SealedInApi5 for T {}
```

`ReadableDatabase: SealedInApi5` is then a single declaration whose bound is real or vacuous depending on the feature. Verified with a throwaway `struct Wrapper(Database)` that delegates `begin_read()` and `cache_stats()`:

| Build | Result |
|---|---|
| `cargo build --tests` (default) | compiles — no break |
| `cargo build --tests --features experimental-api-5` | `E0277: the trait bound Wrapper: redb::sealed::Sealed is not satisfied` |

`ReadableTableMetadata`, `ReadableTable`, and `ReadableMultimapTable` are untouched and stay unsealed, per #794.

### Testing

`just`/podman aren't available in this environment, so the equivalent checks were run directly, in **both** feature configurations since the behavior differs by flag:

| Check | Default | `--all-features` |
|---|---|---|
| `cargo clippy --all-targets` (`RUSTFLAGS=--deny warnings`) | pass | pass |
| `cargo test` (`RUST_BACKTRACE=1`, `--deny warnings`) | pass (19/19 targets) | pass (19/19 targets) |

Plus `cargo fmt --all -- --check`.