### PR TITLE
Skip the allocation tracker's lock when no savepoint needs it

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -13,7 +13,7 @@ use crate::tree_store::encode_bounds;
 use crate::tree_store::{
     AllPageNumbersBtreeIter, BRANCH, Btree, BtreeCursorRange, BtreeHeader, BtreeMut,
     DynamicCollection, DynamicCollectionType, LEAF, LeafAccessor, MAX_PAIR_LENGTH,
-    MAX_VALUE_LENGTH, Page, PageAllocator, PageHint, PageNumber, PageResolver, PageTrackerPolicy,
+    MAX_VALUE_LENGTH, Page, PageAllocator, PageHint, PageNumber, PageResolver, PageTracker,
     RawBtree, RawLeafBuilder, multimap_btree_stats,
 };
 use crate::types::{Key, Value};
@@ -115,7 +115,7 @@ pub struct MultimapValue<'a, V: Key + 'static> {
     inner: Option<ValueIterState<'a, V>>,
     remaining: u64,
     freed_pages: Option<Arc<Mutex<Vec<PageNumber>>>>,
-    allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
+    allocated_pages: Arc<PageTracker>,
     free_on_drop: Vec<PageNumber>,
     _transaction_guard: Arc<TransactionGuard>,
     page_allocator: Option<PageAllocator>,
@@ -132,7 +132,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
             inner: Some(ValueIterState::Subtree(Box::new(inner))),
             remaining: num_values,
             freed_pages: None,
-            allocated_pages: Arc::new(Mutex::new(PageTrackerPolicy::Closed)),
+            allocated_pages: Arc::new(PageTracker::closed()),
             free_on_drop: vec![],
             _transaction_guard: guard,
             page_allocator: None,
@@ -144,7 +144,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
         inner: BtreeCursorRange<V, ()>,
         num_values: u64,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-        allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
+        allocated_pages: Arc<PageTracker>,
         pages: Vec<PageNumber>,
         guard: Arc<TransactionGuard>,
         page_allocator: PageAllocator,
@@ -167,7 +167,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
             inner: Some(ValueIterState::InlineLeaf(inner)),
             remaining,
             freed_pages: None,
-            allocated_pages: Arc::new(Mutex::new(PageTrackerPolicy::Closed)),
+            allocated_pages: Arc::new(PageTracker::closed()),
             free_on_drop: vec![],
             _transaction_guard: guard,
             page_allocator: None,
@@ -206,7 +206,7 @@ impl<'a, V: Key + 'static> MultimapValue<'a, V> {
         collection: AccessGuard<'a, &'static DynamicCollection<V>>,
         pages: Vec<PageNumber>,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-        allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
+        allocated_pages: Arc<PageTracker>,
         guard: Arc<TransactionGuard>,
         page_allocator: PageAllocator,
     ) -> Result<Self> {
@@ -310,13 +310,12 @@ impl<V: Key + 'static> Drop for MultimapValue<'_, V> {
         drop(mem::take(&mut self.inner));
         if !self.free_on_drop.is_empty() {
             let mut freed_pages = self.freed_pages.as_ref().unwrap().lock().unwrap();
-            let mut allocated_pages = self.allocated_pages.lock().unwrap();
             for page in &self.free_on_drop {
                 if !self
                     .page_allocator
                     .as_ref()
                     .unwrap()
-                    .free_if_uncommitted(*page, &mut allocated_pages)
+                    .free_if_uncommitted(*page, &self.allocated_pages)
                 {
                     freed_pages.push(*page);
                 }
@@ -496,7 +495,7 @@ pub struct MultimapTable<'txn, K: Key + 'static, V: Key + 'static> {
     num_values: u64,
     transaction: &'txn WriteTransaction,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-    allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
+    allocated_pages: Arc<PageTracker>,
     tree: BtreeMut<K, &'static DynamicCollection<V>>,
     page_allocator: PageAllocator,
     _value_type: PhantomData<V>,
@@ -515,7 +514,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
         table_root: Option<BtreeHeader>,
         num_values: u64,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-        allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
+        allocated_pages: Arc<PageTracker>,
         page_allocator: PageAllocator,
         transaction: &'txn WriteTransaction,
     ) -> MultimapTable<'txn, K, V> {
@@ -625,11 +624,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                             .insert(key.borrow(), &DynamicCollection::new(&inline_data))?;
                     } else {
                         // convert into a subtree
-                        let mut allocated = self.allocated_pages.lock().unwrap();
                         let mut page = self
                             .page_allocator
-                            .allocate(leaf_data.len(), &mut allocated)?;
-                        drop(allocated);
+                            .allocate(leaf_data.len(), &self.allocated_pages)?;
                         page.memory_mut()[..leaf_data.len()].copy_from_slice(leaf_data);
                         let page_number = page.get_page_number();
                         drop(page);
@@ -822,10 +819,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                                 // these mutexes and may be used from different threads, so the
                                 // reverse order risks an ABBA deadlock with a concurrent insert.
                                 let mut freed_pages = self.freed_pages.lock().unwrap();
-                                let mut allocated_pages = self.allocated_pages.lock().unwrap();
                                 self.page_allocator.conditional_free(
                                     new_root,
-                                    &mut allocated_pages,
+                                    &self.allocated_pages,
                                     &mut freed_pages,
                                 );
                             } else {

--- a/src/table.rs
+++ b/src/table.rs
@@ -11,7 +11,7 @@ use crate::tree_store::encode_bounds;
 use crate::tree_store::{
     AccessGuardMutInPlace, Btree, BtreeCursorRange, BtreeExtractIf, BtreeHeader, BtreeMut,
     MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PageAllocator, PageHint, PageNumber, PageResolver,
-    PageTrackerPolicy, RawBtree,
+    PageTracker, RawBtree,
 };
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, AccessGuardMut, StorageError, WriteTransaction};
@@ -113,7 +113,7 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         name: &str,
         table_root: Option<BtreeHeader>,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-        allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
+        allocated_pages: Arc<PageTracker>,
         page_allocator: PageAllocator,
         transaction: &'txn WriteTransaction,
     ) -> Table<'txn, K, V> {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -7,7 +7,7 @@ use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker}
 use crate::tree_store::{
     AllocationPolicy, Btree, BtreeHeader, BtreeMut, InternalTableDefinition, MAX_PAIR_LENGTH,
     MAX_VALUE_LENGTH, Page, PageAllocator, PageHint, PageListMut, PageNumber, PageResolver,
-    PageTrackerPolicy, SerializedSavepoint, ShrinkPolicy, TableTree, TableTreeMut, TableType,
+    PageTracker, SerializedSavepoint, ShrinkPolicy, TableTree, TableTreeMut, TableType,
     TransactionalMemory,
 };
 use crate::types::{Key, Value};
@@ -402,7 +402,7 @@ impl<'s, K: Key + 'static, V: Value + 'static> SystemTable<'s, K, V> {
     ) -> SystemTable<'s, K, V> {
         // No need to track allocations in the system tree. Savepoint restoration only relies on
         // freeing in the data tree
-        let ignore = Arc::new(Mutex::new(PageTrackerPolicy::Ignore));
+        let ignore = Arc::new(PageTracker::ignore());
         SystemTable {
             name: name.to_string(),
             namespace,
@@ -521,7 +521,7 @@ impl SystemNamespace {
     ) -> Self {
         // No need to track allocations in the system tree. Savepoint restoration only relies on
         // freeing in the data tree
-        let ignore = Arc::new(Mutex::new(PageTrackerPolicy::Ignore));
+        let ignore = Arc::new(PageTracker::ignore());
         let freed_pages = Arc::new(Mutex::new(vec![]));
         Self {
             table_tree: TableTreeMut::new(
@@ -595,7 +595,7 @@ impl SystemNamespace {
 
 struct TableNamespace {
     open_tables: HashMap<String, &'static panic::Location<'static>>,
-    allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
+    allocated_pages: Arc<PageTracker>,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
     table_tree: TableTreeMut,
 }
@@ -606,7 +606,7 @@ impl TableNamespace {
         guard: Arc<TransactionGuard>,
         page_allocator: PageAllocator,
     ) -> Self {
-        let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+        let allocated = Arc::new(PageTracker::new_tracking());
         let freed_pages = Arc::new(Mutex::new(vec![]));
         let table_tree = TableTreeMut::new(
             root_page,
@@ -630,7 +630,7 @@ impl TableNamespace {
         if !transaction.transaction_tracker.any_savepoint_exists() {
             // No savepoints exist, and we don't allow savepoints to be created in a dirty transaction
             // so we can disable allocation tracking now
-            *self.allocated_pages.lock().unwrap() = PageTrackerPolicy::Ignore;
+            self.allocated_pages.disable();
         }
     }
 
@@ -1356,10 +1356,10 @@ impl WriteTransaction {
         {
             let tables = self.tables.lock().unwrap();
             let page_allocator = tables.table_tree.page_allocator();
-            for page in tables.allocated_pages.lock().unwrap().reset() {
+            for page in tables.allocated_pages.reset() {
                 debug_assert!(page_allocator.uncommitted(page));
                 debug_assert!(self.mem.is_allocated(page));
-                page_allocator.free(page, &mut PageTrackerPolicy::Ignore);
+                page_allocator.free(page, &PageTracker::ignore());
             }
             let mut data_freed_pages = tables.freed_pages.lock().unwrap();
             data_freed_pages.clear();
@@ -1943,7 +1943,7 @@ impl WriteTransaction {
         // Immediately free the pages that were freed from the system-tree. These are only
         // accessed by write transactions, so it's safe to free them as soon as the commit is done.
         for page in system_freed_pages.lock().unwrap().drain(..) {
-            page_allocator.free(page, &mut PageTrackerPolicy::Ignore);
+            page_allocator.free(page, &PageTracker::ignore());
         }
 
         drop(system_tables);
@@ -1996,7 +1996,7 @@ impl WriteTransaction {
                     // See process_freed_pages(): free_until excludes pages that are still needed
                     // by a live reader or pending non-durable commit.
                     debug_assert!(!self.mem.unpersisted(page));
-                    page_allocator.free(page, &mut PageTrackerPolicy::Ignore);
+                    page_allocator.free(page, &PageTracker::ignore());
                 },
             )?;
             if !freed_any {
@@ -2103,9 +2103,7 @@ impl WriteTransaction {
         );
 
         for page in post_commit_frees {
-            let removed = self
-                .mem
-                .free_if_unpersisted(page, &mut PageTrackerPolicy::Ignore);
+            let removed = self.mem.free_if_unpersisted(page, &PageTracker::ignore());
             assert!(removed);
         }
 
@@ -2135,8 +2133,8 @@ impl WriteTransaction {
                 continue;
             }
             let old_page = page_allocator.get_page(path.page_number(), PageHint::None)?;
-            let mut new_page = page_allocator
-                .allocate_lowest(old_page.memory().len(), &mut PageTrackerPolicy::Ignore)?;
+            let mut new_page =
+                page_allocator.allocate_lowest(old_page.memory().len(), &PageTracker::ignore())?;
             let new_page_number = new_page.get_page_number();
             // We have to copy at least the page type into the new page.
             // Otherwise its cache priority will be calculated incorrectly
@@ -2150,10 +2148,8 @@ impl WriteTransaction {
                         continue;
                     }
                     let old_parent = page_allocator.get_page(*parent, PageHint::None)?;
-                    let mut new_page = page_allocator.allocate_lowest(
-                        old_parent.memory().len(),
-                        &mut PageTrackerPolicy::Ignore,
-                    )?;
+                    let mut new_page = page_allocator
+                        .allocate_lowest(old_parent.memory().len(), &PageTracker::ignore())?;
                     let new_page_number = new_page.get_page_number();
                     // We have to copy at least the page type into the new page.
                     // Otherwise its cache priority will be calculated incorrectly
@@ -2162,7 +2158,7 @@ impl WriteTransaction {
                     relocation_map.insert(*parent, new_page_number);
                 }
             } else {
-                page_allocator.free(new_page_number, &mut PageTrackerPolicy::Ignore);
+                page_allocator.free(new_page_number, &PageTracker::ignore());
                 break;
             }
         }
@@ -2190,7 +2186,7 @@ impl WriteTransaction {
             // pending non-durable commit (see register_non_durable_commit). As a result, no entry
             // whose pages are still unpersisted is eligible for processing here.
             debug_assert!(!self.mem.unpersisted(page));
-            page_allocator.free(page, &mut PageTrackerPolicy::Ignore);
+            page_allocator.free(page, &PageTracker::ignore());
         };
 
         let extracted_transactions = {
@@ -2294,10 +2290,7 @@ impl WriteTransaction {
                 let mut new_pages = vec![];
                 for i in 0..pages.len() {
                     let page = pages.get(i);
-                    if !self
-                        .mem
-                        .free_if_unpersisted(page, &mut PageTrackerPolicy::Ignore)
-                    {
+                    if !self.mem.free_if_unpersisted(page, &PageTracker::ignore()) {
                         new_pages.push(page);
                     }
                 }

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -13,7 +13,7 @@ use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
     AccessGuardMutInPlace, AllPageNumbersBtreeIter, BtreeCursorRange, BtreeExtractIf,
-    PageAllocator, PageHint, PageNumber, PageResolver, PageTrackerPolicy,
+    PageAllocator, PageHint, PageNumber, PageResolver, PageTracker,
 };
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, Result};
@@ -322,10 +322,10 @@ impl UntypedBtreeMut {
         let mut freed_pages = self.freed_pages.lock().unwrap();
         // No need to track allocations, because this method is only called during compaction when
         // there can't be any savepoints
-        let mut ignore = PageTrackerPolicy::Ignore;
+        let ignore = PageTracker::ignore();
         if !self
             .page_allocator
-            .free_if_uncommitted(page_number, &mut ignore)
+            .free_if_uncommitted(page_number, &ignore)
         {
             freed_pages.push(page_number);
         }
@@ -354,7 +354,7 @@ pub(crate) struct BtreeMut<K: Key + 'static, V: Value + 'static> {
     // that operation returns. Kept here, instead of allocated per operation, so that its capacity
     // is reused across operations that free committed pages.
     local_freed: Vec<PageNumber>,
-    allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
+    allocated_pages: Arc<PageTracker>,
     _key_type: PhantomData<K>,
     _value_type: PhantomData<V>,
 }
@@ -365,7 +365,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         guard: Arc<TransactionGuard>,
         page_allocator: PageAllocator,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-        allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
+        allocated_pages: Arc<PageTracker>,
     ) -> Self {
         Self {
             page_allocator,
@@ -471,7 +471,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         value: &V::SelfType<'_>,
     ) -> Result<()> {
         let mut fake_freed_pages = vec![];
-        let fake_allocated_pages = Arc::new(Mutex::new(PageTrackerPolicy::Closed));
+        let fake_allocated_pages = Arc::new(PageTracker::closed());
         let mut operation = MutateHelper::<K, V>::new(
             &mut self.root,
             &self.page_allocator,
@@ -586,13 +586,14 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
                 self.page_allocator.get_page_mut(root.root)?
             } else {
                 let mut freed_pages = self.freed_pages.lock().unwrap();
-                let mut allocated = self.allocated_pages.lock().unwrap();
                 let required: usize = root
                     .root
                     .page_size_bytes(self.page_allocator.get_page_size().try_into().unwrap())
                     .try_into()
                     .unwrap();
-                let mut new_page = self.page_allocator.allocate(required, &mut allocated)?;
+                let mut new_page = self
+                    .page_allocator
+                    .allocate(required, &self.allocated_pages)?;
                 let old_page = self.page_allocator.get_page(root.root, PageHint::None)?;
                 new_page.memory_mut().copy_from_slice(old_page.memory());
                 drop(old_page);
@@ -645,12 +646,13 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
                     self.page_allocator.get_page_mut(child_page)?
                 } else {
                     let mut freed_pages = self.freed_pages.lock().unwrap();
-                    let mut allocated = self.allocated_pages.lock().unwrap();
                     let required: usize = child_page
                         .page_size_bytes(self.page_allocator.get_page_size().try_into().unwrap())
                         .try_into()
                         .unwrap();
-                    let mut new_page = self.page_allocator.allocate(required, &mut allocated)?;
+                    let mut new_page = self
+                        .page_allocator
+                        .allocate(required, &self.allocated_pages)?;
                     let old_child_page =
                         self.page_allocator.get_page(child_page, PageHint::None)?;
                     new_page
@@ -1409,14 +1411,13 @@ mod tests {
         mem.reset_allocator_state().unwrap();
         let mem = Arc::new(mem);
         let page_allocator = PageAllocator::new(mem.clone(), AllocationPolicy::Default);
-        let allocated_pages = Mutex::new(PageTrackerPolicy::new_tracking());
-        let mut allocated_guard = allocated_pages.lock().unwrap();
+        let allocated_pages = PageTracker::new_tracking();
 
         let mut p1_mut = page_allocator
-            .allocate(PAGE_SIZE, &mut allocated_guard)
+            .allocate(PAGE_SIZE, &allocated_pages)
             .unwrap();
         let mut p2_mut = page_allocator
-            .allocate(PAGE_SIZE, &mut allocated_guard)
+            .allocate(PAGE_SIZE, &allocated_pages)
             .unwrap();
 
         let p1 = p1_mut.get_page_number();
@@ -1444,7 +1445,6 @@ mod tests {
 
         drop(p1_mut);
         drop(p2_mut);
-        drop(allocated_guard);
 
         // Construct the UntypedBtree and RawBtree
         let header = BtreeHeader {

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -1,7 +1,7 @@
 use crate::tree_store::page_store::{
     MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageImpl, PageMut, xxh3_checksum,
 };
-use crate::tree_store::{PageAllocator, PageNumber, PageTrackerPolicy};
+use crate::tree_store::{PageAllocator, PageNumber, PageTracker};
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{Result, StorageError};
 use std::borrow::Borrow;
@@ -10,7 +10,7 @@ use std::collections::VecDeque;
 use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ops::Range;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread;
 
 pub(crate) const LEAF: u8 = 1;
@@ -273,7 +273,7 @@ pub struct AccessGuardMut<'a, V: Value + 'static> {
     entry_index: usize,
     parent: Option<(PageMut<'a>, usize)>,
     page_allocator: PageAllocator,
-    allocated: Arc<Mutex<PageTrackerPolicy>>,
+    allocated: Arc<PageTracker>,
     root_ref: &'a mut BtreeHeader,
     key_width: Option<usize>,
     _value_type: PhantomData<V>,
@@ -288,7 +288,7 @@ impl<'a, V: Value + 'static> AccessGuardMut<'a, V> {
         entry_index: usize,
         parent: Option<(PageMut<'a>, usize)>,
         page_allocator: PageAllocator,
-        allocated: Arc<Mutex<PageTrackerPolicy>>,
+        allocated: Arc<PageTracker>,
         root_ref: &'a mut BtreeHeader,
         key_width: Option<usize>,
     ) -> Self {
@@ -375,10 +375,9 @@ impl<'a, V: Value + 'static> AccessGuardMut<'a, V> {
 
             let old_page_number = self.page.get_page_number();
             self.page = new_page;
-            let mut allocated = self.allocated.lock().unwrap();
             assert!(
                 self.page_allocator
-                    .free_if_uncommitted(old_page_number, &mut allocated)
+                    .free_if_uncommitted(old_page_number, &self.allocated)
             );
         }
 
@@ -657,7 +656,7 @@ pub(super) struct LeafBuilder<'a, 'b> {
     total_key_bytes: usize,
     total_value_bytes: usize,
     page_allocator: &'b PageAllocator,
-    allocated_pages: &'b Mutex<PageTrackerPolicy>,
+    allocated_pages: &'b PageTracker,
 }
 
 // Key-value pairs copied into owned memory, so they survive any tree mutation.
@@ -803,7 +802,7 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
 
     pub(super) fn new(
         page_allocator: &'b PageAllocator,
-        allocated_pages: &'b Mutex<PageTrackerPolicy>,
+        allocated_pages: &'b PageTracker,
         capacity: usize,
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
@@ -894,10 +893,9 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
 
         let required_size =
             self.required_bytes(division, first_split_key_bytes + first_split_value_bytes);
-        let mut allocated_pages = self.allocated_pages.lock().unwrap();
         let mut page1 = self
             .page_allocator
-            .allocate(required_size, &mut allocated_pages)?;
+            .allocate(required_size, self.allocated_pages)?;
         let mut builder = RawLeafBuilder::new(
             page1.memory_mut(),
             division,
@@ -918,7 +916,7 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
         );
         let mut page2 = self
             .page_allocator
-            .allocate(required_size, &mut allocated_pages)?;
+            .allocate(required_size, self.allocated_pages)?;
         let mut builder = RawLeafBuilder::new(
             page2.memory_mut(),
             self.pairs.len() - division,
@@ -939,10 +937,9 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
             self.pairs.len(),
             self.total_key_bytes + self.total_value_bytes,
         );
-        let mut allocated_pages = self.allocated_pages.lock().unwrap();
         let mut page = self
             .page_allocator
-            .allocate(required_size, &mut allocated_pages)?;
+            .allocate(required_size, self.allocated_pages)?;
         let mut builder = RawLeafBuilder::new(
             page.memory_mut(),
             self.pairs.len(),
@@ -1918,13 +1915,13 @@ pub(super) struct BranchBuilder<'a, 'b> {
     total_key_bytes: usize,
     fixed_key_size: Option<usize>,
     page_allocator: &'b PageAllocator,
-    allocated_pages: &'b Mutex<PageTrackerPolicy>,
+    allocated_pages: &'b PageTracker,
 }
 
 impl<'a, 'b> BranchBuilder<'a, 'b> {
     pub(super) fn new(
         page_allocator: &'b PageAllocator,
-        allocated_pages: &'b Mutex<PageTrackerPolicy>,
+        allocated_pages: &'b PageTracker,
         child_capacity: usize,
         fixed_key_size: Option<usize>,
     ) -> Self {
@@ -1986,8 +1983,7 @@ impl<'a, 'b> BranchBuilder<'a, 'b> {
             self.total_key_bytes,
             self.fixed_key_size,
         );
-        let mut allocated_pages = self.allocated_pages.lock().unwrap();
-        let mut page = self.page_allocator.allocate(size, &mut allocated_pages)?;
+        let mut page = self.page_allocator.allocate(size, self.allocated_pages)?;
         let mut builder =
             RawBranchBuilder::new(page.memory_mut(), self.keys.len(), self.fixed_key_size);
         builder.write_first_page(self.children[0].0, self.children[0].1);
@@ -2013,7 +2009,6 @@ impl<'a, 'b> BranchBuilder<'a, 'b> {
     }
 
     pub(super) fn build_split<'txn>(self) -> Result<(PageMut<'txn>, &'a [u8], PageMut<'txn>)> {
-        let mut allocated_pages = self.allocated_pages.lock().unwrap();
         assert_eq!(self.children.len(), self.keys.len() + 1);
         assert!(self.keys.len() >= 3);
         let division = self.keys.len() / 2;
@@ -2023,7 +2018,7 @@ impl<'a, 'b> BranchBuilder<'a, 'b> {
 
         let size =
             RawBranchBuilder::required_bytes(division, first_split_key_len, self.fixed_key_size);
-        let mut page1 = self.page_allocator.allocate(size, &mut allocated_pages)?;
+        let mut page1 = self.page_allocator.allocate(size, self.allocated_pages)?;
         let mut builder = RawBranchBuilder::new(page1.memory_mut(), division, self.fixed_key_size);
         builder.write_first_page(self.children[0].0, self.children[0].1);
         for i in 0..division {
@@ -2042,7 +2037,7 @@ impl<'a, 'b> BranchBuilder<'a, 'b> {
             second_split_key_len,
             self.fixed_key_size,
         );
-        let mut page2 = self.page_allocator.allocate(size, &mut allocated_pages)?;
+        let mut page2 = self.page_allocator.allocate(size, self.allocated_pages)?;
         let mut builder = RawBranchBuilder::new(
             page2.memory_mut(),
             self.keys.len() - division - 1,
@@ -2271,7 +2266,7 @@ mod tests {
 
     fn build_leaf(
         page_allocator: &PageAllocator,
-        allocated_pages: &Mutex<PageTrackerPolicy>,
+        allocated_pages: &PageTracker,
         keys: &[[u8; 8]],
     ) -> PageMut<'static> {
         let mut builder = LeafBuilder::new(
@@ -2297,7 +2292,7 @@ mod tests {
     #[test]
     fn leaf_inplace_insert_rejected_at_max_pairs() {
         let page_allocator = make_allocator();
-        let allocated_pages = Mutex::new(PageTrackerPolicy::new_tracking());
+        let allocated_pages = PageTracker::new_tracking();
         let keys = ascending_keys(MAX_PAIRS);
         let page = build_leaf(&page_allocator, &allocated_pages, &keys);
 
@@ -2322,7 +2317,7 @@ mod tests {
     #[test]
     fn leaf_inplace_append_up_to_max_pairs() {
         let page_allocator = make_allocator();
-        let allocated_pages = Mutex::new(PageTrackerPolicy::new_tracking());
+        let allocated_pages = PageTracker::new_tracking();
         let keys = ascending_keys(MAX_PAIRS - 1);
         let mut page = build_leaf(&page_allocator, &allocated_pages, &keys);
         assert!(page.get_page_number().page_order > 0);
@@ -2349,7 +2344,7 @@ mod tests {
     #[test]
     fn leaf_split_respects_max_pairs() {
         let page_allocator = make_allocator();
-        let allocated_pages = Mutex::new(PageTrackerPolicy::new_tracking());
+        let allocated_pages = PageTracker::new_tracking();
         let num_pairs = MAX_PAIRS + 2;
         let keys = ascending_keys(num_pairs);
         let big_value = vec![0u8; 2 * 1024 * 1024];
@@ -2382,7 +2377,7 @@ mod tests {
     #[test]
     fn leaf_split_respects_max_pairs_by_count() {
         let page_allocator = make_allocator_with_page_size(2 * 1024 * 1024);
-        let allocated_pages = Mutex::new(PageTrackerPolicy::new_tracking());
+        let allocated_pages = PageTracker::new_tracking();
         let num_pairs = MAX_PAIRS + 1;
         let keys = ascending_keys(num_pairs);
         let mut builder = LeafBuilder::new(
@@ -2411,7 +2406,7 @@ mod tests {
     #[test]
     fn branch_split_respects_max_keys_by_count() {
         let page_allocator = make_allocator_with_page_size(4 * 1024 * 1024);
-        let allocated_pages = Mutex::new(PageTrackerPolicy::new_tracking());
+        let allocated_pages = PageTracker::new_tracking();
         // One more key than u16::MAX, i.e. two more children.
         let num_children = MAX_PAIRS + 2;
         let keys = ascending_keys(num_children - 1);

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -6,7 +6,7 @@ use crate::tree_store::btree_base::{
 use crate::tree_store::btree_iters::EntryGuard;
 use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageHint, PageImpl};
-use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageResolver, PageTrackerPolicy};
+use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageResolver, PageTracker};
 use crate::types::{Key, Value};
 use crate::{Result, StorageError};
 use std::cmp::Ordering;
@@ -672,7 +672,7 @@ pub(super) struct CursorMut<'a, 'b, K: Key + 'static, V: Value + 'static> {
     root: &'b mut Option<BtreeHeader>,
     page_allocator: &'b PageAllocator,
     freed: &'b mut Vec<PageNumber>,
-    allocated: &'b Arc<Mutex<PageTrackerPolicy>>,
+    allocated: &'b Arc<PageTracker>,
     state: CursorState,
     _key_type: PhantomData<K>,
     _value_type: PhantomData<V>,
@@ -714,7 +714,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         root: &'b mut Option<BtreeHeader>,
         page_allocator: &'b PageAllocator,
         freed: &'b mut Vec<PageNumber>,
-        allocated: &'b Arc<Mutex<PageTrackerPolicy>>,
+        allocated: &'b Arc<PageTracker>,
     ) -> Self {
         Self::with_state(
             root,
@@ -729,7 +729,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
         root: &'b mut Option<BtreeHeader>,
         page_allocator: &'b PageAllocator,
         freed: &'b mut Vec<PageNumber>,
-        allocated: &'b Arc<Mutex<PageTrackerPolicy>>,
+        allocated: &'b Arc<PageTracker>,
         state: CursorState,
     ) -> Self {
         Self {
@@ -1601,7 +1601,7 @@ impl<K: Key + 'static, V: Value + 'static> CursorMut<'_, '_, K, V> {
 pub(super) struct CursorTree<'a, K: Key + 'static, V: Value + 'static> {
     root: &'a mut Option<BtreeHeader>,
     page_allocator: PageAllocator,
-    allocated: Arc<Mutex<PageTrackerPolicy>>,
+    allocated: Arc<PageTracker>,
     master_free_list: Arc<Mutex<Vec<PageNumber>>>,
     freed: Vec<PageNumber>,
     _key_type: PhantomData<K>,
@@ -1613,7 +1613,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> CursorTree<'a, K, V> {
         root: &'a mut Option<BtreeHeader>,
         page_allocator: PageAllocator,
         master_free_list: Arc<Mutex<Vec<PageNumber>>>,
-        allocated: Arc<Mutex<PageTrackerPolicy>>,
+        allocated: Arc<PageTracker>,
     ) -> Self {
         Self {
             root,
@@ -1641,11 +1641,10 @@ impl<'a, K: Key + 'static, V: Value + 'static> CursorTree<'a, K, V> {
             return;
         }
         let mut master_free_list = self.master_free_list.lock().unwrap();
-        let mut allocated = self.allocated.lock().unwrap();
         for page in self.freed.drain(..) {
             if !self
                 .page_allocator
-                .free_if_uncommitted(page, &mut allocated)
+                .free_if_uncommitted(page, &self.allocated)
             {
                 master_free_list.push(page);
             }
@@ -1764,7 +1763,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
         root: &'a mut Option<BtreeHeader>,
         page_allocator: PageAllocator,
         master_free_list: Arc<Mutex<Vec<PageNumber>>>,
-        allocated: Arc<Mutex<PageTrackerPolicy>>,
+        allocated: Arc<PageTracker>,
     ) -> Self {
         Self {
             tree: CursorTree::new(root, page_allocator, master_free_list, allocated),
@@ -2020,7 +2019,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
         upper_bound: Bound<Vec<u8>>,
         page_allocator: PageAllocator,
         master_free_list: Arc<Mutex<Vec<PageNumber>>>,
-        allocated: Arc<Mutex<PageTrackerPolicy>>,
+        allocated: Arc<PageTracker>,
     ) -> Self {
         Self {
             tree: CursorTree::new(root, page_allocator, master_free_list, allocated),
@@ -2416,9 +2415,7 @@ fn park_bound<K: Key + 'static, V: Value + 'static>(
 mod tests {
     use super::*;
     use crate::tree_store::btree_base::{DEFERRED, LeafBuilder};
-    use crate::tree_store::{
-        AllocationPolicy, InMemoryBackend, PAGE_SIZE, PageTrackerPolicy, TransactionalMemory,
-    };
+    use crate::tree_store::{AllocationPolicy, InMemoryBackend, PAGE_SIZE, TransactionalMemory};
 
     fn test_page_allocator() -> PageAllocator {
         let mem = TransactionalMemory::new(
@@ -2436,11 +2433,9 @@ mod tests {
 
     // The returned tracker records the built page: mutations through a cursor
     // must share it, so the pages they free are found tracked.
-    fn leaf_root_with_entries(
-        entries: &[u64],
-    ) -> (PageAllocator, PageNumber, Arc<Mutex<PageTrackerPolicy>>) {
+    fn leaf_root_with_entries(entries: &[u64]) -> (PageAllocator, PageNumber, Arc<PageTracker>) {
         let page_allocator = test_page_allocator();
-        let allocated_pages = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+        let allocated_pages = Arc::new(PageTracker::new_tracking());
         let keys_and_values: Vec<_> = entries
             .iter()
             .map(|entry| {
@@ -2619,7 +2614,7 @@ mod tests {
                 let page_allocator = test_page_allocator();
                 let mut root = None;
                 let mut freed = vec![];
-                let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+                let allocated = Arc::new(PageTracker::new_tracking());
                 let mut cursor: CursorMut<'_, '_, u64, u64> =
                     CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
                 cursor.seek_to(Position::End).unwrap();
@@ -2642,7 +2637,7 @@ mod tests {
             let page_allocator = test_page_allocator();
             let mut root = None;
             let mut freed = vec![];
-            let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+            let allocated = Arc::new(PageTracker::new_tracking());
             let mut cursor: CursorMut<'_, '_, u64, u64> =
                 CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
             cursor.seek_to(Position::End).unwrap();
@@ -2725,7 +2720,7 @@ mod tests {
             let page_allocator = test_page_allocator();
             let mut root = None;
             let mut freed = vec![];
-            let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+            let allocated = Arc::new(PageTracker::new_tracking());
             let mut cursor: CursorMut<'_, '_, u64, u64> =
                 CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
             cursor.seek_to(Position::End).unwrap();
@@ -2776,7 +2771,7 @@ mod tests {
             let page_allocator = test_page_allocator();
             let mut root = None;
             let mut freed = vec![];
-            let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+            let allocated = Arc::new(PageTracker::new_tracking());
             let mut cursor: CursorMut<'_, '_, u64, u64> =
                 CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
             cursor.seek_to(Position::End).unwrap();
@@ -2869,7 +2864,7 @@ mod tests {
                 let page_allocator = test_page_allocator();
                 let mut root = None;
                 let mut freed = vec![];
-                let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+                let allocated = Arc::new(PageTracker::new_tracking());
                 let mut cursor: CursorMut<'_, '_, u64, u64> =
                     CursorMut::new(&mut root, &page_allocator, &mut freed, &allocated);
                 cursor.seek_to(Position::Start).unwrap();

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -10,14 +10,14 @@ use crate::tree_store::btree_mutator::DeletionResult::{
 };
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
-    AccessGuardMutInPlace, BtreeHeader, PageAllocator, PageHint, PageNumber, PageTrackerPolicy,
+    AccessGuardMutInPlace, BtreeHeader, PageAllocator, PageHint, PageNumber, PageTracker,
 };
 use crate::types::{Key, Value};
 use crate::{AccessGuard, Result};
 use std::cmp::{max, min};
 use std::marker::PhantomData;
 use std::ops::Range;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 #[derive(Debug)]
 enum DeletionResult {
@@ -95,7 +95,7 @@ pub(crate) struct MutateHelper<'a, 'b, K: Key, V: Value> {
     root: &'b mut Option<BtreeHeader>,
     page_allocator: &'b PageAllocator,
     freed: &'b mut Vec<PageNumber>,
-    allocated: &'b Arc<Mutex<PageTrackerPolicy>>,
+    allocated: &'b Arc<PageTracker>,
     _key_type: PhantomData<K>,
     _value_type: PhantomData<V>,
     _lifetime: PhantomData<&'a ()>,
@@ -106,7 +106,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         root: &'b mut Option<BtreeHeader>,
         page_allocator: &'b PageAllocator,
         freed: &'b mut Vec<PageNumber>,
-        allocated: &'b Arc<Mutex<PageTrackerPolicy>>,
+        allocated: &'b Arc<PageTracker>,
     ) -> Self {
         Self {
             root,
@@ -120,9 +120,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     }
 
     fn conditional_free(&mut self, page_number: PageNumber) {
-        let mut allocated = self.allocated.lock().unwrap();
         self.page_allocator
-            .conditional_free(page_number, &mut allocated, self.freed);
+            .conditional_free(page_number, self.allocated, self.freed);
     }
 
     pub(crate) fn delete(&mut self, key: &K::SelfType<'_>) -> Result<Option<AccessGuard<'a, V>>> {
@@ -902,8 +901,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         if self.page_allocator.uncommitted(page_number) {
                             let arc = page.to_arc();
                             drop(page);
-                            let mut allocated = self.allocated.lock().unwrap();
-                            self.page_allocator.free(page_number, &mut allocated);
+                            self.page_allocator.free(page_number, self.allocated);
                             Some(AccessGuard::with_arc_page(arc, start..end))
                         } else {
                             self.freed.push(page_number);
@@ -937,8 +935,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         if self.page_allocator.uncommitted(page_number) {
                             let arc = page.to_arc();
                             drop(page);
-                            let mut allocated = self.allocated.lock().unwrap();
-                            self.page_allocator.free(page_number, &mut allocated);
+                            self.page_allocator.free(page_number, self.allocated);
                             Some(AccessGuard::with_arc_page(arc, start..end))
                         } else {
                             self.freed.push(page_number);
@@ -1217,8 +1214,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             let page_number = page.get_page_number();
             let arc = page.to_arc();
             drop(page);
-            let mut allocated = self.allocated.lock().unwrap();
-            self.page_allocator.free(page_number, &mut allocated);
+            self.page_allocator.free(page_number, self.allocated);
             let key_guard = want_key.then(|| AccessGuard::with_arc_page(arc.clone(), key_range));
             (key_guard, AccessGuard::with_arc_page(arc, value_range))
         } else {
@@ -1794,7 +1790,7 @@ mod tests {
     fn pack_branches(children: &[SplicedNode], page_allocator: &PageAllocator) -> Vec<SplicedNode> {
         let mut root = None;
         let mut freed = vec![];
-        let allocated = Arc::new(Mutex::new(PageTrackerPolicy::new_tracking()));
+        let allocated = Arc::new(PageTracker::new_tracking());
         let mut helper: MutateHelper<'_, '_, u64, u64> =
             MutateHelper::new(&mut root, page_allocator, &mut freed, &allocated);
         helper.build_branch_nodes(children).unwrap()

--- a/src/tree_store/extract_if.rs
+++ b/src/tree_store/extract_if.rs
@@ -1,5 +1,5 @@
 use crate::tree_store::btree_cursor::RangeMut;
-use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageTrackerPolicy};
+use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageTracker};
 use crate::types::{Key, Value};
 use crate::{AccessGuard, Result, StorageError};
 use std::collections::Bound;
@@ -41,7 +41,7 @@ where
         back_bound: Bound<Vec<u8>>,
         predicate: F,
         master_free_list: Arc<Mutex<Vec<PageNumber>>>,
-        allocated: Arc<Mutex<PageTrackerPolicy>>,
+        allocated: Arc<PageTracker>,
         page_allocator: PageAllocator,
     ) -> Self {
         Self {

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multim
 pub(crate) use page_store::ReadOnlyBackend;
 pub(crate) use page_store::{
     AllocationPolicy, FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page,
-    PageAllocator, PageHint, PageNumber, PageNumberHashSet, PageResolver, PageTrackerPolicy,
+    PageAllocator, PageHint, PageNumber, PageNumberHashSet, PageResolver, PageTracker,
     SerializedSavepoint, ShrinkPolicy, TransactionalMemory,
 };
 pub use page_store::{InMemoryBackend, Savepoint, file_backend};

--- a/src/tree_store/multimap_btree.rs
+++ b/src/tree_store/multimap_btree.rs
@@ -6,7 +6,7 @@ use crate::tree_store::btree_base::{
 use crate::tree_store::multimap_btree::DynamicCollectionType::{Inline, SubtreeV2};
 use crate::tree_store::{
     AllPageNumbersBtreeIter, BtreeHeader, BtreeStats, Page, PageAllocator, PageHint, PageNumber,
-    PageResolver, PageTrackerPolicy, RawBtree,
+    PageResolver, PageTracker, RawBtree,
 };
 use crate::types::{Key, TypeName, Value};
 use std::cmp::max;
@@ -270,8 +270,8 @@ pub(super) fn relocate_subtrees(
     drop(old_page);
     // No need to track allocations, because this method is only called during compaction when
     // there can't be any savepoints
-    let mut ignore = PageTrackerPolicy::Ignore;
-    if !page_allocator.free_if_uncommitted(old_page_number, &mut ignore) {
+    let ignore = PageTracker::ignore();
+    if !page_allocator.free_if_uncommitted(old_page_number, &ignore) {
         freed_pages.lock().unwrap().push(old_page_number);
     }
     Ok((new_page_number, DEFERRED))

--- a/src/tree_store/page_store/base.rs
+++ b/src/tree_store/page_store/base.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::tree_store::page_store::cached_file::WritablePage;
 use crate::tree_store::page_store::fast_hash::PageNumberHashSet;
 use crate::tree_store::page_store::page_manager::MAX_MAX_PAGE_ORDER;
@@ -12,8 +13,8 @@ use std::marker::PhantomData;
 use std::mem;
 use std::ops::Range;
 use std::sync::Arc;
-#[cfg(debug_assertions)]
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
 pub(crate) const MAX_VALUE_LENGTH: usize = 3 * 1024 * 1024 * 1024;
 pub(crate) const MAX_PAIR_LENGTH: usize = 3 * 1024 * 1024 * 1024 + 768 * 1024 * 1024;
@@ -279,7 +280,7 @@ pub(crate) enum PageHint {
     Clean,
 }
 
-pub(crate) enum PageTrackerPolicy {
+enum PageTrackerPolicy {
     Ignore,
     Track(PageNumberHashSet),
     Closed,
@@ -344,6 +345,81 @@ impl PageTrackerPolicy {
                 panic!("Page tracker is closed");
             }
         }
+    }
+}
+
+/// The pages a write transaction has allocated, shared by all of its tables.
+///
+/// Only savepoint restore needs this set, so a transaction with no savepoint tracks nothing.
+/// That is the common case, and tables of one transaction may be written from different threads,
+/// so it must not cost a lock on every allocation: `tracking` is checked first, and the mutex is
+/// touched only while tracking is on. The flag is relaxed because nothing is ordered against it --
+/// a writer that misses a concurrent `disable()` merely records a page into a set that is about to
+/// be discarded, and one that sees it early skips a page nothing will read.
+pub(crate) struct PageTracker {
+    tracking: AtomicBool,
+    policy: Mutex<PageTrackerPolicy>,
+}
+
+impl PageTracker {
+    pub(crate) fn new_tracking() -> Self {
+        Self {
+            tracking: AtomicBool::new(true),
+            policy: Mutex::new(PageTrackerPolicy::new_tracking()),
+        }
+    }
+
+    pub(crate) fn ignore() -> Self {
+        Self {
+            tracking: AtomicBool::new(false),
+            policy: Mutex::new(PageTrackerPolicy::Ignore),
+        }
+    }
+
+    pub(crate) fn closed() -> Self {
+        Self {
+            tracking: AtomicBool::new(true),
+            policy: Mutex::new(PageTrackerPolicy::Closed),
+        }
+    }
+
+    fn tracking(&self) -> bool {
+        self.tracking.load(AtomicOrdering::Relaxed)
+    }
+
+    /// Stops tracking, discarding what was recorded. Called once no savepoint can observe the
+    /// pages, after which the tracker never tracks again for the rest of the transaction:
+    /// `reset()` leaves `Ignore` alone, and `close()` only moves to the poisoned `Closed` state.
+    pub(crate) fn disable(&self) {
+        *self.policy.lock().unwrap() = PageTrackerPolicy::Ignore;
+        self.tracking.store(false, AtomicOrdering::Relaxed);
+    }
+
+    pub(crate) fn insert(&self, page: PageNumber) {
+        if self.tracking() {
+            self.policy.lock().unwrap().insert(page);
+        }
+    }
+
+    pub(crate) fn remove(&self, page: PageNumber) {
+        if self.tracking() {
+            self.policy.lock().unwrap().remove(page);
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.policy.lock().unwrap().is_empty()
+    }
+
+    // Leaves the tracker in the `Closed` state, where any further use panics. `tracking` stays
+    // set so that those uses reach the policy rather than being skipped.
+    pub(crate) fn close(&self) -> Result<PageNumberHashSet> {
+        self.tracking.store(true, AtomicOrdering::Relaxed);
+        Ok(self.policy.lock()?.close())
+    }
+
+    pub(crate) fn reset(&self) -> PageNumberHashSet {
+        self.policy.lock().unwrap().reset()
     }
 }
 

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -16,9 +16,7 @@ mod xxh3;
 
 pub use backends::InMemoryBackend;
 pub(crate) use backends::ReadOnlyBackend;
-pub(crate) use base::{
-    MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTrackerPolicy,
-};
+pub(crate) use base::{MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTracker};
 pub(crate) use fast_hash::PageNumberHashSet;
 pub(crate) use header::PAGE_SIZE;
 pub(crate) use page_manager::{

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -11,7 +11,7 @@ use crate::tree_store::page_store::header::{
 use crate::tree_store::page_store::layout::DatabaseLayout;
 use crate::tree_store::page_store::region::{Allocators, RegionTracker};
 use crate::tree_store::page_store::{PageImpl, PageMut, hash128_with_seed};
-use crate::tree_store::{Page, PageNumber, PageTrackerPolicy};
+use crate::tree_store::{Page, PageNumber, PageTracker};
 use crate::{CacheStats, StorageBackend};
 use crate::{DatabaseError, Result, StorageError};
 use std::cmp::{max, min};
@@ -198,15 +198,11 @@ impl PageAllocator {
         self.mem.debug_assert_no_dirty_pages();
         let drained = self.take_allocated_since_commit();
         for page in &drained {
-            self.mem.free(*page, &mut PageTrackerPolicy::Ignore);
+            self.mem.free(*page, &PageTracker::ignore());
         }
     }
 
-    pub(crate) fn allocate<'a>(
-        &self,
-        size: usize,
-        allocated: &mut PageTrackerPolicy,
-    ) -> Result<PageMut<'a>> {
+    pub(crate) fn allocate<'a>(&self, size: usize, allocated: &PageTracker) -> Result<PageMut<'a>> {
         let page = match self.policy {
             AllocationPolicy::Default => self.mem.allocate(size, allocated)?,
             AllocationPolicy::Lowest => self.mem.allocate_lowest(size, allocated)?,
@@ -221,23 +217,19 @@ impl PageAllocator {
     pub(crate) fn allocate_lowest<'a>(
         &self,
         size: usize,
-        allocated: &mut PageTrackerPolicy,
+        allocated: &PageTracker,
     ) -> Result<PageMut<'a>> {
         let page = self.mem.allocate_lowest(size, allocated)?;
         self.allocated_since_commit.insert(page.get_page_number());
         Ok(page)
     }
 
-    pub(crate) fn free(&self, page: PageNumber, allocated: &mut PageTrackerPolicy) {
+    pub(crate) fn free(&self, page: PageNumber, allocated: &PageTracker) {
         self.allocated_since_commit.remove(page);
         self.mem.free(page, allocated);
     }
 
-    pub(crate) fn free_if_uncommitted(
-        &self,
-        page: PageNumber,
-        allocated: &mut PageTrackerPolicy,
-    ) -> bool {
+    pub(crate) fn free_if_uncommitted(&self, page: PageNumber, allocated: &PageTracker) -> bool {
         if self.allocated_since_commit.remove(page) {
             self.mem.free(page, allocated);
             true
@@ -251,7 +243,7 @@ impl PageAllocator {
     pub(crate) fn conditional_free(
         &self,
         page: PageNumber,
-        allocated: &mut PageTrackerPolicy,
+        allocated: &PageTracker,
         freed: &mut Vec<PageNumber>,
     ) {
         if !self.free_if_uncommitted(page, allocated) {
@@ -1066,7 +1058,7 @@ impl TransactionalMemory {
         self.state.lock().unwrap().header.primary_slot().system_root
     }
 
-    pub(crate) fn free(&self, page: PageNumber, allocated: &mut PageTrackerPolicy) {
+    pub(crate) fn free(&self, page: PageNumber, allocated: &PageTracker) {
         self.free_helper(page, allocated);
     }
 
@@ -1093,7 +1085,7 @@ impl TransactionalMemory {
         }
     }
 
-    fn free_helper(&self, page: PageNumber, allocated: &mut PageTrackerPolicy) {
+    fn free_helper(&self, page: PageNumber, allocated: &PageTracker) {
         #[cfg(debug_assertions)]
         {
             assert!(
@@ -1134,11 +1126,7 @@ impl TransactionalMemory {
     }
 
     // Frees the page if no durable commit has occurred, since it was allocated. Returns true, if the page was freed
-    pub(crate) fn free_if_unpersisted(
-        &self,
-        page: PageNumber,
-        allocated: &mut PageTrackerPolicy,
-    ) -> bool {
+    pub(crate) fn free_if_unpersisted(&self, page: PageNumber, allocated: &PageTracker) -> bool {
         if self.unpersisted.lock().unwrap().remove(&page) {
             self.remove_unpersisted_allocation(page);
             self.free_helper(page, allocated);
@@ -1374,7 +1362,7 @@ impl TransactionalMemory {
     fn allocate<'txn>(
         &self,
         allocation_size: usize,
-        allocated: &mut PageTrackerPolicy,
+        allocated: &PageTracker,
     ) -> Result<PageMut<'txn>> {
         let result = self.allocate_helper(allocation_size, false);
         if let Ok(ref page) = result {
@@ -1386,7 +1374,7 @@ impl TransactionalMemory {
     fn allocate_lowest<'txn>(
         &self,
         allocation_size: usize,
-        allocated: &mut PageTrackerPolicy,
+        allocated: &PageTracker,
     ) -> Result<PageMut<'txn>> {
         let result = self.allocate_helper(allocation_size, true);
         if let Ok(ref page) = result {
@@ -1538,7 +1526,7 @@ mod test {
     #[test]
     fn free_merge_remarks_region_tracker() {
         use super::TransactionalMemory;
-        use crate::tree_store::{InMemoryBackend, Page, PageTrackerPolicy};
+        use crate::tree_store::{InMemoryBackend, Page, PageTracker};
 
         // Small pages and regions keep the reproduction cheap to set up.
         let page_size = 128 * 1024;
@@ -1554,7 +1542,7 @@ mod test {
         .unwrap();
         mem.reset_allocator_state().unwrap();
 
-        let mut ignore = PageTrackerPolicy::Ignore;
+        let ignore = PageTracker::ignore();
 
         // Fill region 0 with order-0 pages. The allocation that spills past region 0 fails on it
         // first, which marks region 0 full at every order.
@@ -1568,7 +1556,7 @@ mod test {
             } else {
                 // First page past region 0: it has done its job of forcing region 0 full. Give it
                 // back so the spilled-into region is left entirely free.
-                mem.free(number, &mut ignore);
+                mem.free(number, &ignore);
                 break;
             }
         }
@@ -1581,7 +1569,7 @@ mod test {
         // Free everything in region 0. The order-0 pages buddy-merge back into larger blocks, so
         // region 0 regains free space above order 0.
         for page in region0_pages {
-            mem.free(page, &mut ignore);
+            mem.free(page, &ignore);
         }
 
         // An order-1 allocation must reuse region 0's merged free block. Before the fix the tracker

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -7,7 +7,7 @@ use crate::tree_store::multimap_btree::{
 };
 use crate::tree_store::{
     Btree, BtreeCursorRange, BtreeMut, InternalTableDefinition, PageAllocator, PageHint,
-    PageNumber, PageNumberHashSet, PageResolver, PageTrackerPolicy, RawBtree, TableType,
+    PageNumber, PageNumberHashSet, PageResolver, PageTracker, RawBtree, TableType,
     multimap_btree_stats,
 };
 use crate::types::{Key, Value};
@@ -230,7 +230,7 @@ pub(crate) struct TableTreeMut {
     // on close -- so entries cannot reference pages that an open handle frees.
     pending_table_updates: HashMap<String, (Option<BtreeHeader>, u64, bool)>,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-    allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
+    allocated_pages: Arc<PageTracker>,
 }
 
 impl TableTreeMut {
@@ -239,7 +239,7 @@ impl TableTreeMut {
         guard: Arc<TransactionGuard>,
         page_allocator: PageAllocator,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-        allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
+        allocated_pages: Arc<PageTracker>,
     ) -> Self {
         Self {
             tree: BtreeMut::new(
@@ -315,7 +315,9 @@ impl TableTreeMut {
 
     pub(crate) fn clear_root_updates_and_close(&mut self) {
         self.pending_table_updates.clear();
-        self.allocated_pages.lock().unwrap().close();
+        // This returns no error, so a poisoned tracker panics here as it did when the caller
+        // locked it directly
+        self.allocated_pages.close().unwrap();
     }
 
     pub(crate) fn flush_and_close(
@@ -323,7 +325,7 @@ impl TableTreeMut {
     ) -> Result<(Option<BtreeHeader>, PageNumberHashSet, Vec<PageNumber>)> {
         match self.flush_inner() {
             Ok(header) => {
-                let allocated = self.allocated_pages.lock()?.close();
+                let allocated = self.allocated_pages.close()?;
                 let mut old = vec![];
                 let mut freed_pages = self.freed_pages.lock()?;
                 mem::swap(freed_pages.as_mut(), &mut old);
@@ -332,7 +334,7 @@ impl TableTreeMut {
             Err(err) => {
                 // Ensure that the allocated pages get clear. Otherwise it will cause a panic
                 // when they are dropped
-                self.allocated_pages.lock()?.close();
+                self.allocated_pages.close()?;
                 Err(err)
             }
         }
@@ -591,16 +593,14 @@ impl TableTreeMut {
                 Ok(())
             })?;
             let mut freed_pages = self.freed_pages.lock().unwrap();
-            let mut allocated_pages = self.allocated_pages.lock().unwrap();
             for page in pages {
                 if !self
                     .page_allocator
-                    .free_if_uncommitted(page, &mut allocated_pages)
+                    .free_if_uncommitted(page, &self.allocated_pages)
                 {
                     freed_pages.push(page);
                 }
             }
-            drop(allocated_pages);
             drop(freed_pages);
 
             self.pending_table_updates.remove(name);
@@ -792,7 +792,7 @@ impl Drop for TableTreeMut {
         if thread::panicking() {
             return;
         }
-        assert!(self.allocated_pages.lock().unwrap().is_empty());
+        assert!(self.allocated_pages.is_empty());
     }
 }
 


### PR DESCRIPTION
#1352 has merged, so this is now based directly on master and contains only its own commit.

Sharding the uncommitted-pages set left the other transaction-wide allocation lock as the next one to be contended: every table of a `WriteTransaction` shares an allocation tracker, and every allocation and free locks it — builders held the guard across the allocation *and* the whole page construction (`build_split` held it across two allocations plus all the key/value copying).

**On its own this change measures as nothing** — I tried it standalone against master first and it was indistinguishable, because the uncommitted-pages set was the bottleneck. It only pays now that #1352 is in.

That set exists solely so that restoring a savepoint can free the pages a transaction allocated, so a transaction with no live savepoint tracks nothing and already sets the policy to `Ignore` — but callers still took the lock to reach it. This wraps the policy in a `PageTracker` holding an atomic flag alongside the mutex, checks the flag first, and touches the mutex only while tracking is on, which is the uncommon case.

Two things make that safe:

- **The flag can be relaxed.** Nothing is ordered against it: a writer that misses a concurrent `disable()` records a page into a set that is about to be discarded, and one that sees it early skips a page nothing will read.
- **Tracking never turns back on within a transaction.** It is disabled only while no savepoint exists; `reset()` leaves `Ignore` alone and `close()` only moves to the poisoned `Closed` state. So a page can never be recorded while disabled and then removed while enabled, which would trip the tracker's assertion that a removed page was present.

Passing the tracker rather than a guard also shortens the critical section when tracking *is* on: builders now take the lock per allocation instead of holding it across page construction. `PageTrackerPolicy` becomes an implementation detail of `PageTracker`, and `remove_if_present`/`contains` fall out as dead code.

Benchmark as in #1352 (`multithreaded_insert_benchmark`, 16-core / 32-thread 9950X3D):

| Threads | before #1352 | #1352 | this PR on top |
|---|---|---|---|
| 8 | ~145ms | ~134ms | ~132ms |
| 16 | ~211ms | ~140ms | ~122ms |
| 32 | ~240ms | ~167ms | ~132ms |

It also removes most of the run-to-run variance at 32 threads: #1352 alone gave 192/155/153ms across three runs, with this it is 131/134/132ms.

Scaling still flattens after eight threads (4.8x at 8, 5.2x at 16). What remains is the global `state` mutex in `allocate_helper`, which every allocation takes; that is a different kind of change and not attempted here.

Verified with the full test suite (all features, debug and release) and clippy with denied warnings, on the rebased commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSqVAm9fEDkDW6TN9GZ4SR