### PR TITLE
Add a read-only table cursor API, behind the experimental flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
   between entries, modeled on the standard library's `BTreeMap` cursors. Inserting sorted data
   through its `insert_before()` method can be around 3x faster than calling `insert()` with the
   same data. The feature is unstable and may change incompatibly, or be removed, in any release.
+* Add a read-only counterpart to the experimental cursor API. Behind the new `experimental-api-5`
+  feature flag, which collects trait additions planned for redb 5, `ReadableTable::lower_bound()`
+  and `ReadableTable::upper_bound()` return a `Cursor` pointing at a gap between entries, with
+  reference-counted variants on `ReadOnlyTable` that keep the transaction alive. The cursor's
+  `peek_next()`, `peek_prev()`, `next()`, and `prev()` methods, which mirror the standard
+  library's `BTreeMap` cursors, are behind the `experimental_cursor` feature flag (which enables
+  `experimental-api-5`); the split lets the trait surface stabilize before the cursor's own
+  methods settle.
 * Fix `WriteTransaction::stats()` returning garbage statistics, or panicking when debug assertions
   are enabled, when called while a table is open and modified in the same transaction.
 * Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. A live

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,10 @@ logging = ["dep:log"]
 # Enable cache hit metrics
 cache_metrics = []
 # Unstable cursor API. May change incompatibly, or be removed, in any release
-experimental_cursor = []
+experimental_cursor = ["experimental-api-5"]
+# Unstable additions to the public traits, planned for redb 5. May change incompatibly, or be
+# removed, in any release
+experimental-api-5 = []
 
 [profile.bench]
 debug = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,8 @@ pub use multimap_table::{
     MultimapRange, MultimapTable, MultimapValue, OwnedMultimapRange, OwnedMultimapValue,
     ReadOnlyMultimapTable, ReadOnlyUntypedMultimapTable, ReadableMultimapTable,
 };
+#[cfg(feature = "experimental-api-5")]
+pub use table::Cursor;
 #[cfg(feature = "experimental_cursor")]
 pub use table::CursorMut;
 pub use table::{

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,5 +1,7 @@
 use crate::db::TransactionGuard;
 use crate::sealed::Sealed;
+#[cfg(feature = "experimental-api-5")]
+use crate::tree_store::BtreeCursor;
 #[cfg(feature = "experimental_cursor")]
 use crate::tree_store::BtreeCursorMut;
 use crate::tree_store::{
@@ -13,7 +15,7 @@ use crate::{Result, TableHandle};
 use std::borrow::Borrow;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
-#[cfg(feature = "experimental_cursor")]
+#[cfg(feature = "experimental-api-5")]
 use std::ops::Bound;
 use std::ops::RangeBounds;
 use std::sync::{Arc, Mutex};
@@ -443,6 +445,28 @@ impl<K: Key + 'static, V: Value + 'static> ReadableTable<K, V> for Table<'_, K, 
     fn last(&self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
         self.tree.last()
     }
+
+    #[cfg(feature = "experimental-api-5")]
+    fn lower_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<Cursor<'_, K, V>> {
+        let bound = bound_to_bytes::<K, _>(&bound);
+        let mut inner = self.tree.cursor()?;
+        inner.seek_lower_bound(bound.as_ref().map(|bytes| bytes.as_slice()))?;
+        Ok(Cursor::new(inner, self.transaction.transaction_guard()))
+    }
+
+    #[cfg(feature = "experimental-api-5")]
+    fn upper_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<Cursor<'_, K, V>> {
+        let bound = bound_to_bytes::<K, _>(&bound);
+        let mut inner = self.tree.cursor()?;
+        inner.seek_upper_bound(bound.as_ref().map(|bytes| bytes.as_slice()))?;
+        Ok(Cursor::new(inner, self.transaction.transaction_guard()))
+    }
 }
 
 impl<K: Key, V: Value> Sealed for Table<'_, K, V> {}
