### PR TITLE
Add a directory-backed database, behind experimental-multiprocess (1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   be added behind the `experimental_cursor` feature flag, like the table cursors' were.
 
 ## 4.2.0 - 2026-XX-XX
+* Add `MultiProcessDatabase` behind the new `experimental-multiprocess` feature. It stores a
+  database in a directory, alongside the lock file that coordinates the processes using it, and
+  takes its exclusion from that lock file rather than from a lock on the database file. This is the
+  first step of an incomplete feature: only one process may have the database open, so it has no
+  advantage over `Database` yet.
 * `Durability::None` commits are about 2x faster.
 * Commits now flush table root updates in a deterministic order, removing a source of
   nondeterminism that could make identical operation sequences produce differing database files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ experimental_cursor = ["experimental-api-5"]
 # Unstable additions and changes to the public API, planned for redb 5. May change incompatibly, or
 # be removed, in any release
 experimental-api-5 = []
+# Incomplete support for using a database from several processes. May change incompatibly, or be
+# removed, in any release
+experimental-multiprocess = []
 
 [profile.bench]
 debug = true

--- a/docs/design.md
+++ b/docs/design.md
@@ -496,3 +496,42 @@ Therefore, we make only a few assumptions about the guarantees provided by the u
    a range of bytes in a file, no bytes outside of that range will change,
    even if the write occurs just before a crash or power failure. sqlite makes this same
    assumption, by default, in all modern versions.
+
+# Multi-process access (in progress)
+
+`MultiProcessDatabase`, behind the `experimental-multiprocess` feature, stores a database in a
+directory rather than a single file:
+
+| file | contents |
+|------|----------|
+| `data.redb` | the database, in the ordinary redb file format |
+| `write.lock` | empty; held exclusively by the process that has the database open |
+
+The point of the directory is to move exclusion off the database file. An ordinary `Database` takes
+an exclusive advisory lock on the file itself, which is what stops a second process opening it --
+and which also stops any other process reading it. A multi-process database takes an exclusive lock
+on `write.lock`, before it touches anything else in the directory, so that the process which gets
+it has the directory to itself, including while it is being created. That is the lock later steps
+build on: it is what will exclude other *writers* once readers are allowed in.
+
+Until then the database file keeps its ordinary exclusive lock too. `write.lock` is only visible to
+a process that goes through `MultiProcessDatabase`, and one that reaches past the directory to open
+`data.redb` directly would not be looking at it, so the file needs a lock of its own. It has to be
+the exclusive one: a shared lock would let a `ReadOnlyDatabase` in, and nothing yet stops the
+process holding the directory from freeing pages that such a reader is still using. So today the
+restriction is the same as a `Database`'s -- one process, and `DatabaseError::DatabaseAlreadyOpen`
+for the rest -- and the directory is scaffolding rather than a relaxation of it.
+
+That constraint on the database file's lock is worth recording, because it shapes what comes next.
+Making room for readers means *removing* this lock rather than weakening it: on Windows a shared
+range denies writes to every process including the one holding the lock, so a writer cannot hold a
+shared lock on a file it writes to at all. All reader/writer coordination therefore has to live in
+the directory's own lock files.
+
+The lock is held by the storage backend rather than beside the `Database`, because a live write
+transaction keeps the database open past the point where the handle is dropped. A lock released
+when the handle went away would let another process start writing while that transaction was still
+running; tying it to the backend gives it exactly the lifetime of the open file.
+
+A platform without file locking cannot support any of this safely, so opening fails there rather
+than warning and continuing as `Database` does.

--- a/src/db.rs
+++ b/src/db.rs
@@ -1120,7 +1120,7 @@ impl Database {
         root.map(|header| BtreeHeader::new(header.root, header.checksum, length))
     }
 
-    fn new(
+    pub(crate) fn new(
         file: Box<dyn StorageBackend>,
         allow_initialize: bool,
         page_size: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@ pub use error::{
 };
 #[cfg(feature = "experimental-api-5")]
 pub use key_range::KeyRange;
+#[cfg(feature = "experimental-multiprocess")]
+pub use multi_process::{MultiProcessBuilder, MultiProcessDatabase};
 #[cfg(feature = "experimental-api-5")]
 pub use multimap_table::MultimapCursor;
 pub use multimap_table::{
@@ -106,6 +108,8 @@ mod db;
 mod error;
 #[cfg(feature = "experimental-api-5")]
 mod key_range;
+#[cfg(feature = "experimental-multiprocess")]
+mod multi_process;
 mod multimap_table;
 mod sealed;
 mod table;

--- a/src/multi_process/locks.rs
+++ b/src/multi_process/locks.rs
@@ -1,0 +1,196 @@
+//! The files that make up a multi-process database directory, and the lock that excludes other
+//! processes from it.
+//!
+//! Everything in here uses only `std::fs` file operations and the advisory file locks exposed by
+//! `std::fs::File`. See `docs/design.md` for the protocol these files implement.
+
+use crate::tree_store::file_backend::FileBackend;
+use crate::{DatabaseError, StorageBackend, StorageError};
+use std::fs::{File, OpenOptions, TryLockError};
+use std::io;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+const DATA_FILE_NAME: &str = "data.redb";
+const WRITE_LOCK_FILE_NAME: &str = "write.lock";
+
+/// Maps the "this platform has no file locks" case to an error. A multi-process database has no way
+/// to be safe without them, so unlike [`crate::Database`] it refuses to open rather than warning
+/// and continuing.
+fn lock_unsupported(err: io::Error) -> DatabaseError {
+    if err.kind() == ErrorKind::Unsupported {
+        return StorageError::Io(io::Error::new(
+            ErrorKind::Unsupported,
+            "file locking is not supported on this platform, so a multi-process database cannot \
+             be opened safely",
+        ))
+        .into();
+    }
+    StorageError::Io(err).into()
+}
+
+fn open_or_create(path: &Path) -> Result<File, io::Error> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+}
+
+/// The paths that make up a multi-process database directory.
+pub(super) struct DatabaseDir {
+    root: PathBuf,
+}
+
+impl DatabaseDir {
+    pub(super) fn new(root: impl AsRef<Path>) -> Self {
+        Self {
+            root: root.as_ref().to_path_buf(),
+        }
+    }
+
+    fn data_file(&self) -> PathBuf {
+        self.root.join(DATA_FILE_NAME)
+    }
+
+    fn write_lock_file(&self) -> PathBuf {
+        self.root.join(WRITE_LOCK_FILE_NAME)
+    }
+
+    /// Takes the write lock, which excludes every other process from the database. Held for as
+    /// long as this process has it open.
+    ///
+    /// Taken before anything else in the directory is opened, so that a process which gets it has
+    /// the directory to itself -- including while it is being created. The lock file is only made
+    /// when the database is being created: its absence is what tells `open()` that this directory
+    /// is not a multi-process database.
+    fn acquire_write_lock(&self, create: bool) -> Result<File, DatabaseError> {
+        let path = self.write_lock_file();
+        let file = if create {
+            open_or_create(&path)
+        } else {
+            OpenOptions::new().read(true).write(true).open(&path)
+        }
+        .map_err(|err| {
+            if err.kind() == ErrorKind::NotFound {
+                StorageError::Io(io::Error::new(
+                    ErrorKind::NotFound,
+                    "not a multi-process database directory",
+                ))
+            } else {
+                StorageError::Io(err)
+            }
+        })?;
+
+        match file.try_lock() {
+            Ok(()) => Ok(file),
+            Err(TryLockError::WouldBlock) => Err(DatabaseError::DatabaseAlreadyOpen),
+            Err(TryLockError::Error(err)) => Err(lock_unsupported(err)),
+        }
+    }
+
+    /// Opens the directory, creating it if `create` is set, and returns a backend for the database
+    /// file that holds the write lock for as long as the database is open.
+    pub(super) fn open(&self, create: bool) -> Result<Box<dyn StorageBackend>, DatabaseError> {
+        if create {
+            std::fs::create_dir_all(&self.root).map_err(StorageError::Io)?;
+        } else if !self.root.is_dir() {
+            return Err(StorageError::Io(io::Error::new(
+                ErrorKind::NotFound,
+                "no such multi-process database directory",
+            ))
+            .into());
+        }
+
+        let write_lock = self.acquire_write_lock(create)?;
+        let data = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(create)
+            .truncate(false)
+            .open(self.data_file())
+            .map_err(StorageError::Io)?;
+        // The ordinary exclusive lock, the same one a Database takes. The write lock above is what
+        // other multi-process handles look at, but a process that reaches past the directory and
+        // opens this file directly would not be looking at it, so the file needs a lock of its own.
+        // It has to be the exclusive one: a shared lock would let a ReadOnlyDatabase in, and
+        // nothing yet stops this process from freeing pages that such a reader is still using.
+        // Making room for readers is what the later releases in this series are for, and this is
+        // the lock they have to replace
+        let data = FileBackend::new(data)?;
+
+        Ok(Box::new(DirectoryBackend { data, write_lock }))
+    }
+}
+
+/// The database file, plus the write lock that has to outlive it.
+///
+/// The lock is held here rather than alongside the [`crate::Database`] because a live write
+/// transaction keeps the database open past the point where the handle is dropped. A lock released
+/// when the handle went away would let another process start writing while that transaction was
+/// still running. Tying it to the backend gives it exactly the lifetime of the open file: redb
+/// calls `close()` once, when it has really finished.
+#[derive(Debug)]
+struct DirectoryBackend {
+    data: FileBackend,
+    write_lock: File,
+}
+
+impl StorageBackend for DirectoryBackend {
+    fn len(&self) -> Result<u64, io::Error> {
+        self.data.len()
+    }
+
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), io::Error> {
+        self.data.read(offset, out)
+    }
+
+    fn set_len(&self, len: u64) -> Result<(), io::Error> {
+        self.data.set_len(len)
+    }
+
+    fn sync_data(&self) -> Result<(), io::Error> {
+        self.data.sync_data()
+    }
+
+    fn write(&self, offset: u64, data: &[u8]) -> Result<(), io::Error> {
+        self.data.write(offset, data)
+    }
+
+    fn close(&self) -> Result<(), io::Error> {
+        self.data.close()?;
+        self.write_lock.unlock()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn the_write_lock_excludes_other_handles() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = DatabaseDir::new(tmpdir.path().join("db"));
+
+        let first = dir.open(true).unwrap();
+        assert!(matches!(
+            dir.open(false),
+            Err(DatabaseError::DatabaseAlreadyOpen)
+        ));
+
+        // Closing the backend is what releases the lock, since that is when redb has finished
+        // with the file
+        first.close().unwrap();
+        let _second = dir.open(false).unwrap();
+    }
+
+    #[test]
+    fn a_directory_without_a_lock_file_is_not_a_database() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        std::fs::create_dir(&path).unwrap();
+
+        assert!(DatabaseDir::new(&path).open(false).is_err());
+    }
+}

--- a/src/multi_process/mod.rs
+++ b/src/multi_process/mod.rs
@@ -1,0 +1,166 @@
+//! A multi-process safe interface to a redb database.
+//!
+//! **This is the first step of an incomplete feature.** [`MultiProcessDatabase`] currently allows
+//! only one process to have the database open at all -- it establishes the directory layout and
+//! the lock file that later releases relax, so that other processes can read while one writes. Use
+//! [`Database`] until then; this type has no advantage over it yet.
+
+mod locks;
+
+use crate::db::RepairSession;
+use crate::sealed::Sealed;
+use crate::tree_store::PAGE_SIZE;
+use crate::{
+    CacheStats, Database, DatabaseError, ReadTransaction, ReadableDatabase, Result,
+    TransactionError, WriteTransaction,
+};
+use locks::DatabaseDir;
+use std::path::Path;
+
+/// A redb database stored in a directory, alongside the lock files that coordinate the processes
+/// using it.
+///
+/// Use [`Self::begin_read`] to get a [`ReadTransaction`], and [`Self::begin_write`] to get a
+/// [`WriteTransaction`]. Both behave exactly as they do for a [`Database`].
+///
+/// The directory must be on a filesystem that supports file locking, and belongs to redb -- do not
+/// put anything else in it. A second process that opens the same directory fails with
+/// [`DatabaseError::DatabaseAlreadyOpen`], as it would for a [`Database`] on a single file. What
+/// the directory adds so far is a lock file that carries that exclusion, which is what a later
+/// release needs in order to let other processes read while one writes.
+///
+/// # Examples
+///
+/// ```rust
+/// use redb::*;
+/// # use tempfile::TempDir;
+/// const TABLE: TableDefinition<u64, u64> = TableDefinition::new("my_data");
+///
+/// # fn main() -> Result<(), Error> {
+/// # let tmpdir = TempDir::new().unwrap();
+/// # let path = tmpdir.path().join("my_db");
+/// let db = MultiProcessDatabase::create(&path)?;
+/// let write_txn = db.begin_write()?;
+/// {
+///     let mut table = write_txn.open_table(TABLE)?;
+///     table.insert(&0, &0)?;
+/// }
+/// write_txn.commit()?;
+///
+/// let read_txn = db.begin_read()?;
+/// assert_eq!(0, read_txn.open_table(TABLE)?.get_owned(0)?.unwrap().value());
+/// # Ok(())
+/// # }
+/// ```
+pub struct MultiProcessDatabase {
+    inner: Database,
+}
+
+impl MultiProcessDatabase {
+    /// Opens the directory at `path` as a multi-process database, creating it if it does not
+    /// exist.
+    pub fn create(path: impl AsRef<Path>) -> Result<MultiProcessDatabase, DatabaseError> {
+        Self::builder().create(path)
+    }
+
+    /// Opens an existing multi-process database.
+    pub fn open(path: impl AsRef<Path>) -> Result<MultiProcessDatabase, DatabaseError> {
+        Self::builder().open(path)
+    }
+
+    /// Convenience method for [`MultiProcessBuilder::new`]
+    pub fn builder() -> MultiProcessBuilder {
+        MultiProcessBuilder::new()
+    }
+
+    /// Begins a write transaction
+    ///
+    /// Returns a [`WriteTransaction`] which may be used to read/write to the database. Only a
+    /// single write may be in progress at a time. If a write is in progress, this function blocks
+    /// until it completes.
+    pub fn begin_write(&self) -> Result<WriteTransaction, TransactionError> {
+        self.inner.begin_write()
+    }
+}
+
+impl Sealed for MultiProcessDatabase {}
+
+impl ReadableDatabase for MultiProcessDatabase {
+    fn begin_read(&self) -> Result<ReadTransaction, TransactionError> {
+        self.inner.begin_read()
+    }
+
+    fn cache_stats(&self) -> CacheStats {
+        self.inner.cache_stats()
+    }
+}
+
+impl std::fmt::Debug for MultiProcessDatabase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MultiProcessDatabase").finish()
+    }
+}
+
+/// Configuration builder of a [`MultiProcessDatabase`].
+pub struct MultiProcessBuilder {
+    cache_size: usize,
+    repair_callback: Box<dyn Fn(&mut RepairSession)>,
+}
+
+impl MultiProcessBuilder {
+    /// Construct a new [`MultiProcessBuilder`] with sensible defaults.
+    ///
+    /// ## Defaults
+    ///
+    /// - `cache_size_bytes`: 1GiB
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            cache_size: 1024 * 1024 * 1024,
+            repair_callback: Box::new(|_| {}),
+        }
+    }
+
+    /// Set the amount of memory (in bytes) used for caching data
+    pub fn set_cache_size(&mut self, bytes: usize) -> &mut Self {
+        self.cache_size = bytes;
+        self
+    }
+
+    /// Set a callback which will be invoked periodically in the event that the database file needs
+    /// to be repaired. See [`crate::Builder::set_repair_callback`].
+    pub fn set_repair_callback(
+        &mut self,
+        callback: impl Fn(&mut RepairSession) + 'static,
+    ) -> &mut Self {
+        self.repair_callback = Box::new(callback);
+        self
+    }
+
+    /// Opens the directory at `path` as a multi-process database, creating it if it does not exist
+    pub fn create(&self, path: impl AsRef<Path>) -> Result<MultiProcessDatabase, DatabaseError> {
+        self.open_inner(path.as_ref(), true)
+    }
+
+    /// Opens an existing multi-process database
+    pub fn open(&self, path: impl AsRef<Path>) -> Result<MultiProcessDatabase, DatabaseError> {
+        self.open_inner(path.as_ref(), false)
+    }
+
+    fn open_inner(&self, path: &Path, create: bool) -> Result<MultiProcessDatabase, DatabaseError> {
+        let backend = DatabaseDir::new(path).open(create)?;
+        // `create` alone decides whether an empty database file may be initialized, exactly as it
+        // does for a Database, so a create() that made the directory but died before initializing
+        // the database file can be redone
+        let inner = Database::new(
+            backend,
+            create,
+            PAGE_SIZE,
+            None,
+            self.cache_size,
+            &self.repair_callback,
+        )?;
+
+        Ok(MultiProcessDatabase { inner })
+    }
+}

