### PR TITLE
CI: reject commits with agent co-author trailers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,24 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           git fetch --no-tags --no-recurse-submodules origin "$BASE_SHA"
+          failed=0
           offenders=$(git log --no-merges --pretty=format:'%H %an <%ae> committed by %cn <%ce>' "$BASE_SHA".."$HEAD_SHA" \
             | grep -iE '(claude|codex)' || true)
           if [ -n "$offenders" ]; then
             echo "Commits authored or committed by Claude or Codex are not allowed:"
             echo "$offenders"
-            exit 1
+            failed=1
           fi
+          for sha in $(git log --format=%H "$BASE_SHA".."$HEAD_SHA"); do
+            coauthors=$(git log -1 --format=%B "$sha" \
+              | grep -iE '^[[:space:]]*co[- ]?authored[- ]?by:.*(claude|codex)' || true)
+            if [ -n "$coauthors" ]; then
+              echo "Commit $sha has a co-author trailer referencing Claude or Codex:"
+              echo "$coauthors"
+              failed=1
+            fi
+          done
+          exit "$failed"
 
   ci:
     strategy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ If you are touching workspace crates beyond the main `redb` crate, run
 1) git commits should use your human's name and email address for authorship. Add "Assisted-by:" and
    your agent name at the end of the commit message. In the same style as the
    [Linux Kernel's coding assistant guidelines](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst).
+   Do not add "Co-authored-by:" trailers naming an agent; CI rejects them.
 2) Make one commit per feature / bug fix when opening a PR. Multiple commits or "fixup" commits are
    should not be merged to master.
 


### PR DESCRIPTION
Extends the `commit-authors` CI job to also reject commit messages containing a co-author trailer that references Claude or Codex, in addition to the existing author/committer name and email check.

- New per-commit scan of the full commit message for `^\s*co[- ]?authored[- ]?by:.*(claude|codex)` (case-insensitive), so both `Co-Authored-By: Claude <noreply@anthropic.com>` and `Co-authored-by: Codex <...>` fail the job. The offending SHA and trailer line are printed.
- The regex is loose on the key spelling (hyphen / space / no separator) and scans the whole message rather than relying on git's trailer parsing, so a trailer that isn't in the final paragraph is still caught.
- The job now collects both failures and reports them together instead of exiting on the first one.
- `AGENTS.md` notes under "Git commits" that agent `Co-authored-by:` trailers are rejected by CI.

Verified the detection logic against a scratch repo with one clean commit (using `Assisted-by:`) and two offending commits; only the offenders were flagged.

---
_Generated by [Claude Code](https://claude.ai/code/session_013R52816N4mTxwnUYfjr1Sc)_