@@ -567,6 +591,89 @@ pub trait ReadableTable<K: Key + 'static, V: Value + 'static>: ReadableTableMeta
 
     /// Returns the last key-value pair in the table, if it exists
     fn last(&self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>>;
+
+    /// Returns a read-only [`Cursor`] pointing at the gap before the smallest
+    /// key greater than the given bound.
+    ///
+    /// Passing `Bound::Included(x)` will return a cursor pointing to the gap
+    /// before the smallest key greater than or equal to `x`.
+    ///
+    /// Passing `Bound::Excluded(x)` will return a cursor pointing to the gap
+    /// before the smallest key greater than `x`.
+    ///
+    /// Passing `Bound::Unbounded` will return a cursor pointing to the gap
+    /// before the smallest key in the table.
+    ///
+    /// This is analogous to [`std::collections::BTreeMap::lower_bound`].
+    ///
+    /// # Examples
+    ///
+    /// Probing around a key in any table, read-only or not. The cursor's
+    /// methods additionally require the `experimental_cursor` feature flag:
+    ///
+    #[cfg_attr(feature = "experimental_cursor", doc = "```rust")]
+    #[cfg_attr(not(feature = "experimental_cursor"), doc = "```rust,ignore")]
+    /// use std::ops::Bound;
+    /// use redb::{Database, Error, ReadableDatabase, ReadableTable, TableDefinition};
+    /// # use tempfile::NamedTempFile;
+    /// const TABLE: TableDefinition<u64, u64> = TableDefinition::new("my_data");
+    ///
+    /// fn entry_at_or_after(
+    ///     table: &impl ReadableTable<u64, u64>,
+    ///     key: u64,
+    /// ) -> Result<Option<u64>, Error> {
+    ///     let mut cursor = table.lower_bound(Bound::Included(&key))?;
+    ///     Ok(cursor.peek_next()?.map(|(key, _)| key.value()))
+    /// }
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// # #[cfg(not(target_os = "wasi"))]
+    /// # let tmpfile = NamedTempFile::new().unwrap();
+    /// # #[cfg(target_os = "wasi")]
+    /// # let tmpfile = NamedTempFile::new_in("/tmp").unwrap();
+    /// # let filename = tmpfile.path();
+    /// let db = Database::create(filename)?;
+    /// let write_txn = db.begin_write()?;
+    /// {
+    ///     let mut table = write_txn.open_table(TABLE)?;
+    ///     for key in 0..10 {
+    ///         table.insert(key, &(key * 2))?;
+    ///     }
+    ///     assert_eq!(entry_at_or_after(&table, 5)?, Some(5));
+    /// }
+    /// write_txn.commit()?;
+    ///
+    /// let read_txn = db.begin_read()?;
+    /// let table = read_txn.open_table(TABLE)?;
+    /// assert_eq!(entry_at_or_after(&table, 5)?, Some(5));
+    /// assert_eq!(entry_at_or_after(&table, 100)?, None);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "experimental-api-5")]
+    fn lower_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<Cursor<'_, K, V>>;
+
+    /// Returns a read-only [`Cursor`] pointing at the gap after the greatest
+    /// key smaller than the given bound.
+    ///
+    /// Passing `Bound::Included(x)` will return a cursor pointing to the gap
+    /// after the greatest key smaller than or equal to `x`.
+    ///
+    /// Passing `Bound::Excluded(x)` will return a cursor pointing to the gap
+    /// after the greatest key smaller than `x`.
+    ///
+    /// Passing `Bound::Unbounded` will return a cursor pointing to the gap
+    /// after the greatest key in the table.
+    ///
+    /// This is analogous to [`std::collections::BTreeMap::upper_bound`].
+    #[cfg(feature = "experimental-api-5")]
+    fn upper_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<Cursor<'_, K, V>>;
 
     /// Returns a double-ended iterator over all elements in the table
     fn iter(&self) -> Result<Range<'_, K, V>> {
@@ -695,6 +802,32 @@ impl<K: Key + 'static, V: Value + 'static> ReadOnlyTable<K, V> {
             self.transaction_guard.clone(),
         ))
     }
