### PR TITLE
Flush table root updates in deterministic order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   be added behind the `experimental_cursor` feature flag, like the table cursors' were.
 
 ## 4.2.0 - 2026-XX-XX
+* Commits now flush table root updates in a deterministic order, removing a source of
+  nondeterminism that could make identical operation sequences produce differing database files
 * Add a `std` feature, enabled by default, in preparation for a future `no_std` mode. It gates
   nothing yet, so building with `default-features = false` still links against the standard
   library. Under the `experimental-api-5` feature flag, which collects the changes planned for

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -228,7 +228,9 @@ pub(crate) struct TableTreeMut {
     // The bool indicates whether the root has dirty (DEFERRED) checksums that need finalization.
     // Never contains an entry for an open table -- the update is taken out on open and re-staged
     // on close -- so entries cannot reference pages that an open handle frees.
-    pending_table_updates: HashMap<String, (Option<BtreeHeader>, u64, bool)>,
+    // Ordered so that commits flush table roots in a deterministic order, keeping the pages a
+    // commit allocates -- and therefore the resulting file bytes -- reproducible.
+    pending_table_updates: BTreeMap<String, (Option<BtreeHeader>, u64, bool)>,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
     allocated_pages: Arc<Mutex<PageTrackerPolicy>>,
 }
@@ -251,7 +253,7 @@ impl TableTreeMut {
             ),
             guard,
             page_allocator,
-            pending_table_updates: HashMap::default(),
+            pending_table_updates: BTreeMap::new(),
             freed_pages,
             allocated_pages,
         }
