### PR TITLE
Add CursorMut::remove_next() and remove_prev(), removing the entries around the gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 * Add `next()` and `prev()` to the experimental `CursorMut`, moving the cursor over the entries
   around its gap like their read-only `Cursor` counterparts. Pending buffered inserts are applied
   before the cursor moves.
+* Add `remove_next()` and `remove_prev()` to the experimental `CursorMut`, removing and returning
+  the entry after or before the cursor's gap without moving it. Pending buffered inserts are
+  applied first, so an entry just inserted through the cursor can be removed.
 * Fix `WriteTransaction::stats()` returning garbage statistics, or panicking when debug assertions
   are enabled, when called while a table is open and modified in the same transaction.
 * Fix a deadlock when a `Database` was dropped while a `WriteTransaction` was live. A live

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -131,6 +131,9 @@ pub(crate) enum FuzzOperation {
         // splicing the pending inserts: next() for descending runs (over the
         // inserts just made), prev() for ascending ones.
         moves: U64Between<0, 8>,
+        // Entries to remove through the cursor after the moves, alternating
+        // remove_next()/remove_prev() starting in the walk direction.
+        removes: U64Between<0, 8>,
     },
     Remove {
         key: BoundedU64<KEY_SPACE>,

--- a/fuzz/fuzz_targets/fuzz_redb.rs
+++ b/fuzz/fuzz_targets/fuzz_redb.rs
@@ -6,7 +6,7 @@ use redb::{
     MultimapValue, ReadableDatabase, ReadableMultimapTable, ReadableTable, ReadableTableMetadata,
     Savepoint, StorageBackend, Table, TableDefinition, WriteTransaction,
 };
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::fmt::{Debug, Formatter};
 use std::fs::{File, OpenOptions};
 use std::io::{ErrorKind, Read, Seek, SeekFrom};
@@ -483,6 +483,28 @@ fn check_extract_iter<F: for<'f> FnMut(u64, &'f [u8]) -> bool>(
     Ok(removed)
 }
 