+
+    /// This method is like [`ReadableTable::lower_bound()`], but the cursor is reference counted
+    /// and keeps the transaction alive until it is dropped.
+    #[cfg(feature = "experimental-api-5")]
+    pub fn lower_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<Cursor<'static, K, V>> {
+        let bound = bound_to_bytes::<K, _>(&bound);
+        let mut inner = self.tree.cursor();
+        inner.seek_lower_bound(bound.as_ref().map(|bytes| bytes.as_slice()))?;
+        Ok(Cursor::new(inner, self.transaction_guard.clone()))
+    }
+
+    /// This method is like [`ReadableTable::upper_bound()`], but the cursor is reference counted
+    /// and keeps the transaction alive until it is dropped.
+    #[cfg(feature = "experimental-api-5")]
+    pub fn upper_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<Cursor<'static, K, V>> {
+        let bound = bound_to_bytes::<K, _>(&bound);
+        let mut inner = self.tree.cursor();
+        inner.seek_upper_bound(bound.as_ref().map(|bytes| bytes.as_slice()))?;
+        Ok(Cursor::new(inner, self.transaction_guard.clone()))
+    }
 }
 
 impl<K: Key + 'static, V: Value + 'static> ReadableTableMetadata for ReadOnlyTable<K, V> {
@@ -736,6 +869,22 @@ impl<K: Key + 'static, V: Value + 'static> ReadableTable<K, V> for ReadOnlyTable
 
     fn last(&self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
         self.tree.last()
+    }
+
+    #[cfg(feature = "experimental-api-5")]
+    fn lower_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<Cursor<'_, K, V>> {
+        ReadOnlyTable::lower_bound(self, bound)
+    }
+
+    #[cfg(feature = "experimental-api-5")]
+    fn upper_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<Cursor<'_, K, V>> {
+        ReadOnlyTable::upper_bound(self, bound)
     }
 }
 
@@ -1159,7 +1308,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> VacantEntry<'a, K, V> {
     }
 }
 
-#[cfg(feature = "experimental_cursor")]
+#[cfg(feature = "experimental-api-5")]
 fn bound_to_bytes<'a, K: Key + 'a, KR: Borrow<K::SelfType<'a>>>(
     bound: &Bound<KR>,
 ) -> Bound<Vec<u8>> {
@@ -1167,6 +1316,86 @@ fn bound_to_bytes<'a, K: Key + 'a, KR: Borrow<K::SelfType<'a>>>(
         Bound::Included(key) => Bound::Included(K::as_bytes(key.borrow()).as_ref().to_vec()),
         Bound::Excluded(key) => Bound::Excluded(K::as_bytes(key.borrow()).as_ref().to_vec()),
         Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+/// A read-only cursor over a table, pointing at a gap between two entries.
+///
+/// Cursors are constructed with [`ReadableTable::lower_bound`] and
+/// [`ReadableTable::upper_bound`], and mirror the nightly
+/// [`std::collections::btree_map::Cursor`] as closely as the redb data model
+/// allows: values are stored serialized, so the entries around the gap are
+/// returned as [`AccessGuard`]s instead of references, and every operation
+/// can report a storage error.
+///
+/// The cursor's methods are behind the `experimental_cursor` feature flag,
+/// separately from its constructors, so that the constructors' signatures
+/// can stabilize first.
+#[cfg(feature = "experimental-api-5")]
+pub struct Cursor<'a, K: Key + 'static, V: Value + 'static> {
+    // Only the cursor's own methods read the position; without them the
+    // constructors still store it, ready for the methods' flag to be enabled.
+    #[cfg_attr(not(feature = "experimental_cursor"), allow(dead_code))]
+    inner: BtreeCursor<K, V>,
+    _transaction_guard: Arc<TransactionGuard>,
+    // This lifetime is here so that `&` can be held on `Table` preventing concurrent mutation
+    _lifetime: PhantomData<&'a ()>,
+}
+
+#[cfg(feature = "experimental-api-5")]
+impl<K: Key + 'static, V: Value + 'static> Cursor<'_, K, V> {
+    pub(crate) fn new(inner: BtreeCursor<K, V>, guard: Arc<TransactionGuard>) -> Self {
+        Self {
+            inner,
+            _transaction_guard: guard,
+            _lifetime: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "experimental_cursor")]
+impl<'a, K: Key + 'static, V: Value + 'static> Cursor<'a, K, V> {
+    /// Returns the entry after the cursor's gap without moving the cursor.
+    ///
+    /// Returns `None` if the gap is at the end of the table.
+    #[allow(clippy::type_complexity)]
+    pub fn peek_next(&mut self) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        self.inner.peek_next()
+    }
+
+    /// Returns the entry before the cursor's gap without moving the cursor.
+    ///
+    /// Returns `None` if the gap is at the start of the table.
+    #[allow(clippy::type_complexity)]
+    pub fn peek_prev(&mut self) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        self.inner.peek_prev()
+    }
+
+    /// Moves the cursor past the entry after the gap, returning that entry.
+    ///
+    /// Returns `None`, and does not move, if the gap is at the end of the
+    /// table.
+    ///
+    /// This is analogous to the nightly
+    /// [`std::collections::btree_map::Cursor::next`]. The cursor is not an
+    /// [`Iterator`], since every step can report a storage error; use
+    /// [`ReadableTable::range`] for iteration.
+    #[allow(clippy::should_implement_trait, clippy::type_complexity)]
+    pub fn next(&mut self) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        self.inner.next()
+    }
+
+    /// Moves the cursor before the entry preceding the gap, returning that
+    /// entry.
+    ///
+    /// Returns `None`, and does not move, if the gap is at the start of the
+    /// table.
+    ///
+    /// This is analogous to the nightly
+    /// [`std::collections::btree_map::Cursor::prev`].
+    #[allow(clippy::type_complexity)]
+    pub fn prev(&mut self) -> Result<Option<(AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        self.inner.prev()
     }
 }
 

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -3,6 +3,8 @@ use crate::tree_store::btree_base::{
     AccessGuardMut, BRANCH, BranchAccessor, BranchMutator, BtreeHeader, Checksum, DEFERRED, LEAF,
     LeafAccessor, LeafPageMut, branch_checksum, leaf_checksum,
 };
