### PR TITLE
Take a KeyRange in the range taking methods, behind experimental-api-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # redb - Changelog
 
+## 5.0.0 - 2026-XX-XX
+* Behind the `experimental-api-5` feature flag, the range taking methods --
+  `ReadableTable::range()`, `ReadOnlyTable::range_owned()`, `Table::retain_in()`,
+  `Table::extract_from_if()`, and their multimap equivalents -- take a `KeyRange` instead of a
+  `RangeBounds` over a borrowed key type, so ranges that carry no key type no longer need one
+  named: `table.range(..)` replaces `table.range::<KeyType>(..)`. Calls that named the key type in
+  a turbofish must drop it, and implementations of `ReadableTable` or `ReadableMultimapTable` must
+  update their `range()` signature. The inherent `ReadOnlyTable::range()` and
+  `ReadOnlyMultimapTable::range()`, whose `'static` iterators do not keep the transaction alive,
+  are removed under the flag; use the `ReadableTable` and `ReadableMultimapTable` methods, or the
+  `range_owned()` variants when the iterator must outlive the table.
+
 ## 4.2.0 - 2026-XX-XX
 * Fix a panic when opening a database containing a corrupted persistent savepoint record;
   `StorageError::Corrupted` is now returned instead.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ logging = ["dep:log"]
 cache_metrics = []
 # Unstable cursor API. May change incompatibly, or be removed, in any release
 experimental_cursor = ["experimental-api-5"]
-# Unstable additions to the public traits, planned for redb 5. May change incompatibly, or be
-# removed, in any release
+# Unstable additions and changes to the public API, planned for redb 5. May change incompatibly, or
+# be removed, in any release
 experimental-api-5 = []
 
 [profile.bench]

--- a/crates/redb-bench/benches/common.rs
+++ b/crates/redb-bench/benches/common.rs
@@ -1056,7 +1056,7 @@ impl BenchInserter for RedbBenchInserter<'_> {
         // returned iterator is consumed.
         let iter = self
             .table
-            .extract_from_if::<&[u8], F>(range, predicate)
+            .extract_from_if(range, predicate)
             .map_err(|_| ())?;
         Ok(RedbExtractIfIterator { iter })
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -881,7 +881,7 @@ impl Database {
                 Arc::new(TransactionGuard::untracked()),
                 resolver,
             )?;
