### PR TITLE
Add CursorMut::next() and prev(), moving the cursor over entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   library's `BTreeMap` cursors, are behind the `experimental_cursor` feature flag (which enables
   `experimental-api-5`); the split lets the trait surface stabilize before the cursor's own
   methods settle.
+* Add `next()` and `prev()` to the experimental `CursorMut`, moving the cursor over the entries
+  around its gap like their read-only `Cursor` counterparts. Pending buffered inserts are applied
+  before the cursor moves.
 * Fix `WriteTransaction::stats()` returning garbage statistics, or panicking when debug assertions
   are enabled, when called while a table is open and modified in the same transaction.
 * Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. A live

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -127,6 +127,10 @@ pub(crate) enum FuzzOperation {
         // Walk down from the gap with insert_after instead of up with
         // insert_before
         descending: bool,
+        // Steps to move the cursor over the surrounding entries afterward,
+        // splicing the pending inserts: next() for descending runs (over the
+        // inserts just made), prev() for ascending ones.
+        moves: U64Between<0, 8>,
     },
     Remove {
         key: BoundedU64<KEY_SPACE>,

--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -530,6 +530,7 @@ fn handle_table_op(
             stride,
             value_size,
             descending,
+            moves,
         } => {
             let start = start_key.value;
             let stride = stride.value;
@@ -573,6 +574,49 @@ fn handle_table_op(
                 let last = keys.last().copied().or(predecessor);
                 assert_eq!(cursor.peek_prev()?.map(|(k, _)| k.value()), last);
                 assert_eq!(cursor.peek_next()?.map(|(k, _)| k.value()), successor);
+            }
+            // Moving splices the pending inserts and walks the tree from the
+            // same gap, checked against the reference merged with them: a
+            // descending run's inserts sit after the gap, an ascending run's
+            // before it.
+            let mut merged = reference.clone();
+            for key in &keys {
+                merged.insert(*key, value_size);
+            }
+            if *descending {
+                let lower = predecessor.map_or(Bound::Unbounded, Bound::Excluded);
+                let mut walk = merged.range((lower, Bound::Unbounded));
+                for _ in 0..moves.value {
+                    match (cursor.next()?, walk.next()) {
+                        (Some((key, value)), Some((expected_key, expected_len))) => {
+                            assert_eq!(key.value(), *expected_key);
+                            assert_eq!(value.value().len(), *expected_len);
+                        }
+                        (None, None) => break,
+                        (cursor_entry, walk_entry) => panic!(
+                            "cursor yielded {:?}, reference {:?}",
+                            cursor_entry.map(|(key, _)| key.value()),
+                            walk_entry.map(|(key, _)| key)
+                        ),
+                    }
+                }
+            } else {
+                let upper = successor.map_or(Bound::Unbounded, Bound::Excluded);
+                let mut walk = merged.range((Bound::Unbounded, upper)).rev();
+                for _ in 0..moves.value {
+                    match (cursor.prev()?, walk.next()) {
+                        (Some((key, value)), Some((expected_key, expected_len))) => {
+                            assert_eq!(key.value(), *expected_key);
+                            assert_eq!(value.value().len(), *expected_len);
+                        }
+                        (None, None) => break,
+                        (cursor_entry, walk_entry) => panic!(
+                            "cursor yielded {:?}, reference {:?}",
+                            cursor_entry.map(|(key, _)| key.value()),
+                            walk_entry.map(|(key, _)| key)
+                        ),
+                    }
+                }
             }
             cursor.close()?;
             for key in keys {

--- a/src/table.rs
+++ b/src/table.rs
@@ -1501,6 +1501,61 @@ impl<'a, K: Key + 'static, V: Value + 'static> CursorMut<'a, K, V> {
         }
     }
 
+    /// Moves the cursor past the entry after the gap, returning that entry.
+    ///
+    /// Returns `None`, and does not move, if the gap is at the end of the
+    /// table. Any pending inserts are applied first: moving the cursor
+    /// closes the buffered run.
+    ///
+    /// This is analogous to the nightly
+    /// [`std::collections::btree_map::CursorMut::next`]. The cursor is not
+    /// an [`Iterator`], since every step can report a storage error; use
+    /// [`ReadableTable::range`] for iteration.
+    #[allow(clippy::should_implement_trait, clippy::type_complexity)]
+    pub fn next(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.check_usable()?;
+        // Applied separately from the move so that a splice failure, which
+        // can poison, is told apart from a failed move, which only leaves
+        // the position unreliable.
+        if let Err(err) = self.inner.apply_pending_inserts() {
+            return Err(self.latch_error(err));
+        }
+        match self.inner.next() {
+            Ok(entry) => Ok(entry),
+            Err(err) => {
+                self.errored = true;
+                Err(err)
+            }
+        }
+    }
+
+    /// Moves the cursor before the entry preceding the gap, returning that
+    /// entry.
+    ///
+    /// Returns `None`, and does not move, if the gap is at the start of the
+    /// table. Any pending inserts are applied first: moving the cursor
+    /// closes the buffered run.
+    ///
+    /// This is analogous to the nightly
+    /// [`std::collections::btree_map::CursorMut::prev`].
+    #[allow(clippy::type_complexity)]
+    pub fn prev(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.check_usable()?;
+        // Applied separately from the move so that a splice failure, which
+        // can poison, is told apart from a failed move, which only leaves
+        // the position unreliable.
+        if let Err(err) = self.inner.apply_pending_inserts() {
+            return Err(self.latch_error(err));
+        }
+        match self.inner.prev() {
+            Ok(entry) => Ok(entry),
+            Err(err) => {
+                self.errored = true;
+                Err(err)
+            }
+        }
+    }
+
     /// Inserts a new entry into the gap that the cursor is pointing at. After
     /// the insertion, the cursor points at the gap after the newly inserted
     /// entry.

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -818,7 +818,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
                 break;
             }
             if predicate(entry.key(), entry.value()) {
-                cursor.next()?;
+                cursor.move_next()?;
             } else {
                 cursor.remove_next_discard()?;
             }

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -907,8 +907,10 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         )))
     }
 