+#[cfg(feature = "experimental-api-5")]
+use crate::tree_store::btree_cursor::BtreeCursor;
 #[cfg(feature = "experimental_cursor")]
 use crate::tree_store::btree_cursor::BtreeCursorMut;
 use crate::tree_store::btree_cursor::{CursorMut, Position};
@@ -704,6 +706,14 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         Ok(result)
     }
 
+    // The tree-level cursor behind the public read-only `Cursor`, over the
+    // tree's current (possibly uncommitted) state. The caller positions it
+    // with its seek methods before use.
+    #[cfg(feature = "experimental-api-5")]
+    pub(crate) fn cursor(&self) -> Result<BtreeCursor<K, V>> {
+        Ok(self.read_tree()?.cursor())
+    }
+
     // The tree-level cursor behind the public `CursorMut`. The caller
     // positions it with its seek methods before use.
     #[cfg(feature = "experimental_cursor")]
@@ -994,6 +1004,13 @@ impl<K: Key, V: Value> Btree<K, V> {
 
     pub(crate) fn hint(&self) -> PageHint {
         self.hint
+    }
+
+    // The tree-level cursor behind the public read-only `Cursor`. The caller
+    // positions it with its seek methods before use.
+    #[cfg(feature = "experimental-api-5")]
+    pub(crate) fn cursor(&self) -> BtreeCursor<K, V> {
+        BtreeCursor::new(self.root, self.mem.clone(), self.hint)
     }
 
     pub(crate) fn get_root(&self) -> Option<BtreeHeader> {

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -519,6 +519,29 @@ impl<K: Key + 'static, V: Value + 'static> Cursor<K, V> {
         Ok(Some(entry(leaf, leaf.position)))
     }
 
+    // The entry after the gap, without moving the gap. The position may still
+    // settle onto an adjacent leaf sharing the gap.
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn peek_next(&mut self) -> Result<Option<EntryGuard<K, V>>> {
+        if !self.ensure_has_entry(Direction::Next)? {
+            return Ok(None);
+        }
+
+        let leaf = self.leaf.as_ref().expect("cursor must be positioned");
+        Ok(Some(entry(leaf, leaf.position)))
+    }
+
+    // The entry before the gap, without moving the gap.
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn peek_prev(&mut self) -> Result<Option<EntryGuard<K, V>>> {
+        if !self.ensure_has_entry(Direction::Previous)? {
+            return Ok(None);
+        }
+
+        let leaf = self.leaf.as_ref().expect("cursor must be positioned");
+        Ok(Some(entry(leaf, leaf.position - 1)))
+    }
+
     fn page_number(&self) -> PageNumber {
         self.leaf
             .as_ref()
@@ -1432,6 +1455,97 @@ impl<'a, K: Key + 'static, V: Value + 'static> CursorTree<'a, K, V> {
     }
 }
 
+// The tree-level cursor behind the public read-only `Cursor`. The caller
+// positions it with its seek methods before use; over an empty tree there is
+// no position and every operation reports no entry.
+#[cfg(feature = "experimental-api-5")]
+pub(crate) struct BtreeCursor<K: Key + 'static, V: Value + 'static> {
+    inner: Option<Cursor<K, V>>,
+}
+
+#[cfg(feature = "experimental-api-5")]
+impl<K: Key + 'static, V: Value + 'static> BtreeCursor<K, V> {
+    pub(crate) fn new(root: Option<BtreeHeader>, resolver: PageResolver, hint: PageHint) -> Self {
+        Self {
+            inner: root.map(|header| Cursor::new(header.root, resolver, hint)),
+        }
+    }
+
+    /// Positions the cursor at the gap before the first key `bound` admits.
+    pub(crate) fn seek_lower_bound(&mut self, bound: Bound<&[u8]>) -> Result {
+        if let Some(cursor) = &mut self.inner {
+            cursor.seek_to(Position::from_lower_bound(bound))?;
+        }
+        Ok(())
+    }
+
+    /// Positions the cursor at the gap after the last key `bound` admits.
+    pub(crate) fn seek_upper_bound(&mut self, bound: Bound<&[u8]>) -> Result {
+        if let Some(cursor) = &mut self.inner {
+            cursor.seek_to(Position::from_upper_bound(bound))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "experimental_cursor")]
+impl<K: Key + 'static, V: Value + 'static> BtreeCursor<K, V> {
+    /// The entry after the gap, without moving the gap.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn peek_next(
+        &mut self,
+    ) -> Result<Option<(AccessGuard<'static, K>, AccessGuard<'static, V>)>> {
+        let Some(cursor) = &mut self.inner else {
+            return Ok(None);
+        };
+        Ok(cursor.peek_next()?.map(entry_guards))
+    }
+
+    /// The entry before the gap, without moving the gap.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn peek_prev(
+        &mut self,
+    ) -> Result<Option<(AccessGuard<'static, K>, AccessGuard<'static, V>)>> {
+        let Some(cursor) = &mut self.inner else {
+            return Ok(None);
+        };
+        Ok(cursor.peek_prev()?.map(entry_guards))
+    }
+
+    /// Moves the gap past the entry after it, returning that entry.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn next(
+        &mut self,
+    ) -> Result<Option<(AccessGuard<'static, K>, AccessGuard<'static, V>)>> {
+        let Some(cursor) = &mut self.inner else {
+            return Ok(None);
+        };
+        Ok(cursor.next()?.map(entry_guards))
+    }
+
+    /// Moves the gap before the entry preceding it, returning that entry.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn prev(
+        &mut self,
+    ) -> Result<Option<(AccessGuard<'static, K>, AccessGuard<'static, V>)>> {
+        let Some(cursor) = &mut self.inner else {
+            return Ok(None);
+        };
+        Ok(cursor.prev()?.map(entry_guards))
+    }
+}
+
+#[cfg(feature = "experimental_cursor")]
+fn entry_guards<K: Key + 'static, V: Value + 'static>(
+    entry: EntryGuard<K, V>,
+) -> (AccessGuard<'static, K>, AccessGuard<'static, V>) {
+    let (page, key_range, value_range) = entry.into_raw();
+    (
+        AccessGuard::with_page(page.clone(), key_range),
+        AccessGuard::with_page(page, value_range),
+    )
+}
+
 // The tree-level cursor behind the public `CursorMut`: one gap cursor that
 // owns its state across calls, in the style of `RangeMut` but with a single
 // end and buffered insertion instead of removal batching.
