### PR TITLE
Store minimal key separators in branch nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@
   existing tables report `TableTypeMismatch` and must be migrated. Structs whose fields are
   all built-in types are unaffected.
 
+## 4.3.0 - 2026-XX-XX
+* Add `Key::separator()`, which returns a short slice that separates two keys. Internal btree
+  nodes store the result instead of a whole key, so more children fit in each node and lookups
+  touch fewer pages. The default implementation returns a whole key, leaving existing `Key`
+  implementations unchanged; `&[u8]` keys now store minimal prefixes.
+
 ## 4.2.0 - 2026-08-17
 
 ### New features

--- a/docs/design.md
+++ b/docs/design.md
@@ -230,8 +230,11 @@ only after a clean shutdown; the latter is usable even after a crash.
 ## B+tree pages
 
 redb stores data in a B+tree, in which only leaf pages contain key-value pairs; branch pages
-contain only routing keys and pointers to their children. Allocated pages may therefore be of two
-types: B+tree branch pages, or B+tree leaf pages. The format of each is described below:
+contain only routing keys and pointers to their children. A routing key sorts at or above every key
+in the child before it, and below every key in the child after it. Routing keys are never
+deserialized, so they may be prefixes rather than full keys that exist in the tree. Allocated pages
+may therefore be of two types: B+tree branch pages, or B+tree leaf pages. The format of each is
+described below:
 
 ### Branch page:
 * 1 byte: type

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -1261,7 +1261,7 @@ impl<K: Key, V: Value> Btree<K, V> {
                                 let child = accessor.child_page(i).unwrap();
                                 next_children.push(self.mem.get_page(child, self.hint)?);
                             }
-                            accessor.print_node::<K>();
+                            accessor.print_node();
                         }
                         _ => unreachable!(),
                     }

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -27,6 +27,29 @@ pub(super) type Checksum = u128;
 // Dummy value. Final value will be computed during commit
 pub(super) const DEFERRED: Checksum = 999;
 
+// The key to store in a branch node between a child whose greatest key is `left` and the next,
+// whose least key is `right`. Branch keys only route lookups -- they are compared, never
+// deserialized -- so a `Key` implementation may shorten them, which packs more children into each
+// branch page.
+pub(super) fn branch_separator<'a, K: Key>(left: &'a [u8], right: &'a [u8]) -> &'a [u8] {
+    debug_assert!(K::compare(left, right).is_lt());
+    // Branch keys of a fixed width type are stored at that stride, so a shorter separator would
+    // corrupt the page, and a same width one would save nothing. Never ask for one.
+    if K::fixed_width().is_some() {
+        return left;
+    }
+    let separator = K::separator(left, right);
+    debug_assert!(
+        K::compare(left, separator).is_le(),
+        "separator sorts below the left child's greatest key"
+    );
+    debug_assert!(
+        K::compare(separator, right).is_lt(),
+        "separator does not sort below the right child's least key"
+    );
+    separator
+}
+
 pub(super) fn leaf_checksum<T: Page>(
     page: &T,
     fixed_key_size: Option<usize>,
@@ -873,7 +896,10 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
         )
     }
 
-    pub(super) fn build_split<'txn>(self) -> Result<(PageMut<'txn>, &'a [u8], PageMut<'txn>)> {
+    // Returns the two halves, and the separator to store between them in their parent
+    pub(super) fn build_split<'txn, K: Key>(
+        self,
+    ) -> Result<(PageMut<'txn>, &'a [u8], PageMut<'txn>)> {
         let total_size = self.total_key_bytes + self.total_value_bytes;
         let mut division = 0;
         let mut first_split_key_bytes = 0;
@@ -937,7 +963,8 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
         }
         drop(builder);
 
