### PR TITLE
Align Table::extract_if() with BTreeMap, behind experimental-api-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # redb - Changelog
 
 ## 4.2.0 - 2026-XX-XX
+* Add an `experimental-api-5` feature flag, which enables the `Table` API changes planned for the
+  5.0 release ahead of that release, so that they can be tried out and ported to early. Under it
+  `Table::extract_if()` takes the range to extract from, matching
+  `std::collections::BTreeMap::extract_if()`, and the now redundant `Table::extract_from_if()` is
+  removed. Calls port over as `extract_from_if(range, predicate)` ->
+  `extract_if(range, predicate)`, and `extract_if(predicate)` ->
+  `extract_if::<KeyType, _>(.., predicate)`. The feature is unstable and may change incompatibly,
+  or be removed, in any release.
 * Fix a panic when opening a database containing a corrupted persistent savepoint record;
   `StorageError::Corrupted` is now returned instead.
 * Add an experimental cursor API, behind the `experimental_cursor` feature flag:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ logging = ["dep:log"]
 cache_metrics = []
 # Unstable cursor API. May change incompatibly, or be removed, in any release
 experimental_cursor = []
+# Enables the API changes planned for the 5.0 release, ahead of it. May change incompatibly, or be
+# removed, in any release
+experimental-api-5 = []
 
 [profile.bench]
 debug = true

--- a/crates/redb-bench/Cargo.toml
+++ b/crates/redb-bench/Cargo.toml
@@ -9,6 +9,11 @@ homepage.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[features]
+# Tracks redb's feature of the same name, so that --all-features builds this crate against the
+# 5.0 signatures
+experimental-api-5 = ["redb/experimental-api-5"]
+
 # Common test/bench dependencies
 [dev-dependencies]
 redb = { path = "../..", features = ["experimental_cursor"] }

--- a/crates/redb-bench/benches/common.rs
+++ b/crates/redb-bench/benches/common.rs
@@ -1052,12 +1052,13 @@ impl BenchInserter for RedbBenchInserter<'_> {
     where
         F: for<'f> FnMut(&'f [u8], &'f [u8]) -> bool + 'a,
     {
-        // redb has a native cursor-based extract_from_if that removes entries lazily as the
-        // returned iterator is consumed.
-        let iter = self
-            .table
-            .extract_from_if::<&[u8], F>(range, predicate)
-            .map_err(|_| ())?;
+        // redb natively extracts over a range, removing entries lazily as the returned iterator
+        // is consumed.
+        #[cfg(feature = "experimental-api-5")]
+        let iter = self.table.extract_if::<&[u8], F>(range, predicate);
+        #[cfg(not(feature = "experimental-api-5"))]
+        let iter = self.table.extract_from_if::<&[u8], F>(range, predicate);
+        let iter = iter.map_err(|_| ())?;
         Ok(RedbExtractIfIterator { iter })
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -160,11 +160,39 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     /// The predicate must not panic. If it panics, the write transaction is
     /// poisoned and [`crate::WriteTransaction::commit`] will return
     /// [`crate::CommitError::TransactionPoisoned`].
+    #[cfg(not(feature = "experimental-api-5"))]
     pub fn extract_if<F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
         &mut self,
         predicate: F,
     ) -> Result<ExtractIf<'_, K, V, F>> {