@@ -1490,11 +1604,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
             let entry = cursor
                 .next()?
                 .expect("the captured upper bound is in the tree");
-            let (page, key_range, value_range) = entry.into_raw();
-            return Ok(Some((
-                AccessGuard::with_page(page.clone(), key_range),
-                AccessGuard::with_page(page, value_range),
-            )));
+            return Ok(Some(entry_guards(entry)));
         }
         self.with_cursor(|cursor| Ok(cursor.peek_next()?.map(|entry| entry.to_guards())))
     }

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -14,6 +14,8 @@ pub(crate) use btree::{Btree, BtreeMut, BtreeStats, RawBtree};
 pub(crate) use btree_base::BtreeHeader;
 pub use btree_base::{AccessGuard, AccessGuardMut, AccessGuardMutInPlace};
 pub(crate) use btree_base::{BRANCH, LEAF, LeafAccessor, RawLeafBuilder};
+#[cfg(feature = "experimental-api-5")]
+pub(crate) use btree_cursor::BtreeCursor;
 #[cfg(feature = "experimental_cursor")]
 pub(crate) use btree_cursor::BtreeCursorMut;
 pub(crate) use btree_cursor_range::BtreeCursorRange;

--- a/tests/cursor_tests.rs
+++ b/tests/cursor_tests.rs
@@ -446,3 +446,235 @@ fn abort_discards_cursor_inserts() {
 
     assert_u64_table_contents(&db, &[(1, 1)]);
 }
