### PR TITLE
Add a thread-local cache for hot btree pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@
   optional, and lets container types holding that key store shorter separators.
 * Shorten separators for array keys, when the element type is variable width. Tables with such
   keys use slightly less space, and lookups are faster.
+* Improve multithreaded read scaling. Each thread now caches the level below the root of the
+  btrees it reads, removing lock and reference-count contention on those hot pages. Random reads
+  are about 1.2x faster with 16 threads and 1.6x faster with 32.
 * Fix a crash shortly after a commit being able to silently roll that commit back during
   recovery, if `check_integrity()` had previously repaired the database.
 * Fix iterators silently omitting data when iteration continues after an error. An iterator

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,6 +5,7 @@ use crate::tree_store::ReadOnlyBackend;
 use crate::tree_store::{
     AllocationPolicy, BtreeHeader, InternalTableDefinition, PAGE_SIZE, PageHint, PageNumber,
     PageResolver, ShrinkPolicy, TableTree, TableType, TransactionalMemory,
+    release_thread_local_page_cache,
 };
 use crate::types::{Key, Value};
 use crate::{
@@ -341,6 +342,10 @@ impl TransactionGuard {
             }
         }
     }
+
+    pub(crate) fn is_read(&self) -> bool {
+        matches!(self, Self::Read { .. })
+    }
 }
 
 impl Drop for TransactionGuard {
@@ -349,7 +354,12 @@ impl Drop for TransactionGuard {
             Self::Read {
                 tracker,
                 transaction_id,
-            } => tracker.deallocate_read_transaction(*transaction_id),
+            } => {
+                // Clear the thread local cache, so that it doesn't leak cache space if this
+                // thread doesn't run another transaction
+                release_thread_local_page_cache();
+                tracker.deallocate_read_transaction(*transaction_id);
+            }
             Self::Write {
                 tracker,
                 transaction_id,

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -11,13 +11,16 @@ use crate::tree_store::btree_cursor::BtreeCursorMut;
 use crate::tree_store::btree_cursor::{CursorMut, Position};
 use crate::tree_store::btree_iters::{bounds_are_empty, encode_bounds};
 use crate::tree_store::btree_mutator::MutateHelper;
-use crate::tree_store::page_store::{Page, PageImpl, PageMut};
+use crate::tree_store::page_store::{
+    CacheTag, Page, PageImpl, PageMut, ThreadLocalPageCache, with_thread_local_page_cache,
+};
 use crate::tree_store::{
     AccessGuardMutInPlace, AllPageNumbersBtreeIter, BtreeCursorRange, BtreeExtractIf,
     PageAllocator, PageHint, PageNumber, PageNumberHashMap, PageResolver, PageTracker,
 };
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, Result, StorageError};
+use alloc::rc::Rc;
 use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec;
@@ -1005,11 +1008,40 @@ impl RawBtree {
     }
 }
 
