### PR TITLE
Add a stub MultimapCursor behind experimental-api-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   and iterators likewise do not keep the transaction alive, are also removed under the
   `experimental-api-5` flag; use the `ReadableTable` and `ReadableMultimapTable` methods, or the
   `get_owned()` variants when the guard must outlive the table.
+* Add `ReadableMultimapTable::lower_bound()` and `ReadableMultimapTable::upper_bound()`, behind
+  the `experimental-api-5` feature flag, returning a `MultimapCursor` pointing at a gap between
+  entries. The type reserves the constructors' signatures in the trait; navigation methods will
+  be added behind the `experimental_cursor` feature flag, like the table cursors' were.
 
 ## 4.2.0 - 2026-XX-XX
 * Add a `std` feature, enabled by default, in preparation for a future `no_std` mode. It gates

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@ pub use error::{
 };
 #[cfg(feature = "experimental-api-5")]
 pub use key_range::KeyRange;
+#[cfg(feature = "experimental-api-5")]
+pub use multimap_table::MultimapCursor;
 pub use multimap_table::{
     MultimapRange, MultimapTable, MultimapValue, OwnedMultimapRange, OwnedMultimapValue,
     ReadOnlyMultimapTable, ReadOnlyUntypedMultimapTable, ReadableMultimapTable,

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -3,7 +3,11 @@ use crate::KeyRange;
 use crate::db::TransactionGuard;
 use crate::multimap_table::DynamicCollectionType::{Inline, SubtreeV2};
 use crate::sealed::Sealed;
+#[cfg(feature = "experimental-api-5")]
+use crate::table::bound_to_bytes;
 use crate::table::{OwnedAccessGuard, ReadableTableMetadata, TableStats};
+#[cfg(feature = "experimental-api-5")]
+use crate::tree_store::BtreeCursor;
 #[cfg(not(feature = "experimental-api-5"))]
 use crate::tree_store::encode_bounds;
 use crate::tree_store::{
@@ -972,6 +976,34 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V> for Multima
         let (lower, upper) = encode_bounds::<K, KR, _>(&range);
         self.range_in_bounds(lower, upper)
     }
+
+    #[cfg(feature = "experimental-api-5")]
+    fn lower_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<MultimapCursor<'_, K, V>> {
+        let bound = bound_to_bytes::<K, _>(&bound);
+        let mut inner = self.tree.cursor()?;
+        inner.seek_lower_bound(bound.as_ref().map(|bytes| bytes.as_slice()))?;
+        Ok(MultimapCursor::new(
+            inner,
+            self.transaction.transaction_guard(),
+        ))
+    }
+
+    #[cfg(feature = "experimental-api-5")]
+    fn upper_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<MultimapCursor<'_, K, V>> {
+        let bound = bound_to_bytes::<K, _>(&bound);
+        let mut inner = self.tree.cursor()?;
+        inner.seek_upper_bound(bound.as_ref().map(|bytes| bytes.as_slice()))?;
+        Ok(MultimapCursor::new(
+            inner,
+            self.transaction.transaction_guard(),
+        ))
+    }
 }
 
 impl<K: Key + 'static, V: Key + 'static> MultimapTable<'_, K, V> {
@@ -1011,6 +1043,47 @@ pub trait ReadableMultimapTable<K: Key + 'static, V: Key + 'static>: ReadableTab
     fn range<'a, KR>(&self, range: impl RangeBounds<KR> + 'a) -> Result<MultimapRange<'_, K, V>>
     where
         KR: Borrow<K::SelfType<'a>> + 'a;