-        self.extract_from_if::<K::SelfType<'_>, F>(.., predicate)
+        self.extract_range_if::<K::SelfType<'_>, F>(.., predicate)
+    }
+
+    /// Applies `predicate` to all key-value pairs in the specified range. All entries for which
+    /// `predicate` evaluates to `true` are returned in an iterator, and those which are read from the iterator are removed
+    ///
+    /// This is analogous to [`std::collections::BTreeMap::extract_if`].
+    ///
+    /// Note: values not read from the iterator will not be removed
+    ///
+    /// If the iterator returns an error, later calls keep returning an error
+    /// (the failure is not recoverable). Entries already yielded stay
+    /// removed; if finalizing their removal fails too, the write transaction
+    /// is poisoned and cannot be committed.
+    ///
+    /// The predicate must not panic. If it panics, the write transaction is
+    /// poisoned and [`crate::WriteTransaction::commit`] will return
+    /// [`crate::CommitError::TransactionPoisoned`].
+    #[cfg(feature = "experimental-api-5")]
+    pub fn extract_if<'a, KR, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
+        &mut self,
+        range: impl RangeBounds<KR> + 'a,
+        predicate: F,
+    ) -> Result<ExtractIf<'_, K, V, F>>
+    where
+        KR: Borrow<K::SelfType<'a>> + 'a,
+    {
+        self.extract_range_if(range, predicate)
     }
 
     /// Applies `predicate` to all key-value pairs in the specified range. All entries for which
@@ -180,7 +208,19 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     /// The predicate must not panic. If it panics, the write transaction is
     /// poisoned and [`crate::WriteTransaction::commit`] will return
     /// [`crate::CommitError::TransactionPoisoned`].
+    #[cfg(not(feature = "experimental-api-5"))]
     pub fn extract_from_if<'a, KR, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
+        &mut self,
+        range: impl RangeBounds<KR> + 'a,
+        predicate: F,
+    ) -> Result<ExtractIf<'_, K, V, F>>
+    where
+        KR: Borrow<K::SelfType<'a>> + 'a,
+    {
+        self.extract_range_if(range, predicate)
+    }
+
+    fn extract_range_if<'a, KR, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
         &mut self,
         range: impl RangeBounds<KR> + 'a,
         predicate: F,

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -17,6 +17,30 @@ const SLICE_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("slice")
 const STR_TABLE: TableDefinition<&str, &str> = TableDefinition::new("x");
 const U64_TABLE: TableDefinition<u64, u64> = TableDefinition::new("u64");
 
