### PR TITLE
Route the range taking methods through encoded bounds

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -2,6 +2,7 @@ use crate::db::TransactionGuard;
 use crate::multimap_table::DynamicCollectionType::{Inline, SubtreeV2};
 use crate::sealed::Sealed;
 use crate::table::{OwnedAccessGuard, ReadableTableMetadata, TableStats};
+use crate::tree_store::encode_bounds;
 use crate::tree_store::{
     AllPageNumbersBtreeIter, BRANCH, Btree, BtreeCursorRange, BtreeHeader, BtreeMut,
     DynamicCollection, DynamicCollectionType, LEAF, LeafAccessor, MAX_PAIR_LENGTH,
@@ -13,7 +14,8 @@ use crate::{AccessGuard, MultimapTableHandle, Result, StorageError, WriteTransac
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 use std::mem;
-use std::ops::{Range, RangeBounds, RangeFull};
+use std::ops::RangeBounds;
+use std::ops::{Bound, Range, RangeFull};
 use std::sync::{Arc, Mutex};
 
 pub(crate) struct LeafKeyIter<'a, V: Key + 'static> {
@@ -956,7 +958,18 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V> for Multima
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
-        let inner = self.tree.range(&range)?;
+        let (lower, upper) = encode_bounds::<K, KR, _>(&range);
+        self.range_in_bounds(lower, upper)
+    }
+}
+
+impl<K: Key + 'static, V: Key + 'static> MultimapTable<'_, K, V> {
+    fn range_in_bounds(
+        &self,
+        lower: Bound<Vec<u8>>,
+        upper: Bound<Vec<u8>>,
+    ) -> Result<MultimapRange<'_, K, V>> {
+        let inner = self.tree.range_bounds(lower, upper)?;
         Ok(MultimapRange::new(
             inner,
             self.transaction.transaction_guard(),
@@ -1142,7 +1155,16 @@ impl<K: Key + 'static, V: Key + 'static> ReadOnlyMultimapTable<K, V> {
     where
         KR: Borrow<K::SelfType<'a>>,
     {
-        let inner = self.tree.range(&range)?;
+        let (lower, upper) = encode_bounds::<K, KR, _>(&range);
+        self.range_in_bounds(lower, upper)
+    }
+
+    fn range_in_bounds(
+        &self,
+        lower: Bound<Vec<u8>>,
+        upper: Bound<Vec<u8>>,
+    ) -> Result<MultimapRange<'static, K, V>> {
+        let inner = self.tree.range_bounds(lower, upper)?;
         Ok(MultimapRange::new(
             inner,
             self.transaction_guard.clone(),
@@ -1160,8 +1182,9 @@ impl<K: Key + 'static, V: Key + 'static> ReadOnlyMultimapTable<K, V> {
     where
         KR: Borrow<K::SelfType<'a>>,
     {
+        let (lower, upper) = encode_bounds::<K, KR, _>(&range);
         Ok(OwnedMultimapRange::new(
-            self.range(range)?,
+            self.range_in_bounds(lower, upper)?,
             self.transaction_guard.clone(),
         ))
     }
@@ -1223,12 +1246,8 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V>
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
-        let inner = self.tree.range(&range)?;
-        Ok(MultimapRange::new(
-            inner,
-            self.transaction_guard.clone(),
-            self.mem.clone(),
-        ))
+        let (lower, upper) = encode_bounds::<K, KR, _>(&range);
+        self.range_in_bounds(lower, upper)
     }
 }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -4,6 +4,7 @@ use crate::sealed::Sealed;
 use crate::tree_store::BtreeCursor;
 #[cfg(feature = "experimental_cursor")]
 use crate::tree_store::BtreeCursorMut;
+use crate::tree_store::encode_bounds;
 use crate::tree_store::{
     AccessGuardMutInPlace, Btree, BtreeCursorRange, BtreeExtractIf, BtreeHeader, BtreeMut,
     MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PageAllocator, PageHint, PageNumber, PageResolver,
@@ -15,7 +16,6 @@ use crate::{Result, TableHandle};
 use std::borrow::Borrow;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
-#[cfg(feature = "experimental-api-5")]
 use std::ops::Bound;
 use std::ops::RangeBounds;
 use std::sync::{Arc, Mutex};
@@ -166,7 +166,7 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         &mut self,
         predicate: F,
     ) -> Result<ExtractIf<'_, K, V, F>> {
-        self.extract_from_if::<K::SelfType<'_>, F>(.., predicate)
+        self.extract_in_bounds(Bound::Unbounded, Bound::Unbounded, predicate)
     }
 
     /// Applies `predicate` to all key-value pairs in the specified range. All entries for which
@@ -190,7 +190,27 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
-        let inner = self.tree.extract_from_if(&range, predicate)?;
+        let (lower, upper) = encode_bounds::<K, KR, _>(&range);
+        self.extract_in_bounds(lower, upper, predicate)
+    }
+
+    fn range_in_bounds(
+        &self,
+        lower: Bound<Vec<u8>>,
+        upper: Bound<Vec<u8>>,
+    ) -> Result<Range<'_, K, V>> {
+        self.tree
+            .range_bounds(lower, upper)
+            .map(|x| Range::new(x, self.transaction.transaction_guard()))
+    }
+
+    fn extract_in_bounds<F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
+        &mut self,
+        lower: Bound<Vec<u8>>,
+        upper: Bound<Vec<u8>>,
+        predicate: F,
+    ) -> Result<ExtractIf<'_, K, V, F>> {
+        let inner = self.tree.extract_from_bounds(lower, upper, predicate)?;
         Ok(ExtractIf::new(inner, Some(self.transaction)))
     }
 