-    pub(super) fn next(&mut self) -> Result<bool> {
-        if self.peek_next()?.is_none() {
+    // Steps the gap past the entry after it without reading the entry, for
+    // callers that already peeked it.
+    pub(super) fn move_next(&mut self) -> Result<bool> {
+        if !self.ensure_has_entry(Direction::Next)? {
             return Ok(false);
         }
         self.state
@@ -917,6 +919,52 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
             .expect("cursor must be positioned")
             .move_once(Direction::Next);
         Ok(true)
+    }
+
+    // Steps the gap before the entry preceding it without reading the entry.
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn move_prev(&mut self) -> Result<bool> {
+        if !self.ensure_has_entry(Direction::Previous)? {
+            return Ok(false);
+        }
+        self.state
+            .position
+            .as_mut()
+            .expect("cursor must be positioned")
+            .move_once(Direction::Previous);
+        Ok(true)
+    }
+
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn next(&mut self) -> Result<Option<EntryRef<'_, K, V>>> {
+        if !self.move_next()? {
+            return Ok(None);
+        }
+        let position = self
+            .state
+            .position
+            .as_ref()
+            .expect("cursor must be positioned");
+        Ok(Some(entry_ref(
+            &position.leaf,
+            position.entry_index(Direction::Previous),
+        )))
+    }
+
+    #[cfg(feature = "experimental_cursor")]
+    pub(super) fn prev(&mut self) -> Result<Option<EntryRef<'_, K, V>>> {
+        if !self.move_prev()? {
+            return Ok(None);
+        }
+        let position = self
+            .state
+            .position
+            .as_ref()
+            .expect("cursor must be positioned");
+        Ok(Some(entry_ref(
+            &position.leaf,
+            position.entry_index(Direction::Next),
+        )))
     }
 
     /// Removes and returns the next entry.
@@ -1750,6 +1798,27 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
         self.with_cursor(|cursor| Ok(cursor.peek_prev()?.map(|entry| entry.to_guards())))
     }
 