--- a/tests/multi_process_tests.rs
+++ b/tests/multi_process_tests.rs
@@ -1,0 +1,316 @@
+//! Tests for the multi-process database interface.
+//!
+//! At this step the interface allows only one process to have the database open, so what there is
+//! to test is the directory layout and the lock file that enforces that. The lock is exercised
+//! both from a second handle in this process -- file locks belong to the open file description
+//! rather than the process, so a second handle is excluded exactly as a second process is -- and
+//! from a real child process, which is what the lock is ultimately for.
+
+#![cfg(all(feature = "experimental-multiprocess", not(target_os = "wasi")))]
+
+use redb::{
+    Database, DatabaseError, MultiProcessDatabase, ReadOnlyDatabase, ReadableDatabase,
+    TableDefinition, WriteTransaction,
+};
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+fn tempdir() -> TempDir {
+    TempDir::new().unwrap()
+}
+
+fn db_path(dir: &TempDir) -> PathBuf {
+    dir.path().join("db")
+}
+
+fn write(db: &MultiProcessDatabase, key: u64, value: u64) {
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        table.insert(&key, &value).unwrap();
+    }
+    txn.commit().unwrap();
+}
+
+fn read(db: &MultiProcessDatabase, key: u64) -> Option<u64> {
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(TABLE).unwrap();
+    table.get_owned(key).unwrap().map(|value| value.value())
+}
+
+#[test]
+fn create_and_reopen() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    {
+        let db = MultiProcessDatabase::create(&path).unwrap();
+        write(&db, 0, 1);
+        assert_eq!(Some(1), read(&db, 0));
+    }
+
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(1), read(&db, 0));
+    write(&db, 0, 2);
+    drop(db);
+
+    // create() on an existing database opens it rather than starting over
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    assert_eq!(Some(2), read(&db, 0));
+}
+
+#[test]
+fn create_makes_a_directory() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 1);
+
+    assert!(path.join("data.redb").is_file());
+    assert!(path.join("write.lock").is_file());
+}
+
+#[test]
+fn a_second_handle_is_rejected() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 1);
+
+    assert!(matches!(
+        MultiProcessDatabase::open(&path),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+    assert!(matches!(
+        MultiProcessDatabase::create(&path),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+
+    // Once the first handle is gone the directory can be opened again
+    drop(db);
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(1), read(&db, 0));
+}
+
+/// A live write transaction keeps the database open past the point where the handle is dropped, so
+/// the lock has to outlive the handle too -- otherwise another process could start writing while
+/// this transaction is still running.
+#[test]
+fn the_lock_outlives_a_handle_dropped_during_a_write() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 1);
+
+    let txn: WriteTransaction = db.begin_write().unwrap();
+    drop(db);
+
+    assert!(matches!(
+        MultiProcessDatabase::open(&path),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        table.insert(&0, &2).unwrap();
+    }
+    txn.commit().unwrap();
+
+    // ... and is released once the transaction that was keeping it open finishes
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(2), read(&db, 0));
+}
+
+#[test]
+fn opening_something_that_is_not_a_database_fails() {
+    let dir = tempdir();
+    assert!(MultiProcessDatabase::open(dir.path().join("missing")).is_err());
+
+    let empty = dir.path().join("empty");
+    std::fs::create_dir(&empty).unwrap();
+    assert!(MultiProcessDatabase::open(&empty).is_err());
+
+    // A directory holding a plain redb database is not one of these either -- there is no lock
+    // file in it, which is all that identifies one at this step
+    let plain = dir.path().join("plain");
+    std::fs::create_dir(&plain).unwrap();
+    drop(Database::create(plain.join("data.redb")).unwrap());
+    assert!(MultiProcessDatabase::open(&plain).is_err());
+}
+
+#[test]
+fn open_does_not_create() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    assert!(MultiProcessDatabase::open(&path).is_err());
+    assert!(!path.exists());
+}
+
+#[test]
+fn the_builder_configures_the_database() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = MultiProcessDatabase::builder()
+        .set_cache_size(1024 * 1024)
+        .create(&path)
+        .unwrap();
+    write(&db, 0, 1);
+    assert_eq!(Some(1), read(&db, 0));
+}
+
+/// A create() that made the directory but died before the database file was initialized must not
+/// leave the directory permanently unopenable: a later create() finishes the job, exactly as it
+/// would for a `Database` whose file was created and then not written to.
+#[test]
+fn an_interrupted_create_can_be_redone() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    drop(MultiProcessDatabase::create(&path).unwrap());
+    std::fs::write(path.join("data.redb"), []).unwrap();
+
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 1);
+    assert_eq!(Some(1), read(&db, 0));
+}
+
+/// The write lock is invisible to a process that reaches past the directory and opens the database
+/// file itself, so that file carries the ordinary exclusive lock as well. Readers are turned away
+/// along with writers: nothing yet stops the process holding the directory from freeing pages that
+/// a `ReadOnlyDatabase` in another process is still reading.
+#[test]
+fn an_ordinary_database_cannot_open_the_data_file() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 1);
+
+    let data = path.join("data.redb");
+    assert!(matches!(
+        Database::open(&data),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+    assert!(matches!(
+        Database::create(&data),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+    assert!(matches!(
+        ReadOnlyDatabase::open(&data),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+
+    // ... and once the directory is closed the database file is an ordinary redb database again
+    drop(db);
+    assert_eq!(
+        Some(1),
+        ReadOnlyDatabase::open(&data)
+            .unwrap()
+            .begin_read()
+            .unwrap()
+            .open_table(TABLE)
+            .unwrap()
+            .get_owned(0)
+            .unwrap()
+            .map(|value| value.value())
+    );
+}
+
+// --------------------------------------------------------------------------------------------
+// Tests that need a real process
+// --------------------------------------------------------------------------------------------
+
+/// Entry point for the child processes the tests below spawn. Ignored so that it only runs when
+/// named explicitly, and does nothing unless the parent asked for a role.
+#[test]
+#[ignore]
+fn child_process_worker() {
+    let Ok(role) = env::var("REDB_MP_ROLE") else {
+        return;
+    };
+    let path = PathBuf::from(env::var("REDB_MP_PATH").unwrap());
+    match role.as_str() {
+        // Expects to be turned away by the lock the parent holds
+        "rejected" => {
+            assert!(matches!(
+                MultiProcessDatabase::open(&path),
+                Err(DatabaseError::DatabaseAlreadyOpen)
+            ));
+        }
+        // Expects to get in, and leaves a value behind for the parent to find
+        "writer" => {
+            let db = MultiProcessDatabase::open(&path).unwrap();
+            write(&db, 0, 7);
+        }
+        // Opens the database and dies without closing it, leaving the lock to the operating system
+        "crasher" => {
+            let db = MultiProcessDatabase::open(&path).unwrap();
+            write(&db, 0, 9);
+            std::process::abort();
+        }
+        other => panic!("unknown role {other}"),
+    }
+}
+
+fn run_child(role: &str, path: &Path) -> std::process::ExitStatus {
+    Command::new(env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "child_process_worker",
+            "--ignored",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env("REDB_MP_ROLE", role)
+        .env("REDB_MP_PATH", path)
+        .status()
+        .unwrap()
+}
+
+#[test]
+fn a_child_process_cannot_open_a_database_this_one_holds() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 1);
+
+    assert!(run_child("rejected", &path).success());
+
+    // The child's failed open must not have disturbed anything
+    write(&db, 0, 2);
+    assert_eq!(Some(2), read(&db, 0));
+}
+
+#[test]
+fn a_child_process_can_open_a_database_this_one_has_closed() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    {
+        let db = MultiProcessDatabase::create(&path).unwrap();
+        write(&db, 0, 1);
+    }
+
+    assert!(run_child("writer", &path).success());
+
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(7), read(&db, 0));
+}
+
+#[test]
+fn a_process_that_dies_releases_the_lock() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    {
+        let db = MultiProcessDatabase::create(&path).unwrap();
+        write(&db, 0, 1);
+    }
+
+    assert!(!run_child("crasher", &path).success());
+
+    // Nothing has to clean up after it: the operating system dropped its lock when it died
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(9), read(&db, 0));
+    write(&db, 0, 10);
+    assert_eq!(Some(10), read(&db, 0));
+}