@@ -343,7 +345,8 @@ impl TableTreeMut {
     }
 
     pub(crate) fn flush_table_root_updates(&mut self) -> Result<&mut Self> {
-        for (name, (new_root, new_length, dirty)) in self.pending_table_updates.drain() {
+        for (name, (new_root, new_length, dirty)) in std::mem::take(&mut self.pending_table_updates)
+        {
             // Bypass .get_table() since the table types are dynamic
             let mut definition = self.tree.get(&name.as_str())?.unwrap().value();
             // No-op if the root has not changed and checksums are already finalized

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -3580,3 +3580,124 @@ fn u8_array_serialization() {
         assert_eq!(ref_order, generic_order);
     }
 }
+
+#[test]
+fn multi_table_commit_writes_are_deterministic() {
+    use redb::StorageBackend;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug, PartialEq)]
+    enum BackendEvent {
+        Write { offset: u64, data: Vec<u8> },
+        SetLen(u64),
+        Sync,
+    }
+
+    type EventLog = Arc<Mutex<Vec<BackendEvent>>>;
+
+    #[derive(Debug)]
+    struct RecordingBackend {
+        inner: InMemoryBackend,
+        log: EventLog,
+    }
+
+    impl StorageBackend for RecordingBackend {
+        fn len(&self) -> Result<u64, std::io::Error> {
+            self.inner.len()
+        }
+
+        fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
+            self.inner.read(offset, out)
+        }
+
+        fn set_len(&self, len: u64) -> Result<(), std::io::Error> {
+            self.log.lock().unwrap().push(BackendEvent::SetLen(len));
+            self.inner.set_len(len)
+        }
+
+        fn sync_data(&self) -> Result<(), std::io::Error> {
+            self.log.lock().unwrap().push(BackendEvent::Sync);
+            self.inner.sync_data()
+        }
+
+        fn write(&self, offset: u64, data: &[u8]) -> Result<(), std::io::Error> {
+            self.log.lock().unwrap().push(BackendEvent::Write {
+                offset,
+                data: data.to_vec(),
+            });
+            self.inner.write(offset, data)
+        }
+    }
+
+    // A history rich enough to exercise order-sensitive allocation. Every branch depends only
+    // on loop indices, so two executions perform an identical operation sequence.
+    fn run_workload() -> Vec<BackendEvent> {
+        let log: EventLog = Arc::new(Mutex::new(Vec::new()));
+        let backend = RecordingBackend {
+            inner: InMemoryBackend::new(),
+            log: Arc::clone(&log),
+        };
+        let db = Database::builder().create_with_backend(backend).unwrap();
+        let mut persistent_ids: Vec<u64> = Vec::new();
+        for round in 0..8u32 {
+            let mut txn = db.begin_write().unwrap();
+            let ephemeral = if round % 2 == 0 {
+                Some(txn.ephemeral_savepoint().unwrap())
+            } else {
+                None
+            };
+            if round == 3 || round == 5 {
+                persistent_ids.push(txn.persistent_savepoint().unwrap());
+            }
+            for i in 0..120u32 {
+                if (i + round) % 3 == 0 {
+                    let name = format!("table_{i:0>60}");
+                    let def: TableDefinition<u32, Vec<u8>> = TableDefinition::new(&name);
+                    let mut table = txn.open_table(def).unwrap();
+                    for k in 0..(1 + (i + round) % 7) {
+                        let len = ((i * 37 + k * 101 + round * 13) % 900) as usize;
+                        table.insert(k, vec![(i % 251) as u8; len]).unwrap();
+                    }
+                    if round > 2 && i % 5 == 0 {
+                        table.remove(0u32).unwrap();
+                    }
+                }
+            }
+            if round >= 4 {
+                for i in 0..120u32 {
+                    if (i + round) % 9 == 0 {
+                        let name = format!("table_{i:0>60}");
+                        let def: TableDefinition<u32, Vec<u8>> = TableDefinition::new(&name);
+                        let _ = txn.delete_table(def).unwrap();
+                    }
+                }
+            }
+            if let Some(sp) = ephemeral {
+                if round % 4 == 0 {
+                    txn.restore_savepoint(&sp).unwrap();
+                }
+                drop(sp);
+            }
+            if round == 6 {
+                for id in persistent_ids.drain(..) {
+                    txn.delete_persistent_savepoint(id).unwrap();
+                }
+            }
+            txn.commit().unwrap();
+            if round == 5 {
+                let abort_txn = db.begin_write().unwrap();
+                let _doomed = abort_txn.persistent_savepoint().unwrap();
+                abort_txn.abort().unwrap();
+            }
+        }
+        drop(db);
+        Arc::try_unwrap(log).unwrap().into_inner().unwrap()
+    }
+
+    let first = run_workload();
+    let second = run_workload();
+    assert_eq!(
+        first, second,
+        "identical operation sequences must produce identical backend write sequences"
+    );
+}


### PR DESCRIPTION
Commits drain `pending_table_updates` from a `HashMap`, so the order in which closed tables' roots are flushed — and with it the pages a commit allocates and the resulting file bytes — varies between executions of an identical operation sequence.

The variation doesn't show up in simple workloads: a single commit creating many tables produces identical bytes because the updates land in loop order on fresh pages. It surfaces once the allocator has history — the included test (several commits over ~120 tables with key churn, removals, table drops, and savepoint operations) reliably produces differing write streams on master before this change, and the same effect reproduces on 4.1.0.

Storing the pending updates in a `BTreeMap` makes the flush order deterministic by construction; the test's two identical executions then record byte-identical backend write sequences.

I also audited the remaining `RandomState` iterations for write-stream visibility: savepoint-abort tracker deallocation and non-durable ancestor refcount decrements are order-invariant, relocation maps are built in tree-visit order and consumed by lookup only, and the rest are debug-only output. The savepoint paths are additionally covered empirically by the test's ephemeral-restore / persistent-create-delete / aborted-creator weave.

Motivation: we're building deterministic simulation testing on top of `StorageBackend` (seed-replayable crash and fault exploration in the FoundationDB/TigerBeetle tradition), which needs identical operation sequences to produce identical write streams so that torn-write outcomes replay exactly from a seed. Deterministic commits also help differential testing and reproducible database artifacts generally.