-            for result in ReadableTable::range::<TransactionIdWithPagination>(&table, ..)? {
+            for result in ReadableTable::iter(&table)? {
                 let (_, pages) = result?;
                 for i in 0..pages.value().len() {
                     assert!(mem.is_allocated(pages.value().get(i)));
@@ -938,7 +938,7 @@ impl Database {
                     Arc::new(TransactionGuard::untracked()),
                     resolver,
                 )?;
-            for result in ReadableTable::range::<TransactionIdWithPagination>(&table, ..)? {
+            for result in ReadableTable::iter(&table)? {
                 let (_, page_list) = result?;
                 for i in 0..page_list.value().len() {
                     visitor(page_list.value().get(i))?;

--- a/src/key_range.rs
+++ b/src/key_range.rs
@@ -1,0 +1,62 @@
+use crate::sealed::Sealed;
+use crate::tree_store::encode_bounds;
+use crate::types::Key;
+use std::borrow::Borrow;
+use std::ops::{Bound, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+
+/// A range of keys, accepted by the range taking methods of a table
+///
+/// Implemented for the standard range types over any type that borrows the table's key type, so
+/// `5..10`, `&5..&10`, and `(Bound::Excluded(5), Bound::Unbounded)` are all accepted, and for `..`.
+///
+/// Unlike a plain [`std::ops::RangeBounds`] bound, the borrowed key type is a parameter of the implementing
+/// range type rather than of the method, so `..` carries no type to infer and needs no annotation.
+///
+/// This trait is sealed and cannot be implemented outside of redb.
+pub trait KeyRange<'a, K: Key + 'a>: Sealed {
+    /// Returns the range's bounds, as encoded by [`Key::as_bytes`]
+    #[doc(hidden)]
+    fn key_bounds(&self) -> (Bound<Vec<u8>>, Bound<Vec<u8>>);
+}
+
+macro_rules! impl_key_range {
+    ($range:ident) => {
+        impl<KR> Sealed for $range<KR> {}
+
+        impl<'a, K: Key + 'a, KR: Borrow<K::SelfType<'a>>> KeyRange<'a, K> for $range<KR> {
+            fn key_bounds(&self) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
+                encode_bounds::<K, KR, Self>(self)
+            }
+        }
+    };
+}
+
+impl_key_range!(Range);
+impl_key_range!(RangeFrom);
+impl_key_range!(RangeInclusive);
+impl_key_range!(RangeTo);
+impl_key_range!(RangeToInclusive);
+
+impl Sealed for RangeFull {}
+
+impl<'a, K: Key + 'a> KeyRange<'a, K> for RangeFull {
+    fn key_bounds(&self) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
+        (Bound::Unbounded, Bound::Unbounded)
+    }
+}
+
+impl<KR> Sealed for (Bound<KR>, Bound<KR>) {}
+
+impl<'a, K: Key + 'a, KR: Borrow<K::SelfType<'a>>> KeyRange<'a, K> for (Bound<KR>, Bound<KR>) {
+    fn key_bounds(&self) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
+        encode_bounds::<K, KR, Self>(self)
+    }
+}
+
+impl<R: Sealed> Sealed for &R {}
+
+impl<'a, K: Key + 'a, R: KeyRange<'a, K>> KeyRange<'a, K> for &R {
+    fn key_bounds(&self) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
+        (*self).key_bounds()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@ pub use error::{
     CommitError, CompactionError, DatabaseError, Error, SavepointError, SetDurabilityError,
     StorageError, TableError, TransactionError,
 };
+#[cfg(feature = "experimental-api-5")]
+pub use key_range::KeyRange;
 pub use multimap_table::{
     MultimapRange, MultimapTable, MultimapValue, OwnedMultimapRange, OwnedMultimapValue,
     ReadOnlyMultimapTable, ReadOnlyUntypedMultimapTable, ReadableMultimapTable,
@@ -91,6 +93,8 @@ pub mod backends;
 mod complex_types;
 mod db;
 mod error;
+#[cfg(feature = "experimental-api-5")]
+mod key_range;
 mod multimap_table;
 mod sealed;
 mod table;

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -1,7 +1,10 @@
+#[cfg(feature = "experimental-api-5")]
+use crate::KeyRange;
 use crate::db::TransactionGuard;
 use crate::multimap_table::DynamicCollectionType::{Inline, SubtreeV2};
 use crate::sealed::Sealed;
 use crate::table::{OwnedAccessGuard, ReadableTableMetadata, TableStats};
+#[cfg(not(feature = "experimental-api-5"))]
 use crate::tree_store::encode_bounds;
 use crate::tree_store::{
     AllPageNumbersBtreeIter, BRANCH, Btree, BtreeCursorRange, BtreeHeader, BtreeMut,
@@ -14,6 +17,7 @@ use crate::{AccessGuard, MultimapTableHandle, Result, StorageError, WriteTransac
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 use std::mem;
+#[cfg(not(feature = "experimental-api-5"))]
 use std::ops::RangeBounds;
 use std::ops::{Bound, Range, RangeFull};
 use std::sync::{Arc, Mutex};
@@ -954,6 +958,13 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V> for Multima
         Ok(iter)
     }
 
+    #[cfg(feature = "experimental-api-5")]
+    fn range<'a>(&self, range: impl KeyRange<'a, K>) -> Result<MultimapRange<'_, K, V>> {
+        let (lower, upper) = range.key_bounds();
+        self.range_in_bounds(lower, upper)
+    }
+
+    #[cfg(not(feature = "experimental-api-5"))]
     fn range<'a, KR>(&self, range: impl RangeBounds<KR> + 'a) -> Result<MultimapRange<'_, K, V>>
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
@@ -992,6 +1003,11 @@ pub trait ReadableMultimapTable<K: Key + 'static, V: Key + 'static>: ReadableTab
     fn get<'a>(&self, key: impl Borrow<K::SelfType<'a>>) -> Result<MultimapValue<'_, V>>;
 
     /// Returns a double-ended iterator over a range of elements in the table
+    #[cfg(feature = "experimental-api-5")]
+    fn range<'a>(&self, range: impl KeyRange<'a, K>) -> Result<MultimapRange<'_, K, V>>;
+
+    /// Returns a double-ended iterator over a range of elements in the table
+    #[cfg(not(feature = "experimental-api-5"))]
     fn range<'a, KR>(&self, range: impl RangeBounds<KR> + 'a) -> Result<MultimapRange<'_, K, V>>
     where
         KR: Borrow<K::SelfType<'a>> + 'a;