+// Bridge the extract_if() signature change made by the experimental-api-5 feature, so that these
+// tests cover the extraction machinery in both configurations. The 5.0 signature takes the range
+// that extract_from_if() takes today, and extracting the whole table must name the key type,
+// because an unbounded range does not pin it down.
+macro_rules! extract_if {
+    ($table:expr, $key:ty, $predicate:expr) => {{
+        #[cfg(feature = "experimental-api-5")]
+        let iter = $table.extract_if::<$key, _>(.., $predicate);
+        #[cfg(not(feature = "experimental-api-5"))]
+        let iter = $table.extract_if($predicate);
+        iter
+    }};
+}
+
+macro_rules! extract_from_if {
+    ($table:expr, $range:expr, $predicate:expr) => {{
+        #[cfg(feature = "experimental-api-5")]
+        let iter = $table.extract_if($range, $predicate);
+        #[cfg(not(feature = "experimental-api-5"))]
+        let iter = $table.extract_from_if($range, $predicate);
+        iter
+    }};
+}
+
 fn create_tempfile() -> tempfile::NamedTempFile {
     if cfg!(target_os = "wasi") {
         tempfile::NamedTempFile::new_in("/tmp").unwrap()
@@ -298,12 +322,12 @@ fn extract_if() {
             table.insert(&i, &i).unwrap();
         }
         // Test retain uncommitted data
-        let mut extracted = table.extract_if(|k, _| k >= 5).unwrap();
+        let mut extracted = extract_if!(table, u64, |k, _| k >= 5).unwrap();
         assert_eq!(extracted.next().unwrap().unwrap().0.value(), 5);
         extracted.close().unwrap();
         assert_eq!(table.len().unwrap(), 9);
 
-        let mut extracted = table.extract_from_if(5.., |k, _| k < 8).unwrap();
+        let mut extracted = extract_from_if!(table, 5.., |k, _| k < 8).unwrap();
         assert_eq!(extracted.next().unwrap().unwrap().0.value(), 6);
         assert_eq!(extracted.next().unwrap().unwrap().0.value(), 7);
         assert!(extracted.next().is_none());
@@ -321,7 +345,7 @@ fn extract_if() {
     {
         let mut table = write_txn.open_table(U64_TABLE).unwrap();
         assert_eq!(table.len().unwrap(), 10);
-        let mut extracted = table.extract_if(|_, _| true).unwrap();
+        let mut extracted = extract_if!(table, u64, |_, _| true).unwrap();
         assert_eq!(extracted.next().unwrap().unwrap().1.value(), 0);
         drop(extracted);
         assert_eq!(table.len().unwrap(), 9);
@@ -332,8 +356,8 @@ fn extract_if() {
     {
         let mut table = write_txn.open_table(U64_TABLE).unwrap();
         assert_eq!(table.len().unwrap(), 10);
-        for _ in table.extract_if(|x, _| x % 2 != 0).unwrap() {}
-        table.extract_if(|_, _| true).unwrap().next_back();
+        for _ in extract_if!(table, u64, |x, _| x % 2 != 0).unwrap() {}
+        extract_if!(table, u64, |_, _| true).unwrap().next_back();
     }
     write_txn.commit().unwrap();
 
@@ -363,12 +387,11 @@ fn extract_if_predicate_panic_poisons_transaction() {
         }
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let mut extracted = table
-                .extract_if(|key, _| {
-                    assert_ne!(key, 2);
-                    key == 0
-                })
-                .unwrap();
+            let mut extracted = extract_if!(table, u64, |key, _| {
+                assert_ne!(key, 2);
+                key == 0
+            })
+            .unwrap();
             assert_eq!(extracted.next().unwrap().unwrap().0.value(), 0);
             let _ = extracted.next();
         }));
@@ -393,7 +416,7 @@ fn extract_if_caller_panic_does_not_poison_transaction() {
         }
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let mut extracted = table.extract_if(|key, _| key == 0).unwrap();
+            let mut extracted = extract_if!(table, u64, |key, _| key == 0).unwrap();
             assert_eq!(extracted.next().unwrap().unwrap().0.value(), 0);
             panic!("caller panic");
         }));