+// A page visited during a lookup: the borrowed root, one from the shared page cache, or this
+// thread's private copy of a branch page
+enum NodePage<'a> {
+    Root(&'a PageImpl),
+    Shared(PageImpl),
+    Local(PageNumber, Rc<[u8]>),
+}
+
+impl Page for NodePage<'_> {
+    fn memory(&self) -> &[u8] {
+        match self {
+            Self::Root(page) => page.memory(),
+            Self::Shared(page) => page.memory(),
+            Self::Local(_, bytes) => bytes,
+        }
+    }
+
+    fn get_page_number(&self) -> PageNumber {
+        match self {
+            Self::Root(page) => page.get_page_number(),
+            Self::Shared(page) => page.get_page_number(),
+            Self::Local(page_number, _) => *page_number,
+        }
+    }
+}
+
 pub(crate) struct Btree<K: Key + 'static, V: Value + 'static> {
     mem: PageResolver,
     transaction_guard: Arc<TransactionGuard>,
     // Cache of the root page to avoid repeated lookups
     cached_root: Option<PageImpl>,
+    // None for write transactions, which can free and reallocate pages within one generation
+    cache_tag: Option<CacheTag>,
+    cache_max_pages: usize,
     root: Option<BtreeHeader>,
     hint: PageHint,
     _key_type: PhantomData<K>,
@@ -1028,10 +1060,20 @@ impl<K: Key, V: Value> Btree<K, V> {
         } else {
             None
         };
+        let cache_tag = if guard.is_read() {
+            Some(CacheTag {
+                instance: mem.cache_instance_id(),
+                generation: guard.id().raw_id(),
+            })
+        } else {
+            None
+        };
         Ok(Self {
+            cache_max_pages: mem.thread_local_cache_pages(),
             mem,
             transaction_guard: guard,
             cached_root,
+            cache_tag,
             root,
             hint,
             _key_type: PhantomData,
@@ -1084,38 +1126,88 @@ impl<K: Key, V: Value> Btree<K, V> {
     }
 
     pub(crate) fn get(&self, key: &K::SelfType<'_>) -> Result<Option<AccessGuard<'static, V>>> {
-        if let Some(ref root_page) = self.cached_root {
-            self.get_helper(root_page, K::as_bytes(key).as_ref())
+        let Some(ref root_page) = self.cached_root else {
+            return Ok(None);
+        };
+        let key_bytes = K::as_bytes(key);
+        let query = key_bytes.as_ref();
+        if let Some(tag) = self.cache_tag {
+            with_thread_local_page_cache(|cache| {
+                self.get_helper(&mut cache.map(|cache| (cache, tag)), root_page, query)
+            })
         } else {
-            Ok(None)
+            self.get_helper(&mut None, root_page, query)
         }
     }
 
     // Returns the value for the queried key, if present
-    fn get_helper(&self, page: &PageImpl, query: &[u8]) -> Result<Option<AccessGuard<'static, V>>> {
-        let mut descended: Option<PageImpl> = None;
+    fn get_helper(
+        &self,
+        cache: &mut Option<(&mut ThreadLocalPageCache, CacheTag)>,
+        root: &PageImpl,
+        query: &[u8],
+    ) -> Result<Option<AccessGuard<'static, V>>> {
+        let mut node = NodePage::Root(root);
+        // Counting the root's children as 1
+        let mut child_depth = 1;
         for _ in 0..MAX_BTREE_DEPTH {
-            let page = descended.as_ref().unwrap_or(page);
-            let child_page = match page.memory()[0] {
+            let child_number = match node.memory()[0] {
                 LEAF => {
                     let accessor =
-                        LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
-                    return Ok(accessor.find_key::<K>(query).map(|entry_index| {
-                        let (start, end) = accessor.value_range(entry_index).unwrap();
-                        AccessGuard::with_page(page.clone(), start..end)
-                    }));
+                        LeafAccessor::new(node.memory(), K::fixed_width(), V::fixed_width());
+                    let Some(entry_index) = accessor.find_key::<K>(query) else {
+                        return Ok(None);
+                    };
+                    let (start, end) = accessor.value_range(entry_index).unwrap();
+                    let page = match node {
+                        NodePage::Root(page) => page.clone(),
+                        NodePage::Shared(page) => page,
+                        NodePage::Local(..) => unreachable!("only branch pages are cached"),
+                    };
+                    return Ok(Some(AccessGuard::with_page(page, start..end)));
                 }
                 BRANCH => {
-                    let accessor = BranchAccessor::new(page, K::fixed_width());
+                    let accessor = BranchAccessor::new(&node, K::fixed_width());
                     accessor.child_for_key::<K>(query).1
                 }
                 _ => unreachable!(),
             };
-            descended = Some(self.mem.get_page(child_page, self.hint)?);
+            node = self.get_page_for_read(cache, child_number, child_depth)?;
+            child_depth += 1;
         }
         Err(StorageError::Corrupted(
             "Btree exceeded maximum depth".to_string(),
         ))
+    }
+
+    // Levels below the root served from the thread local cache. Only the first, because a level
+    // holds roughly a page's worth of children per page of the level above it: the one below the
+    // root is small enough to cache whole, and the next is already too large. Caching a level
+    // that does not fit is worse than not caching it, since each miss copies a page
+    const MAX_CACHED_DEPTH: u32 = 1;
+
+    // Fetches a page during a lookup, from this thread's cache when it holds it. Only branch
+    // pages are cached, because an AccessGuard returned for a leaf holds the PageImpl
+    fn get_page_for_read<'a>(
+        &'a self,
+        cache: &mut Option<(&mut ThreadLocalPageCache, CacheTag)>,
+        page_number: PageNumber,
+        depth: u32,
+    ) -> Result<NodePage<'a>> {
+        if depth <= Self::MAX_CACHED_DEPTH
+            && page_number.page_order == 0
+            && let Some((cache, tag)) = cache
+        {
+            if let Some(bytes) = cache.get(*tag, page_number) {
+                return Ok(NodePage::Local(page_number, bytes));
+            }
+            let page = self.mem.get_page(page_number, self.hint)?;
+            if page.memory()[0] == BRANCH {
+                cache.insert(*tag, self.cache_max_pages, page_number, page.memory());
+            }
+            return Ok(NodePage::Shared(page));
+        }
+        Ok(NodePage::Shared(self.mem.get_page(page_number, self.hint)?))
     }
 
     pub(crate) fn first(

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -30,6 +30,7 @@ pub(crate) use page_store::{
     AllocationPolicy, FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page,
     PageAllocator, PageHint, PageNumber, PageNumberHashMap, PageNumberHashSet, PageResolver,
     PageTracker, SerializedSavepoint, ShrinkPolicy, TransactionalMemory,
+    release_thread_local_page_cache,
 };
 pub use page_store::{InMemoryBackend, Savepoint};
 pub(crate) use table_tree::{PageListMut, TableTree, TableTreeMut};

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -328,6 +328,10 @@ impl PagedCachedFile {
         &self.write_buffer[stripe]
     }
 
+    pub(super) fn max_cache_size(&self) -> usize {
+        self.max_cache_size
+    }
+
     #[allow(clippy::unused_self)]
     pub(crate) fn cache_stats(&self) -> CacheStats {
         #[cfg(not(feature = "cache_metrics"))]

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -12,6 +12,7 @@ mod lru_cache;
 mod page_manager;
 mod region;
 mod savepoint;
+mod thread_local_page_cache;
 #[allow(clippy::pedantic, dead_code)]
 mod xxh3;
 
@@ -27,6 +28,10 @@ pub(crate) use page_manager::{
 };
 pub use savepoint::Savepoint;
 pub(crate) use savepoint::SerializedSavepoint;
+pub(crate) use thread_local_page_cache::release_thread_local_page_cache;
+pub(super) use thread_local_page_cache::{
+    CacheTag, ThreadLocalPageCache, with_thread_local_page_cache,
+};
 
 pub(super) use base::{PageImpl, PageMut};
 pub(super) use xxh3::hash128_with_seed;

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -28,6 +28,28 @@ use core::marker::PhantomData;
 use core::mem;
 use core::sync::atomic::{AtomicBool, Ordering};
 
+// Assigns every TransactionalMemory, and every in-place reload of one, an id that no other
+// instance in this process has held, which is what lets a thread local page cache tell whose
+// pages it is holding. The id must be unique process wide, not just within one database:
+// thread local caches outlive the databases that filled them, and every database a thread
+// reads shares one cache, so an id unique only within a database would let one database's
+// pages match another's tag. Ids are never reused -- incrementing a u64 once per instance and
+// per reload cannot wrap in practice -- so a tag from a dropped database matches nothing.
+//
+// A mutex rather than an atomic, because 64 bit atomics are unavailable on some of the targets
+// redb supports, and this is taken only when a database is opened or reloaded.
+static NEXT_CACHE_INSTANCE_ID: Mutex<u64> = Mutex::new(1);
+
+fn next_cache_instance_id() -> u64 {
+    let mut next = NEXT_CACHE_INSTANCE_ID.lock().unwrap();
+    let id = *next;
+    *next += 1;
+    id
+}
+
+// Enough for the top levels of a large btree. 512KiB with 4KiB pages
+const MAX_THREAD_LOCAL_CACHE_PAGES: usize = 128;
+
 // The region header is optional in the v3 file format
 // It's an artifact of the v2 file format, so we initialize new databases without headers to save space
 const NO_HEADER: u32 = 0;
@@ -102,6 +124,14 @@ impl PageResolver {
 
     pub(crate) fn get_page(&self, page_number: PageNumber, hint: PageHint) -> Result<PageImpl> {
         self.mem.get_page(page_number, hint)
+    }
+
+    pub(crate) fn cache_instance_id(&self) -> u64 {
+        self.mem.cache_instance_id
+    }
+
+    pub(crate) fn thread_local_cache_pages(&self) -> usize {
+        self.mem.thread_local_cache_pages()
     }
 
     pub(crate) fn count_allocated_pages(&self) -> Result<u64> {
@@ -500,6 +530,10 @@ impl UnpersistedState {
 }
 
 pub(crate) struct TransactionalMemory {
+    // Identifies this instance's pages in the thread local cache. A transaction id alone is
+    // not enough, because a reload can rewind it and later commits then reuse ids that named
+    // different data
+    cache_instance_id: u64,
     unpersisted: Mutex<UnpersistedState>,
     storage: PagedCachedFile,
     state: Mutex<InMemoryState>,
@@ -650,6 +684,7 @@ impl TransactionalMemory {
         assert!(page_size >= DB_HEADER_SIZE);
 
         Ok(Self {
+            cache_instance_id: next_cache_instance_id(),
             unpersisted: Mutex::new(UnpersistedState::default()),
             storage,
             state: Mutex::new(state),
@@ -741,6 +776,9 @@ impl TransactionalMemory {
         // leave cached pages that disagree with the file.
         self.storage.discard_write_buffer();
         self.storage.invalidate_cache_all();
+        // Invalidate the thread local caches too, since the state being loaded can give a
+        // transaction id already read under this instance different contents
+        self.cache_instance_id = next_cache_instance_id();
         self.storage.sync_file()?;
 
         let header_bytes = self.storage.read_direct(0, DB_HEADER_SIZE)?;
@@ -1666,6 +1704,14 @@ impl TransactionalMemory {
 
     pub(crate) fn get_page_size(&self) -> usize {
         self.page_size.try_into().unwrap()
+    }
+
+    // Pages each thread may cache. Bounded by the configured cache size, so that a small one
+    // shrinks it and set_cache_size(0) disables it, but this is a per thread bound: threads
+    // reading concurrently can hold this many pages each, beyond the configured size
+    fn thread_local_cache_pages(&self) -> usize {
+        let budget = self.storage.max_cache_size() / (self.page_size as usize);
+        budget.min(MAX_THREAD_LOCAL_CACHE_PAGES)
     }
 
     pub(crate) fn close(&self) -> Result {

--- a/src/tree_store/page_store/thread_local_page_cache.rs
+++ b/src/tree_store/page_store/thread_local_page_cache.rs
@@ -1,0 +1,186 @@
+use crate::tree_store::page_store::base::PageNumber;
+use crate::tree_store::page_store::fast_hash::{PageNumberHashMap, Shrink};
+use alloc::rc::Rc;
+#[cfg(not(redb_no_std))]
+use core::cell::RefCell;
+
+/// The snapshot a cached page belongs to.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub(crate) struct CacheTag {
+    /// Assigned by `TransactionalMemory`, to distinguish databases and reloads of one
+    pub(crate) instance: u64,
+    /// The read transaction's id
+    pub(crate) generation: u64,
+}
+
+/// A thread's copies of the hottest btree pages, so that lookups in read transactions can skip
+/// the shared page cache, whose lock stripe, LRU flag and `Arc` refcount are all writes to
+/// memory other cores read. Being thread local, it needs no locks or atomics.
+///
+/// Every entry belongs to the snapshot named by `tag`, and reading a different one empties the
+/// cache. That is what keeps entries from going stale: a transaction is given generation `G`
+/// only while `G` is the last committed transaction, and pins it, and releasing a page for
+/// reuse takes commits past `G` plus a `process_freed_pages()` that stops at the oldest live
+/// read.
+///
+/// Only the level below the root is cached, which is small enough that a snapshot's pages
+/// normally all fit. Once `max_pages` are held the cache stops admitting, rather than replacing
+/// entries: admitting copies a page, so a level that does not fit would otherwise pay that copy
+/// on nearly every lookup, which costs far more than the shared cache lookup it saves.
+#[derive(Default)]
+pub(crate) struct ThreadLocalPageCache {
+    tag: Option<CacheTag>,
+    max_pages: usize,
+    pages: PageNumberHashMap<Rc<[u8]>>,
+}
+
+#[cfg(not(redb_no_std))]
+thread_local! {
+    static PAGE_CACHE: RefCell<ThreadLocalPageCache> = RefCell::default();
+}
+
+/// Runs `f` with this thread's page cache, or `None` when it is unavailable: a reentrant call,
+/// or a thread being torn down. Lookups then run uncached rather than panicking.
+#[cfg(not(redb_no_std))]
+pub(crate) fn with_thread_local_page_cache<R>(
+    f: impl FnOnce(Option<&mut ThreadLocalPageCache>) -> R,
+) -> R {
+    let mut f = Some(f);
+    PAGE_CACHE
+        .try_with(|cell| {
+            let f = f.take().unwrap();
+            match cell.try_borrow_mut() {
+                Ok(mut cache) => f(Some(&mut cache)),
+                Err(_) => f(None),
+            }
+        })
+        .unwrap_or_else(|_| (f.take().unwrap())(None))
+}
+
+/// Always runs `f` without a cache: no_std has no thread local storage to keep one in.
+#[cfg(redb_no_std)]
+pub(crate) fn with_thread_local_page_cache<R>(
+    f: impl FnOnce(Option<&mut ThreadLocalPageCache>) -> R,
+) -> R {
+    f(None)
+}
+
+/// Releases this thread's cached pages. A transaction dropped on a different thread than it
+/// read from leaves that thread's pages until it caches another snapshot.
+pub(crate) fn release_thread_local_page_cache() {
+    with_thread_local_page_cache(|cache| {
+        if let Some(cache) = cache {
+            cache.clear();
+        }
+    });
+}
+
+impl ThreadLocalPageCache {
+    pub(crate) fn get(&self, tag: CacheTag, page_number: PageNumber) -> Option<Rc<[u8]>> {
+        if self.tag != Some(tag) {
+            return None;
+        }
+        self.pages.get(&page_number).cloned()
+    }
+
+    /// Caches a copy of `bytes`, holding at most `max_pages` of them, and empties the cache
+    /// first if it holds another snapshot's. Interleaving two snapshots on one thread therefore
+    /// keeps refilling it: correct, but a page copy per lookup
+    pub(crate) fn insert(
+        &mut self,
+        tag: CacheTag,
+        max_pages: usize,
+        page_number: PageNumber,
+        bytes: &[u8],
+    ) {
+        // Caching a multi-page value would break this cache's memory bound
+        assert_eq!(page_number.page_order, 0);
+        if self.tag != Some(tag) {
+            self.clear();
+            self.tag = Some(tag);
+            self.max_pages = max_pages;
+        }
+        if self.pages.len() < self.max_pages {
+            self.pages.insert(page_number, Rc::from(bytes));
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.tag = None;
+        self.max_pages = 0;
+        self.pages.clear();
+        self.pages.shrink();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{CacheTag, ThreadLocalPageCache};
+    use crate::tree_store::page_store::base::PageNumber;
+
+    const MAX_PAGES: usize = 128;
+
+    fn page(index: u32) -> PageNumber {
+        PageNumber::new(0, index, 0)
+    }
+
+    fn tag(instance: u64, generation: u64) -> CacheTag {
+        CacheTag {
+            instance,
+            generation,
+        }
+    }
+
+    #[test]
+    fn hit_requires_matching_tag() {
+        let mut cache = ThreadLocalPageCache::default();
+
+        assert!(cache.get(tag(1, 7), page(1)).is_none());
+        cache.insert(tag(1, 7), MAX_PAGES, page(1), &[1, 2, 3]);
+        assert_eq!(cache.get(tag(1, 7), page(1)).unwrap().as_ref(), [1, 2, 3]);
+        assert!(cache.get(tag(1, 7), page(2)).is_none());
+        // Another generation of this database, and the same generation of another database
+        assert!(cache.get(tag(1, 8), page(1)).is_none());
+        assert!(cache.get(tag(2, 7), page(1)).is_none());
+    }
+
+    #[test]
+    fn reading_another_snapshot_empties_the_cache() {
+        let mut cache = ThreadLocalPageCache::default();
+        cache.insert(tag(1, 7), MAX_PAGES, page(1), &[1]);
+        cache.insert(tag(1, 7), MAX_PAGES, page(2), &[2]);
+
+        cache.insert(tag(1, 8), MAX_PAGES, page(3), &[3]);
+        assert_eq!(cache.pages.len(), 1);
+        assert_eq!(cache.get(tag(1, 8), page(3)).unwrap().as_ref(), [3]);
+        assert!(cache.get(tag(1, 8), page(1)).is_none());
+    }
+
+    #[test]
+    fn bounded() {
+        let mut cache = ThreadLocalPageCache::default();
+        let count = u32::try_from(3 * MAX_PAGES).unwrap();
+        for i in 0..count {
+            cache.insert(tag(1, 1), MAX_PAGES, page(i), &i.to_le_bytes());
+            assert!(cache.pages.len() <= MAX_PAGES);
+        }
+
+        let mut hits = 0;
+        for i in 0..count {
+            if let Some(bytes) = cache.get(tag(1, 1), page(i)) {
+                assert_eq!(bytes.as_ref(), i.to_le_bytes());
+                hits += 1;
+            }
+        }
+        assert_eq!(hits, MAX_PAGES);
+    }
+
+    #[test]
+    fn clear_releases_entries() {
+        let mut cache = ThreadLocalPageCache::default();
+        cache.insert(tag(1, 1), MAX_PAGES, page(1), &[1]);
+        cache.clear();
+        assert!(cache.pages.is_empty());
+        assert!(cache.get(tag(1, 1), page(1)).is_none());
+    }
+}

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -4103,3 +4103,184 @@ fn multi_table_commit_writes_are_deterministic() {
         "identical operation sequences must produce identical backend write sequences"
     );
 }
+
+#[test]
+// The read transaction's page cache holds pages of the snapshot for the duration of the
+// transaction. Verify that a long-lived reader keeps seeing its own snapshot while later
+// write transactions rewrite the whole tree, and that the pages pinned by the cache are
+// released when the transaction ends.
+fn read_snapshot_stable_while_writes_proceed() {
+    const TABLE: TableDefinition<u32, &[u8]> = TableDefinition::new("snapshot");
+    // Enough entries for a tree with several branch pages, so lookups populate the
+    // read transaction's page cache
+    const ELEMENTS: u32 = 20_000;
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(TABLE).unwrap();
+        for i in 0..ELEMENTS {
+            table.insert(i, [0u8; 50].as_slice()).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(TABLE).unwrap();
+    // Only branch pages below the root are cached, so a tree of height <= 2 would leave the
+    // cache empty and make this test vacuous
+    assert!(table.stats().unwrap().tree_height() > 2);
+    for i in 0..ELEMENTS {
+        assert_eq!(table.get(i).unwrap().unwrap().value(), [0u8; 50]);
+    }
+
+    // Rewrite every entry to copy-on-write the whole tree and free the reader's pages
+    for round in 1..=2u8 {
+        let write_txn = db.begin_write().unwrap();
+        {
+            let mut table = write_txn.open_table(TABLE).unwrap();
+            for i in 0..ELEMENTS {
+                table.insert(i, [round; 50].as_slice()).unwrap();
+            }
+        }
+        write_txn.commit().unwrap();
+    }
+
+    // The reader still sees its snapshot, including through its cached pages
+    for i in 0..ELEMENTS {
+        assert_eq!(table.get(i).unwrap().unwrap().value(), [0u8; 50]);
+    }
+
+    drop(table);
+    read_txn.close().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(TABLE).unwrap();
+    for i in 0..ELEMENTS {
+        assert_eq!(table.get(i).unwrap().unwrap().value(), [2u8; 50]);
+    }
+}
+
+#[test]
+// The thread-local page cache is keyed by snapshot generation: short read transactions on
+// one thread, interleaved with writes, must never see an earlier generation's cached pages.
+fn alternating_reads_and_writes_invalidate_thread_cache() {
+    const TABLE: TableDefinition<u32, &[u8]> = TableDefinition::new("alternating");
+    const ELEMENTS: u32 = 20_000;
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(TABLE).unwrap();
+        for i in 0..ELEMENTS {
+            table.insert(i, [0u8; 50].as_slice()).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    // Only branch pages below the root are cached, so a tree of height <= 2 would leave the
+    // cache empty and make this test vacuous
+    let read_txn = db.begin_read().unwrap();
+    assert!(
+        read_txn
+            .open_table(TABLE)
+            .unwrap()
+            .stats()
+            .unwrap()
+            .tree_height()
+            > 2
+    );
+    drop(read_txn);
+
+    for round in 1..=3u8 {
+        {
+            let read_txn = db.begin_read().unwrap();
+            let table = read_txn.open_table(TABLE).unwrap();
+            for i in 0..ELEMENTS {
+                assert_eq!(table.get(i).unwrap().unwrap().value(), [round - 1; 50]);
+            }
+        }
+        let write_txn = db.begin_write().unwrap();
+        {
+            let mut table = write_txn.open_table(TABLE).unwrap();
+            for i in 0..ELEMENTS {
+                table.insert(i, [round; 50].as_slice()).unwrap();
+            }
+        }
+        write_txn.commit().unwrap();
+
+        let read_txn = db.begin_read().unwrap();
+        let table = read_txn.open_table(TABLE).unwrap();
+        for i in 0..ELEMENTS {
+            assert_eq!(table.get(i).unwrap().unwrap().value(), [round; 50]);
+        }
+    }
+}
+
+#[test]
+// set_cache_size() bounds the thread-local page cache too, so a database configured with a
+// tiny cache does not gain memory back through each reading thread.
+fn small_cache_size_bounds_thread_local_cache() {
+    const TABLE: TableDefinition<u32, &[u8]> = TableDefinition::new("small_cache");
+    const ELEMENTS: u32 = 20_000;
+
+    let tmpfile = create_tempfile();
+    let db = Database::builder()
+        .set_cache_size(0)
+        .create(tmpfile.path())
+        .unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(TABLE).unwrap();
+        for i in 0..ELEMENTS {
+            table.insert(i, [7u8; 50].as_slice()).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    // Reads are still correct with the cache disabled by the configured budget
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(TABLE).unwrap();
+    assert!(table.stats().unwrap().tree_height() > 2);
+    for i in 0..ELEMENTS {
+        assert_eq!(table.get(i).unwrap().unwrap().value(), [7u8; 50]);
+    }
+}
+
+#[test]
+// Two databases open in one process share the thread's page cache, and their page numbers
+// overlap, so reads interleaved between them must not serve each other's pages.
+fn two_databases_do_not_share_cached_pages() {
+    const TABLE: TableDefinition<u32, &[u8]> = TableDefinition::new("two_dbs");
+    const ELEMENTS: u32 = 20_000;
+
+    let build = |value: u8| {
+        let tmpfile = create_tempfile();
+        let db = Database::create(tmpfile.path()).unwrap();
+        let write_txn = db.begin_write().unwrap();
+        {
+            let mut table = write_txn.open_table(TABLE).unwrap();
+            for i in 0..ELEMENTS {
+                table.insert(i, [value; 50].as_slice()).unwrap();
+            }
+        }
+        write_txn.commit().unwrap();
+        (tmpfile, db)
+    };
+    let (_file_a, db_a) = build(1);
+    let (_file_b, db_b) = build(2);
+
+    let txn_a = db_a.begin_read().unwrap();
+    let table_a = txn_a.open_table(TABLE).unwrap();
+    let txn_b = db_b.begin_read().unwrap();
+    let table_b = txn_b.open_table(TABLE).unwrap();
+    assert!(table_a.stats().unwrap().tree_height() > 2);
+
+    for i in 0..ELEMENTS {
+        assert_eq!(table_a.get(i).unwrap().unwrap().value(), [1u8; 50]);
+        assert_eq!(table_b.get(i).unwrap().unwrap().value(), [2u8; 50]);
+    }
+}

--- a/tests/multithreading_tests.rs
+++ b/tests/multithreading_tests.rs
@@ -184,4 +184,73 @@ mod multithreading_test {
         let table = read_txn.open_table(DEF3).unwrap();
         assert_eq!(table.len().unwrap(), 1);
     }
+
+    #[test]
+    // Readers fill their transactions' page caches while a writer concurrently rewrites
+    // the whole tree. Each read snapshot must stay internally consistent: every lookup
+    // in one transaction must observe the same round of writes.
+    fn concurrent_reads_and_writes() {
+        const TABLE: TableDefinition<u32, &[u8]> = TableDefinition::new("reads_and_writes");
+        const ELEMENTS: u32 = 20_000;
+        const ROUNDS: u8 = 4;
+        const READERS: usize = 3;
+
+        let tmpfile = create_tempfile();
+        let db = Database::create(tmpfile.path()).unwrap();
+        let write_txn = db.begin_write().unwrap();
+        {
+            let mut table = write_txn.open_table(TABLE).unwrap();
+            for i in 0..ELEMENTS {
+                table.insert(i, [0u8; 50].as_slice()).unwrap();
+            }
+        }
+        write_txn.commit().unwrap();
+
+        // Only branch pages below the root are cached, so a tree of height <= 2 would leave
+        // the cache empty and make this test vacuous
+        let read_txn = db.begin_read().unwrap();
+        assert!(
+            read_txn
+                .open_table(TABLE)
+                .unwrap()
+                .stats()
+                .unwrap()
+                .tree_height()
+                > 2
+        );
+        drop(read_txn);
+
+        thread::scope(|s| {
+            s.spawn(|| {
+                for round in 1..=ROUNDS {
+                    let write_txn = db.begin_write().unwrap();
+                    {
+                        let mut table = write_txn.open_table(TABLE).unwrap();
+                        for i in 0..ELEMENTS {
+                            table.insert(i, [round; 50].as_slice()).unwrap();
+                        }
+                    }
+                    write_txn.commit().unwrap();
+                }
+            });
+            for _ in 0..READERS {
+                s.spawn(|| {
+                    for _ in 0..2 {
+                        let read_txn = db.begin_read().unwrap();
+                        let table = read_txn.open_table(TABLE).unwrap();
+                        let round = table.get(0).unwrap().unwrap().value()[0];
+                        for i in 0..ELEMENTS {
+                            assert_eq!(table.get(i).unwrap().unwrap().value(), [round; 50]);
+                        }
+                    }
+                });
+            }
+        });
+
+        let read_txn = db.begin_read().unwrap();
+        let table = read_txn.open_table(TABLE).unwrap();
+        for i in 0..ELEMENTS {
+            assert_eq!(table.get(i).unwrap().unwrap().value(), [ROUNDS; 50]);
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Multithreaded random reads scale well below linearly. Every page lookup through the shared page cache performs three writes to memory shared between threads: acquiring the stripe `RwLock`, storing the LRU second-chance flag, and incrementing the page's `Arc` refcount. For the hottest pages — the top of each btree — those cache lines ping-pong between cores, and per-thread throughput degrades as threads are added.

## Change

Each thread keeps a small bounded cache (`ThreadLocalPageCache`) of private copies of the branch pages **one level below** the roots it reads, and lookups in read transactions serve those pages from it. Hits touch only thread-local memory, so the implementation needs no locks or atomics at all: a `PageNumberHashMap<Rc<[u8]>>` behind a `RefCell`, plain single-threaded code.

**Why only one level.** A level holds roughly a page's worth of children per page of the level above it, so the level below the root is small enough for a snapshot's pages to fit in the budget, while the next one down is already far too large. On the `lmdb_benchmark` shape (5M rows, 24-byte keys) the tree is height 4 with ~15 branch pages at depth 1 and ~4050 at depth 2. Caching depth 2 against a 128-page budget misses ~97% of the time, and admitting a page copies it, so it paid a 4KiB copy on nearly every lookup — far more than the shared-cache lookup it saved. An earlier revision of this PR cached two levels and **regressed** reads by 14-25%, which is what @cberner's benchmark caught. For the same reason the cache stops admitting once full rather than replacing entries: freezing is self-limiting under thrash, replacing is not.

**Correctness.** A thread-local cache outlives transactions and page numbers are recycled, so every entry is tagged with (database instance id, snapshot generation) and the tag is validated on lookup. Generation is the read transaction's id, and bytes of a page number cannot change within a generation: snapshots are copy-on-write, and a freed page is only reused by a later write transaction whose commit advances the generation. In-place reload is the exception — rolling a non-durable commit back rewinds the id, so later commits reuse ids that named different data — so `clear_cache_and_reload()` bumps the instance id, invalidating every thread's entries at once. Reading a different snapshot empties the cache, so a stale entry is never returned. Write transactions never use the cache (they can free and reallocate pages within one generation); leaf pages are never cached (`AccessGuard`s need real `PageImpl`s). Reentrant lookups (pathological `Key::compare` implementations) and thread teardown degrade to uncached reads rather than panicking.

**Memory.** At most 128 order-zero pages per thread with a live read transaction (512KiB at 4KiB pages), further bounded by the configured cache size so a small `set_cache_size` shrinks it and `set_cache_size(0)` disables it. Released when the read transaction is dropped, so a thread that reads once does not retain them for its lifetime.

**`no_std`.** `thread_local!` is std-only, so `no_std` builds compile the cache out and their lookups are unchanged. For the same reason the instance-id counter is a `Mutex<u64>` rather than an `AtomicU64`: 64-bit atomics are unavailable on `thumbv7em-none-eabihf`, and it is taken only when a database is opened or reloaded.

## Results

`lmdb_benchmark` on a 16-core 9950X3D, measured by @cberner against master `5e6ad02`:

| | master | this PR | |
|---|---|---|---|
| random reads (1 thread) | 1.18M | 1.25M | 1.06x |
| random range reads | 531K | 534K | — |
| random reads (4 threads) | 4.44M | 4.64M | 1.05x |
| random reads (8 threads) | 7.61M | 8.61M | 1.13x |
| random reads (16 threads) | 13.2M | 15.8M | **1.20x** |
| random reads (32 threads) | 17.4M | **27.4M** | **1.57x** |

The gain grows with thread count, which is the shape the design predicts. Write benchmarks are unchanged within noise; write transactions never consult or populate the cache. One caveat: individual writes read 1.13K vs 982 txn/s across the two runs, but those are fsync-bound at ~1ms per transaction and sit on a path this change does not touch, so that looks like disk variance rather than a regression.

Shared-page-cache reads per lookup drop from 3.00 to 2.00.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets --all-features` with `-D warnings`, and `cargo test --all-features` all pass (podman sandbox unavailable in this environment, so the `just test` steps were run directly; `cargo deny` not run). `cargo check --target thumbv7em-none-eabihf --no-default-features --features experimental-api-5[,logging,experimental_cursor]` also passes with `-D warnings`.
- Unit tests in `thread_local_page_cache.rs`: tag validation including cross-database, snapshot change empties the cache, the page bound holds, and `clear()` releases entries.
- Integration tests, each asserting `tree_height() > 2` so the tree actually has cacheable branch pages below its root: snapshot stability of a long-lived reader while writers rewrite the tree, alternating short reads and writes on one thread (generation invalidation), a small `set_cache_size` bounding the per-thread cache, and two databases open on one thread not sharing entries. `concurrent_reads_and_writes` in `multithreading_tests.rs` gained the same height guard.
- Fuzzing (`cargo fuzz run --sanitizer=none fuzz_redb`, debug assertions on): 196,920 runs on this design, zero failures and no crash artifacts, plus ~660k runs across earlier revisions of the branch. The harness interleaves reads with commits, savepoints and reopens on one thread whose cache persists throughout, checked against a reference map.

Tunables to sanity-check in review: `MAX_THREAD_LOCAL_CACHE_PAGES = 128` (page_manager.rs) and `MAX_CACHED_DEPTH = 1` (btree.rs). Not covered by design: `range()`/iterators, `first()`/`last()`, and single-page tables (the guard clone on a root-leaf remains).

Open question: the 128-page bound is **per thread**, so N concurrently-reading threads can hold N x 512KiB beyond the configured cache size. That is documented on `thread_local_cache_pages()` but not enforced; making it an aggregate bound would need either a guessed thread count or an atomic total, both of which cost something. Left as-is pending your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMLXF7RTMhhhp1jhL9XkNi