@@ -999,7 +1015,11 @@ pub trait ReadableMultimapTable<K: Key + 'static, V: Key + 'static>: ReadableTab
     /// Returns an double-ended iterator over all elements in the table. Values are in ascending
     /// order.
     fn iter(&self) -> Result<MultimapRange<'_, K, V>> {
-        self.range::<K::SelfType<'_>>(..)
+        #[cfg(feature = "experimental-api-5")]
+        let range = self.range(..);
+        #[cfg(not(feature = "experimental-api-5"))]
+        let range = self.range::<K::SelfType<'_>>(..);
+        range
     }
 }
 
@@ -1151,6 +1171,7 @@ impl<K: Key + 'static, V: Key + 'static> ReadOnlyMultimapTable<K, V> {
 
     /// This method is like [`ReadableMultimapTable::range()`], but the iterator is reference counted and keeps the transaction
     /// alive until it is dropped.
+    #[cfg(not(feature = "experimental-api-5"))]
     pub fn range<'a, KR>(&self, range: impl RangeBounds<KR>) -> Result<MultimapRange<'static, K, V>>
     where
         KR: Borrow<K::SelfType<'a>>,
@@ -1175,6 +1196,19 @@ impl<K: Key + 'static, V: Key + 'static> ReadOnlyMultimapTable<K, V> {
     /// This method is like [`ReadableMultimapTable::range()`], but the returned iterator is
     /// reference counted and keeps the transaction alive until it is dropped, as do the entries
     /// it yields.
+    #[cfg(feature = "experimental-api-5")]
+    pub fn range_owned<'a>(&self, range: impl KeyRange<'a, K>) -> Result<OwnedMultimapRange<K, V>> {
+        let (lower, upper) = range.key_bounds();
+        Ok(OwnedMultimapRange::new(
+            self.range_in_bounds(lower, upper)?,
+            self.transaction_guard.clone(),
+        ))
+    }
+
+    /// This method is like [`ReadableMultimapTable::range()`], but the returned iterator is
+    /// reference counted and keeps the transaction alive until it is dropped, as do the entries
+    /// it yields.
+    #[cfg(not(feature = "experimental-api-5"))]
     pub fn range_owned<'a, KR>(
         &self,
         range: impl RangeBounds<KR>,
@@ -1242,6 +1276,13 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V>
         Ok(iter)
     }
 
+    #[cfg(feature = "experimental-api-5")]
+    fn range<'a>(&self, range: impl KeyRange<'a, K>) -> Result<MultimapRange<'_, K, V>> {
+        let (lower, upper) = range.key_bounds();
+        self.range_in_bounds(lower, upper)
+    }
+
+    #[cfg(not(feature = "experimental-api-5"))]
     fn range<'a, KR>(&self, range: impl RangeBounds<KR> + 'a) -> Result<MultimapRange<'_, K, V>>
     where
         KR: Borrow<K::SelfType<'a>> + 'a,

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,9 +1,12 @@
+#[cfg(feature = "experimental-api-5")]
+use crate::KeyRange;
 use crate::db::TransactionGuard;
 use crate::sealed::Sealed;
 #[cfg(feature = "experimental-api-5")]
 use crate::tree_store::BtreeCursor;
 #[cfg(feature = "experimental_cursor")]
 use crate::tree_store::BtreeCursorMut;
+#[cfg(not(feature = "experimental-api-5"))]
 use crate::tree_store::encode_bounds;
 use crate::tree_store::{
     AccessGuardMutInPlace, Btree, BtreeCursorRange, BtreeExtractIf, BtreeHeader, BtreeMut,
@@ -17,6 +20,7 @@ use std::borrow::Borrow;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
 use std::ops::Bound;
+#[cfg(not(feature = "experimental-api-5"))]
 use std::ops::RangeBounds;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -182,6 +186,30 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     /// The predicate must not panic. If it panics, the write transaction is
     /// poisoned and [`crate::WriteTransaction::commit`] will return
     /// [`crate::CommitError::TransactionPoisoned`].
+    #[cfg(feature = "experimental-api-5")]
+    pub fn extract_from_if<'a, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
+        &mut self,
+        range: impl KeyRange<'a, K>,
+        predicate: F,
+    ) -> Result<ExtractIf<'_, K, V, F>> {
+        let (lower, upper) = range.key_bounds();
+        self.extract_in_bounds(lower, upper, predicate)
+    }
+
+    /// Applies `predicate` to all key-value pairs in the specified range. All entries for which
+    /// `predicate` evaluates to `true` are returned in an iterator, and those which are read from the iterator are removed
+    ///
+    /// Note: values not read from the iterator will not be removed
+    ///
+    /// If the iterator returns an error, later calls keep returning an error
+    /// (the failure is not recoverable). Entries already yielded stay
+    /// removed; if finalizing their removal fails too, the write transaction
+    /// is poisoned and cannot be committed.
+    ///
+    /// The predicate must not panic. If it panics, the write transaction is
+    /// poisoned and [`crate::WriteTransaction::commit`] will return
+    /// [`crate::CommitError::TransactionPoisoned`].
+    #[cfg(not(feature = "experimental-api-5"))]
     pub fn extract_from_if<'a, KR, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
         &mut self,
         range: impl RangeBounds<KR> + 'a,
@@ -235,6 +263,24 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     /// poisoned and [`crate::WriteTransaction::commit`] will return
     /// [`crate::CommitError::TransactionPoisoned`].
     ///
+    #[cfg(feature = "experimental-api-5")]
+    pub fn retain_in<'a, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
+        &mut self,
+        range: impl KeyRange<'a, K>,
+        predicate: F,
+    ) -> Result {
+        let (lower, upper) = range.key_bounds();
+        self.retain_in_bounds(lower, upper, predicate)
+    }
+
+    /// Applies `predicate` to all key-value pairs in the range `start..end`. All entries for which
+    /// `predicate` evaluates to `false` are removed.
+    ///
+    /// The predicate must not panic. If it panics, the write transaction is
+    /// poisoned and [`crate::WriteTransaction::commit`] will return
+    /// [`crate::CommitError::TransactionPoisoned`].
+    ///
+    #[cfg(not(feature = "experimental-api-5"))]
     pub fn retain_in<'a, KR, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
         &mut self,
         range: impl RangeBounds<KR> + 'a,
@@ -452,6 +498,13 @@ impl<K: Key + 'static, V: Value + 'static> ReadableTable<K, V> for Table<'_, K, 
         self.tree.get(key.borrow())
     }
 
+    #[cfg(feature = "experimental-api-5")]
+    fn range<'a>(&self, range: impl KeyRange<'a, K>) -> Result<Range<'_, K, V>> {
+        let (lower, upper) = range.key_bounds();
+        self.range_in_bounds(lower, upper)
+    }
+
+    #[cfg(not(feature = "experimental-api-5"))]
     fn range<'a, KR>(&self, range: impl RangeBounds<KR> + 'a) -> Result<Range<'_, K, V>>
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
@@ -604,6 +657,45 @@ pub trait ReadableTable<K: Key + 'static, V: Value + 'static>: ReadableTableMeta
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "experimental-api-5")]
+    fn range<'a>(&self, range: impl KeyRange<'a, K>) -> Result<Range<'_, K, V>>;
+
+    /// Returns a double-ended iterator over a range of elements in the table
+    ///
+    /// # Examples
+    ///
+    /// Usage:
+    /// ```rust
+    /// use redb::*;
+    /// # use tempfile::NamedTempFile;
+    /// const TABLE: TableDefinition<&str, u64> = TableDefinition::new("my_data");
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// # #[cfg(not(target_os = "wasi"))]
+    /// # let tmpfile = NamedTempFile::new().unwrap();
+    /// # #[cfg(target_os = "wasi")]
+    /// # let tmpfile = NamedTempFile::new_in("/tmp").unwrap();
+    /// # let filename = tmpfile.path();
+    /// let db = Database::create(filename)?;
+    /// let write_txn = db.begin_write()?;
+    /// {
+    ///     let mut table = write_txn.open_table(TABLE)?;
+    ///     table.insert("a", &0)?;
+    ///     table.insert("b", &1)?;
+    ///     table.insert("c", &2)?;
+    /// }
+    /// write_txn.commit()?;
+    ///
+    /// let read_txn = db.begin_read()?;
+    /// let table = read_txn.open_table(TABLE)?;
+    /// let mut iter = table.range("a".."c")?;
+    /// let (key, value) = iter.next().unwrap()?;
+    /// assert_eq!("a", key.value());
+    /// assert_eq!(0, value.value());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(not(feature = "experimental-api-5"))]
     fn range<'a, KR>(&self, range: impl RangeBounds<KR> + 'a) -> Result<Range<'_, K, V>>
     where
         KR: Borrow<K::SelfType<'a>> + 'a;
@@ -699,7 +791,11 @@ pub trait ReadableTable<K: Key + 'static, V: Value + 'static>: ReadableTableMeta
 
     /// Returns a double-ended iterator over all elements in the table
     fn iter(&self) -> Result<Range<'_, K, V>> {
-        self.range::<K::SelfType<'_>>(..)
+        #[cfg(feature = "experimental-api-5")]
+        let range = self.range(..);
+        #[cfg(not(feature = "experimental-api-5"))]
+        let range = self.range::<K::SelfType<'_>>(..);
+        range
     }
 }
 
@@ -803,6 +899,7 @@ impl<K: Key + 'static, V: Value + 'static> ReadOnlyTable<K, V> {
 
     /// This method is like [`ReadableTable::range()`], but the iterator is reference counted and keeps the transaction
     /// alive until it is dropped.
+    #[cfg(not(feature = "experimental-api-5"))]
     pub fn range<'a, KR>(&self, range: impl RangeBounds<KR>) -> Result<Range<'static, K, V>>
     where
         KR: Borrow<K::SelfType<'a>>,
@@ -824,6 +921,19 @@ impl<K: Key + 'static, V: Value + 'static> ReadOnlyTable<K, V> {
     /// This method is like [`ReadableTable::range()`], but the returned iterator is reference
     /// counted and keeps the transaction alive until it is dropped, as do the
     /// [`OwnedAccessGuard`]s it yields.
+    #[cfg(feature = "experimental-api-5")]
+    pub fn range_owned<'a>(&self, range: impl KeyRange<'a, K>) -> Result<OwnedRange<K, V>> {
+        let (lower, upper) = range.key_bounds();
+        Ok(OwnedRange::new(
+            self.range_in_bounds(lower, upper)?,
+            self.transaction_guard.clone(),
+        ))
+    }
+
+    /// This method is like [`ReadableTable::range()`], but the returned iterator is reference
+    /// counted and keeps the transaction alive until it is dropped, as do the
+    /// [`OwnedAccessGuard`]s it yields.
+    #[cfg(not(feature = "experimental-api-5"))]
     pub fn range_owned<'a, KR>(&self, range: impl RangeBounds<KR>) -> Result<OwnedRange<K, V>>
     where
         KR: Borrow<K::SelfType<'a>>,
@@ -886,6 +996,13 @@ impl<K: Key + 'static, V: Value + 'static> ReadableTable<K, V> for ReadOnlyTable
         self.tree.get(key.borrow())
     }
 
+    #[cfg(feature = "experimental-api-5")]
+    fn range<'a>(&self, range: impl KeyRange<'a, K>) -> Result<Range<'_, K, V>> {
+        let (lower, upper) = range.key_bounds();
+        self.range_in_bounds(lower, upper)
+    }
+
+    #[cfg(not(feature = "experimental-api-5"))]
     fn range<'a, KR>(&self, range: impl RangeBounds<KR> + 'a) -> Result<Range<'_, K, V>>
     where
         KR: Borrow<K::SelfType<'a>> + 'a,

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -10,12 +10,37 @@ use redb::{
     TableError, TableHandle, TypeName, Value, WriteTransaction,
 };
 use std::cmp::Ordering;
+#[cfg(feature = "experimental-api-5")]
+use std::ops::Bound;
 #[cfg(not(target_os = "wasi"))]
 use std::sync;
 
 const SLICE_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("slice");
 const STR_TABLE: TableDefinition<&str, &str> = TableDefinition::new("x");
 const U64_TABLE: TableDefinition<u64, u64> = TableDefinition::new("u64");