+
+fn populate_u64_table(db: &Database, entries: impl Iterator<Item = (u64, u64)>) {
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for (key, value) in entries {
+            table.insert(key, &value).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+}
+
+#[allow(clippy::type_complexity)]
+fn peeked_key(entry: Option<(redb::AccessGuard<u64>, redb::AccessGuard<u64>)>) -> Option<u64> {
+    entry.map(|(key, _)| key.value())
+}
+
+#[test]
+fn read_cursor_all_bound_positions() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    populate_u64_table(&db, [10, 20, 30].into_iter().map(|key| (key, key * 2)));
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(U64_TABLE).unwrap();
+
+    // (bound constructor, is_lower, expected peek_prev, expected peek_next)
+    #[allow(clippy::type_complexity)]
+    let cases: &[(Bound<u64>, bool, Option<u64>, Option<u64>)] = &[
+        (Bound::Unbounded, true, None, Some(10)),
+        (Bound::Included(20), true, Some(10), Some(20)),
+        (Bound::Excluded(20), true, Some(20), Some(30)),
+        (Bound::Included(15), true, Some(10), Some(20)),
+        (Bound::Unbounded, false, Some(30), None),
+        (Bound::Included(20), false, Some(20), Some(30)),
+        (Bound::Excluded(20), false, Some(10), Some(20)),
+        (Bound::Included(15), false, Some(10), Some(20)),
+    ];
+    for (bound, is_lower, previous, next) in cases {
+        let mut cursor = if *is_lower {
+            table.lower_bound(bound.as_ref()).unwrap()
+        } else {
+            table.upper_bound(bound.as_ref()).unwrap()
+        };
+        assert_eq!(peeked_key(cursor.peek_prev().unwrap()), *previous);
+        assert_eq!(peeked_key(cursor.peek_next().unwrap()), *next);
+        // Peeks never move the cursor.
+        assert_eq!(peeked_key(cursor.peek_prev().unwrap()), *previous);
+        assert_eq!(peeked_key(cursor.peek_next().unwrap()), *next);
+        // The values came along.
+        if let Some((key, value)) = cursor.peek_next().unwrap() {
+            assert_eq!(value.value(), key.value() * 2);
+        }
+    }
+}
+
+#[test]
+fn read_cursor_walks_both_directions() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    populate_u64_table(&db, (0..1_000).map(|key| (key, key * 3)));
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(U64_TABLE).unwrap();
+
+    let mut cursor = table.lower_bound(Bound::<u64>::Unbounded).unwrap();
+    for expected in 0..1_000 {
+        let (key, value) = cursor.next().unwrap().unwrap();
+        assert_eq!(key.value(), expected);
+        assert_eq!(value.value(), expected * 3);
+    }
+    assert!(cursor.next().unwrap().is_none());
+    // The gap is now at the end; walk all the way back.
+    for expected in (0..1_000).rev() {
+        let (key, _) = cursor.prev().unwrap().unwrap();
+        assert_eq!(key.value(), expected);
+    }
+    assert!(cursor.prev().unwrap().is_none());
+
+    // Stepping over an entry and back returns the same entry.
+    let mut cursor = table.lower_bound(Bound::Included(&500)).unwrap();
+    assert_eq!(peeked_key(cursor.next().unwrap()), Some(500));
+    assert_eq!(peeked_key(cursor.prev().unwrap()), Some(500));
+    assert_eq!(peeked_key(cursor.peek_next().unwrap()), Some(500));
+    assert_eq!(peeked_key(cursor.peek_prev().unwrap()), Some(499));
+}
+
+#[test]
+fn read_cursor_string_keys() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(STR_TABLE).unwrap();
+        for i in 0..100u64 {
+            table.insert(key(i).as_str(), key(i).as_bytes()).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(STR_TABLE).unwrap();
+    let mut cursor = table
+        .lower_bound(Bound::Included(key(50).as_str()))
+        .unwrap();
+    let (first, _) = cursor.peek_next().unwrap().unwrap();
+    assert_eq!(first.value(), key(50));
+    drop(first);
+    for i in 50..100 {
+        let (entry_key, entry_value) = cursor.next().unwrap().unwrap();
+        assert_eq!(entry_key.value(), key(i));
+        assert_eq!(entry_value.value(), key(i).as_bytes());
+    }
+    assert!(cursor.next().unwrap().is_none());
+}
+
+#[test]
+fn read_cursor_empty_table() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let txn = db.begin_write().unwrap();
+    txn.open_table(U64_TABLE).map(drop).unwrap();
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(U64_TABLE).unwrap();
+    let mut cursor = table.lower_bound(Bound::<u64>::Unbounded).unwrap();
+    assert!(cursor.peek_next().unwrap().is_none());
+    assert!(cursor.peek_prev().unwrap().is_none());
+    assert!(cursor.next().unwrap().is_none());
+    assert!(cursor.prev().unwrap().is_none());
+    let mut cursor = table.upper_bound(Bound::Included(&5)).unwrap();
+    assert!(cursor.next().unwrap().is_none());
+    assert!(cursor.prev().unwrap().is_none());
+}
+
+#[test]
+fn read_cursor_sees_uncommitted_writes() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in 0..100 {
+            table.insert(i, &(i + 1)).unwrap();
+        }
+        // A read-only cursor over the write table sees the uncommitted state.
+        let mut cursor = table.upper_bound(Bound::<u64>::Unbounded).unwrap();
+        assert_eq!(peeked_key(cursor.peek_prev().unwrap()), Some(99));
+        assert_eq!(peeked_key(cursor.prev().unwrap()), Some(99));
+        assert_eq!(peeked_key(cursor.prev().unwrap()), Some(98));
+        drop(cursor);
+
+        let mut cursor = table.lower_bound(Bound::Excluded(&41)).unwrap();
+        let (key, value) = cursor.next().unwrap().unwrap();
+        assert_eq!((key.value(), value.value()), (42, 43));
+    }
+    txn.abort().unwrap();
+}
+
+#[test]
+fn read_cursor_keeps_transaction_alive() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    populate_u64_table(&db, (0..10).map(|key| (key, key)));
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(U64_TABLE).unwrap();
+    let mut cursor = table.lower_bound(Bound::Included(&3)).unwrap();
+    // The ReadOnlyTable cursor is 'static: it stays usable after the table
+    // (and the guards it yields after the cursor) are dropped.
+    drop(table);
+    drop(txn);
+    let (key, _) = cursor.next().unwrap().unwrap();
+    assert_eq!(key.value(), 3);
+    let entry = cursor.peek_next().unwrap().unwrap();
+    drop(cursor);
+    assert_eq!(entry.0.value(), 4);
+}
+
+#[test]
+fn read_cursor_guards_outlive_cursor() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    populate_u64_table(&db, (0..10).map(|key| (key, key)));
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(U64_TABLE).unwrap();
+    let mut cursor = table.lower_bound(Bound::Included(&3)).unwrap();
+    // The guards borrow the table, not the cursor: they stay valid after the
+    // cursor moves on or is dropped.
+    let (stepped, _) = cursor.next().unwrap().unwrap();
+    let peeked = cursor.peek_next().unwrap().unwrap();
+    drop(cursor);
+    assert_eq!(stepped.value(), 3);
+    assert_eq!(peeked.0.value(), 4);
+}
+
+#[test]
+fn read_cursor_generic_over_readable_table() {
+    fn nearest_at_or_above<T: ReadableTable<u64, u64>>(table: &T, key: u64) -> Option<u64> {
+        let mut cursor = table.lower_bound(Bound::Included(&key)).unwrap();
+        cursor.peek_next().unwrap().map(|(key, _)| key.value())
+    }
+
+    fn nearest_below<T: ReadableTable<u64, u64>>(table: &T, key: u64) -> Option<u64> {
+        let mut cursor = table.upper_bound(Bound::Excluded(&key)).unwrap();
+        cursor.peek_prev().unwrap().map(|(key, _)| key.value())
+    }
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    populate_u64_table(&db, [10, 20, 30].into_iter().map(|key| (key, key)));
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(nearest_at_or_above(&table, 15), Some(20));
+    assert_eq!(nearest_below(&table, 15), Some(10));
+    assert_eq!(nearest_at_or_above(&table, 31), None);
+    drop(table);
+    drop(txn);
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        table.insert(25, &25).unwrap();
+        assert_eq!(nearest_at_or_above(&table, 21), Some(25));
+        assert_eq!(nearest_below(&table, 25), Some(20));
+    }
+    txn.abort().unwrap();
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3893,6 +3893,22 @@ impl<K: Key + 'static, V: Value + 'static, T: ReadableTable<K, V>> ReadableTable
     fn last(&self) -> redb::Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
         self.inner.last()
     }