+
+    /// Returns a read-only [`MultimapCursor`] pointing at the gap before the
+    /// first entry of the smallest key greater than the given bound.
+    ///
+    /// Passing `Bound::Included(x)` will return a cursor pointing to the gap
+    /// before the first entry of the smallest key greater than or equal to
+    /// `x`.
+    ///
+    /// Passing `Bound::Excluded(x)` will return a cursor pointing to the gap
+    /// before the first entry of the smallest key greater than `x`.
+    ///
+    /// Passing `Bound::Unbounded` will return a cursor pointing to the gap
+    /// before the first entry in the table.
+    ///
+    /// This is the multimap counterpart of
+    /// [`ReadableTable::lower_bound`](crate::ReadableTable::lower_bound).
+    #[cfg(feature = "experimental-api-5")]
+    fn lower_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<MultimapCursor<'_, K, V>>;
+
+    /// Returns a read-only [`MultimapCursor`] pointing at the gap after the
+    /// last entry of the greatest key smaller than the given bound.
+    ///
+    /// Passing `Bound::Included(x)` will return a cursor pointing to the gap
+    /// after the last entry of the greatest key smaller than or equal to `x`.
+    ///
+    /// Passing `Bound::Excluded(x)` will return a cursor pointing to the gap
+    /// after the last entry of the greatest key smaller than `x`.
+    ///
+    /// Passing `Bound::Unbounded` will return a cursor pointing to the gap
+    /// after the last entry in the table.
+    ///
+    /// This is the multimap counterpart of
+    /// [`ReadableTable::upper_bound`](crate::ReadableTable::upper_bound).
+    #[cfg(feature = "experimental-api-5")]
+    fn upper_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<MultimapCursor<'_, K, V>>;
 
     /// Returns an double-ended iterator over all elements in the table. Values are in ascending
     /// order.
@@ -1298,6 +1371,71 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V>
         let (lower, upper) = encode_bounds::<K, KR, _>(&range);
         self.range_in_bounds(lower, upper)
     }
+
+    #[cfg(feature = "experimental-api-5")]
+    fn lower_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<MultimapCursor<'_, K, V>> {
+        let bound = bound_to_bytes::<K, _>(&bound);
+        let mut inner = self.tree.cursor();
+        inner.seek_lower_bound(bound.as_ref().map(|bytes| bytes.as_slice()))?;
+        Ok(MultimapCursor::new(inner, self.transaction_guard.clone()))
+    }
+
+    #[cfg(feature = "experimental-api-5")]
+    fn upper_bound<'a>(
+        &self,
+        bound: Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> Result<MultimapCursor<'_, K, V>> {
+        let bound = bound_to_bytes::<K, _>(&bound);
+        let mut inner = self.tree.cursor();
+        inner.seek_upper_bound(bound.as_ref().map(|bytes| bytes.as_slice()))?;
+        Ok(MultimapCursor::new(inner, self.transaction_guard.clone()))
+    }
 }
 
 impl<K: Key, V: Key> Sealed for ReadOnlyMultimapTable<K, V> {}
+
+/// A read-only cursor over a multimap table, pointing at a gap between two
+/// entries.
+///
+/// Cursors are constructed with [`ReadableMultimapTable::lower_bound`] and
+/// [`ReadableMultimapTable::upper_bound`]. For now the type only reserves the
+/// constructors' signatures in the trait: methods for navigating the table,
+/// mirroring the table cursors ([`Cursor`](crate::Cursor)) with
+/// multimap-aware movement, will be added behind the `experimental_cursor`
+/// feature flag, separately from the constructors, so that the constructors'
+/// signatures can stabilize first.
+#[cfg(feature = "experimental-api-5")]
+pub struct MultimapCursor<'a, K: Key + 'static, V: Key + 'static> {
+    // Only the cursor's future methods will read the position; until they
+    // land the constructors still store it, ready for the methods to be
+    // added.
+    #[allow(dead_code)]
+    inner: BtreeCursor<K, &'static DynamicCollection<V>>,
+    // The cursor owns page handles, so it must keep the transaction registered for as long as it
+    // is alive. The lifetime below cannot do that job: the cursor has no `Drop` impl, so the
+    // borrow it represents ends at the cursor's last use, leaving the table free to be dropped
+    // and the transaction free to be closed while the cursor still holds its pages
+    _transaction_guard: Arc<TransactionGuard>,
+    // This lifetime is here so that `&` can be held on the table preventing concurrent mutation.
+    // It will also bound the guards the cursor yields, which is why there is no `'static` cursor:
+    // such a guard could outlive both the cursor and the transaction, letting a writer reclaim
+    // the pages it points at
+    _lifetime: PhantomData<&'a ()>,
+}
+
+#[cfg(feature = "experimental-api-5")]
+impl<K: Key + 'static, V: Key + 'static> MultimapCursor<'_, K, V> {
+    pub(crate) fn new(
+        inner: BtreeCursor<K, &'static DynamicCollection<V>>,
+        guard: Arc<TransactionGuard>,
+    ) -> Self {
+        Self {
+            inner,
+            _transaction_guard: guard,
+            _lifetime: PhantomData,
+        }
+    }
+}

