### PR TITLE
Add CursorMut::insert_after(), inserting through the gap's other side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   `Table::lower_bound_mut()` and `Table::upper_bound_mut()` return a `CursorMut` pointing at a gap
   between entries, modeled on the standard library's `BTreeMap` cursors. Inserting sorted data
   through its `insert_before()` method can be around 3x faster than calling `insert()` with the
-  same data. The feature is unstable and may change incompatibly, or be removed, in any release.
+  same data; `insert_after()` inserts through the gap in descending order at the same speed. The
+  feature is unstable and may change incompatibly, or be removed, in any release.
 * Add a read-only counterpart to the experimental cursor API. Behind the new `experimental-api-5`
   feature flag, which collects trait additions planned for redb 5, `ReadableTable::lower_bound()`
   and `ReadableTable::upper_bound()` return a `Cursor` pointing at a gap between entries, with

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -124,6 +124,9 @@ pub(crate) enum FuzzOperation {
         count: U64Between<0, 64>,
         stride: U64Between<1, 8>,
         value_size: BinomialDifferenceBoundedUSize<MAX_VALUE_SIZE>,
+        // Walk down from the gap with insert_after instead of up with
+        // insert_before
+        descending: bool,
     },
     Remove {
         key: BoundedU64<KEY_SPACE>,

--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -529,6 +529,7 @@ fn handle_table_op(
             count,
             stride,
             value_size,
+            descending,
         } => {
             let start = start_key.value;
             let stride = stride.value;
@@ -538,20 +539,41 @@ fn handle_table_op(
             // reference bound the keys the cursor accepts.
             let successor = reference.range(start..).next().map(|(k, _)| *k);
             let predecessor = reference.range(..start).next_back().map(|(k, _)| *k);
-            let keys: Vec<u64> = (0..count.value)
-                .map(|i| start + i * stride)
-                .take_while(|k| *k < KEY_SPACE && successor.is_none_or(|s| *k < s))
-                .collect();
+            let keys: Vec<u64> = if *descending {
+                // insert_after runs descend from the gap toward its
+                // predecessor.
+                (0..count.value)
+                    .map_while(|i| start.checked_sub(i * stride))
+                    .take_while(|k| {
+                        successor.is_none_or(|s| *k < s) && predecessor.is_none_or(|p| *k > p)
+                    })
+                    .collect()
+            } else {
+                (0..count.value)
+                    .map(|i| start + i * stride)
+                    .take_while(|k| *k < KEY_SPACE && successor.is_none_or(|s| *k < s))
+                    .collect()
+            };
             let mut cursor = table.lower_bound_mut(Bound::Included(&start))?;
             assert_eq!(cursor.peek_prev()?.map(|(k, _)| k.value()), predecessor);
             assert_eq!(cursor.peek_next()?.map(|(k, _)| k.value()), successor);
-            for key in &keys {
-                cursor.insert_before(key, value.as_slice())?;
+            if *descending {
+                for key in &keys {
+                    cursor.insert_after(key, value.as_slice())?;
+                }
+                // Peeks observe pending inserts without splicing them
+                let nearest = keys.last().copied().or(successor);
+                assert_eq!(cursor.peek_prev()?.map(|(k, _)| k.value()), predecessor);
+                assert_eq!(cursor.peek_next()?.map(|(k, _)| k.value()), nearest);
+            } else {
+                for key in &keys {
+                    cursor.insert_before(key, value.as_slice())?;
+                }
+                // Peeks observe pending inserts without splicing them
+                let last = keys.last().copied().or(predecessor);
+                assert_eq!(cursor.peek_prev()?.map(|(k, _)| k.value()), last);
+                assert_eq!(cursor.peek_next()?.map(|(k, _)| k.value()), successor);
             }
-            // Peeks observe pending inserts without splicing them
-            let last = keys.last().copied().or(predecessor);
-            assert_eq!(cursor.peek_prev()?.map(|(k, _)| k.value()), last);
-            assert_eq!(cursor.peek_next()?.map(|(k, _)| k.value()), successor);
             cursor.close()?;
             for key in keys {
                 reference.insert(key, value_size);

--- a/src/table.rs
+++ b/src/table.rs
@@ -1511,6 +1511,10 @@ impl<'a, K: Key + 'static, V: Value + 'static> CursorMut<'a, K, V> {
     /// Unlike [`Table::insert`], an existing key is never overwritten:
     /// inserting a key equal to either neighbor is unordered.
     ///
+    /// Runs of calls in one direction are buffered together; switching
+    /// between `insert_before` and [`insert_after`](Self::insert_after)
+    /// applies the other direction's pending inserts first.
+    ///
     /// This is analogous to the nightly
     /// [`std::collections::btree_map::CursorMut::insert_before`].
     pub fn insert_before<'k, 'v>(
@@ -1525,6 +1529,41 @@ impl<'a, K: Key + 'static, V: Value + 'static> CursorMut<'a, K, V> {
         match self
             .inner
             .insert_before(key_bytes.as_ref(), value_bytes.as_ref())
+        {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(StorageError::UnorderedKey),
+            Err(err) => Err(self.latch_error(err)),
+        }
+    }
+
+    /// Inserts a new entry into the gap that the cursor is pointing at. After
+    /// the insertion, the cursor points at the gap before the newly inserted
+    /// entry.
+    ///
+    /// If the key does not sort strictly greater than the entry before the
+    /// gap and strictly smaller than the entry after it,
+    /// [`StorageError::UnorderedKey`] is returned and nothing is changed.
+    /// Unlike [`Table::insert`], an existing key is never overwritten:
+    /// inserting a key equal to either neighbor is unordered.
+    ///
+    /// Runs of calls in one direction are buffered together; switching
+    /// between `insert_after` and [`insert_before`](Self::insert_before)
+    /// applies the other direction's pending inserts first.
+    ///
+    /// This is analogous to the nightly
+    /// [`std::collections::btree_map::CursorMut::insert_after`].
+    pub fn insert_after<'k, 'v>(
+        &mut self,
+        key: impl Borrow<K::SelfType<'k>>,
+        value: impl Borrow<V::SelfType<'v>>,
+    ) -> Result<()> {
+        self.check_usable()?;
+        let key_bytes = K::as_bytes(key.borrow());
+        let value_bytes = V::as_bytes(value.borrow());
+        Self::check_lengths(key_bytes.as_ref(), value_bytes.as_ref())?;
+        match self
+            .inner
+            .insert_after(key_bytes.as_ref(), value_bytes.as_ref())
         {
             Ok(true) => Ok(()),
             Ok(false) => Err(StorageError::UnorderedKey),

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -720,26 +720,45 @@ impl OwnedEntryBuffer {
 
     // Appends one pair, which must be greater than every buffered entry.
     #[cfg(feature = "experimental_cursor")]
-    pub(super) fn push(&mut self, key: &[u8], value: &[u8]) {
+    pub(super) fn push_back(&mut self, key: &[u8], value: &[u8]) {
         let pair = self.store(key, value);
         self.pairs.push_back(pair);
     }
 
-    // Copies `range` of the leaf's pairs to the back of the buffer. The pairs
-    // must all be greater than the buffered entries.
+    // Prepends one pair, which must be smaller than every buffered entry.
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn push_front(&mut self, key: &[u8], value: &[u8]) {
+        let pair = self.store(key, value);
+        self.pairs.push_front(pair);
+    }
+
+    // Copies `range` of the leaf's pairs to one end of the buffer. The pairs
+    // must all be greater than the buffered entries when `back` is true, and
+    // entirely smaller otherwise.
     #[cfg(feature = "experimental_cursor")]
     pub(super) fn extend_from_leaf_range(
         &mut self,
         accessor: &LeafAccessor<'_>,
         range: Range<usize>,
+        back: bool,
     ) {
         self.pairs.reserve(range.len());
         self.data
             .reserve(accessor.length_of_pairs(range.start, range.end));
-        for index in range {
-            let entry = accessor.entry(index).unwrap();
-            let pair = self.store(entry.key(), entry.value());
-            self.pairs.push_back(pair);
+        if back {
+            for index in range {
+                let entry = accessor.entry(index).unwrap();
+                let pair = self.store(entry.key(), entry.value());
+                self.pairs.push_back(pair);
+            }
+        } else {
+            // Prepending in reverse leaves the leaf's entries ascending at
+            // the front.
+            for index in range.rev() {
+                let entry = accessor.entry(index).unwrap();
+                let pair = self.store(entry.key(), entry.value());
+                self.pairs.push_front(pair);
+            }
         }
     }
 
@@ -755,6 +774,13 @@ impl OwnedEntryBuffer {
     pub(super) fn back(&self) -> Option<(&[u8], &[u8])> {
         self.pairs
             .back()
+            .map(|(key, value)| (&self.data[key.clone()], &self.data[value.clone()]))
+    }
+
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn front(&self) -> Option<(&[u8], &[u8])> {
+        self.pairs
+            .front()
             .map(|(key, value)| (&self.data[key.clone()], &self.data[value.clone()]))
     }
 

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -342,18 +342,33 @@ impl LeafRunRewrite {
 #[cfg(feature = "experimental_cursor")]
 const INSERT_FLUSH_BYTES: usize = 1024 * 1024;
 
-// Pending inserts at the cursor's gap. The buffer holds the current leaf's
-// entries before the gap followed by the inserts, in ascending key order, so
-// the splice packs it (plus the rest of the leaf) into full leaves in one
-// parent update per flush instead of descending the tree per insert.
+// Which side of the gap a run's pending inserts fall on: `insert_before`
+// buffers ascending arrivals behind the gap, `insert_after` descending
+// arrivals in front of it. The two cannot share the ends-only buffer, so
+// switching direction splices the pending run first.
+#[cfg(feature = "experimental_cursor")]
+#[derive(Copy, Clone, PartialEq)]
+enum RunDirection {
+    Ascending,
+    Descending,
+}
+
+// Pending inserts at the cursor's gap, in ascending key order throughout. An
+// ascending run's buffer holds the current leaf's entries before the gap and
+// then the inserts, appended in arrival order; a descending run's holds only
+// the inserts, prepended in arrival order, and the leaf's entries join at
+// the flush. Either way the splice packs the buffer plus the rest of the
+// leaf into full leaves in one parent update per flush instead of descending
+// the tree per insert.
 //
 // While a run is open the tree is never mutated and the cursor position never
 // moves, so the position's path stays valid until the splice.
 #[cfg(feature = "experimental_cursor")]
 struct InsertRun {
+    direction: RunDirection,
     // Key of the entry after the gap when the run opened; None when the gap
     // is at the end of the tree.
-    upper_key: Option<Vec<u8>>,
+    opening_next_key: Option<Vec<u8>>,
     // Greatest key at or before the gap: the last insert or, before any
     // insert, the entry preceding the gap; None at the start of the tree.
     // Inserts must sort strictly above it.
@@ -367,15 +382,31 @@ struct InsertRun {
 #[cfg(feature = "experimental_cursor")]
 impl InsertRun {
     // The buffered entry nearest the gap on the entry-before side, if any:
-    // a pending insert or an entry copied from the leaf's head.
+    // a pending insert or an entry copied from the leaf's head. A descending
+    // run buffers nothing on that side; the predecessor stays in the leaf.
     fn buffered_previous(&self) -> Option<(&[u8], &[u8])> {
-        self.entries.back()
+        match self.direction {
+            RunDirection::Ascending => self.entries.back(),
+            RunDirection::Descending => None,
+        }
     }
 
-    // Smallest key at or after the gap: the entry following the gap when the
-    // run opened. Inserts must sort strictly below it.
+    // The buffered entry nearest the gap on the entry-after side, if any:
+    // the most recent pending insert. An ascending run buffers nothing on
+    // that side; the successor stays in the leaf.
+    fn buffered_next(&self) -> Option<(&[u8], &[u8])> {
+        match self.direction {
+            RunDirection::Ascending => None,
+            RunDirection::Descending => self.entries.front(),
+        }
+    }
+
+    // Smallest key at or after the gap: the last `insert_after` or, before
+    // any, the entry following the gap. Inserts must sort strictly below it.
     fn next_key(&self) -> Option<&[u8]> {
-        self.upper_key.as_deref()
+        self.buffered_next()
+            .map(|(key, _)| key)
+            .or(self.opening_next_key.as_deref())
     }
 
     // True unless `key` sorts strictly between the gap's live bounds.
@@ -1303,9 +1334,7 @@ impl<K: Key + 'static, V: Value + 'static> CursorMut<'_, '_, K, V> {
         self.check_not_poisoned()?;
         assert!(self.state.removed_indexes.is_empty());
         assert!(self.state.leaf_run_rewrite.is_none());
-        if self.state.insert_run.is_none() {
-            self.open_insert_run()?;
-        }
+        self.ensure_insert_run(RunDirection::Ascending)?;
         let run = self.state.insert_run.as_mut().unwrap();
         if run.rejects::<K>(key) {
             // A run opened just for a rejected key holds nothing; drop it
@@ -1316,7 +1345,7 @@ impl<K: Key + 'static, V: Value + 'static> CursorMut<'_, '_, K, V> {
             }
             return Ok(false);
         }
-        run.entries.push(key, value);
+        run.entries.push_back(key, value);
         run.previous_key = Some(key.to_vec());
         run.inserted_pairs += 1;
         if run.entries.total_bytes() >= INSERT_FLUSH_BYTES {
@@ -1325,27 +1354,75 @@ impl<K: Key + 'static, V: Value + 'static> CursorMut<'_, '_, K, V> {
         Ok(true)
     }
 
+    /// Buffers `key`/`value` for insertion into the gap, leaving the gap
+    /// before the new entry. Returns false, leaving the tree and any pending
+    /// inserts unchanged, unless `key` sorts strictly between the entries
+    /// adjacent to the gap.
+    pub(super) fn insert_after(&mut self, key: &[u8], value: &[u8]) -> Result<bool> {
+        self.check_not_poisoned()?;
+        assert!(self.state.removed_indexes.is_empty());
+        assert!(self.state.leaf_run_rewrite.is_none());
+        self.ensure_insert_run(RunDirection::Descending)?;
+        let run = self.state.insert_run.as_mut().unwrap();
+        if run.rejects::<K>(key) {
+            // A run opened just for a rejected key holds nothing; drop it
+            // again, so rejection never leaves an open run behind to trip
+            // operations that require no pending inserts.
+            if run.inserted_pairs == 0 {
+                self.state.insert_run = None;
+            }
+            return Ok(false);
+        }
+        run.entries.push_front(key, value);
+        run.inserted_pairs += 1;
+        if run.entries.total_bytes() >= INSERT_FLUSH_BYTES {
+            self.flush_insert_run(true)?;
+        }
+        Ok(true)
+    }
+
+    // Opens a run in `direction` if none is open, splicing a pending run on
+    // the gap's other side first: the two directions cannot share the
+    // ends-only buffer.
+    fn ensure_insert_run(&mut self, direction: RunDirection) -> Result {
+        if let Some(run) = &self.state.insert_run {
+            if run.direction == direction {
+                return Ok(());
+            }
+            self.flush_insert_run(true)?;
+        }
+        if self.state.insert_run.is_none() {
+            self.open_insert_run(direction)?;
+        }
+        Ok(())
+    }
+
     // Captures the gap's neighbor keys and the current leaf's entries before
     // the gap. The peeks first settle a gap at the edge of two leaves on the
     // later leaf and then back on the earlier one, so afterward the gap's
     // remaining predecessors all sit in the current leaf before `position`,
     // and its successors are `position..` of the current leaf plus every
     // later leaf.
-    fn open_insert_run(&mut self) -> Result {
+    fn open_insert_run(&mut self, direction: RunDirection) -> Result {
         assert!(self.state.insert_run.is_none());
-        let upper_key = self.peek_next()?.map(|entry| entry.key_bytes().to_vec());
+        let opening_next_key = self.peek_next()?.map(|entry| entry.key_bytes().to_vec());
         let previous_key = self.peek_prev()?.map(|entry| entry.key_bytes().to_vec());
         let mut entries = OwnedEntryBuffer::default();
-        if let Some(position) = &self.state.position {
+        // A descending run's buffer only ever grows at the front, so the
+        // leaf's entries before the gap join at the flush instead of here.
+        if direction == RunDirection::Ascending
+            && let Some(position) = &self.state.position
+        {
             let accessor = LeafAccessor::new(
                 position.leaf.page.memory(),
                 K::fixed_width(),
                 V::fixed_width(),
             );
-            entries.extend_from_leaf_range(&accessor, 0..position.leaf.position);
+            entries.extend_from_leaf_range(&accessor, 0..position.leaf.position, true);
         }
         self.state.insert_run = Some(Box::new(InsertRun {
-            upper_key,
+            direction,
+            opening_next_key,
             previous_key,
             entries,
             inserted_pairs: 0,
@@ -1369,18 +1446,29 @@ impl<K: Key + 'static, V: Value + 'static> CursorMut<'_, '_, K, V> {
             // remains valid.
             return Ok(());
         }
-        let resume_key = run
-            .previous_key
-            .expect("a run with inserts records the last inserted key");
+        // The gap sits between the pending inserts on its two sides; resume
+        // on whichever side has one, at the same gap.
+        let resume_before = run.buffered_next().map(|(key, _)| key.to_vec());
+        let resume_after = run.previous_key;
+        let descending = run.direction == RunDirection::Descending;
         let mut entries = run.entries;
         let replaced = if let Some(position) = self.state.position.take() {
-            // The rest of the current leaf follows every pending insert.
             let accessor = LeafAccessor::new(
                 position.leaf.page.memory(),
                 K::fixed_width(),
                 V::fixed_width(),
             );
-            entries.extend_from_leaf_range(&accessor, position.leaf.position..position.leaf.len);
+            // A descending run's buffer holds only the pending inserts; the
+            // leaf's entries before the gap join at the front here. The rest
+            // of the leaf follows every pending insert either way.
+            if descending {
+                entries.extend_from_leaf_range(&accessor, 0..position.leaf.position, false);
+            }
+            entries.extend_from_leaf_range(
+                &accessor,
+                position.leaf.position..position.leaf.len,
+                true,
+            );
             let CursorPosition { path, leaf } = position;
             let replaced_leaf = leaf.page.get_page_number();
             // The leaf is one of the pages the splice frees, so its page
@@ -1402,7 +1490,12 @@ impl<K: Key + 'static, V: Value + 'static> CursorMut<'_, '_, K, V> {
         }
         result?;
         if reseek {
-            self.seek_to(Position::After(&resume_key))?;
+            if let Some(key) = &resume_before {
+                self.seek_to(Position::Before(key))?;
+            } else {
+                let key = resume_after.expect("a run with inserts bounds its gap on some side");
+                self.seek_to(Position::After(&key))?;
+            }
         }
         Ok(())
     }
@@ -1591,31 +1684,34 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
         self.with_cursor(|cursor| cursor.seek_to(Position::from_upper_bound(bound)))
     }
 
-    /// The entry after the gap, including while inserts are pending: peeking
-    /// never splices them.
+    /// The entry after the gap, including while inserts are pending: the
+    /// most recent `insert_after` is returned without splicing.
     #[allow(clippy::type_complexity)]
     pub(crate) fn peek_next(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
         if let Some(run) = &self.state.insert_run {
+            if let Some((key, value)) = run.buffered_next() {
+                return Ok(Some((
+                    AccessGuard::with_owned_value(key.to_vec()),
+                    AccessGuard::with_owned_value(value.to_vec()),
+                )));
+            }
             // The position must not move while a run is open, so the entry
-            // after the gap (the run's captured upper bound, unchanged since
-            // the tree is not mutated during a run) is re-read with a
-            // detached read-only cursor.
-            let Some(upper_key) = &run.upper_key else {
+            // after the gap (the run's opening next key, unchanged since the
+            // tree is not mutated during a run) is re-read with a detached
+            // read-only cursor.
+            let Some(next_key) = &run.opening_next_key else {
                 return Ok(None);
             };
-            let header = self
-                .tree
-                .root
-                .expect("a captured upper bound implies a root");
+            let header = self.tree.root.expect("a captured next key implies a root");
             let mut cursor: Cursor<K, V> = Cursor::new(
                 header.root,
                 self.tree.page_allocator.resolver(),
                 PageHint::None,
             );
-            cursor.seek_to(Position::Before(upper_key))?;
+            cursor.seek_to(Position::Before(next_key))?;
             let entry = cursor
                 .next()?
-                .expect("the captured upper bound is in the tree");
+                .expect("the captured next key is in the tree");
             return Ok(Some(entry_guards(entry)));
         }
         self.with_cursor(|cursor| Ok(cursor.peek_next()?.map(|entry| entry.to_guards())))
@@ -1624,19 +1720,32 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
     /// The entry before the gap, including while inserts are pending: the
     /// most recent insert is returned without splicing.
     ///
-    /// While a run is open, its buffer holds every predecessor the gap has in
-    /// the current leaf (the normalizing peeks settled the position on the
-    /// earlier of two leaves sharing the gap), so no buffered entry before
-    /// the gap means the gap is at the start of the tree.
+    /// While a run is open, the gap's predecessors in the current leaf are
+    /// either buffered (ascending runs) or untouched at the position
+    /// (descending runs); the normalizing peeks settled the position on the
+    /// earlier of two leaves sharing the gap, so finding none on either path
+    /// means the gap is at the start of the tree.
     #[allow(clippy::type_complexity)]
     pub(crate) fn peek_prev(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
         if let Some(run) = &self.state.insert_run {
-            return Ok(run.buffered_previous().map(|(key, value)| {
-                (
+            if let Some((key, value)) = run.buffered_previous() {
+                return Ok(Some((
                     AccessGuard::with_owned_value(key.to_vec()),
                     AccessGuard::with_owned_value(value.to_vec()),
-                )
-            }));
+                )));
+            }
+            // A descending run's buffer holds only entries after the gap;
+            // the predecessor still sits in the current leaf, untouched
+            // while the run is open. No such entry means the gap is at the
+            // start of the tree.
+            if run.direction == RunDirection::Descending
+                && let Some(position) = &self.state.position
+                && position.leaf.position > 0
+            {
+                let entry = entry_ref::<K, V>(&position.leaf, position.leaf.position - 1);
+                return Ok(Some(entry.to_guards()));
+            }
+            return Ok(None);
         }
         self.with_cursor(|cursor| Ok(cursor.peek_prev()?.map(|entry| entry.to_guards())))
     }
@@ -1644,6 +1753,11 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
     /// See [`CursorMut::insert_before`].
     pub(crate) fn insert_before(&mut self, key: &[u8], value: &[u8]) -> Result<bool> {
         self.with_cursor(|cursor| cursor.insert_before(key, value))
+    }
+
+    /// See [`CursorMut::insert_after`].
+    pub(crate) fn insert_after(&mut self, key: &[u8], value: &[u8]) -> Result<bool> {
+        self.with_cursor(|cursor| cursor.insert_after(key, value))
     }
 
     /// Splices any pending inserts into the tree, consuming the position.
@@ -2253,6 +2367,12 @@ mod tests {
                 .unwrap()
         }
 
+        fn insert_after(cursor: &mut CursorMut<'_, '_, u64, u64>, key: u64, value: u64) -> bool {
+            cursor
+                .insert_after(u64::as_bytes(&key).as_ref(), u64::as_bytes(&value).as_ref())
+                .unwrap()
+        }
+
         fn scan(root: Option<BtreeHeader>, page_allocator: &PageAllocator) -> Vec<(u64, u64)> {
             let Some(header) = root else {
                 return vec![];
@@ -2556,6 +2676,104 @@ mod tests {
             drop(cursor);
 
             let expected = [10, 20, 25, 26, 30].map(|key| (key, key));
+            assert_tree(root, &page_allocator, &expected);
+        }
+
+        // A run of insert_after calls arrives descending: each insert becomes
+        // the gap's new successor, mirroring insert_before's ascending runs.
+        #[test]
+        fn insert_run_descending_from_empty() {
+            for flush_every in [1, 3, 64] {
+                let page_allocator = test_page_allocator();
+                let mut root = None;
+                let mut freed = vec![];
+                let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+                let mut cursor: CursorMut<'_, '_, u64, u64> =
+                    CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+                cursor.seek_to(Position::Start).unwrap();
+                for key in (0..2000).rev() {
+                    assert!(insert_after(&mut cursor, key, key * 3));
+                    if key % flush_every == 0 {
+                        cursor.flush_insert_run(true).unwrap();
+                    }
+                }
+                cursor.flush_insert_run(true).unwrap();
+                drop(cursor);
+
+                let expected: Vec<_> = (0..2000).map(|key| (key, key * 3)).collect();
+                assert_tree(root, &page_allocator, &expected);
+            }
+        }
+
+        // Both piles fill in one run: insert_before advances the gap's lower
+        // bound while insert_after lowers its upper bound, and the flush
+        // splices them around the same gap.
+        #[test]
+        fn insert_run_mixed_directions() {
+            let (page_allocator, root_page, allocated) = leaf_root_with_entries(&[10, 20, 30]);
+            let mut root = Some(BtreeHeader::new(root_page, DEFERRED, 3));
+            let mut freed = vec![];
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor
+                .seek_to(Position::After(u64::as_bytes(&20).as_ref()))
+                .unwrap();
+            assert!(insert(&mut cursor, 21, 21));
+            assert!(insert_after(&mut cursor, 29, 29));
+            assert!(insert_after(&mut cursor, 25, 25));
+            assert!(insert(&mut cursor, 22, 22));
+            // The live bounds are the piles' innermost pending inserts.
+            assert!(!insert(&mut cursor, 25, 25));
+            assert!(!insert_after(&mut cursor, 22, 22));
+            assert!(!insert_after(&mut cursor, 25, 25));
+            assert!(insert(&mut cursor, 24, 24));
+            // A mid-run flush resumes at the same gap, between the piles.
+            cursor.flush_insert_run(true).unwrap();
+            assert_eq!(cursor.peek_prev().unwrap().unwrap().key(), 24);
+            assert_eq!(cursor.peek_next().unwrap().unwrap().key(), 25);
+            drop(cursor);
+
+            let expected = [10, 20, 21, 22, 24, 25, 29, 30].map(|key| (key, key));
+            assert_tree(root, &page_allocator, &expected);
+        }
+
+        #[test]
+        fn insert_run_after_rejects_unordered_keys() {
+            let (page_allocator, root_page, allocated) = leaf_root_with_entries(&[10, 20, 30]);
+            let mut root = Some(BtreeHeader::new(root_page, DEFERRED, 3));
+            let mut freed = vec![];
+            let mut cursor: CursorMut<'_, '_, u64, u64> =
+                CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
+            cursor
+                .seek_to(Position::After(u64::as_bytes(&20).as_ref()))
+                .unwrap();
+            // Equal to the previous entry, below it, equal to the next entry,
+            // and above it are all rejected.
+            assert!(!insert_after(&mut cursor, 20, 20));
+            assert!(!insert_after(&mut cursor, 15, 15));
+            assert!(!insert_after(&mut cursor, 30, 30));
+            assert!(!insert_after(&mut cursor, 35, 35));
+            // Rejections that leave no pending inserts also drop the run they
+            // opened; seek_to asserts exactly that.
+            assert!(cursor.state.insert_run.is_none());
+            cursor
+                .seek_to(Position::After(u64::as_bytes(&20).as_ref()))
+                .unwrap();
+            assert!(insert_after(&mut cursor, 25, 25));
+            // Inserts must also stay below the pending insert.
+            assert!(!insert_after(&mut cursor, 25, 25));
+            assert!(!insert_after(&mut cursor, 26, 26));
+            assert!(cursor.state.insert_run.is_some());
+            // Switching direction splices the pending insert first, so this
+            // rejection sees it as the gap's upper bound in the tree, and
+            // the rejected run is dropped again.
+            assert!(!insert(&mut cursor, 25, 25));
+            assert!(cursor.state.insert_run.is_none());
+            assert!(insert(&mut cursor, 21, 21));
+            cursor.flush_insert_run(false).unwrap();
+            drop(cursor);
+
+            let expected = [10, 20, 21, 25, 30].map(|key| (key, key));
             assert_tree(root, &page_allocator, &expected);
         }
     }

--- a/tests/cursor_tests.rs
+++ b/tests/cursor_tests.rs
@@ -678,3 +678,137 @@ fn read_cursor_generic_over_readable_table() {
     }
     txn.abort().unwrap();
 }
+
+#[test]
+fn bulk_load_descending() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        let mut cursor = table.lower_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        for i in (0..10_000).rev() {
+            cursor.insert_after(i, &(i * 7)).unwrap();
+        }
+        cursor.close().unwrap();
+        assert_eq!(table.len().unwrap(), 10_000);
+        assert_eq!(table.get(&5432).unwrap().unwrap().value(), 5432 * 7);
+    }
+    txn.commit().unwrap();
+
+    let expected: Vec<(u64, u64)> = (0..10_000).map(|i| (i, i * 7)).collect();
+    assert_u64_table_contents(&db, &expected);
+
+    // Also readable after reopening the database
+    drop(db);
+    let db = Database::open(tmpfile.path()).unwrap();
+    assert_u64_table_contents(&db, &expected);
+}
+
+// Enough data to cross the cursor's internal buffer threshold several times
+// while loading backward, so mid-run splices and reseeks on the after side
+// are exercised through the public API.
+#[test]
+fn descending_load_crosses_flush_threshold() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(STR_TABLE).unwrap();
+        let mut cursor = table.lower_bound_mut(Bound::<&str>::Unbounded).unwrap();
+        for i in (0..600u64).rev() {
+            let value = vec![i as u8; 2000 + (i as usize % 3000)];
+            cursor
+                .insert_after(key(i).as_str(), value.as_slice())
+                .unwrap();
+        }
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(STR_TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 600);
+    for (index, entry) in table.iter().unwrap().enumerate() {
+        let (k, v) = entry.unwrap();
+        let i = index as u64;
+        assert_eq!(k.value(), key(i));
+        assert_eq!(v.value(), vec![i as u8; 2000 + (index % 3000)]);
+    }
+}
+
+#[test]
+fn mixed_direction_inserts_and_peeks() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 20, 30] {
+            table.insert(i, &i).unwrap();
+        }
+        let mut cursor = table.upper_bound_mut(Bound::Included(&20)).unwrap();
+        cursor.insert_before(21, &21).unwrap();
+        cursor.insert_after(29, &29).unwrap();
+        cursor.insert_after(25, &25).unwrap();
+        // The peeks return the pending inserts nearest the gap on each side.
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 21);
+        assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 25);
+        cursor.insert_before(22, &22).unwrap();
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 22);
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    let expected: Vec<(u64, u64)> = [10, 20, 21, 22, 25, 29, 30]
+        .map(|i| (i, i))
+        .into_iter()
+        .collect();
+    assert_u64_table_contents(&db, &expected);
+}
+
+#[test]
+fn insert_after_unordered_keys_rejected() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 30] {
+            table.insert(i, &i).unwrap();
+        }
+        let mut cursor = table.lower_bound_mut(Bound::Included(&30)).unwrap();
+        // The gap is between 10 and 30.
+        assert!(matches!(
+            cursor.insert_after(10, &10),
+            Err(StorageError::UnorderedKey)
+        ));
+        assert!(matches!(
+            cursor.insert_after(30, &30),
+            Err(StorageError::UnorderedKey)
+        ));
+        cursor.insert_after(25, &25).unwrap();
+        // Later inserts must stay strictly below the pending one.
+        assert!(matches!(
+            cursor.insert_after(25, &25),
+            Err(StorageError::UnorderedKey)
+        ));
+        assert!(matches!(
+            cursor.insert_after(27, &27),
+            Err(StorageError::UnorderedKey)
+        ));
+        assert!(matches!(
+            cursor.insert_before(26, &26),
+            Err(StorageError::UnorderedKey)
+        ));
+        cursor.insert_after(20, &20).unwrap();
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    assert_u64_table_contents(&db, &[(10, 10), (20, 20), (25, 25), (30, 30)]);
+}


### PR DESCRIPTION
Modeled on the standard library&#39;s nightly `BTreeMap` cursors: `insert_after()` inserts into the gap and leaves the cursor **before** the new entry, so each accepted key becomes the gap&#39;s successor and a run of `insert_after` calls loads descending data with the same buffered splices as `insert_before`&#39;s ascending runs.

A run&#39;s pending inserts all fall on one side of the gap, and the buffer uses only end operations, per review:

- An ascending run buffers the leaf&#39;s entries before the gap and appends each `insert_before`, as before.
- A descending run prepends each `insert_after` (`push_front`), which keeps the buffer ascending since the arrivals descend; the leaf&#39;s entries before the gap join once at the flush, and `peek_prev` reads the untouched leaf at the cursor&#39;s position.
- Switching direction splices the pending run first, so mixed workloads pay one splice per switch while single-direction runs keep O(1) buffering. The public docs note this.
- Both kinds validate against the gap&#39;s live bounds and reject out-of-order keys with `UnorderedKey`; a rejection that leaves no pending inserts still closes the run.

The fuzzer&#39;s `CursorInsert` operation gains a descending mode that walks down from the gap with `insert_after`, checking the peeks against the reference model on both sides. Tests cover descending bulk loads (including across the flush threshold), mixed-direction runs in a single gap with live-bound rejections on both sides and the implicit switch splices, and the mirror of the unordered-key tests.

### Remaining std `btree_map` cursor surface not yet in redb

- `CursorMut::next()` / `prev()` -- moving the mutable cursor over an entry (redb&#39;s `CursorMut` can currently only move by inserting; the read-only `Cursor` has both).
- `CursorMut::remove_next()` / `remove_prev()` -- removing the gap&#39;s neighbors through the cursor.
- `CursorMut::as_cursor()` -- reborrowing the mutable cursor as a read-only `Cursor` at the same gap.
- `insert_before_unchecked()` / `insert_after_unchecked()` -- std&#39;s order-check-skipping variants; probably never appropriate for a database, since an unordered key would corrupt the table rather than just break iteration order.
- `CursorMutKey` / `with_mutable_key()` -- mutable access to keys; does not map to redb&#39;s serialized keys.

`Cursor` itself (`next`/`prev`/`peek_next`/`peek_prev`) and the four `lower_bound`/`upper_bound`/`lower_bound_mut`/`upper_bound_mut` constructors are all covered.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