+
+// Bridges the range signature change made by the experimental-api-5 feature, so that these tests
+// cover both configurations. The 5.0 signature infers the key type from the range itself, and an
+// unbounded range has none to infer, so today's signature needs it named.
+macro_rules! range_all {
+    ($table:expr, $key:ty) => {{
+        #[cfg(feature = "experimental-api-5")]
+        let range = $table.range(..);
+        #[cfg(not(feature = "experimental-api-5"))]
+        let range = $table.range::<$key>(..);
+        range
+    }};
+}
+
+macro_rules! range_owned_all {
+    ($table:expr, $key:ty) => {{
+        #[cfg(feature = "experimental-api-5")]
+        let range = $table.range_owned(..);
+        #[cfg(not(feature = "experimental-api-5"))]
+        let range = $table.range_owned::<$key>(..);
+        range
+    }};
+}
 
 fn create_tempfile() -> tempfile::NamedTempFile {
     if cfg!(target_os = "wasi") {
@@ -2227,7 +2252,7 @@ fn i128_type() {
     let read_txn = db.begin_read().unwrap();
     let table = read_txn.open_table(definition).unwrap();
     assert_eq!(-2, table.get(&-1).unwrap().unwrap().value());
-    let mut iter: OwnedRange<i128, i128> = table.range_owned::<i128>(..).unwrap();
+    let mut iter: OwnedRange<i128, i128> = range_owned_all!(table, i128).unwrap();
     for i in -11..10 {
         assert_eq!(iter.next().unwrap().unwrap().1.value(), i);
     }
@@ -2403,7 +2428,7 @@ fn array_type() {
     let hello = b"hello";
     assert_eq!(b"world_123", table.get(hello).unwrap().unwrap().value());
 
-    let mut iter: OwnedRange<&[u8; 5], &[u8; 9]> = table.range_owned::<&[u8; 5]>(..).unwrap();
+    let mut iter: OwnedRange<&[u8; 5], &[u8; 9]> = range_owned_all!(table, &[u8; 5]).unwrap();
     assert_eq!(iter.next().unwrap().unwrap().1.value(), b"world_123");
     assert!(iter.next().is_none());
 }
@@ -2510,7 +2535,7 @@ fn range_lifetime() {
 
     let mut iter = {
         let start = "hello".to_string();
-        table.range::<&str>(start.as_str()..).unwrap()
+        table.range(start.as_str()..).unwrap()
     };
     assert_eq!(iter.next().unwrap().unwrap().1.value(), "world");
     assert!(iter.next().is_none());
@@ -3095,7 +3120,13 @@ fn range_arc() {
         let read_txn = db.begin_read().unwrap();
         let table = read_txn.open_table(definition).unwrap();
         let start = "hello".to_string();
-        table.range::<&str>(start.as_str()..).unwrap()
+        // The 'static range() does not keep the transaction alive, so experimental-api-5 drops it
+        // in favour of range_owned()
+        #[cfg(feature = "experimental-api-5")]
+        let iter = table.range_owned(start.as_str()..).unwrap();
+        #[cfg(not(feature = "experimental-api-5"))]
+        let iter = table.range(start.as_str()..).unwrap();
+        iter
     };
     assert_eq!(iter.next().unwrap().unwrap().1.value(), "world");
     assert!(iter.next().is_none());
@@ -3215,7 +3246,7 @@ fn owned_get_signatures() {
 
     assert_eq!(2, table.get(&1).unwrap().unwrap().value());
 
-    let mut iter: OwnedRange<u32, u32> = table.range_owned::<u32>(..).unwrap();
+    let mut iter: OwnedRange<u32, u32> = range_owned_all!(table, u32).unwrap();
     for i in 0..10 {
         assert_eq!(iter.next().unwrap().unwrap().1.value(), i + 1);
     }
@@ -3225,11 +3256,76 @@ fn owned_get_signatures() {
         assert_eq!(iter.next().unwrap().unwrap().1.value(), i + 1);
     }
     assert!(iter.next().is_none());
+    // Naming the key type is only needed for today's signature: with a `KR` type parameter to
+    // infer, a reference bound is ambiguous.
+    #[cfg(feature = "experimental-api-5")]
+    let mut iter = table.range(&0..&10).unwrap();
+    #[cfg(not(feature = "experimental-api-5"))]
     let mut iter = table.range::<&u32>(&0..&10).unwrap();
     for i in 0..10 {
         assert_eq!(iter.next().unwrap().unwrap().1.value(), i + 1);
     }
     assert!(iter.next().is_none());
+}
+
+// Every range shape the range taking methods accept under experimental-api-5, without a type
+// annotation. `..` in particular carries no key type, which is why the methods take a KeyRange
+// rather than a RangeBounds over a key type parameter.
+#[cfg(feature = "experimental-api-5")]
+#[test]
+fn range_signature_inference() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..10 {
+            table.insert(&i, &i).unwrap();
+        }
+
+        assert_eq!(table.range(..).unwrap().count(), 10);
+        assert_eq!(table.range(2..8).unwrap().count(), 6);
+        assert_eq!(table.range(2..=8).unwrap().count(), 7);
+        assert_eq!(table.range(8..).unwrap().count(), 2);
+        assert_eq!(table.range(..8).unwrap().count(), 8);
+        assert_eq!(table.range(..=8).unwrap().count(), 9);
+        assert_eq!(table.range(&2..&8).unwrap().count(), 6);
+        assert_eq!(
+            table
+                .range((Bound::Excluded(2), Bound::Unbounded))
+                .unwrap()
+                .count(),
+            7
+        );
+        let range = 2..8;
+        assert_eq!(table.range(&range).unwrap().count(), 6);
+        assert_eq!(table.iter().unwrap().count(), 10);
+
+        table.retain_in(.., |_, _| true).unwrap();
+        table.retain_in(0..1, |_, _| true).unwrap();
+        assert_eq!(table.extract_from_if(.., |_, _| false).unwrap().count(), 0);
+        assert_eq!(
+            table.extract_from_if(2..8, |_, _| false).unwrap().count(),
+            0
+        );
+    }
+    {
+        // A borrowed key type, with bounds that borrow from a temporary
+        let mut table = write_txn.open_table(STR_TABLE).unwrap();
+        table.insert("a", "1").unwrap();
+        let key = "a".to_string();
+        assert_eq!(table.range(..).unwrap().count(), 1);
+        assert_eq!(table.range(key.as_str()..).unwrap().count(), 1);
+        assert_eq!(table.range("a".."b").unwrap().count(), 1);
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.range(..).unwrap().count(), 10);
+    assert_eq!(table.range(2..8).unwrap().count(), 6);
+    assert_eq!(table.range_owned(..).unwrap().count(), 10);
+    assert_eq!(table.range_owned(2..8).unwrap().count(), 6);
 }
 
 #[test]
@@ -3255,7 +3351,7 @@ fn ref_get_signatures() {
 
     let start = vec![0u8];
     let end = vec![10u8];
-    let mut iter = table.range::<&[u8]>(..).unwrap();
+    let mut iter = range_all!(table, &[u8]).unwrap();
     for i in 0..10 {
         assert_eq!(iter.next().unwrap().unwrap().1.value(), &[i + 1]);
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,7 @@
 use rand::RngExt;
 use rand::prelude::SliceRandom;
+#[cfg(feature = "experimental-api-5")]
+use redb::KeyRange;
 use redb::backends::FileBackend;
 use redb::{
     AccessGuard, Builder, CommitError, CompactionError, Database, Durability, Key, MultimapRange,
@@ -12,6 +14,7 @@ use std::borrow::Borrow;
 use std::fs;
 use std::io::{ErrorKind, Write};
 use std::marker::PhantomData;
+#[cfg(not(feature = "experimental-api-5"))]
 use std::ops::RangeBounds;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, RwLock, mpsc};
@@ -3879,6 +3882,12 @@ impl<K: Key + 'static, V: Value + 'static, T: ReadableTable<K, V>> ReadableTable
         self.inner.get(key)
     }
 
+    #[cfg(feature = "experimental-api-5")]
+    fn range<'a>(&self, range: impl KeyRange<'a, K>) -> redb::Result<Range<'_, K, V>> {
+        self.inner.range(range)
+    }
+
+    #[cfg(not(feature = "experimental-api-5"))]
     fn range<'a, KR>(&self, range: impl RangeBounds<KR> + 'a) -> redb::Result<Range<'_, K, V>>
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
@@ -3936,6 +3945,12 @@ impl<K: Key + 'static, V: Key + 'static, T: ReadableMultimapTable<K, V>> Readabl
         self.inner.get(key)
     }
 
