### PR TITLE
Remove the broken read-only get() accessors behind experimental-api-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   `ReadOnlyMultimapTable::range()`, whose `'static` iterators do not keep the transaction alive,
   are removed under the flag; use the `ReadableTable` and `ReadableMultimapTable` methods, or the
   `range_owned()` variants when the iterator must outlive the table.
+* The inherent `ReadOnlyTable::get()` and `ReadOnlyMultimapTable::get()`, whose `'static` guards
+  and iterators likewise do not keep the transaction alive, are also removed under the
+  `experimental-api-5` flag; use the `ReadableTable` and `ReadableMultimapTable` methods, or the
+  `get_owned()` variants when the guard must outlive the table.
 
 ## 4.2.0 - 2026-XX-XX
 * Fix a panic when opening a database containing a corrupted persistent savepoint record;

--- a/crates/redb-derive/tests/crate_attr_tests.rs
+++ b/crates/redb-derive/tests/crate_attr_tests.rs
@@ -54,6 +54,8 @@ use new::NewValue;
 use old::OldValue;
 use old3::{Old3Inner, Old3Value};
 use redb::ReadableDatabase;
+#[allow(unused_imports)]
+use redb::ReadableTable;
 use redb3_0::ReadableDatabase as _;
 
 fn create_tempfile() -> tempfile::NamedTempFile {

--- a/crates/redb-derive/tests/derive_tests.rs
+++ b/crates/redb-derive/tests/derive_tests.rs
@@ -1,3 +1,5 @@
+#[allow(unused_imports)]
+use redb::ReadableTable;
 use redb::{Database, Key, ReadableDatabase, TableDefinition, TableError, TypeName, Value};
 use redb_derive::{Key, Value};
 use std::fmt::Debug;

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -1133,7 +1133,15 @@ impl<K: Key + 'static, V: Key + 'static> ReadOnlyMultimapTable<K, V> {
 
     /// This method is like [`ReadableMultimapTable::get()`], but the iterator is reference counted and keeps the transaction
     /// alive until it is dropped.
+    #[cfg(not(feature = "experimental-api-5"))]
     pub fn get<'a>(&self, key: impl Borrow<K::SelfType<'a>>) -> Result<MultimapValue<'static, V>> {
+        self.get_inner(key)
+    }
+
+    fn get_inner<'a>(
+        &self,
+        key: impl Borrow<K::SelfType<'a>>,
+    ) -> Result<MultimapValue<'static, V>> {
         let iter = if let Some(collection) = self.tree.get(key.borrow())? {
             MultimapValue::from_collection(
                 collection,
@@ -1164,7 +1172,7 @@ impl<K: Key + 'static, V: Key + 'static> ReadOnlyMultimapTable<K, V> {
         key: impl Borrow<K::SelfType<'a>>,
     ) -> Result<OwnedMultimapValue<V>> {
         Ok(OwnedMultimapValue::new(
-            self.get(key)?,
+            self.get_inner(key)?,
             self.transaction_guard.clone(),
         ))
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -879,6 +879,7 @@ impl<K: Key + 'static, V: Value + 'static> ReadOnlyTable<K, V> {
 
     /// This method is like [`ReadableTable::get()`], but the [`AccessGuard`] is reference counted
     /// and keeps the transaction alive until it is dropped.
+    #[cfg(not(feature = "experimental-api-5"))]
     pub fn get<'a>(
         &self,
         key: impl Borrow<K::SelfType<'a>>,
@@ -893,7 +894,8 @@ impl<K: Key + 'static, V: Value + 'static> ReadOnlyTable<K, V> {
         key: impl Borrow<K::SelfType<'a>>,
     ) -> Result<Option<OwnedAccessGuard<V>>> {
         Ok(self
-            .get(key)?
+            .tree
+            .get(key.borrow())?
             .map(|x| OwnedAccessGuard::new(x, self.transaction_guard.clone())))
     }
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2682,6 +2682,8 @@ impl Debug for ReadTransaction {
 
 #[cfg(test)]
 mod test {
+    #[cfg(feature = "experimental-api-5")]
+    use crate::ReadableTable;
     use crate::{Database, ReadableDatabase, StorageError, TableDefinition, TransactionError};
 
     const X: TableDefinition<&str, &str> = TableDefinition::new("x");

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -563,6 +563,8 @@ impl TransactionHeader {
 
 #[cfg(test)]
 mod test {
+    #[cfg(feature = "experimental-api-5")]
+    use crate::ReadableTable;
     use crate::backends::FileBackend;
     use crate::db::TableDefinition;
     use crate::tree_store::page_store::base::MAX_REGIONS;

--- a/tests/backward_compatibility.rs
+++ b/tests/backward_compatibility.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "experimental-api-5")]
+use redb::ReadableTable;
 use redb::{ReadableDatabase, ReadableTableMetadata};
 
 const ELEMENTS: usize = 3;

--- a/tests/check_integrity_nondurable.rs
+++ b/tests/check_integrity_nondurable.rs
@@ -3,6 +3,8 @@
 //! the live state from disk; it refuses to promote when the backing file was externally truncated
 //! or extended, falling back to repairing the durable state instead.
 
+#[cfg(feature = "experimental-api-5")]
+use redb::ReadableTable;
 use redb::{
     Database, Durability, ReadableDatabase, ReadableTableMetadata, StorageBackend, TableDefinition,
 };

--- a/tests/crash_consistency.rs
+++ b/tests/crash_consistency.rs
@@ -6,6 +6,8 @@
 //! `Corrupted("File truncated below stored layout")` -- permanent data loss -- even though the
 //! previous durable state was intact. The fix makes the file extension durable as the file grows.
 
+#[cfg(feature = "experimental-api-5")]
+use redb::ReadableTable;
 use redb::backends::InMemoryBackend;
 use redb::{Database, ReadableDatabase, StorageBackend, TableDefinition};
 use std::io::ErrorKind;

--- a/tests/multimap_tests.rs
+++ b/tests/multimap_tests.rs
@@ -237,7 +237,13 @@ fn get_arc_lifetime() {
         let read_txn = db.begin_read().unwrap();
         let table = read_txn.open_multimap_table(definition).unwrap();
         let start = "hello".to_string();
-        table.get(start.as_str()).unwrap()
+        // The 'static get() does not keep the transaction alive, so experimental-api-5 drops it
+        // in favour of get_owned()
+        #[cfg(feature = "experimental-api-5")]
+        let iter = table.get_owned(start.as_str()).unwrap();
+        #[cfg(not(feature = "experimental-api-5"))]
+        let iter = table.get(start.as_str()).unwrap();
+        iter
     };
     assert_eq!(iter.next().unwrap().unwrap().value(), "world");
     assert!(iter.next().is_none());


### PR DESCRIPTION
Follow-up to #1306; companion to #1307, which adds deprecation notices for default-feature builds.

## Change

The inherent `ReadOnlyTable::get()` and `ReadOnlyMultimapTable::get()` return `'static` guards and iterators that, contrary to their documentation, do not keep the read transaction alive: holding one after dropping the `ReadTransaction` lets a concurrent writer reclaim the referenced pages, which panics the writer's `commit()` on a debug assertion.

redb 5 will drop them in favor of the `Readable*` trait accessors (zero cost, lifetime-bound) and the `_owned()` variants from #1306. This PR previews that removal under `experimental-api-5`, the same way the `KeyRange` change already removed the inherent `range()` methods under the flag: the two `get()` methods do not exist when it is enabled, and calls resolve to the trait accessor instead.

Supporting changes:

- `get_owned()` previously delegated to the removed methods; it now goes through the tree directly / a private `get_inner()` helper, matching how `range_owned` routes through the private `range_in_bounds()`.
- Tests that read through the inherent methods incidentally keep their `get()` calls, which resolve to the non-`'static` trait accessor under the feature. Files that didn't have `ReadableTable` in scope gain a cfg-gated import; the redb-derive tests, which cannot cfg on redb's features, import it under `#[allow(unused_imports)]` since the inherent method shadows it on default features. `get_arc_lifetime`, which exercises the removed behavior itself, switches to `get_owned()` under the feature like `range_arc` already does.
- Since CI builds with `--all-features`, CI no longer compiles or runs the two methods after this change; they remain in default-feature builds until redb 5.

## Testing

- `cargo test --all --all-features` passes; the arc-lifetime tests also pass under default features
- clippy (default and `--all-features`), fmt, and `cargo doc` are clean under `--deny warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCYPuM4nb94pF36ZX7R8sa