### PR DESCRIPTION
**This PR was 1.4k lines and has been split into three.** This one is now just the directory and the lock; the marker and the hardening follow as stacked PRs. Force-pushed, so the earlier review threads show as outdated — the code they point at now lives in #1361 and #1362, and each of those PRs describes the rules those threads produced.

| | what | added |
|---|---|---|
| **1/3** | this PR — the directory and the write lock | 730 |
| 2/3 | #1361 — the `metadata` marker | 479 |
| 3/3 | #1362 — refusing directories that are not redb&#39;s | 610 |

---

redb takes an exclusive advisory lock on the database file to stop a second process opening it. That also stops any other process *reading* it, which is what has to change before a database can be shared: the exclusion has to move somewhere the file itself is not.

This adds `MultiProcessDatabase`, which stores the database in a directory:

| file | contents |
|------|----------|
| `data.redb` | the database, in the ordinary redb file format |
| `write.lock` | empty; held exclusively by the process that has it open |

Today that is the same restriction by a different mechanism -- one process at a time, `DatabaseError::DatabaseAlreadyOpen` for the rest -- so **this type has no advantage over `Database` yet**. It is the first step of an incomplete feature, and sits behind the new `experimental-multiprocess` feature flag until the rest of it lands: recognizing a directory as one of these (#1361), refusing directories that are not (#1362), and then the actual point of the exercise -- readers attaching to a database another process is writing, and handing the writer role between processes.

## Where the lock lives

The lock is held by the storage backend rather than alongside the `Database`. A live write transaction keeps the database open past the point where the `Database` is dropped, so a lock held by the handle would be released while that transaction was still writing, and another process could start writing too. Tying it to the backend gives it exactly the lifetime of the open file: it is released by `close()`, which redb calls once, when it has really finished with the file.

`the_lock_outlives_a_handle_dropped_during_a_write` covers this. Moving the lock onto the handle -- the obvious placement -- makes that test fail and no other.

## The database file keeps its own lock, for now

`write.lock` is only visible to a process that goes through `MultiProcessDatabase`. A process that reaches past the directory and opens `data.redb` directly would not be looking at it, so the file still takes the ordinary exclusive lock as well.

It has to be the exclusive one rather than a shared one, for two reasons. A shared lock would let a `ReadOnlyDatabase` in, and nothing here yet stops this process from freeing pages that such a reader is still using -- readers are only safe once they can publish what they are reading, which is a later step. And on Windows a shared range denies writes to every process *including* the one holding the lock, so a writer cannot hold one on a file it writes to at all.

That second point constrains what comes next, so `docs/design.md` records it: making room for readers means *removing* this lock, not weakening it, and all reader/writer coordination has to live in the directory&#39;s separate lock files.

## Other notes

* At this step a directory is identified by having a `write.lock` in it. #1361 replaces that with an explicit marker, which is also what gives the layout a version to change later.
* A platform without file locking cannot support this safely, so opening fails there rather than warning and continuing as `Database` does.
* The transaction layer is untouched: `transaction_tracker.rs`, `transactions.rs`, `page_manager.rs` and `header.rs` have no changes, and neither do the file backends. The whole thing sits on top of the existing `Database`.

## Testing

12 integration tests plus 2 unit tests, including real child processes for the cases the lock exists for: a child refused while this process holds the database, a child opening it after this one closes, and a child that dies without closing -- where the operating system drops the lock and nothing has to clean up.

`cargo build`, `cargo clippy --all-targets` and the full test suite pass both with `--all-features` and with default features, and clippy is checked against `x86_64-pc-windows-msvc` as well, since this crate denies `clippy::pedantic` and some of the later parts are platform-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJFSfcturbVcnPqY5CNzQv

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJFSfcturbVcnPqY5CNzQv)_