### PR TITLE
Defer non-durable commits' freed-page records to the next durable commit

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1102,6 +1102,12 @@ impl Database {
             mem.mark_page_allocated(page);
             Ok(())
         })?;
+        // Non-durable commits hold their data-freed records in memory rather than in
+        // DATA_FREED_TABLE, so the walk above does not reach those pages. They are still allocated
+        // until a commit processes the records, so mark them like any other freed-table page.
+        for page in mem.unpersisted_data_freed_pages() {
+            mem.mark_page_allocated(page);
+        }
         #[cfg(debug_assertions)]
         {
             Self::check_repaired_allocated_pages_table(system_root, mem.clone())?;

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -907,6 +907,9 @@ pub struct WriteTransaction {
     shrink_policy: ShrinkPolicy,
     quick_repair: bool,
     post_commit_free: PostCommitFree,
+    // Set by a savepoint restore, to discard the in-memory freed-page records of the non-durable
+    // commits it rolled back. Kept transaction-local so that an abort leaves them in place.
+    restored_transaction: Option<TransactionId>,
     // All transaction-local savepoint lifecycle state. See
     // `SavepointTransactionState` for the commit/abort contract.
     savepoint_state: Mutex<SavepointTransactionState>,
@@ -943,6 +946,7 @@ impl WriteTransaction {
             two_phase_commit: false,
             quick_repair: false,
             post_commit_free: PostCommitFree::Enabled,
+            restored_transaction: None,
             shrink_policy: ShrinkPolicy::Default,
             savepoint_state: Mutex::new(SavepointTransactionState::default()),
         })
@@ -1405,6 +1409,8 @@ impl WriteTransaction {
             }
         }
 
+        self.restored_transaction = Some(savepoint.get_transaction_id());
+
         Ok(())
     }
 
@@ -1649,10 +1655,27 @@ impl WriteTransaction {
             self.two_phase_commit = true;
         }
 
+        // The rolled-back commits' pages are queued for freeing by restore_savepoint(), so their
+        // deferred records must not also be written out by a durable commit.
+        if let Some(transaction_id) = self.restored_transaction {
+            self.mem.drop_unpersisted_data_freed_after(transaction_id);
+        }
+
         let (user_root, allocated_pages, data_freed) =
             self.tables.lock().unwrap().table_tree.flush_and_close()?;
 