+    /// Moves the gap past the entry after it, returning that entry. Any
+    /// pending inserts are spliced first: moving the cursor closes the run.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn next(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.with_cursor(|cursor| {
+            cursor.flush_insert_run(true)?;
+            Ok(cursor.next()?.map(|entry| entry.to_guards()))
+        })
+    }
+
+    /// Moves the gap before the entry preceding it, returning that entry.
+    /// Any pending inserts are spliced first: moving the cursor closes the
+    /// run.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn prev(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.with_cursor(|cursor| {
+            cursor.flush_insert_run(true)?;
+            Ok(cursor.prev()?.map(|entry| entry.to_guards()))
+        })
+    }
+
     /// See [`CursorMut::insert_before`].
     pub(crate) fn insert_before(&mut self, key: &[u8], value: &[u8]) -> Result<bool> {
         self.with_cursor(|cursor| cursor.insert_before(key, value))
@@ -1758,6 +1827,12 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
     /// See [`CursorMut::insert_after`].
     pub(crate) fn insert_after(&mut self, key: &[u8], value: &[u8]) -> Result<bool> {
         self.with_cursor(|cursor| cursor.insert_after(key, value))
+    }
+
+    /// Splices any pending inserts into the tree, keeping the cursor at its
+    /// gap.
+    pub(crate) fn apply_pending_inserts(&mut self) -> Result {
+        self.with_cursor(|cursor| cursor.flush_insert_run(true))
     }
 
     /// Splices any pending inserts into the tree, consuming the position.
@@ -2328,7 +2403,7 @@ mod tests {
 
         cursor.seek_to(Position::Start).unwrap();
         for _ in 0..3 {
-            assert!(cursor.next().unwrap());
+            assert!(cursor.move_next().unwrap());
         }
         assert!(cursor.peek_next().unwrap().is_none());
         assert!(cursor.state.position.is_some());

--- a/tests/cursor_tests.rs
+++ b/tests/cursor_tests.rs
@@ -812,3 +812,125 @@ fn insert_after_unordered_keys_rejected() {
 
     assert_u64_table_contents(&db, &[(10, 10), (20, 20), (25, 25), (30, 30)]);
 }
+
+#[test]
+fn moves_walk_both_directions() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 20, 30] {
+            table.insert(i, &(i * 7)).unwrap();
+        }
+        let step = |cursor: &mut redb::CursorMut<'_, u64, u64>| {
+            cursor.next().unwrap().map(|(k, v)| (k.value(), v.value()))
+        };
+        let step_back = |cursor: &mut redb::CursorMut<'_, u64, u64>| {
+            cursor.prev().unwrap().map(|(k, v)| (k.value(), v.value()))
+        };
+
+        let mut cursor = table.lower_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        assert_eq!(step(&mut cursor), Some((10, 70)));
+        assert_eq!(step(&mut cursor), Some((20, 140)));
+        assert_eq!(step(&mut cursor), Some((30, 210)));
+        // At the end of the table the cursor stays put
+        assert_eq!(step(&mut cursor), None);
+        assert_eq!(step_back(&mut cursor), Some((30, 210)));
+        assert_eq!(step_back(&mut cursor), Some((20, 140)));
+        assert_eq!(step_back(&mut cursor), Some((10, 70)));
+        assert_eq!(step_back(&mut cursor), None);
+        // A move over an entry is undone by the opposite move
+        assert_eq!(step(&mut cursor), Some((10, 70)));
+        assert_eq!(step_back(&mut cursor), Some((10, 70)));
+        cursor.close().unwrap();
+    }
+    txn.abort().unwrap();
+}
+
+// Moving splices the pending inserts and continues from the same gap, so
+// entries just inserted are walked like entries the table already had.
+#[test]
+fn moves_apply_pending_inserts() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 30] {
+            table.insert(i, &i).unwrap();
+        }
+        let mut cursor = table.upper_bound_mut(Bound::Included(&10)).unwrap();
+        // The gap is between 10 and 30.
+        cursor.insert_before(20, &20).unwrap();
+        assert_eq!(cursor.next().unwrap().unwrap().0.value(), 30);
+        assert_eq!(cursor.prev().unwrap().unwrap().0.value(), 30);
+        // The insert is in the tree now, on the walked path
+        assert_eq!(cursor.prev().unwrap().unwrap().0.value(), 20);
+        assert_eq!(cursor.prev().unwrap().unwrap().0.value(), 10);
+        assert!(cursor.prev().unwrap().is_none());
+        // A pending descending run is spliced by prev() the same way
+        cursor.insert_after(5, &5).unwrap();
+        cursor.insert_after(3, &3).unwrap();
+        assert!(cursor.prev().unwrap().is_none());
+        assert_eq!(cursor.next().unwrap().unwrap().0.value(), 3);
+        assert_eq!(cursor.next().unwrap().unwrap().0.value(), 5);
+        assert_eq!(cursor.next().unwrap().unwrap().0.value(), 10);
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    assert_u64_table_contents(&db, &[(3, 3), (5, 5), (10, 10), (20, 20), (30, 30)]);
+}
+
+#[test]
+fn moves_cross_leaf_boundaries() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in 0..2_000u64 {
+            table.insert(i, &(i * 7)).unwrap();
+        }
+        let mut cursor = table.lower_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        for i in 0..2_000u64 {
+            let (k, v) = cursor.next().unwrap().unwrap();
+            assert_eq!((k.value(), v.value()), (i, i * 7));
+        }
+        assert!(cursor.next().unwrap().is_none());
+        for i in (0..2_000u64).rev() {
+            let (k, v) = cursor.prev().unwrap().unwrap();
+            assert_eq!((k.value(), v.value()), (i, i * 7));
+        }
+        assert!(cursor.prev().unwrap().is_none());
+        cursor.close().unwrap();
+    }
+    txn.abort().unwrap();
+}
+
+#[test]
+fn moves_on_empty_table_and_at_edges() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        let mut cursor = table.lower_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        assert!(cursor.next().unwrap().is_none());
+        assert!(cursor.prev().unwrap().is_none());
+        // A move that finds nothing still applies the pending inserts
+        cursor.insert_before(1, &1).unwrap();
+        assert!(cursor.next().unwrap().is_none());
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 1);
+        assert_eq!(cursor.prev().unwrap().unwrap().0.value(), 1);
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    assert_u64_table_contents(&db, &[(1, 1)]);
+}