@@ -205,16 +225,7 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         &mut self,
         predicate: F,
     ) -> Result {
-        let mut panic_guard = RetainPanicGuard::new(self.transaction);
-        let mut poisoned = false;
-        let result = self
-            .tree
-            .retain_in::<K::SelfType<'_>, F>(predicate, .., &mut poisoned);
-        panic_guard.disarm();
-        if poisoned {
-            self.transaction.poison();
-        }
-        result
+        self.retain_in_bounds(Bound::Unbounded, Bound::Unbounded, predicate)
     }
 
     /// Applies `predicate` to all key-value pairs in the range `start..end`. All entries for which
@@ -232,9 +243,21 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
+        let (lower, upper) = encode_bounds::<K, KR, _>(&range);
+        self.retain_in_bounds(lower, upper, predicate)
+    }
+
+    fn retain_in_bounds<F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
+        &mut self,
+        lower: Bound<Vec<u8>>,
+        upper: Bound<Vec<u8>>,
+        predicate: F,
+    ) -> Result {
         let mut panic_guard = RetainPanicGuard::new(self.transaction);
         let mut poisoned = false;
-        let result = self.tree.retain_in(predicate, range, &mut poisoned);
+        let result = self
+            .tree
+            .retain_in_bounds(predicate, lower, upper, &mut poisoned);
         panic_guard.disarm();
         if poisoned {
             self.transaction.poison();
@@ -433,9 +456,8 @@ impl<K: Key + 'static, V: Value + 'static> ReadableTable<K, V> for Table<'_, K, 
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
-        self.tree
-            .range(&range)
-            .map(|x| Range::new(x, self.transaction.transaction_guard()))
+        let (lower, upper) = encode_bounds::<K, KR, _>(&range);
+        self.range_in_bounds(lower, upper)
     }
 
     fn first(&self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
@@ -785,8 +807,17 @@ impl<K: Key + 'static, V: Value + 'static> ReadOnlyTable<K, V> {
     where
         KR: Borrow<K::SelfType<'a>>,
     {
+        let (lower, upper) = encode_bounds::<K, KR, _>(&range);
+        self.range_in_bounds(lower, upper)
+    }
+
+    fn range_in_bounds(
+        &self,
+        lower: Bound<Vec<u8>>,
+        upper: Bound<Vec<u8>>,
+    ) -> Result<Range<'static, K, V>> {
         self.tree
-            .range(&range)
+            .range_bounds(lower, upper)
             .map(|x| Range::new(x, self.transaction_guard.clone()))
     }
 
@@ -797,8 +828,9 @@ impl<K: Key + 'static, V: Value + 'static> ReadOnlyTable<K, V> {
     where
         KR: Borrow<K::SelfType<'a>>,
     {
+        let (lower, upper) = encode_bounds::<K, KR, _>(&range);
         Ok(OwnedRange::new(
-            self.range(range)?,
+            self.range_in_bounds(lower, upper)?,
             self.transaction_guard.clone(),
         ))
     }
@@ -858,9 +890,8 @@ impl<K: Key + 'static, V: Value + 'static> ReadableTable<K, V> for ReadOnlyTable
     where
         KR: Borrow<K::SelfType<'a>> + 'a,
     {
-        self.tree
-            .range(&range)
-            .map(|x| Range::new(x, self.transaction_guard.clone()))
+        let (lower, upper) = encode_bounds::<K, KR, _>(&range);
+        self.range_in_bounds(lower, upper)
     }
 
     fn first(&self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -8,7 +8,7 @@ use crate::tree_store::btree_cursor::BtreeCursor;
 #[cfg(feature = "experimental_cursor")]
 use crate::tree_store::btree_cursor::BtreeCursorMut;
 use crate::tree_store::btree_cursor::{CursorMut, Position};
-use crate::tree_store::btree_iters::range_is_empty;
+use crate::tree_store::btree_iters::{bounds_are_empty, encode_bounds};
 use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
@@ -672,6 +672,14 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         self.read_tree()?.range(range)
     }
 
+    pub(crate) fn range_bounds(
+        &self,
+        lower_bound: Bound<Vec<u8>>,
+        upper_bound: Bound<Vec<u8>>,
+    ) -> Result<BtreeCursorRange<K, V>> {
+        self.read_tree()?.range_bounds(lower_bound, upper_bound)
+    }
+
     pub(crate) fn extract_from_if<
         'a,
         'a0,
@@ -686,13 +694,19 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
     where
         K: 'a0,
     {
-        let lower_bound = range
-            .start_bound()
-            .map(|key| K::as_bytes(key.borrow()).as_ref().to_vec());
-        let upper_bound = range
-            .end_bound()
-            .map(|key| K::as_bytes(key.borrow()).as_ref().to_vec());
+        let (lower_bound, upper_bound) = encode_bounds::<K, KR, T>(range);
+        self.extract_from_bounds(lower_bound, upper_bound, predicate)
+    }
 
+    pub(crate) fn extract_from_bounds<
+        'a,
+        F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool,
+    >(
+        &'a mut self,
+        lower_bound: Bound<Vec<u8>>,
+        upper_bound: Bound<Vec<u8>>,
+        predicate: F,
+    ) -> Result<BtreeExtractIf<'a, K, V, F>> {
         let result = BtreeExtractIf::new(
             &mut self.root,
             lower_bound,
@@ -729,25 +743,17 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
     // Sets `poisoned` if an error left entries in the tree that the
     // predicate had already rejected; the caller must then poison the
     // transaction so they cannot be committed.
-    pub(crate) fn retain_in<'a, KR, F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
+    pub(crate) fn retain_in_bounds<F: for<'f> FnMut(K::SelfType<'f>, V::SelfType<'f>) -> bool>(
         &mut self,
         mut predicate: F,
-        range: impl RangeBounds<KR> + 'a,
+        lower_bound: Bound<Vec<u8>>,
+        upper_bound: Bound<Vec<u8>>,
         poisoned: &mut bool,
-    ) -> Result
-    where
-        KR: Borrow<K::SelfType<'a>> + 'a,
-    {
-        if self.root.is_none() || range_is_empty::<K, KR, _>(&range) {
+    ) -> Result {
+        if self.root.is_none() || bounds_are_empty::<K>(&lower_bound, &upper_bound) {
             return Ok(());
         }
 
-        let lower_bound = range
-            .start_bound()
-            .map(|key| K::as_bytes(key.borrow()).as_ref().to_vec());
-        let upper_bound = range
-            .end_bound()
-            .map(|key| K::as_bytes(key.borrow()).as_ref().to_vec());
         let mut freed = vec![];
         let result = self.retain_in_helper(
             lower_bound.as_ref().map(Vec::as_slice),
@@ -1145,6 +1151,20 @@ impl<K: Key, V: Value> Btree<K, V> {
     ) -> Result<BtreeCursorRange<K, V>> {
         BtreeCursorRange::new(
             range,
+            self.root.map(|x| x.root),
+            self.mem.clone(),
+            self.hint,
+        )
+    }
+
+    pub(crate) fn range_bounds(
+        &self,
+        lower_bound: Bound<Vec<u8>>,
+        upper_bound: Bound<Vec<u8>>,
+    ) -> Result<BtreeCursorRange<K, V>> {
+        BtreeCursorRange::from_bounds(
+            lower_bound,
+            upper_bound,
             self.root.map(|x| x.root),
             self.mem.clone(),
             self.hint,

--- a/src/tree_store/btree_cursor_range.rs
+++ b/src/tree_store/btree_cursor_range.rs
@@ -1,6 +1,6 @@
 use crate::Result;
 use crate::tree_store::btree_cursor::{Cursor, Position};
-use crate::tree_store::btree_iters::{EntryGuard, range_is_empty};
+use crate::tree_store::btree_iters::{EntryGuard, bounds_are_empty, encode_bounds};
 use crate::tree_store::page_store::PageHint;
 use crate::tree_store::{PageNumber, PageResolver};
 use crate::types::{Key, Value};
@@ -61,16 +61,21 @@ impl<K: Key + 'static, V: Value + 'static> BtreeCursorRange<K, V> {
         manager: PageResolver,
         hint: PageHint,
     ) -> Result<Self> {
-        if table_root.is_none() || range_is_empty::<K, KR, T>(query_range) {
+        let (lower_bound, upper_bound) = encode_bounds::<K, KR, T>(query_range);
+        Self::from_bounds(lower_bound, upper_bound, table_root, manager, hint)
+    }
+
+    pub(crate) fn from_bounds(
+        lower_bound: Bound<Vec<u8>>,
+        upper_bound: Bound<Vec<u8>>,
+        table_root: Option<PageNumber>,
+        manager: PageResolver,
+        hint: PageHint,
+    ) -> Result<Self> {
+        if table_root.is_none() || bounds_are_empty::<K>(&lower_bound, &upper_bound) {
             return Ok(Self::empty(manager, hint));
         }
 
-        let lower_bound = query_range
-            .start_bound()
-            .map(|key| K::as_bytes(key.borrow()).as_ref().to_vec());
-        let upper_bound = query_range
-            .end_bound()
-            .map(|key| K::as_bytes(key.borrow()).as_ref().to_vec());
         Ok(Self {
             root: table_root,
             lower_bound,

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -97,29 +97,30 @@ impl Iterator for AllPageNumbersBtreeIter {
     }
 }
 
-pub(super) fn range_is_empty<
-    'a,
-    K: Key + 'static,
+// Encodes a range's bounds with Key::as_bytes
+pub(crate) fn encode_bounds<'a, K, KR, R>(range: &R) -> (Bound<Vec<u8>>, Bound<Vec<u8>>)
+where
+    K: Key + 'a,
     KR: Borrow<K::SelfType<'a>>,
-    T: RangeBounds<KR>,
->(
-    range: &T,
+    R: RangeBounds<KR>,
+{
+    let encode = |key: &KR| K::as_bytes(key.borrow()).as_ref().to_vec();
+    (
+        range.start_bound().map(encode),
+        range.end_bound().map(encode),
+    )
+}
+
+// Whether the encoded bounds select no keys, i.e. the range is reversed or empty
+pub(crate) fn bounds_are_empty<K: Key + 'static>(
+    lower: &Bound<Vec<u8>>,
+    upper: &Bound<Vec<u8>>,
 ) -> bool {
-    match (range.start_bound(), range.end_bound()) {
+    match (lower, upper) {
         (Unbounded, _) | (_, Unbounded) => false,
         (Included(start), Excluded(end)) | (Excluded(start), Included(end) | Excluded(end)) => {
-            let start_tmp = K::as_bytes(start.borrow());
-            let start_value = start_tmp.as_ref();
-            let end_tmp = K::as_bytes(end.borrow());
-            let end_value = end_tmp.as_ref();
-            K::compare(start_value, end_value).is_ge()
+            K::compare(start, end).is_ge()
         }
-        (Included(start), Included(end)) => {
-            let start_tmp = K::as_bytes(start.borrow());
-            let start_value = start_tmp.as_ref();
-            let end_tmp = K::as_bytes(end.borrow());
-            let end_value = end_tmp.as_ref();
-            K::compare(start_value, end_value).is_gt()
-        }
+        (Included(start), Included(end)) => K::compare(start, end).is_gt(),
     }
 }

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use btree_cursor::BtreeCursor;
 #[cfg(feature = "experimental_cursor")]
 pub(crate) use btree_cursor::BtreeCursorMut;
 pub(crate) use btree_cursor_range::BtreeCursorRange;
-pub(crate) use btree_iters::AllPageNumbersBtreeIter;
+pub(crate) use btree_iters::{AllPageNumbersBtreeIter, encode_bounds};
 pub(crate) use extract_if::BtreeExtractIf;
 pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multimap_btree_stats};
 pub(crate) use page_store::ReadOnlyBackend;


### PR DESCRIPTION
Split out of #1337 as its base, per review: this is the internal refactoring on its own, with no public API change.

Every range taking path already reduced its range to `Bound<Vec<u8>>` before touching the tree, but each did it separately, and the `KR`-generic range type was threaded several layers deep to get there.

This encodes once at the API boundary instead:

* `encode_bounds()` and the byte-level `bounds_are_empty()` — which replaces `range_is_empty()` — now sit next to each other in `btree_iters`.
* `range_bounds()`, `extract_from_bounds()`, and `retain_in_bounds()` take the encoded bounds; `BtreeCursorRange::from_bounds()` backs the first.
* The public methods convert and call them, so the whole-table methods (`retain()`, `extract_if()`, and the `Table` side of `range()`) pass a pair of `Unbounded` instead of routing an unbounded range back through the ranged methods and naming the key type in a turbofish to do it.
* `BtreeCursorRange::new()` and the `KR`-generic `Btree::range()` stay for the internal callers that pass concrete ranges.

No public signatures change — the only added items are private `*_in_bounds` helpers — and no allocation is added, since the bounds were already encoded to `Vec<u8>` on every call.

## Testing

* `cargo test --all-features`: 368 passed, `cargo test`: 324 passed — both identical to master
* `cargo clippy -p redb --all-targets` and `--all-targets --all-features`: clean
* `cargo clippy --workspace --all-targets --all-features`: clean
* `cargo fmt --all -- --check`: clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWixTK4bUrh4ANWstPeGVG)_