+    #[cfg(feature = "experimental-api-5")]
+    fn range<'a>(&self, range: impl KeyRange<'a, K>) -> redb::Result<MultimapRange<'_, K, V>> {
+        self.inner.range(range)
+    }
+
+    #[cfg(not(feature = "experimental-api-5"))]
     fn range<'a, KR>(
         &self,
         range: impl RangeBounds<KR> + 'a,

--- a/tests/multimap_tests.rs
+++ b/tests/multimap_tests.rs
@@ -163,7 +163,7 @@ fn range_lifetime() {
 
     let mut iter = {
         let start = "hello".to_string();
-        table.range::<&str>(start.as_str()..).unwrap()
+        table.range(start.as_str()..).unwrap()
     };
     assert_eq!(
         iter.next()
@@ -197,7 +197,13 @@ fn range_arc_lifetime() {
         let read_txn = db.begin_read().unwrap();
         let table = read_txn.open_multimap_table(definition).unwrap();
         let start = "hello".to_string();
-        table.range::<&str>(start.as_str()..).unwrap()
+        // The 'static range() does not keep the transaction alive, so experimental-api-5 drops it
+        // in favour of range_owned()
+        #[cfg(feature = "experimental-api-5")]
+        let iter = table.range_owned(start.as_str()..).unwrap();
+        #[cfg(not(feature = "experimental-api-5"))]
+        let iter = table.range(start.as_str()..).unwrap();
+        iter
     };
     assert_eq!(
         iter.next()


### PR DESCRIPTION
Adds the `KeyRange` trait behind `experimental-api-5`, the flag that collects the API changes planned for redb 5. Rebased onto master now that #1339, which carried the internal refactoring, has merged.

## The problem

The range taking methods are generic over `KR: Borrow<K::SelfType<'a>>`, and `RangeFull` constrains nothing, so `..` cannot infer `KR` and every unbounded call needs a turbofish — including redb's own `iter()`, which spells it `self.range::<K::SelfType<'_>>(..)`. A pair of `Bound`s and a range of references are ambiguous for the same reason: `table.range(&0..&10)` and `extract_from_if((Bound::Excluded(k), Bound::Unbounded), f)` both need the key type named today.

## The change

Under the feature, `range()`, `range_owned()`, `retain_in()`, `extract_from_if()`, and their multimap equivalents replace that bound with a `KeyRange<'a, K>` trait:

```rust
// today
fn range<'a, KR>(&self, range: impl RangeBounds<KR> + 'a) -> Result<Range<'_, K, V>>
where KR: Borrow<K::SelfType<'a>> + 'a;
// under experimental-api-5
fn range<'a>(&self, range: impl KeyRange<'a, K>) -> Result<Range<'_, K, V>>;
```

One impl per concrete range shape — `Range`, `RangeFrom`, `RangeTo`, `RangeInclusive`, `RangeToInclusive`, `(Bound, Bound)`, `&R` — plus a standalone `RangeFull` impl. With no blanket impl over `RangeBounds`, `..` resolves to the `RangeFull` impl, which has no key type left to infer, while `2..8` and `&2..&8` still pin their bound type. The trait is sealed, since its one method returns bounds in redb's internal key encoding — which, after #1339, is what the methods convert their range to anyway.

## Compatibility

With the feature off the public signatures are unchanged: the diff adds the gated variants beside them rather than editing them, so the default build's API is identical to master's. Under the feature it is a breaking change — calls that name the key type in a turbofish must drop it, and implementations of `ReadableTable` / `ReadableMultimapTable` must update their `range()` signature (the delegating tables in the tests show both).

Only the calls that the 5.0 signature infers differently need bridging in the tests, through macros that expand to whichever form the feature selects; everything else compiles unchanged under both.

## Testing

New `range_signature_inference` test (feature-gated) covers every shape with no annotation: `..`, `2..8`, `2..=8`, `8..`, `..8`, `..=8`, `&2..&8`, `(Bound::Excluded(2), Bound::Unbounded)`, `&range`, `key.as_str()..` on a `&str` table, plus `iter()`, `retain_in()`, and `extract_from_if()`.

* `cargo test --all-features`: 369 passed, 0 failed
* `cargo test` (default features): 324 passed, 0 failed — same count as master, doctests included
* `cargo clippy --workspace --all-targets` and `--workspace --all-targets --all-features`: clean
* `cargo clippy -p redb --all-targets` in both feature configurations: clean
* `cargo fmt --all -- --check`: clean
* `cargo doc --all-features`: no new warnings
* `redb-bench` compiles; the fuzz target compiles unchanged