+// Checks one cursor step or removal against the reference model's expected
+// entry, returning whether an entry was consumed. A mismatch panics; storage
+// errors are propagated by the caller before this runs.
+fn check_cursor_entry(
+    entry: Option<(AccessGuard<'_, u64>, AccessGuard<'_, &'static [u8]>)>,
+    expected: Option<(u64, usize)>,
+) -> bool {
+    match (entry, expected) {
+        (Some((key, value)), Some((expected_key, expected_len))) => {
+            assert_eq!(key.value(), expected_key);
+            assert_eq!(value.value().len(), expected_len);
+            true
+        }
+        (None, None) => false,
+        (entry, expected) => panic!(
+            "cursor yielded {:?}, reference {:?}",
+            entry.map(|(key, _)| key.value()),
+            expected.map(|(key, _)| key)
+        ),
+    }
+}
+
 fn handle_table_op(
     op: &FuzzOperation,
     reference: &mut BTreeMap<u64, usize>,
@@ -531,6 +553,7 @@ fn handle_table_op(
             value_size,
             descending,
             moves,
+            removes,
         } => {
             let start = start_key.value;
             let stride = stride.value;
@@ -575,52 +598,77 @@ fn handle_table_op(
                 assert_eq!(cursor.peek_prev()?.map(|(k, _)| k.value()), last);
                 assert_eq!(cursor.peek_next()?.map(|(k, _)| k.value()), successor);
             }
-            // Moving splices the pending inserts and walks the tree from the
-            // same gap, checked against the reference merged with them: a
-            // descending run's inserts sit after the gap, an ascending run's
-            // before it.
+            // The merged view (reference plus pending inserts) split at the
+            // gap: `before` holds the entries below it nearest-first, `after`
+            // the entries above it nearest-first. Moves shuttle entries
+            // between the two; removals consume them.
             let mut merged = reference.clone();
             for key in &keys {
                 merged.insert(*key, value_size);
             }
-            if *descending {
-                let lower = predecessor.map_or(Bound::Unbounded, Bound::Excluded);
-                let mut walk = merged.range((lower, Bound::Unbounded));
-                for _ in 0..moves.value {
-                    match (cursor.next()?, walk.next()) {
-                        (Some((key, value)), Some((expected_key, expected_len))) => {
-                            assert_eq!(key.value(), *expected_key);
-                            assert_eq!(value.value().len(), *expected_len);
-                        }
-                        (None, None) => break,
-                        (cursor_entry, walk_entry) => panic!(
-                            "cursor yielded {:?}, reference {:?}",
-                            cursor_entry.map(|(key, _)| key.value()),
-                            walk_entry.map(|(key, _)| key)
-                        ),
-                    }
-                }
+            // An ascending run leaves the gap above its pending inserts, a
+            // descending run below them.
+            let boundary = if *descending {
+                predecessor
             } else {
-                let upper = successor.map_or(Bound::Unbounded, Bound::Excluded);
-                let mut walk = merged.range((Bound::Unbounded, upper)).rev();
-                for _ in 0..moves.value {
-                    match (cursor.prev()?, walk.next()) {
-                        (Some((key, value)), Some((expected_key, expected_len))) => {
-                            assert_eq!(key.value(), *expected_key);
-                            assert_eq!(value.value().len(), *expected_len);
-                        }
-                        (None, None) => break,
-                        (cursor_entry, walk_entry) => panic!(
-                            "cursor yielded {:?}, reference {:?}",
-                            cursor_entry.map(|(key, _)| key.value()),
-                            walk_entry.map(|(key, _)| key)
-                        ),
+                keys.last().copied().or(predecessor)
+            };
+            let mut before: VecDeque<(u64, usize)> = match boundary {
+                Some(bound) => merged.range(..=bound).rev().map(|(k, v)| (*k, *v)).collect(),
+                None => VecDeque::new(),
+            };
+            let mut after: VecDeque<(u64, usize)> = match boundary {
+                Some(bound) => merged
+                    .range((Bound::Excluded(bound), Bound::Unbounded))
+                    .map(|(k, v)| (*k, *v))
+                    .collect(),
+                None => merged.iter().map(|(k, v)| (*k, *v)).collect(),
+            };
+            // Moving splices the pending inserts and walks the tree from the
+            // same gap: next() over a descending run's inserts, prev() over
+            // an ascending run's.
+            for _ in 0..moves.value {
+                if *descending {
+                    if check_cursor_entry(cursor.next()?, after.front().copied()) {
+                        before.push_front(after.pop_front().unwrap());
+                    } else {
+                        break;
                     }
+                } else if check_cursor_entry(cursor.prev()?, before.front().copied()) {
+                    after.push_front(before.pop_front().unwrap());
+                } else {
+                    break;
                 }
             }
+            // Removals take the entry adjacent to the gap without moving it,
+            // alternating sides from the walk direction onward.
+            let mut removed_keys = vec![];
+            let mut forward = *descending;
+            for _ in 0..removes.value {
+                if forward {
+                    if check_cursor_entry(cursor.remove_next()?, after.front().copied()) {
+                        removed_keys.push(after.pop_front().unwrap().0);
+                    }
+                } else if check_cursor_entry(cursor.remove_prev()?, before.front().copied()) {
+                    removed_keys.push(before.pop_front().unwrap().0);
+                }
+                forward = !forward;
+            }
+            // The gap ends up between the surviving neighbors.
+            assert_eq!(
+                cursor.peek_prev()?.map(|(k, _)| k.value()),
+                before.front().map(|(k, _)| *k)
+            );
+            assert_eq!(
+                cursor.peek_next()?.map(|(k, _)| k.value()),
+                after.front().map(|(k, _)| *k)
+            );
             cursor.close()?;
             for key in keys {
                 reference.insert(key, value_size);
+            }
+            for key in removed_keys {
+                reference.remove(&key);
             }
         }
         FuzzOperation::Remove { key } | FuzzOperation::RemoveOne { key, .. } => {

--- a/src/table.rs
+++ b/src/table.rs
@@ -1535,7 +1535,8 @@ impl<'a, K: Key + 'static, V: Value + 'static> Cursor<'a, K, V> {
 }
 
 /// A cursor over a [`Table`], pointing at a gap between two entries, with
-/// support for inserting new entries into that gap.
+/// support for inserting new entries into that gap and removing the entries
+/// around it.
 ///
 /// Cursors are constructed with [`Table::lower_bound_mut`] and
 /// [`Table::upper_bound_mut`], and mirror the nightly
@@ -1727,6 +1728,62 @@ impl<'a, K: Key + 'static, V: Value + 'static> CursorMut<'a, K, V> {
             Ok(true) => Ok(()),
             Ok(false) => Err(StorageError::UnorderedKey),
             Err(err) => Err(self.latch_error(err)),
+        }
+    }
+
+    /// Removes the entry after the cursor's gap, returning it.
+    ///
+    /// The cursor does not move: the gap ends up between the removed entry's
+    /// old neighbors. Returns `None`, and removes nothing, if the gap is at
+    /// the end of the table. Any pending inserts are applied first, so an
+    /// entry just inserted through the cursor is removed like an entry the
+    /// table already had.
+    ///
+    /// This is analogous to the nightly
+    /// [`std::collections::btree_map::CursorMut::remove_next`].
+    #[allow(clippy::type_complexity)]
+    pub fn remove_next(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.check_usable()?;
+        // Applied separately from the removal so that a splice failure,
+        // which can poison, is told apart from a failed removal, which only
+        // leaves the position unreliable.
+        if let Err(err) = self.inner.apply_pending_inserts() {
+            return Err(self.latch_error(err));
+        }
+        match self.inner.remove_next() {
+            Ok(entry) => Ok(entry),
+            Err(err) => {
+                self.errored = true;
+                Err(err)
+            }
+        }
+    }
+
+    /// Removes the entry before the cursor's gap, returning it.
+    ///
+    /// The cursor does not move: the gap ends up between the removed entry's
+    /// old neighbors. Returns `None`, and removes nothing, if the gap is at
+    /// the start of the table. Any pending inserts are applied first, so an
+    /// entry just inserted through the cursor is removed like an entry the
+    /// table already had.
+    ///
+    /// This is analogous to the nightly
+    /// [`std::collections::btree_map::CursorMut::remove_prev`].
+    #[allow(clippy::type_complexity)]
+    pub fn remove_prev(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.check_usable()?;
+        // Applied separately from the removal so that a splice failure,
+        // which can poison, is told apart from a failed removal, which only
+        // leaves the position unreliable.
+        if let Err(err) = self.inner.apply_pending_inserts() {
+            return Err(self.latch_error(err));
+        }
+        match self.inner.remove_prev() {
+            Ok(entry) => Ok(entry),
+            Err(err) => {
+                self.errored = true;
+                Err(err)
+            }
         }
     }
 

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -1044,6 +1044,51 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         Ok(Some(self.record_removal_deferred(Direction::Previous)))
     }
 
+    /// Removes the entry after the gap, returning it with a copy of its key.
+    /// The mutation consumes the position: once the returned guards have
+    /// dropped, seeking to `Position::Before` the key restores the gap
+    /// between the removed entry's old neighbors.
+    ///
+    /// The returned guards must be dropped before mutating the tree again.
+    #[cfg(feature = "experimental_cursor")]
+    #[allow(clippy::type_complexity)]
+    pub(super) fn remove_next_taking_key(
+        &mut self,
+    ) -> Result<Option<(Vec<u8>, AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        self.remove_taking_key(Direction::Next)
+    }
+
+    /// Removes the entry before the gap; see
+    /// [`remove_next_taking_key`](Self::remove_next_taking_key).
+    #[cfg(feature = "experimental_cursor")]
+    #[allow(clippy::type_complexity)]
+    pub(super) fn remove_prev_taking_key(
+        &mut self,
+    ) -> Result<Option<(Vec<u8>, AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        self.remove_taking_key(Direction::Previous)
+    }
+
+    #[cfg(feature = "experimental_cursor")]
+    #[allow(clippy::type_complexity)]
+    fn remove_taking_key(
+        &mut self,
+        direction: Direction,
+    ) -> Result<Option<(Vec<u8>, AccessGuard<'a, K>, AccessGuard<'a, V>)>> {
+        assert!(self.state.removed_indexes.is_empty());
+        if !self.ensure_has_entry(direction)? {
+            return Ok(None);
+        }
+        let position = self
+            .state
+            .position
+            .take()
+            .expect("cursor must be positioned");
+        let index = position.entry_index(direction);
+        let key = key_data::<K, V>(&position.leaf, index);
+        let entry = self.remove_leaf_entry(position.leaf.page, position.path, index)?;
+        Ok(entry.map(|(key_guard, value_guard)| (key, key_guard, value_guard)))
+    }
+
     fn record_removal(&mut self, direction: Direction) -> usize {
         let position = self
             .state
@@ -1706,6 +1751,11 @@ fn entry_guards<K: Key + 'static, V: Value + 'static>(
 pub(crate) struct BtreeCursorMut<'a, K: Key + 'static, V: Value + 'static> {
     tree: CursorTree<'a, K, V>,
     state: CursorState,
+    // Key of the last removed entry, whose removal consumed the position.
+    // The next operation reseeks to the gap the key names; the reseek must
+    // wait, since an in-place removal is applied only when the returned
+    // value guard drops.
+    pending_reseek: Option<Vec<u8>>,
 }
 
 #[cfg(feature = "experimental_cursor")]
@@ -1719,23 +1769,37 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
         Self {
             tree: CursorTree::new(root, page_allocator, master_free_list, allocated),
             state: CursorState::default(),
+            pending_reseek: None,
         }
     }
 
     /// Positions the cursor at the gap before the first key `bound` admits.
     pub(crate) fn seek_lower_bound(&mut self, bound: Bound<&[u8]>) -> Result {
+        self.pending_reseek = None;
         self.with_cursor(|cursor| cursor.seek_to(Position::from_lower_bound(bound)))
     }
 
     /// Positions the cursor at the gap after the last key `bound` admits.
     pub(crate) fn seek_upper_bound(&mut self, bound: Bound<&[u8]>) -> Result {
+        self.pending_reseek = None;
         self.with_cursor(|cursor| cursor.seek_to(Position::from_upper_bound(bound)))
+    }
+
+    // Restores the gap a removal consumed: the removed key, now absent from
+    // the tree, names the gap between its old neighbors. Every operation
+    // except the seeks, which position anew, settles this first.
+    fn settle_reseek(&mut self) -> Result {
+        let Some(key) = self.pending_reseek.take() else {
+            return Ok(());
+        };
+        self.with_cursor(|cursor| cursor.seek_to(Position::Before(&key)))
     }
 
     /// The entry after the gap, including while inserts are pending: the
     /// most recent `insert_after` is returned without splicing.
     #[allow(clippy::type_complexity)]
     pub(crate) fn peek_next(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.settle_reseek()?;
         if let Some(run) = &self.state.insert_run {
             if let Some((key, value)) = run.buffered_next() {
                 return Ok(Some((
@@ -1775,6 +1839,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
     /// means the gap is at the start of the tree.
     #[allow(clippy::type_complexity)]
     pub(crate) fn peek_prev(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.settle_reseek()?;
         if let Some(run) = &self.state.insert_run {
             if let Some((key, value)) = run.buffered_previous() {
                 return Ok(Some((
@@ -1802,6 +1867,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
     /// pending inserts are spliced first: moving the cursor closes the run.
     #[allow(clippy::type_complexity)]
     pub(crate) fn next(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.settle_reseek()?;
         self.with_cursor(|cursor| {
             cursor.flush_insert_run(true)?;
             Ok(cursor.next()?.map(|entry| entry.to_guards()))
@@ -1813,6 +1879,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
     /// run.
     #[allow(clippy::type_complexity)]
     pub(crate) fn prev(&mut self) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.settle_reseek()?;
         self.with_cursor(|cursor| {
             cursor.flush_insert_run(true)?;
             Ok(cursor.prev()?.map(|entry| entry.to_guards()))
@@ -1821,12 +1888,52 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
 
     /// See [`CursorMut::insert_before`].
     pub(crate) fn insert_before(&mut self, key: &[u8], value: &[u8]) -> Result<bool> {
+        self.settle_reseek()?;
         self.with_cursor(|cursor| cursor.insert_before(key, value))
     }
 
     /// See [`CursorMut::insert_after`].
     pub(crate) fn insert_after(&mut self, key: &[u8], value: &[u8]) -> Result<bool> {
+        self.settle_reseek()?;
         self.with_cursor(|cursor| cursor.insert_after(key, value))
+    }
+
+    /// Removes the entry after the gap, returning it. The gap does not move:
+    /// it ends up between the removed entry's old neighbors. Any pending
+    /// inserts are spliced first: removing through the cursor closes the run.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn remove_next(
+        &mut self,
+    ) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.settle_reseek()?;
+        let removed = self.with_cursor(|cursor| {
+            cursor.flush_insert_run(true)?;
+            cursor.remove_next_taking_key()
+        })?;
+        Ok(removed.map(|(key, key_guard, value_guard)| {
+            // The mutation consumed the position, and an in-place removal is
+            // applied only when the value guard drops; the reseek waits for
+            // the next operation, by which time the guards are gone.
+            self.pending_reseek = Some(key);
+            (key_guard, value_guard)
+        }))
+    }
+
+    /// Removes the entry before the gap, returning it; the counterpart of
+    /// [`remove_next`](Self::remove_next).
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn remove_prev(
+        &mut self,
+    ) -> Result<Option<(AccessGuard<'_, K>, AccessGuard<'_, V>)>> {
+        self.settle_reseek()?;
+        let removed = self.with_cursor(|cursor| {
+            cursor.flush_insert_run(true)?;
+            cursor.remove_prev_taking_key()
+        })?;
+        Ok(removed.map(|(key, key_guard, value_guard)| {
+            self.pending_reseek = Some(key);
+            (key_guard, value_guard)
+        }))
     }
 
     /// Splices any pending inserts into the tree, keeping the cursor at its

--- a/tests/cursor_tests.rs
+++ b/tests/cursor_tests.rs
@@ -967,3 +967,233 @@ fn moves_on_empty_table_and_at_edges() {
 
     assert_u64_table_contents(&db, &[(1, 1)]);
 }
+
+#[test]
+fn removes_walk_both_directions() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 20, 30] {
+            table.insert(i, &(i * 7)).unwrap();
+        }
+        {
+            let mut cursor = table.lower_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            for expected in [10u64, 20, 30] {
+                let (k, v) = cursor.remove_next().unwrap().unwrap();
+                assert_eq!(k.value(), expected);
+                assert_eq!(v.value(), expected * 7);
+            }
+            assert!(cursor.remove_next().unwrap().is_none());
+            assert!(cursor.peek_prev().unwrap().is_none());
+            assert!(cursor.peek_next().unwrap().is_none());
+            cursor.close().unwrap();
+        }
+        assert_eq!(table.len().unwrap(), 0);
+
+        for i in [10u64, 20, 30] {
+            table.insert(i, &(i * 7)).unwrap();
+        }
+        {
+            let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            for expected in [30u64, 20, 10] {
+                let (k, v) = cursor.remove_prev().unwrap().unwrap();
+                assert_eq!(k.value(), expected);
+                assert_eq!(v.value(), expected * 7);
+            }
+            assert!(cursor.remove_prev().unwrap().is_none());
+            cursor.close().unwrap();
+        }
+        assert_eq!(table.len().unwrap(), 0);
+    }
+    txn.commit().unwrap();
+
+    assert_u64_table_contents(&db, &[]);
+}
+
+// A removal does not move the gap: it ends up between the removed entry's
+// old neighbors, in either direction and under alternation.
+#[test]
+fn removes_keep_the_gap_in_place() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 20, 30, 40] {
+            table.insert(i, &i).unwrap();
+        }
+        let mut cursor = table.lower_bound_mut(Bound::Included(&30)).unwrap();
+        // The gap starts between 20 and 30.
+        assert_eq!(cursor.remove_prev().unwrap().unwrap().0.value(), 20);
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 10);
+        assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 30);
+        assert_eq!(cursor.remove_next().unwrap().unwrap().0.value(), 30);
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 10);
+        assert_eq!(cursor.peek_next().unwrap().unwrap().0.value(), 40);
+        assert_eq!(cursor.remove_next().unwrap().unwrap().0.value(), 40);
+        assert_eq!(cursor.remove_prev().unwrap().unwrap().0.value(), 10);
+        assert!(cursor.remove_next().unwrap().is_none());
+        assert!(cursor.remove_prev().unwrap().is_none());
+        cursor.close().unwrap();
+        assert_eq!(table.len().unwrap(), 0);
+    }
+    txn.commit().unwrap();
+
+    assert_u64_table_contents(&db, &[]);
+}
+
+// Removals apply pending inserts first and take from the same gap, so an
+// entry just inserted through the cursor is removed like a pre-existing one.
+#[test]
+fn removes_apply_pending_inserts() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in [10u64, 30] {
+            table.insert(i, &i).unwrap();
+        }
+        let mut cursor = table.upper_bound_mut(Bound::Included(&10)).unwrap();
+        // The gap is between 10 and 30.
+        cursor.insert_before(20, &20).unwrap();
+        assert_eq!(cursor.remove_next().unwrap().unwrap().0.value(), 30);
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 20);
+        assert!(cursor.peek_next().unwrap().is_none());
+        cursor.insert_after(25, &25).unwrap();
+        // The entry before the gap is the earlier insert, already spliced.
+        assert_eq!(cursor.remove_prev().unwrap().unwrap().0.value(), 20);
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 10);
+        // The entry after the gap is the pending insert, spliced and removed.
+        assert_eq!(cursor.remove_next().unwrap().unwrap().0.value(), 25);
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    assert_u64_table_contents(&db, &[(10, 10)]);
+}
+
+// Draining a multi-leaf table in each direction exercises leaf-boundary
+// crossings, merges of underfilled leaves, and root collapse. The table
+// sits on dirty pages, covering the in-place removal fast path and the
+// deferred reseek over its guard-drop-time rewrite.
+#[test]
+fn removes_cross_leaf_boundaries() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        for i in 0..2_000u64 {
+            table.insert(i, &(i * 7)).unwrap();
+        }
+        {
+            let mut cursor = table.lower_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            for i in 0..2_000u64 {
+                let (k, v) = cursor.remove_next().unwrap().unwrap();
+                assert_eq!((k.value(), v.value()), (i, i * 7));
+            }
+            assert!(cursor.remove_next().unwrap().is_none());
+            cursor.close().unwrap();
+        }
+        assert_eq!(table.len().unwrap(), 0);
+
+        for i in 0..2_000u64 {
+            table.insert(i, &(i * 7)).unwrap();
+        }
+        {
+            let mut cursor = table.upper_bound_mut(Bound::<u64>::Unbounded).unwrap();
+            for i in (0..2_000u64).rev() {
+                let (k, v) = cursor.remove_prev().unwrap().unwrap();
+                assert_eq!((k.value(), v.value()), (i, i * 7));
+            }
+            assert!(cursor.remove_prev().unwrap().is_none());
+            cursor.close().unwrap();
+        }
+        assert_eq!(table.len().unwrap(), 0);
+    }
+    txn.abort().unwrap();
+}
+
+// The same drain over committed pages, whose removals rewrite leaves
+// instead of mutating them in place.
+#[test]
+fn removes_from_committed_pages() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    populate_u64_table(&db, (0..2_000).map(|key| (key, key * 7)));
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        let mut cursor = table.lower_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        for i in 0..2_000u64 {
+            let (k, v) = cursor.remove_next().unwrap().unwrap();
+            assert_eq!((k.value(), v.value()), (i, i * 7));
+        }
+        assert!(cursor.remove_next().unwrap().is_none());
+        cursor.close().unwrap();
+    }
+    txn.commit().unwrap();
+
+    assert_u64_table_contents(&db, &[]);
+}
+
+// Values that get pages of their own ride the same removal path.
+#[test]
+fn removes_large_values() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(STR_TABLE).unwrap();
+        for i in 0..20u64 {
+            let size = if i % 4 == 0 { 100_000 } else { 10 };
+            table
+                .insert(key(i).as_str(), vec![i as u8; size].as_slice())
+                .unwrap();
+        }
+        let mut cursor = table.lower_bound_mut(Bound::<&str>::Unbounded).unwrap();
+        for i in 0..20u64 {
+            let size = if i % 4 == 0 { 100_000 } else { 10 };
+            let (k, v) = cursor.remove_next().unwrap().unwrap();
+            assert_eq!(k.value(), key(i));
+            assert_eq!(v.value(), vec![i as u8; size]);
+        }
+        assert!(cursor.remove_next().unwrap().is_none());
+        cursor.close().unwrap();
+        assert_eq!(table.len().unwrap(), 0);
+    }
+    txn.commit().unwrap();
+}
+
+#[test]
+fn removes_on_empty_table_and_at_edges() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        let mut cursor = table.lower_bound_mut(Bound::<u64>::Unbounded).unwrap();
+        assert!(cursor.remove_next().unwrap().is_none());
+        assert!(cursor.remove_prev().unwrap().is_none());
+        // A removal that finds nothing still applies the pending inserts
+        cursor.insert_before(1, &1).unwrap();
+        assert!(cursor.remove_next().unwrap().is_none());
+        assert_eq!(cursor.peek_prev().unwrap().unwrap().0.value(), 1);
+        assert_eq!(cursor.remove_prev().unwrap().unwrap().0.value(), 1);
+        cursor.close().unwrap();
+        assert_eq!(table.len().unwrap(), 0);
+    }
+    txn.commit().unwrap();
+
+    assert_u64_table_contents(&db, &[]);
+}