### PR DESCRIPTION
Modeled on the standard library's nightly `BTreeMap` cursors: `next()` moves the cursor past the entry after its gap and `prev()` before the entry preceding it, returning the entry moved over. The mutable cursor could previously move only by inserting; these complete its peek/move parity with the read-only `Cursor` (`CursorMut` already had `peek_next()`/`peek_prev()`).

Design notes:

- Both moves splice any pending inserts first -- the run's buffer is tied to the gap it was opened at -- then step from the same gap, so entries just inserted are walked like entries the table already had. A move that finds no entry (at the table's edge) still applies the pending inserts. The public docs say so.
- At the table layer the splice is applied separately from the move, telling a splice failure, which can lose reported inserts and must poison, apart from a failed move, which only leaves the position unreliable (the same split the peeks use). This also sidesteps returning a borrow from one arm of a match while touching `self` in the other, which the borrow checker rejects.
- The returned guards borrow the cursor mutably (like the mutable peeks, unlike the read-only cursor's `'static`-page guards), so they cannot outlive a later mutation through the cursor.
- Every layer returns the moved-over entry, per review: the tree-level cursor's pre-existing `next()` was reshaped from `Result<bool>` to return the entry like `BTreeMap`'s cursors, its new `prev()` matches, and `BtreeCursorMut`'s moves are just flush + step.
- Callers that step without reading the entry use the tree-level `move_next()`/`move_prev()` instead, per review: `retain`'s keep path already peeked the entry for its predicate, so stepping through the entry-returning `next()` would parse the leaf entry a second time. With the split it moves without re-reading -- one parse per kept entry, where the old bool-returning `next()` cost two.

Tests cover walking both directions over existing entries (including a 2000-entry table crossing leaf boundaries), moves splicing pending ascending and descending runs mid-walk, and edge/empty-table behavior. The fuzzer's `CursorInsert` operation gains a move phase that walks the cursor over the surrounding entries after its inserts -- `next()` for descending runs, `prev()` for ascending ones -- checking each yielded entry against the reference model merged with the pending keys.

### Remaining std `btree_map` cursor surface not yet in redb

- `CursorMut::remove_next()` / `remove_prev()` -- removing the gap's neighbors through the cursor.
- `CursorMut::as_cursor()` -- reborrowing the mutable cursor as a read-only `Cursor` at the same gap.
- `insert_before_unchecked()` / `insert_after_unchecked()` -- std's order-check-skipping variants; probably never appropriate for a database, since an unordered key would corrupt the table rather than just break iteration order.
- `CursorMutKey` / `with_mutable_key()` -- mutable access to keys; does not map to redb's serialized keys.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