--- a/src/table.rs
+++ b/src/table.rs
@@ -1439,7 +1439,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> VacantEntry<'a, K, V> {
 }
 
 #[cfg(feature = "experimental-api-5")]
-fn bound_to_bytes<'a, K: Key + 'a, KR: Borrow<K::SelfType<'a>>>(
+pub(crate) fn bound_to_bytes<'a, K: Key + 'a, KR: Borrow<K::SelfType<'a>>>(
     bound: &Bound<KR>,
 ) -> Bound<Vec<u8>> {
     match bound {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3960,6 +3960,22 @@ impl<K: Key + 'static, V: Key + 'static, T: ReadableMultimapTable<K, V>> Readabl
     {
         self.inner.range(range)
     }
+
+    #[cfg(feature = "experimental-api-5")]
+    fn lower_bound<'a>(
+        &self,
+        bound: std::ops::Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> redb::Result<redb::MultimapCursor<'_, K, V>> {
+        self.inner.lower_bound(bound)
+    }
+
+    #[cfg(feature = "experimental-api-5")]
+    fn upper_bound<'a>(
+        &self,
+        bound: std::ops::Bound<impl Borrow<K::SelfType<'a>>>,
+    ) -> redb::Result<redb::MultimapCursor<'_, K, V>> {
+        self.inner.upper_bound(bound)
+    }
 }
 
 impl<K: Key + 'static, V: Key + 'static, T: ReadableMultimapTable<K, V>> ReadableTableMetadata

--- a/tests/multimap_tests.rs
+++ b/tests/multimap_tests.rs
@@ -748,3 +748,32 @@ fn read_only_range_entries_keep_transaction_alive() {
     assert_eq!(back_key.value(), 1);
     assert_eq!(back_value.value(), 2);
 }
+
+// The stub cursor has no methods yet; the constructors still position it, so
+// they are exercised on empty and populated tables through both table types.
+#[cfg(feature = "experimental-api-5")]
+#[test]
+fn cursor_constructors() {
+    use std::ops::Bound;
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_TABLE).unwrap();
+        table.lower_bound(Bound::<u64>::Unbounded).unwrap();
+        table.upper_bound(Bound::<u64>::Unbounded).unwrap();
+        for i in 0..10u64 {
+            table.insert(i, i).unwrap();
+            table.insert(i, i + 1).unwrap();
+        }
+        table.lower_bound(Bound::Included(&5)).unwrap();
+        table.upper_bound(Bound::Excluded(&5)).unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_multimap_table(U64_TABLE).unwrap();
+    table.lower_bound(Bound::Included(&5)).unwrap();
+    table.upper_bound(Bound::<u64>::Unbounded).unwrap();
+}


### PR DESCRIPTION
`ReadableMultimapTable` gains required `lower_bound()` and `upper_bound()` methods returning a new `MultimapCursor`, mirroring `ReadableTable`'s cursor constructors, so the redb 5 trait surface carries multimap cursors before their methods exist and can grow them later without breaking the trait again.

The type only reserves the constructors' signatures: it has no public methods yet. Navigation methods will follow behind `experimental_cursor`, like the table cursors' did. The constructors already seek the internal gap cursor over the key tree, so the stored position is real, and the bound semantics are documented in entry terms ("gap before the first entry of the smallest key greater than the bound") so they stay accurate whether the eventual cursor moves by entry or by key.

The trait-growth concern is not hypothetical: the first build failed because `DelegatingMultimapTable` in the integration tests — an implementor of the trait — was missing the new methods; it now delegates both, matching `DelegatingTable`'s handling of the table cursor constructors.

The changelog entry sits under 5.0.0, since the addition is part of the redb 5 trait surface rather than the 4.2.0 cursor features.

Checks run: `cargo fmt --check`; clippy on all three feature combinations (none, `experimental-api-5`, all features); `cargo test --all-features` (includes a new constructor test over empty and populated tables through both table types); docs build with no new warnings; fuzz crate still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Brnuq3uRWRXYn9iqKk2ZnJ)_