-        let stored_data_freed_pages = self.store_data_freed_pages(data_freed)?;
+        // A non-durable commit keeps its freed-page records in memory rather than writing them to
+        // DATA_FREED_TABLE, which would mutate the system tree on every commit. durable_commit()
+        // writes the accumulated records out.
+        let stored_data_freed_pages = match self.durability {
+            InternalDurability::None => {
+                let stored_pages = !data_freed.is_empty();
+                self.mem
+                    .record_unpersisted_data_freed(self.transaction_id, data_freed);
+                stored_pages
+            }
+            InternalDurability::Immediate => self.store_data_freed_pages(data_freed)?,
+        };
 
         #[cfg(feature = "logging")]
         debug!(
@@ -1703,8 +1726,19 @@ impl WriteTransaction {
             .apply_on_commit(&self.transaction_tracker);
     }
 
-    fn store_data_freed_pages(&self, mut freed_pages: Vec<PageNumber>) -> Result<bool> {
+    fn store_data_freed_pages(&self, freed_pages: Vec<PageNumber>) -> Result<bool> {
         let stored_pages = !freed_pages.is_empty();
+        // Open the table even when there is nothing to store: creating it lazily later would put
+        // its metadata pages outside the baseline state that the initial cleanup commit captures.
+        self.store_data_freed_pages_for(self.transaction_id, freed_pages)?;
+        Ok(stored_pages)
+    }
+
+    fn store_data_freed_pages_for(
+        &self,
+        transaction_id: TransactionId,
+        mut freed_pages: Vec<PageNumber>,
+    ) -> Result {
         let mut system_tables = self.system_tables.lock().unwrap();
         let mut freed_table = system_tables.open_system_table(self, DATA_FREED_TABLE)?;
         let mut pagination_counter = 0;
@@ -1714,7 +1748,7 @@ impl WriteTransaction {
             let chunk_size = 400;
             let buffer_size = PageList::required_bytes(chunk_size);
             let key = TransactionIdWithPagination {
-                transaction_id: self.transaction_id.raw_id(),
+                transaction_id: transaction_id.raw_id(),
                 pagination_id: pagination_counter,
             };
             let mut access_guard = freed_table.insert_reserve(&key, buffer_size)?;
@@ -1738,7 +1772,7 @@ impl WriteTransaction {
             pagination_counter += 1;
         }
 
-        Ok(stored_pages)
+        Ok(())
     }
 
     // Flushes this transaction's data-tree allocations to DATA_ALLOCATED_TABLE, along with any
@@ -1868,6 +1902,12 @@ impl WriteTransaction {
         user_root: Option<BtreeHeader>,
         allocated_pages: Vec<PageNumber>,
     ) -> Result {
+        // Write out the freed-page records that earlier non-durable commits kept in memory, so
+        // that they survive from here on like any other durable record.
+        for (transaction_id, pages) in self.mem.take_unpersisted_data_freed() {
+            self.store_data_freed_pages_for(transaction_id, pages)?;
+        }
+
         let free_until_transaction = self
             .transaction_tracker
             .oldest_live_read_transaction()
@@ -2324,9 +2364,16 @@ impl WriteTransaction {
         // We assume below that PageNumber is length 8
         assert_eq!(PageNumber::serialized_size(), 8);
 
-        // Handle the data freed tree
+        // Data-tree records are held in memory by non-durable commits, so process them there
+        let oldest_unprocessed = self
+            .transaction_tracker
+            .oldest_unprocessed_non_durable_commit()
+            .unwrap_or(free_until);
         let mut processed =
-            self.process_freed_pages_nondurable_helper(free_until, DATA_FREED_TABLE)?;
+            self.mem
+                .process_unpersisted_data_freed(oldest_unprocessed, free_until, |page| {
+                    self.mem.free_if_unpersisted(page, &PageTracker::ignore())
+                });
 
         // Handle the system freed tree
         processed

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -351,6 +351,10 @@ struct UnpersistedState {
     allocations: BTreeMap<TransactionId, PageNumberHashSet>,
     // Reverse index into `allocations`
     allocation_txn: PageNumberHashMap<TransactionId>,
+    // Data-tree pages freed per transaction: the in-memory stand-in for DATA_FREED_TABLE. Held
+    // here for the same reason as `allocations` -- the commits that freed them are volatile, so a
+    // crash that loses the records also rolls back the commits they describe.
+    data_freed: BTreeMap<TransactionId, Vec<PageNumber>>,
 }
 
 impl UnpersistedState {
@@ -359,6 +363,7 @@ impl UnpersistedState {
         self.pages.shrink_to_fit();
         self.allocations.clear();
         self.allocation_txn.clear();
+        self.data_freed.clear();
     }
 
     fn contains(&self, page: PageNumber) -> bool {
@@ -418,6 +423,61 @@ impl UnpersistedState {
             .range(transaction_id.next()..)
             .flat_map(|(_, pages)| pages.iter().copied())
             .collect()
+    }
+
+    fn record_data_freed(&mut self, transaction_id: TransactionId, pages: Vec<PageNumber>) {
+        if !pages.is_empty() {
+            self.data_freed
+                .entry(transaction_id)
+                .or_default()
+                .extend(pages);
+        }
+    }
+
+    /// The records of transactions in `start..end`, copied out so that the caller can reclaim
+    /// pages without holding this state locked.
+    fn data_freed_in_range(
+        &self,
+        start: TransactionId,
+        end: TransactionId,
+    ) -> Vec<(TransactionId, Vec<PageNumber>)> {
+        // The bounds are derived independently -- `start` from the oldest unprocessed non-durable
+        // commit, `end` from the oldest live read -- so a live read older than that commit inverts
+        // the range, which BTreeMap::range panics on.
+        if start >= end {
+            return vec![];
+        }
+        self.data_freed
+            .range(start..end)
+            .map(|(id, pages)| (*id, pages.clone()))
+            .collect()
+    }
+
+    /// Replaces a transaction's record with the pages that were not reclaimed, dropping the
+    /// record entirely when none are left.
+    fn replace_data_freed(&mut self, transaction_id: TransactionId, pages: Vec<PageNumber>) {
+        if pages.is_empty() {
+            self.data_freed.remove(&transaction_id);
+        } else {
+            self.data_freed.insert(transaction_id, pages);
+        }
+    }
+
+    fn take_data_freed(&mut self) -> BTreeMap<TransactionId, Vec<PageNumber>> {
+        mem::take(&mut self.data_freed)
+    }
+
+    /// Drops the records of transactions after `transaction_id`, whose commits a savepoint restore
+    /// has discarded.
+    fn drop_data_freed_after(&mut self, transaction_id: TransactionId) {
+        self.data_freed.split_off(&transaction_id.next());
+    }
+
+    /// The pages this state keeps allocated but unreachable from the roots: those freed by a
+    /// non-durable commit and not yet released. An allocator rebuild has to mark them allocated,
+    /// exactly as it does for the pages named by the on-disk freed tables.
+    fn pages_pending_free(&self) -> Vec<PageNumber> {
+        self.data_freed.values().flatten().copied().collect()
     }
 }
 
@@ -1216,6 +1276,62 @@ impl TransactionalMemory {
 
     pub(crate) fn unpersisted(&self, page: PageNumber) -> bool {
         self.unpersisted.lock().unwrap().contains(page)
+    }
+
+    // Record the data-tree pages a non-durable commit freed, for the next durable commit to write
+    // to DATA_FREED_TABLE.
+    pub(crate) fn record_unpersisted_data_freed(
+        &self,
+        transaction_id: TransactionId,
+        pages: Vec<PageNumber>,
+    ) {
+        self.unpersisted
+            .lock()
+            .unwrap()
+            .record_data_freed(transaction_id, pages);
+    }
+
+    // Offers every page freed by a transaction in `start..end` to `free_page`, dropping the ones
+    // it reports having reclaimed. Returns the transactions considered.
+    pub(crate) fn process_unpersisted_data_freed(
+        &self,
+        start: TransactionId,
+        end: TransactionId,
+        mut free_page: impl FnMut(PageNumber) -> bool,
+    ) -> Vec<TransactionId> {
+        // The records are copied out before `free_page` runs, because reclaiming a page locks this
+        // same state. Only the committing write transaction mutates these records, so nothing can
+        // add to a transaction's record in between.
+        let snapshot = self
+            .unpersisted
+            .lock()
+            .unwrap()
+            .data_freed_in_range(start, end);
+        let mut transaction_ids = Vec::with_capacity(snapshot.len());
+        for (transaction_id, pages) in snapshot {
+            let kept: Vec<PageNumber> = pages.into_iter().filter(|p| !free_page(*p)).collect();
+            self.unpersisted
+                .lock()
+                .unwrap()
+                .replace_data_freed(transaction_id, kept);
+            transaction_ids.push(transaction_id);
+        }
+        transaction_ids
+    }
+
+    pub(crate) fn take_unpersisted_data_freed(&self) -> BTreeMap<TransactionId, Vec<PageNumber>> {
+        self.unpersisted.lock().unwrap().take_data_freed()
+    }
+
+    pub(crate) fn drop_unpersisted_data_freed_after(&self, transaction_id: TransactionId) {
+        self.unpersisted
+            .lock()
+            .unwrap()
+            .drop_data_freed_after(transaction_id);
+    }
+
+    pub(crate) fn unpersisted_data_freed_pages(&self) -> Vec<PageNumber> {
+        self.unpersisted.lock().unwrap().pages_pending_free()
     }
 
     pub(crate) fn allocate_helper<'txn>(


### PR DESCRIPTION
Follow-up to #1318, which stopped `Durability::None` commits writing dirty pages to the file. This removes the other per-commit cost: the system-tree mutation that records freed pages.

Every commit records the data-tree pages it freed in `DATA_FREED_TABLE`, so they can be released once no reader needs them. For a non-durable commit that means allocating pages, copying nodes and recomputing checksums in the system tree, on a path that otherwise touches only the data tree and (after #1318) does no I/O at all.

Those records are now kept in memory, keyed by transaction, and written to `DATA_FREED_TABLE` at the start of the next durable commit. This mirrors what redb already does on the allocation side -- non-durable commits record allocations in `UnpersistedState::allocations` rather than `DATA_ALLOCATED_TABLE`, for the same reason: a crash that loses the records also rolls back the commits that produced them, so the two stay consistent. The new records join that state, so they are cleared by the same `clear()` (see #1356).

## What has to account for the records not being on disk

- **Allocator rebuild.** `rebuild_allocator_state()` marks the pages named by the freed tables as allocated, because they are still in use until a commit processes them. It now marks the in-memory records the same way, via `pages_pending_free()`. Without this a repair hands those pages out while a record still names them, and `check_integrity()` reports a healthy database as unclean because the rebuilt allocator no longer matches the live one.
- **Savepoint restore.** A restore discards the commits whose records these are, so the restoring transaction drops them. Tracked transaction-locally, so an abort leaves them in place.
- **Range bounds.** The non-durable path reads its records from memory rather than the table. Its two bounds come from different places -- the oldest unprocessed non-durable commit and the oldest live read -- so a live read older than that commit inverts the range. `BTreeMap::range` panics on that, unlike the table range it replaces, so the empty case is handled explicitly.
- **Lock re-entrancy.** Reclaiming a page locks the same state that holds these records, so `process_unpersisted_data_freed()` copies the records out before running its callback and writes back what was not reclaimed. Holding the lock across the callback self-deadlocks every non-durable commit that frees a page.

Note that only the data-tree records are deferred. The system tree is written by every commit regardless, so `process_freed_pages_nondurable_helper()` still reads `SYSTEM_FREED_TABLE`.

## Benchmarks

20k single-key `Durability::None` commits over a 500k row table, alternating runs on one machine (medians):

| | pre-#1318 | master (#1318 merged) | this PR |
|---|---|---|---|
| overwrites | 1116 ms | 817 ms | **467 ms** |
| fresh inserts | 1235 ms | 915 ms | **559 ms** |

So about **1.7x** on top of master, and about **2.2-2.4x** against master before #1318. The work moves to the next durable commit, which pays for it once.

(An earlier revision of this description quoted ~2.4-2.7x for this PR alone. That came from measuring the original implementation against a base that predated the write-buffer striping and other merged work, and does not hold against current master. The numbers above are same-machine, same-session.)

## Validation

- Full test suite (418 tests), clippy and fmt clean.
- `fuzz_redb` over the corpus: 46,595 runs, no artifacts. Both the range-inversion panic and the lock re-entrancy above were caught by testing rather than inspection -- the first by fuzzing, the second by the non-durable tests hanging -- so the fuzz and test passes here are load-bearing, not a formality.

## Attribution

The approach comes from an independent implementation by Codex on `hitch/redb/20260810170452-04f36b3b`, which paired it with a write-buffer change equivalent to #1318. This port keeps its design and adds the range guard; the read-path cache-pressure reclaim from #1318 is retained, which that branch does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6r1JSUJ54zhBzWoVNxsYx