### PR TITLE
Extract the cursor's key and value length checks into a helper

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -1490,17 +1490,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> CursorMut<'a, K, V> {
         self.check_usable()?;
         let key_bytes = K::as_bytes(key.borrow());
         let value_bytes = V::as_bytes(value.borrow());
-        let key_len = key_bytes.as_ref().len();
-        let value_len = value_bytes.as_ref().len();
-        if value_len > MAX_VALUE_LENGTH {
-            return Err(StorageError::ValueTooLarge(value_len));
-        }
-        if key_len > MAX_VALUE_LENGTH {
-            return Err(StorageError::ValueTooLarge(key_len));
-        }
-        if value_len + key_len > MAX_PAIR_LENGTH {
-            return Err(StorageError::ValueTooLarge(value_len + key_len));
-        }
+        Self::check_lengths(key_bytes.as_ref(), value_bytes.as_ref())?;
         match self
             .inner
             .insert_before(key_bytes.as_ref(), value_bytes.as_ref())
@@ -1509,6 +1499,19 @@ impl<'a, K: Key + 'static, V: Value + 'static> CursorMut<'a, K, V> {
             Ok(false) => Err(StorageError::UnorderedKey),
             Err(err) => Err(self.latch_error(err)),
         }
+    }
+
+    fn check_lengths(key: &[u8], value: &[u8]) -> Result {
+        if value.len() > MAX_VALUE_LENGTH {
+            return Err(StorageError::ValueTooLarge(value.len()));
+        }
+        if key.len() > MAX_VALUE_LENGTH {
+            return Err(StorageError::ValueTooLarge(key.len()));
+        }
+        if value.len() + key.len() > MAX_PAIR_LENGTH {
+            return Err(StorageError::ValueTooLarge(value.len() + key.len()));
+        }
+        Ok(())
     }
 
     /// Closes the cursor, applying any of its inserts that have not yet

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -352,7 +352,7 @@ const INSERT_FLUSH_BYTES: usize = 1024 * 1024;
 #[cfg(feature = "experimental_cursor")]
 struct InsertRun {
     // Key of the entry after the gap when the run opened; None when the gap
-    // is at the end of the tree. Inserts must sort strictly below it.
+    // is at the end of the tree.
     upper_key: Option<Vec<u8>>,
     // Greatest key at or before the gap: the last insert or, before any
     // insert, the entry preceding the gap; None at the start of the tree.
@@ -366,15 +366,27 @@ struct InsertRun {
 
 #[cfg(feature = "experimental_cursor")]
 impl InsertRun {
-    // True unless `key` sorts strictly between the run's bounds.
+    // The buffered entry nearest the gap on the entry-before side, if any:
+    // a pending insert or an entry copied from the leaf's head.
+    fn buffered_previous(&self) -> Option<(&[u8], &[u8])> {
+        self.entries.back()
+    }
+
+    // Smallest key at or after the gap: the entry following the gap when the
+    // run opened. Inserts must sort strictly below it.
+    fn next_key(&self) -> Option<&[u8]> {
+        self.upper_key.as_deref()
+    }
+
+    // True unless `key` sorts strictly between the gap's live bounds.
     fn rejects<K: Key>(&self, key: &[u8]) -> bool {
         if let Some(previous) = &self.previous_key
             && K::compare(key, previous).is_le()
         {
             return true;
         }
-        if let Some(upper) = &self.upper_key
-            && K::compare(key, upper).is_ge()
+        if let Some(next) = self.next_key()
+            && K::compare(key, next).is_ge()
         {
             return true;
         }
@@ -1614,12 +1626,12 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
     ///
     /// While a run is open, its buffer holds every predecessor the gap has in
     /// the current leaf (the normalizing peeks settled the position on the
-    /// earlier of two leaves sharing the gap), so an empty buffer means the
-    /// gap is at the start of the tree.
+    /// earlier of two leaves sharing the gap), so no buffered entry before
+    /// the gap means the gap is at the start of the tree.
     #[allow(clippy::type_complexity)]
     pub(crate) fn peek_prev(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
         if let Some(run) = &self.state.insert_run {
-            return Ok(run.entries.back().map(|(key, value)| {
+            return Ok(run.buffered_previous().map(|(key, value)| {
                 (
                     AccessGuard::with_owned_value(key.to_vec()),
                     AccessGuard::with_owned_value(value.to_vec()),


### PR DESCRIPTION
Preparation refactors split out of #1338, per review, so `insert_after()` lands as pure new functionality. All behavior-preserving:

- `CursorMut::insert_before`'s key and value length checks move into a `check_lengths()` helper the second insert method will share.
- The insert run names the gap's neighbors: `buffered_previous()` is the buffered entry nearest the gap (today the buffer's back), and `next_key()` is the gap's live upper bound (today it never moves). `insert_after` will change both.

The positional `OwnedEntryBuffer::insert(index)` from the earlier revision is gone, per review: the buffer keeps only end operations, and #1338 now flushes when the insert direction switches instead of shifting.

The existing cursor tests pass unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