-        Ok((page1, self.pairs[division - 1].0, page2))
+        let separator = branch_separator::<K>(self.pairs[division - 1].0, self.pairs[division].0);
+        Ok((page1, separator, page2))
     }
 
     pub(super) fn build<'txn>(self) -> Result<PageMut<'txn>> {
@@ -1797,7 +1824,7 @@ impl<'a: 'b, 'b, T: Page + 'a> BranchAccessor<'a, 'b, T> {
     }
 
     #[cfg(not(redb_no_std))]
-    pub(super) fn print_node<K: Key>(&self) {
+    pub(super) fn print_node(&self) {
         eprint!(
             "Internal[ (page={:?}), child_0={:?}",
             self.page.get_page_number(),
@@ -1805,8 +1832,9 @@ impl<'a: 'b, 'b, T: Page + 'a> BranchAccessor<'a, 'b, T> {
         );
         for i in 0..(self.count_children() - 1) {
             if let Some(child) = self.child_page(i + 1) {
+                // Branch keys are separators, which need not be valid encodings of the key type
                 let key = self.key(i).unwrap();
-                eprint!(" key_{i}={:?}", K::from_bytes(key));
+                eprint!(" key_{i}={key:?}");
                 eprint!(" child_{}={child:?}", i + 1);
             }
         }
@@ -2348,6 +2376,72 @@ mod tests {
         assert_eq!(accessor.last_entry().key(), key);
     }
 
+    // A split promotes a separator, not the left half's greatest key, so the parent stores only
+    // enough of the boundary to route between the halves
+    #[test]
+    fn leaf_split_promotes_separator() {
+        let page_allocator = make_allocator();
+        let allocated_pages = PageTracker::new_tracking();
+        let value = vec![0u8; page_allocator.get_page_size() / 2];
+        let mut builder = LeafBuilder::new(&page_allocator, &allocated_pages, 2, None, None);
+        builder.push(b"abc0-left", &value);
+        builder.push(b"abc1-right", &value);
+        assert!(builder.should_split());
+
+        let (_, separator, _) = builder.build_split::<&[u8]>().unwrap();
+        assert_eq!(separator, b"abc1");
+    }
+
+    // Branch keys of a fixed width type are stored at that stride, so a `Key` implementation that
+    // returns a shorter separator must not be able to corrupt the page
+    #[test]
+    fn fixed_width_keys_ignore_custom_separators() {
+        #[derive(Debug)]
+        struct BadSeparator;
+
+        impl Value for BadSeparator {
+            type SelfType<'a> = u64;
+            type AsBytes<'a> = [u8; 8];
+
+            fn fixed_width() -> Option<usize> {
+                Some(8)
+            }
+
+            // Only the width and the ordering are needed to pick a separator
+            fn from_bytes<'a>(_data: &'a [u8]) -> u64
+            where
+                Self: 'a,
+            {
+                unreachable!()
+            }
+
+            fn as_bytes<'a, 'b: 'a>(_value: &'a u64) -> [u8; 8]
+            where
+                Self: 'b,
+            {
+                unreachable!()
+            }
+
+            fn type_name() -> crate::TypeName {
+                unreachable!()
+            }
+        }
+
+        impl Key for BadSeparator {
+            fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+                data1.cmp(data2)
+            }
+
+            fn separator<'a>(_left: &'a [u8], right: &'a [u8]) -> &'a [u8] {
+                &right[..1]
+            }
+        }
+
+        let left = [1u8; 8];
+        let right = [2u8; 8];
+        assert_eq!(branch_separator::<BadSeparator>(&left, &right), left);
+    }
+
     // Splitting divides by total bytes, which can be arbitrarily lopsided when one pair
     // contains a huge value. Neither half may end up with more than u16::MAX pairs
     #[test]
@@ -2371,7 +2465,7 @@ mod tests {
             builder.push(key, &[]);
         }
         assert!(builder.should_split());
-        let (page1, _, page2) = builder.build_split().unwrap();
+        let (page1, _, page2) = builder.build_split::<u64>().unwrap();
 
         let accessor1 = LeafAccessor::new(page1.memory(), u64::fixed_width(), None);
         let accessor2 = LeafAccessor::new(page2.memory(), u64::fixed_width(), None);
@@ -2401,7 +2495,7 @@ mod tests {
         }
         // The pairs are tiny, so the leaf fits in the page by bytes; only the count forces a split.
         assert!(builder.should_split());
-        let (page1, _, page2) = builder.build_split().unwrap();
+        let (page1, _, page2) = builder.build_split::<u64>().unwrap();
 
         let accessor1 = LeafAccessor::new(page1.memory(), u64::fixed_width(), None);
         let accessor2 = LeafAccessor::new(page2.memory(), u64::fixed_width(), None);

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -2,8 +2,8 @@
 use crate::tree_store::btree_base::RawBranchBuilder;
 use crate::tree_store::btree_base::{
     BRANCH, BranchAccessor, BranchBuilder, BranchMutator, Checksum, DEFERRED, LEAF, LeafAccessor,
-    LeafBuilder, LeafMutator, OwnedEntryBuffer, is_single_large_value, leaf_below_merge_threshold,
-    leaf_split_required, retained_after_removals,
+    LeafBuilder, LeafMutator, OwnedEntryBuffer, branch_separator, is_single_large_value,
+    leaf_below_merge_threshold, leaf_split_required, retained_after_removals,
 };
 use crate::tree_store::btree_mutator::DeletionResult::{
     DeletedBranch, DeletedSubtree, PartialBranch, PartialLeaf, Subtree,
@@ -62,9 +62,10 @@ impl DeletedPairs {
     }
 }
 
-// A page produced while splicing an insert run into the tree, with its
-// subtree's greatest key. The key is None only for the node whose subtree
-// contains the tree's original last entry, which stays last at every level.
+// A page produced while splicing an insert run into the tree, with a bound on
+// its subtree: a separator no less than the subtree's greatest key. The bound
+// is None when the parent's stored separator still covers the subtree, which
+// includes the node holding the tree's original last entry.
 #[cfg(feature = "experimental_cursor")]
 type SplicedNode = (PageNumber, Checksum, Option<Vec<u8>>);
 
@@ -255,8 +256,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
 
     // Replaces the contiguous `replaced_children` range of the leaf path's
     // parent branch with packed leaves built from `entries`, then rebuilds the
-    // rest of the path. Each replacement's separator is its own greatest key;
-    // separators for preserved children are reused from the original branch.
+    // rest of the path. Separators for preserved children are reused from the
+    // original branch.
     pub(super) fn replace_leaf_children(
         &mut self,
         mut path: Vec<(PageImpl, usize)>,
@@ -329,7 +330,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 );
                 // Preserved children reuse their original checksum and
                 // separator; freshly built replacements have a deferred
-                // checksum and their greatest key as separator.
+                // checksum and the separators computed above.
                 let preserved = |i: usize| {
                     (
                         accessor.child_page(i).unwrap(),
@@ -382,10 +383,10 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
     }
 
     // Packs the buffered entries into full leaves, in key order, returning
-    // each page with its greatest key as separator. No cleanup on error: any
-    // failure here has latched the storage layer's io_failed flag, which
-    // blocks every later commit, so pages already built are transient
-    // in-memory state reclaimed on rollback.
+    // each page with its separator. No cleanup on error: any failure here has
+    // latched the storage layer's io_failed flag, which blocks every later
+    // commit, so pages already built are transient in-memory state reclaimed
+    // on rollback.
     fn build_replacement_leaves(
         &self,
         buffer: &OwnedEntryBuffer,
@@ -451,14 +452,21 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             }
             builder
         };
-        // Build the planned pages; each separator key is its page's greatest key.
+        // Build the planned pages. Every page but the last is separated from the one that follows
+        // it; the last has no successor here, so it falls back to its greatest key, which
+        // separates it from whatever the caller places after it.
         let mut leaves = vec![];
-        for range in &plan {
+        for (index, range) in plan.iter().enumerate() {
             let page = fill(range).build()?;
-            leaves.push((page.get_page_number(), entries[range.end - 1].0.to_vec()));
+            let last_key = entries[range.end - 1].0;
+            let separator = match plan.get(index + 1).or(balance_tail.as_ref()) {
+                Some(next) => branch_separator::<K>(last_key, entries[next.start].0),
+                None => last_key,
+            };
+            leaves.push((page.get_page_number(), separator.to_vec()));
         }
         if let Some(range) = balance_tail {
-            let (page1, split_key, page2) = fill(&range).build_split()?;
+            let (page1, split_key, page2) = fill(&range).build_split::<K>()?;
             leaves.push((page1.get_page_number(), split_key.to_vec()));
             leaves.push((page2.get_page_number(), entries[range.end - 1].0.to_vec()));
         }
@@ -487,7 +495,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         let leaves = self.build_replacement_leaves(entries)?;
         let mut nodes: Vec<SplicedNode> = leaves
             .into_iter()
-            .map(|(page, greatest_key)| (page, DEFERRED, Some(greatest_key)))
+            .map(|(page, bound)| (page, DEFERRED, Some(bound)))
             .collect();
         // Freed only after every fallible step, so an error never leaves the
         // surviving root referencing a freed page.
@@ -495,8 +503,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         if let Some((path, replaced_leaf)) = replaced {
             removed_pages.push(replaced_leaf);
             for (page, child_index) in path.into_iter().rev() {
-                // Once the replacement has collapsed to a single node whose
-                // stored separator is still exact, the remaining ancestors
+                // Once the replacement has collapsed to a single node that the
+                // stored separator still routes to, the remaining ancestors
                 // need only their child pointer replaced. This shares the
                 // deletion path's pointer swap, whose in-place write for
                 // uncommitted pages keeps repeated flushes from rebuilding
@@ -504,15 +512,20 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                 if nodes.len() == 1 {
                     let accessor = BranchAccessor::new(&page, K::fixed_width());
                     let stored = accessor.key(child_index);
-                    let separator = nodes[0].2.as_deref();
-                    // Exact when the node kept its subtree's original bound
-                    // (None), when the stored separator already equals the
-                    // new bound, or when the slot is the branch's last child
-                    // and stores no separator at all.
-                    if separator.is_none() || stored.is_none() || stored == separator {
+                    let bound = nodes[0].2.as_deref();
+                    // Still routing when the node kept its subtree's original
+                    // bound (None), when the slot is the branch's last child
+                    // and stores no separator at all, or when the new bound
+                    // has not risen above the stored separator.
+                    let routes = match (stored, bound) {
+                        (None, _) | (_, None) => true,
+                        (Some(stored), Some(bound)) => K::compare(bound, stored).is_le(),
+                    };
+                    if routes {
                         // With no stored separator, a raised bound must keep
-                        // propagating; a matching stored separator proves the
-                        // bound unchanged, which None expresses upward.
+                        // propagating; a stored separator that still routes
+                        // leaves this subtree's bound unchanged as its parent
+                        // sees it, which None expresses upward.
                         let carried = if stored.is_none() {
                             core::mem::take(&mut nodes[0].2)
                         } else {
@@ -557,19 +570,18 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
         let accessor = BranchAccessor::new(parent, K::fixed_width());
         let count = accessor.count_children();
         assert!(child_index < count);
-        // A replacement ending in None kept the replaced subtree's original
-        // last entry, whose key the lower level does not store: this level's
-        // separator for the slot is exactly that unchanged bound. It stays
-        // None only for the parent's own last child, so after this, None
-        // appears only at the end of the level.
+        // A replacement ending in None is still covered by what this level
+        // stores for the slot, so that separator is its bound. It stays None
+        // only for the parent's own last child, so after this, None appears
+        // only at the end of the level.
         if let Some(last) = replacement.last_mut()
             && last.2.is_none()
         {
             last.2 = accessor.key(child_index).map(<[u8]>::to_vec);
         }
         // Preserved children keep their checksum, and reuse the original
-        // separator as their greatest key; only the original last child's is
-        // unknown (None), and it stays last through every rebuild above.
+        // separator as their bound; only the original last child's is unknown
+        // (None), and it stays last through every rebuild above.
         let preserved = |i: usize| {
             (
                 accessor.child_page(i).unwrap(),
@@ -763,11 +775,13 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     let offset = new_page_accessor.offset_of_first_value();
                     let guard = AccessGuardMutInPlace::new(new_page, offset, value.len());
                     return if position == 0 {
+                        let split_key =
+                            branch_separator::<K>(key, accessor.entry(0).unwrap().key()).to_vec();
                         Ok(InsertionResult {
                             new_root: new_page_number,
                             root_checksum: DEFERRED,
                             additional_sibling: Some((
-                                key.to_vec(),
+                                split_key,
                                 page.get_page_number(),
                                 page_checksum,
                             )),
@@ -775,7 +789,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                             old_value: None,
                         })
                     } else {
-                        let split_key = accessor.last_entry().key().to_vec();
+                        let split_key =
+                            branch_separator::<K>(accessor.last_entry().key(), key).to_vec();
                         Ok(InsertionResult {
                             new_root: page.get_page_number(),
                             root_checksum: page_checksum,
@@ -882,7 +897,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         self.page_allocator.get_page_size(),
                     )
                 {
-                    let split_key = accessor.last_entry().key().to_vec();
+                    let split_key =
+                        branch_separator::<K>(accessor.last_entry().key(), key).to_vec();
                     let mut builder = LeafBuilder::new(
                         self.page_allocator,
                         self.allocated,
@@ -960,7 +976,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         old_value: existing_value,
                     }
                 } else {
-                    let (new_page1, split_key, new_page2) = builder.build_split()?;
+                    let (new_page1, split_key, new_page2) = builder.build_split::<K>()?;
                     let split_key = split_key.to_vec();
                     let page_number = page.get_page_number();
                     let existing_value = if found {
@@ -1620,7 +1636,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                             );
                         }
                         if child_builder.should_split() {
-                            let (new_page1, split_key, new_page2) = child_builder.build_split()?;
+                            let (new_page1, split_key, new_page2) =
+                                child_builder.build_split::<K>()?;
                             builder.push_key(split_key);
                             builder.push_child(new_page1.get_page_number(), DEFERRED);
                             builder.push_child(new_page2.get_page_number(), DEFERRED);

--- a/src/types.rs
+++ b/src/types.rs
@@ -216,6 +216,23 @@ pub trait Key: Value {
     ///
     /// The implementation must ensure there is a total order
     fn compare(data1: &[u8], data2: &[u8]) -> Ordering;
+
+    /// Returns a separator between `left` and `right`.
+    ///
+    /// `left` and `right` are encoded values for which [`compare()`](Self::compare) returns
+    /// [`Ordering::Less`]. The result must be greater than or equal to `left`, and less than
+    /// `right`, under [`compare()`](Self::compare).
+    ///
+    /// The result is only used to route lookups through the btree's internal nodes: it is passed
+    /// to [`compare()`](Self::compare), and never to [`Value::from_bytes()`], so it need not be a
+    /// valid encoding of `Self`. The shorter it is, the more children fit in each internal node,
+    /// which makes the tree shallower and cheaper to search.
+    ///
+    /// The default implementation returns `left`, which is always valid.
+    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> &'a [u8] {
+        debug_assert!(Self::compare(left, right).is_lt());
+        left
+    }
 }
 
 impl Value for () {
@@ -408,6 +425,21 @@ impl Value for &[u8] {
 impl Key for &[u8] {
     fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
         data1.cmp(data2)
+    }
+
+    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> &'a [u8] {
+        debug_assert!(left < right);
+        // Truncating `right` just past the first byte where it exceeds `left` leaves something
+        // greater than `left`, and less than `right` as long as bytes were dropped. When that is
+        // no shorter than `left`, `left` itself is the shortest: anything shorter shares fewer
+        // bytes with `left` than `left` and `right` do, so it sorts either below `left` or above
+        // `right`.
+        let separator_len = left.iter().zip(right).take_while(|(x, y)| x == y).count() + 1;
+        if separator_len < left.len() && separator_len < right.len() {
+            &right[..separator_len]
+        } else {
+            left
+        }
     }
 }
 
@@ -755,6 +787,35 @@ mod tests {
                 type_name == TypeName::new(type_name.name())
             );
         }
+    }
+
+    #[test]
+    fn byte_slice_separator() {
+        // (left, right, the shortest slice that separates them)
+        let cases: &[(&[u8], &[u8], &[u8])] = &[
+            (b"abc0suffix", b"abc1suffix", b"abc1"),
+            // Nothing is shorter than `left` and still above it
+            (b"abc", b"abd-suffix", b"abc"),
+            (b"abc", b"abc-suffix", b"abc"),
+            (b"\x01\xff", b"\x02\x00", b"\x02"),
+            // Truncating `right` at all would reach `right` itself
+            (b"\x01\xff", b"\x02", b"\x01\xff"),
+            (b"", b"\x00", b""),
+        ];
+
+        for &(left, right, expected) in cases {
+            let separator = <&[u8] as Key>::separator(left, right);
+            assert_eq!(separator, expected);
+            assert!(<&[u8] as Key>::compare(left, separator).is_le());
+            assert!(<&[u8] as Key>::compare(separator, right).is_lt());
+        }
+    }
+
+    #[test]
+    fn default_separator_returns_full_key() {
+        let left = 1u64.to_le_bytes();
+        let right = 2u64.to_le_bytes();
+        assert_eq!(<u64 as Key>::separator(&left, &right), left);
     }
 
     // A user-defined type whose name deliberately collides with the built-in `u32`, and whose

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -3290,6 +3290,78 @@ fn custom_ordering() {
     assert!(iter.next().is_none());
 }
 
+// Branch keys are separators, which need not be valid encodings: nothing may deserialize them
+#[test]
+fn branch_separators_are_not_deserialized() {
+    #[derive(Debug)]
+    struct SeparatorKey;
+
+    impl Value for SeparatorKey {
+        type SelfType<'a> = u64;
+        type AsBytes<'a> = [u8; 8];
+
+        fn fixed_width() -> Option<usize> {
+            None
+        }
+
+        fn from_bytes<'a>(data: &'a [u8]) -> u64
+        where
+            Self: 'a,
+        {
+            assert_eq!(data.len(), 8, "separator passed to from_bytes()");
+            (u64::from(data[0]) << 8) | u64::from(data[1])
+        }
+
+        fn as_bytes<'a, 'b: 'a>(value: &'a u64) -> [u8; 8]
+        where
+            Self: 'b,
+        {
+            let mut result = [0; 8];
+            result[0] = u8::try_from(value >> 8).unwrap();
+            result[1] = *value as u8;
+            result
+        }
+
+        fn type_name() -> TypeName {
+            TypeName::new("test::SeparatorKey")
+        }
+    }
+
+    impl Key for SeparatorKey {
+        fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+            data1.cmp(data2)
+        }
+
+        fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> &'a [u8] {
+            // Every pair of keys differs within the first two bytes, so a separator is always
+            // shorter than the 8 byte encoding, and so always invalid to deserialize
+            let separator = <&[u8] as Key>::separator(left, right);
+            assert!(separator.len() < left.len());
+            separator
+        }
+    }
+
+    const NUM_KEYS: u64 = 1_024;
+    let definition: TableDefinition<SeparatorKey, u64> = TableDefinition::new("separators");
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for i in 0..NUM_KEYS {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(definition).unwrap();
+    assert!(table.stats().unwrap().tree_height() > 1);
+    for i in 0..NUM_KEYS {
+        assert_eq!(table.get(&i).unwrap().unwrap().value(), i);
+    }
+}
+
 #[test]
 fn owned_get_signatures() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
Branch pages only route lookups: their keys are compared against the query, never deserialized. Storing a whole key there is more than routing needs, and for long keys it is most of what a branch page holds -- with 24 byte keys, a separator costs half the bytes a child entry occupies.

This adds `Key::separator()`, which returns a slice that sorts at or above one key and below the next, and stores its result in branch pages instead of the boundary key.

```rust
fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> &'a [u8] { left }
```

The default returns a whole key, so existing `Key` implementations -- including any that assume branch keys are encoded values -- are unaffected. `&[u8]` overrides it to return the next key truncated one byte past the first that distinguishes them. `&str` and `String` deliberately do not: their `compare()` calls `from_bytes()`, so a truncated separator would panic on invalid UTF-8.

Shortness is the motivation rather than part of the contract -- the trait only requires `left <= result < right`, and the default returns a whole key -- so the method is named for what it produces, not for how well.

## Results

For 5M random 24 byte keys with 150 byte values, ~50% more children fit in each branch page, and the tree loses a level:

| | before | after |
|---|---|---|
| tree height | 5 | **4** |
| branch pages | 6134 | 4076 (-33.5%) |
| leaf pages | 324030 | 323774 |

That level is the whole mechanism: one fewer page fetch and binary search per lookup. Over five iterations each:

| | before | after | change |
|---|---|---|---|
| 1M random gets | 2295-2518 ms | 1847-2051 ms | **-17%** |
| 500K x 10 range scans | 1952-2086 ms | 1663-1814 ms | **-13%** |

`redb_benchmark`'s write phases are dominated by leaf writes and I/O and did not move by more than the noise between runs -- a first pair of runs showed removals -9% and compaction -20%, but a second pair did not reproduce it (baseline bulk load alone moved 49.6s to 33.6s between runs), so I would not claim those.

One phase looks consistently **slower**: `pop` by around 15% (582/566 ms to 687/632 ms across both run pairs). Denser branches would explain it -- each rebuild of a branch page now copies more children.

## Implementation notes

Every place that promotes a boundary into a branch goes through one helper, `branch_separator()`, which also enforces what a `Key` implementation cannot be trusted with: branch keys of a fixed width type are stored at that stride, so a shorter separator would corrupt the page. Fixed width types keep using a whole key regardless of what they return.

One path needs more than the two boundary keys to hand. The cursor's splice path compares a stored separator against the greatest key beneath it to decide whether an ancestor needs rebuilding -- previously `stored == separator`, which worked only because the two were the same thing. They no longer are, so that test would almost always say yes, giving up the cheap child-pointer swap for a full spine rebuild. It now asks the question the separator actually answers, whether the replacement's bound still sorts at or below it, which is both correct and true more often than the equality test it replaces.

`build_replacement_leaves()` has no successor for its last page, so that one separator stays a whole key. An earlier revision substituted the branch's stored separator there; it was dropped as not worth its complexity, since the cost is one long separator per rebuilt branch out of ~80.

## Testing

* `cargo test --all-features`: 440 tests pass. `cargo clippy --all-targets --all-features` clean under `--deny warnings`; `cargo fmt --check` clean; both `no_std` / `thumbv7em-none-eabihf` feature combinations compile clean.
* `cargo fuzz run --sanitizer=none fuzz_redb -- -max_len=10000`: 336,972 runs in 901s, no crashes. Note `fuzz_redb`'s table is keyed by `u64`, a fixed width type, so it covers the refactor but not the `&[u8]` separator path.
* A randomized differential test written for that gap: `&[u8]` keys against a `BTreeMap` reference, with keys shaped to stress separators (long shared prefixes, keys that are prefixes of other keys, empty keys, `0x00`/`0xff` runs), mixing insert/remove/`pop_first`/`pop_last`/`retain`/`extract_from_if`, verified by full forward scan, a point get of every key, random ranges, and `check_integrity()`. 140 seeds passed across several campaigns, 22 of them against the final revision, reaching 255K entries and height 4 (three branch levels), with `retain` repeatedly halving a 400K entry table to exercise merges at depth. Emitting a separator one byte too short makes it fail immediately, so it is not vacuous.

New tests cover the `&[u8]` separator's edge cases, that a leaf split promotes a separator rather than the boundary key, that a fixed width key type cannot install a shorter one, and that branch separators are never passed to `Value::from_bytes()`.

The on-disk layout is unchanged -- branch keys were already variable length for variable width key types, and only their contents differ. A whole key is still a valid separator, so existing databases keep working; `tests/backward_compatibility.rs` covers that direction.