### PR DESCRIPTION
Modeled on the standard library's nightly `BTreeMap` cursors: `remove_next()` removes and returns the entry after the cursor's gap and `remove_prev()` the entry before it. The cursor does not move: the gap ends up between the removed entry's old neighbors. This is the next slice of the `CursorMut` surface after the moves in #1342.

Design notes:

- Both removes splice any pending inserts first and then take from the same gap, so an entry just inserted through the cursor is removed like an entry the table already had. A remove that finds no entry (at the table's edge) still applies the pending inserts, like the moves. At the table layer the splice is applied separately from the removal, telling a splice failure, which can lose reported inserts and must poison, apart from a failed removal, which only leaves the position unreliable -- the same split the moves and peeks use.
- The removal reuses the tree cursor's pop machinery behind `pop_first()`/`pop_last()`, which consumes the cursor position. On dirty leaves that machinery takes an in-place fast path whose removal is physically applied only when the returned value guard drops, so the cursor cannot reseek eagerly: it defers restoring the gap until its next operation, by which time the guards are gone (they borrow the cursor mutably, like the mutable peeks) and the removed key, now absent from the tree, names exactly the gap between its old neighbors. A remove-then-close pays no reseek at all, keeping `pop_first`-style usage at one descent.
- Each removal costs one tree descent (the deferred reseek) plus the leaf rewrite, like `Table::remove`. Batching consecutive removals per leaf, the way `retain`/`extract_if` do internally through deferred removal batches, is left for a follow-up: those batches are direction-locked, while the public cursor allows arbitrary direction changes.

Tests cover draining a table through each direction (including 2000-entry tables crossing leaf boundaries, on both same-transaction dirty pages -- the in-place path -- and committed pages), alternating removes over one gap, the pending-inserts interplay in both directions, values large enough to get pages of their own, and edge/empty-table behavior. The fuzzer's `CursorInsert` operation gains a removal phase that alternates `remove_next()`/`remove_prev()` after its move phase; the reference walk is reworked into a pair of deques around the gap, so moves and removals in either direction check against a single model of the gap's neighborhood.

### Remaining std `btree_map` cursor surface not yet in redb

- `CursorMut::as_cursor()` -- reborrowing the mutable cursor as a read-only `Cursor` at the same gap.
- `insert_before_unchecked()` / `insert_after_unchecked()` -- std's order-check-skipping variants; probably never appropriate for a database, since an unordered key would corrupt the table rather than just break iteration order.
- `CursorMutKey` / `with_mutable_key()` -- mutable access to keys; does not map to redb's serialized keys.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ)_