+
+    #[cfg(feature = "experimental-api-5")]
+    fn lower_bound<'a>(
+        &self,
+        bound: std::ops::Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> redb::Result<redb::Cursor<'_, K, V>> {
+        self.inner.lower_bound(bound)
+    }
+
+    #[cfg(feature = "experimental-api-5")]
+    fn upper_bound<'a>(
+        &self,
+        bound: std::ops::Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> redb::Result<redb::Cursor<'_, K, V>> {
+        self.inner.upper_bound(bound)
+    }
 }
 
 impl<K: Key + 'static, V: Value + 'static, T: ReadableTable<K, V>> ReadableTableMetadata


### PR DESCRIPTION
The read-only counterpart to #1327's `CursorMut`, modeled on the standard library's nightly `BTreeMap` cursors.

Behind the new `experimental-api-5` feature flag, which collects trait additions planned for redb 5:

- `ReadableTable::lower_bound()` / `upper_bound()` return a read-only `Cursor` pointing at a gap between entries, with the same bound semantics as the `_mut` variants. There are no `Table` counterparts, so the required trait methods are the whole surface; a new required trait method breaks external `ReadableTable` implementations, which is why they sit behind their own flag -- the test suite's own delegating table demonstrates exactly that, and now implements the gated methods.
- `ReadOnlyTable` additionally has reference-counted variants, like its other accessors, whose cursors keep the read transaction alive until dropped.

Behind the `experimental_cursor` flag (which enables `experimental-api-5`), the cursor's methods: `peek_next()` / `peek_prev()` inspect the gap's neighbors without moving the cursor, while `next()` / `prev()` step the gap over an entry and return it. All return `AccessGuard`s and can report storage errors, so the cursor is deliberately not an `Iterator`. The split lets the trait surface stabilize while the cursor's own method names are still settling; with only `experimental-api-5` the cursor is an opaque token.

Cursors over a write-transaction `Table` see its uncommitted state. Internally this is thin: it reuses the read-only gap walker that `CursorMut`'s detached peeks already use, adding non-moving peeks and an empty-tree wrapper; no btree logic changes.

Integration tests cover all six bound positions, bidirectional walks across leaf boundaries, string keys, empty tables, uncommitted write-table state, cursors keeping the transaction alive after the table and transaction are dropped, guards outliving the cursor, and generic use through the trait against both table types. All feature-flag combinations compile and pass clippy; the trait method's doctest is `ignore`d in builds without `experimental_cursor` so no combination has a broken doctest.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ)_