@@ -415,12 +438,11 @@ fn extract_if_is_lazy_until_read() {
 
         let mut predicate_calls = 0;
         drop(
-            table
-                .extract_if(|_, _| {
-                    predicate_calls += 1;
-                    true
-                })
-                .unwrap(),
+            extract_if!(table, u64, |_, _| {
+                predicate_calls += 1;
+                true
+            })
+            .unwrap(),
         );
         assert_eq!(predicate_calls, 0);
         assert_eq!(table.len().unwrap(), 10);
@@ -439,7 +461,7 @@ fn extract_if_mixed_direction_removes_only_yielded_entries() {
             table.insert(&i, &i).unwrap();
         }
 
-        let mut extracted = table.extract_if(|key, _| key % 2 == 0).unwrap();
+        let mut extracted = extract_if!(table, u64, |key, _| key % 2 == 0).unwrap();
         assert_eq!(extracted.next().unwrap().unwrap().0.value(), 0);
         assert_eq!(extracted.next_back().unwrap().unwrap().0.value(), 8);
         drop(extracted);
@@ -465,9 +487,7 @@ fn extract_from_if_mixed_direction_early_drop_range() {
             table.insert(&i, &i).unwrap();
         }
 
-        let mut extracted = table
-            .extract_from_if(200..800, |key, _| key % 5 == 0)
-            .unwrap();
+        let mut extracted = extract_from_if!(table, 200..800, |key, _| key % 5 == 0).unwrap();
         assert_eq!(extracted.next().unwrap().unwrap().0.value(), 200);
         assert_eq!(extracted.next_back().unwrap().unwrap().0.value(), 795);
         drop(extracted);
@@ -498,9 +518,7 @@ fn extract_from_if_next_back_large_range() {
             .filter(|key| key % 7 == 0)
             .rev()
             .collect::<Vec<_>>();
-        let mut extracted = table
-            .extract_from_if(n / 2.., |key, _| key % 7 == 0)
-            .unwrap();
+        let mut extracted = extract_from_if!(table, n / 2.., |key, _| key % 7 == 0).unwrap();
         let mut removed = vec![];
         while let Some(entry) = extracted.next_back() {
             removed.push(entry.unwrap().0.value());
@@ -527,7 +545,7 @@ fn extract_if_returned_guards_survive_finalize() {
             table.insert(&i, &(i * 10)).unwrap();
         }
 
-        let mut extracted = table.extract_if(|key, _| key == 4).unwrap();
+        let mut extracted = extract_if!(table, u64, |key, _| key == 4).unwrap();
         let (key, value) = extracted.next().unwrap().unwrap();
         assert!(extracted.next().is_none());
         assert_eq!(key.value(), 4);
@@ -542,7 +560,7 @@ fn extract_if_returned_guards_survive_finalize() {
     let write_txn = db.begin_write().unwrap();
     {
         let mut table = write_txn.open_table(U64_TABLE).unwrap();
-        let mut extracted = table.extract_if(|key, _| key == 5).unwrap();
+        let mut extracted = extract_if!(table, u64, |key, _| key == 5).unwrap();
         let (key, value) = extracted.next().unwrap().unwrap();
         drop(extracted);
         assert_eq!(key.value(), 5);
@@ -572,7 +590,7 @@ fn extract_if_all_guards_survive_iteration() {
             table.insert(&i, &(i * 10)).unwrap();
         }
         let mut guards = vec![];
-        for entry in table.extract_if(|key, _| key % 2 == 0).unwrap() {
+        for entry in extract_if!(table, u64, |key, _| key % 2 == 0).unwrap() {
             guards.push(entry.unwrap());
         }
         assert_eq!(guards.len() as u64, elements / 2);
@@ -590,7 +608,7 @@ fn extract_if_all_guards_survive_iteration() {
     {
         let mut table = write_txn.open_table(U64_TABLE).unwrap();
         let mut guards = vec![];
-        let mut iter = table.extract_if(|_, _| true).unwrap();
+        let mut iter = extract_if!(table, u64, |_, _| true).unwrap();
         for entry in &mut iter {
             guards.push(entry.unwrap());
         }
@@ -625,7 +643,7 @@ fn extract_from_if_alternating_drain() {
     let write_txn = db.begin_write().unwrap();
     {
         let mut table = write_txn.open_table(U64_TABLE).unwrap();
-        let mut extracted = table.extract_from_if(1000..9000, |_, _| true).unwrap();
+        let mut extracted = extract_from_if!(table, 1000..9000, |_, _| true).unwrap();
         let mut front_next = 1000;
         let mut back_next = 8999;
         let mut front = true;
@@ -682,9 +700,7 @@ fn extract_from_if_alternating_directions() {
         let mut table = write_txn.open_table(U64_TABLE).unwrap();
         let mut expected: std::collections::BTreeSet<u64> =
             (1000..9000).filter(|key| key % 3 == 0).collect();
-        let mut extracted = table
-            .extract_from_if(1000..9000, |key, _| key % 3 == 0)
-            .unwrap();
+        let mut extracted = extract_from_if!(table, 1000..9000, |key, _| key % 3 == 0).unwrap();
         let mut front = true;
         loop {
             let entry = if front {
@@ -744,7 +760,7 @@ fn extract_if_alternating_directions_dense_removals() {
         let mut got: Vec<u64> = vec![];
         {
             // Remove everything except key 0, alternating directions.
-            let mut extracted = table.extract_if(|k, _| k != 0).unwrap();
+            let mut extracted = extract_if!(table, u64, |k, _| k != 0).unwrap();
             let mut front = true;
             loop {
                 let entry = if front {
@@ -788,7 +804,7 @@ fn extract_if_alternating_directions_partial_consumption() {
     {
         let mut table = write_txn.open_table(U64_TABLE).unwrap();
         {
-            let mut extracted = table.extract_if(|k, _| k != 0).unwrap();
+            let mut extracted = extract_if!(table, u64, |k, _| k != 0).unwrap();
             let mut front = true;
             // Consume most of the range, then drop the iterator.
             for _ in 0..280 {
@@ -832,7 +848,7 @@ fn extract_if_mostly_forward_occasional_next_back() {
         let mut table = write_txn.open_table(U64_TABLE).unwrap();
         let mut got: Vec<u64> = vec![];
         {
-            let mut extracted = table.extract_if(|k, _| k != 0).unwrap();
+            let mut extracted = extract_if!(table, u64, |k, _| k != 0).unwrap();
             let mut i = 0u64;
             loop {
                 let entry = if i.is_multiple_of(50) {
@@ -876,7 +892,7 @@ fn extract_if_alternating_directions_held_guards() {
         let mut table = write_txn.open_table(U64_TABLE).unwrap();
         let mut held = vec![];
         {
-            let mut extracted = table.extract_if(|k, _| k != 0).unwrap();
+            let mut extracted = extract_if!(table, u64, |k, _| k != 0).unwrap();
             let mut front = true;
             loop {
                 let entry = if front {
@@ -2550,7 +2566,7 @@ fn extract_from_if_empty() {
             table.insert(i, i).unwrap();
         }
         #[expect(clippy::reversed_empty_ranges)]
-        let mut iter = table.extract_from_if(500..0, |_, _| true).unwrap();
+        let mut iter = extract_from_if!(table, 500..0, |_, _| true).unwrap();
         assert!(iter.next().is_none());
     }
     write_txn.commit().unwrap();
@@ -3354,11 +3370,11 @@ fn signature_lifetimes() {
             table.range(key.as_str()..).unwrap()
         };
 
-        let _ = { table.extract_if(|_, _| true).unwrap() };
+        let _ = { extract_if!(table, &str, |_, _| true).unwrap() };
 
         let _ = {
             let key = "hi".to_string();
-            table.extract_from_if(key.as_str().., |_, _| true).unwrap()
+            extract_from_if!(table, key.as_str().., |_, _| true).unwrap()
         };
     }
     write_txn.commit().unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -28,6 +28,20 @@ const SLICE_TABLE2: TableDefinition<&[u8], &[u8]> = TableDefinition::new("slice2
 const STR_TABLE: TableDefinition<&str, &str> = TableDefinition::new("x");
 const U64_TABLE: TableDefinition<u64, u64> = TableDefinition::new("u64");
 
+// Bridge the extract_if() signature change made by the experimental-api-5 feature, so that these
+// tests cover the extraction machinery in both configurations. The 5.0 signature takes a range,
+// and extracting the whole table must name the key type, because an unbounded range does not pin
+// it down.
+macro_rules! extract_if {
+    ($table:expr, $key:ty, $predicate:expr) => {{
+        #[cfg(feature = "experimental-api-5")]
+        let iter = $table.extract_if::<$key, _>(.., $predicate);
+        #[cfg(not(feature = "experimental-api-5"))]
+        let iter = $table.extract_if($predicate);
+        iter
+    }};
+}
+
 fn create_tempfile() -> tempfile::NamedTempFile {
     if cfg!(target_os = "wasi") {
         tempfile::NamedTempFile::new_in("/tmp").unwrap()
@@ -305,7 +319,7 @@ fn extract_if_error_latches() {
     let txn = db.begin_write().unwrap();
     {
         let mut table = txn.open_table(U64_TABLE).unwrap();
-        let mut iter = table.extract_if(|_, _| true).unwrap();
+        let mut iter = extract_if!(table, u64, |_, _| true).unwrap();
         assert!(iter.next().unwrap().is_ok());
         fail_reads.store(true, Ordering::SeqCst);
         // The current leaf may drain from memory before a read is needed.
@@ -355,7 +369,7 @@ fn extract_if_error_commit_reports_storage_failure() {
         fail_reads.store(true, Ordering::SeqCst);
         // The predicate never matches, so no removals are pending when the
         // read error surfaces and finalization succeeds without I/O.
-        let mut iter = table.extract_if(|_, _| false).unwrap();
+        let mut iter = extract_if!(table, u64, |_, _| false).unwrap();
         assert!(iter.next().unwrap().is_err());
         fail_reads.store(false, Ordering::SeqCst);
     }
@@ -4655,7 +4669,7 @@ fn extract_if_next_then_next_back_panic() {
     let txn = db.begin_write().unwrap();
     {
         let mut table = txn.open_table(table_def).unwrap();
-        let mut iter = table.extract_if(|_, _| true).unwrap();
+        let mut iter = extract_if!(table, u64, |_, _| true).unwrap();
 
         let first = iter.next();
         assert!(first.is_some());


### PR DESCRIPTION
Adds an `experimental-api-5` feature flag for the `Table` API changes planned for the 5.0 release, so they can be tried out and ported to ahead of it, and makes the extraction API its first change.

## Changes

* **`Cargo.toml`**: new `experimental-api-5` feature, documented as unstable like `experimental_cursor`.
* **`Table::extract_if()`** (gated): takes the range to extract from, matching `std::collections::BTreeMap::extract_if()`. Its signature is the one `extract_from_if()` has today.
* **`Table::extract_from_if()`** (gated): removed, now that `extract_if()` covers it.
* Both public methods are thin wrappers over one private `extract_range_if()`, so the two configurations share a single implementation and nothing about the extraction machinery changes.

Calls port over as `extract_from_if(range, predicate)` -> `extract_if(range, predicate)`, and `extract_if(predicate)` -> `extract_if::<KeyType, _>(.., predicate)`.

## Note on the unbounded case

Because the range parameter is `impl RangeBounds<KR>` with `KR: Borrow<K::SelfType<'a>>`, `..` cannot be inferred and callers must name the key type: `table.extract_if::<u64, _>(.., predicate)`. That is the same wart `range()` already has (`table.range::<&str>(..)`), and it is the cost of keeping `extract_from_if()`'s signature exactly. `BTreeMap` does not have it, because its range is bound to the map's own key type. If matching `BTreeMap`'s ergonomics matters more than accepting borrowed bound types, `impl RangeBounds<K::SelfType<'a>>` would make `extract_if(.., predicate)` infer, at the cost of rejecting e.g. a `String` bound for a `&str`-keyed table. Happy to switch if you prefer that for 5.0.

## Testing

The tests call the extraction API through a pair of macros that expand to whichever signature the feature selects, so the full set runs against both the current and the 5.0 API rather than only one of them.

* `cargo test --all-features` (includes `experimental-api-5`): 359 passed, 0 failed
* `cargo test` (default features): 324 passed, 0 failed
* `cargo clippy --all --all-targets --all-features`: clean
* `cargo clippy -p redb --all-targets` (default features): clean
* `cargo fmt --all -- --check`: clean
* `cargo doc --all-features`: no new warnings

`redb-bench` gains a passthrough feature of the same name, because a workspace `--all-features` build unifies the flag into its redb dev-dependency; verified it compiles both with and without the feature. The fuzz target builds in its own workspace with only `experimental_cursor`, so it keeps using the current signatures.

## Release notes

`CHANGELOG.md` gets an entry under 4.2.0 describing the flag, the new `extract_if()` signature, the removal of `extract_from_if()`, and how calls port over.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWixTK4bUrh4ANWstPeGVG)_