### PR TITLE
Copy and patch B-tree pages whose layout is unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ## 4.2.0 - 2026-XX-XX
 * `Durability::None` commits are about 2x faster.
+* Writes that do not split a page are faster: about 15% for single-key `Durability::None` commits,
+  and about 6% for batched writes.
 * Commits now flush table root updates in a deterministic order, removing a source of
   nondeterminism that could make identical operation sequences produce differing database files
 * Add a `std` feature, enabled by default, in preparation for a future `no_std` mode. It gates

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -835,6 +835,37 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     });
                 }
 
+                // A same-size replacement leaves every leaf offset unchanged. Preserve copy-on-
+                // write by cloning the committed page, then patch only the value bytes.
+                if found && accessor.entry(position).unwrap().value().len() == value.len() {
+                    let page_number = page.get_page_number();
+                    // Only committed pages reach here: sufficient_replace_inplace_space() is
+                    // always satisfied when the value length is unchanged, so an uncommitted
+                    // page took the in-place path above.
+                    debug_assert!(!self.page_allocator.uncommitted(page_number));
+                    let (value_start, value_end) = accessor.value_range(position).unwrap();
+                    let mut new_page = self
+                        .page_allocator
+                        .allocate(page.memory().len(), self.allocated)?;
+                    new_page.memory_mut().copy_from_slice(page.memory());
+                    new_page.memory_mut()[value_start..value_end].copy_from_slice(value);
+                    let new_page_number = new_page.get_page_number();
+                    let inserted_value =
+                        AccessGuardMutInPlace::new(new_page, value_start, value.len());
+                    // Deferred, not conditional_free()'d: the old value returned below borrows
+                    // this page, and releasing it now would let the allocator hand it out again
+                    // while that guard is still reading it.
+                    self.freed.push(page_number);
+                    let old_value = AccessGuard::with_page(page, value_start..value_end);
+                    return Ok(InsertionResult {
+                        new_root: new_page_number,
+                        root_checksum: DEFERRED,
+                        additional_sibling: None,
+                        inserted_value,
+                        old_value: Some(old_value),
+                    });
+                }
+
                 // Fast-path for a key greater than every key in the tree, when the rightmost
                 // leaf is too full to take it: leave that leaf packed and start a new one
                 // holding only the new pair. Splitting evenly instead would strand half of a
@@ -1029,7 +1060,32 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     });
                 }
 
-                // A child was added, or we couldn't use the fast-path above
+                // Without a split, only one child pointer and checksum changed. Preserve copy-on-
+                // write by cloning the committed branch, then patch those fields.
+                if sub_result.additional_sibling.is_none() {
+                    let page_number = page.get_page_number();
+                    let mut new_page = self
+                        .page_allocator
+                        .allocate(page.memory().len(), self.allocated)?;
+                    new_page.memory_mut().copy_from_slice(page.memory());
+                    BranchMutator::new(new_page.memory_mut()).write_child_page(
+                        child_index,
+                        sub_result.new_root,
+                        sub_result.root_checksum,
+                    );
+                    let new_page_number = new_page.get_page_number();
+                    drop(page);
+                    self.conditional_free(page_number);
+                    return Ok(InsertionResult {
+                        new_root: new_page_number,
+                        root_checksum: DEFERRED,
+                        additional_sibling: None,
+                        inserted_value: sub_result.inserted_value,
+                        old_value: sub_result.old_value,
+                    });
+                }
+
+                // A child was added, so rebuild the branch and split it if necessary.
                 let mut builder = BranchBuilder::new(
                     self.page_allocator,
                     self.allocated,

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1599,6 +1599,50 @@ fn insert_overwrite() {
 }
 
 #[test]
+fn same_size_overwrite_preserves_snapshot() {
+    const DEFINITION: TableDefinition<u64, [u8; 32]> = TableDefinition::new("x");
+    const ELEMENTS: u64 = 10_000;
+
+    let tmpfile = create_tempfile();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(DEFINITION).unwrap();
+        for key in 0..ELEMENTS {
+            table.insert(&key, &[0; 32]).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let old_read = db.begin_read().unwrap();
+    let old_table = old_read.open_table(DEFINITION).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(DEFINITION).unwrap();
+        for key in 0..ELEMENTS {
+            let old_value = table.insert(&key, &[1; 32]).unwrap().unwrap();
+            assert_eq!(old_value.value(), [0; 32]);
+        }
+    }
+    write_txn.commit().unwrap();
+
+    for key in (0..ELEMENTS).step_by(101) {
+        assert_eq!(old_table.get(&key).unwrap().unwrap().value(), [0; 32]);
+    }
+    drop(old_table);
+    drop(old_read);
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(DEFINITION).unwrap();
+    for key in (0..ELEMENTS).step_by(101) {
+        assert_eq!(table.get(&key).unwrap().unwrap().value(), [1; 32]);
+    }
+    drop(table);
+    drop(read_txn);
+    assert!(db.check_integrity().unwrap());
+}
+
+#[test]
 fn insert_reserve() {
     let tmpfile = create_tempfile();
     let db = Database::create(tmpfile.path()).unwrap();
@@ -1613,9 +1657,30 @@ fn insert_reserve() {
     write_txn.commit().unwrap();
 
     let read_txn = db.begin_read().unwrap();
+    {
+        let table = read_txn.open_table(def).unwrap();
+        assert_eq!(
+            value.as_bytes(),
+            table.get("hello").unwrap().unwrap().value()
+        );
+    }
+    drop(read_txn);
+
+    // Reserving over an existing key, at the length it already has
+    let replacement = "earth";
+    assert_eq!(replacement.len(), value.len());
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(def).unwrap();
+        let mut reserved = table.insert_reserve("hello", replacement.len()).unwrap();
+        reserved.as_mut().copy_from_slice(replacement.as_bytes());
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
     let table = read_txn.open_table(def).unwrap();
     assert_eq!(
-        value.as_bytes(),
+        replacement.as_bytes(),
         table.get("hello").unwrap().unwrap().value()
     );
 }


### PR DESCRIPTION
Two of the most common B-tree updates leave a page's serialized layout untouched: replacing a value with one of the same length moves no offset within a leaf, and updating a branch whose child did not split changes only one child pointer and its checksum. Both still went through `LeafBuilder`/`BranchBuilder`, re-pushing every entry to build a copy identical to the original apart from the bytes that changed. This clones the page and patches those bytes instead, keeping the builders for everything that does change the layout: splits, inserts, and the deletion paths.

Both new paths sit after the existing fast paths for uncommitted pages, so only committed pages reach them and copy-on-write is preserved.

## Benchmarks

`redb_benchmark`, 8 interleaved pairs of runs, reported as median of per-pair deltas (this box has 15-50% run-to-run variance on write phases, so single runs are not usable):

| phase | median delta | codex wins |
|---|---|---|
| **nosync writes** | **-15.7%** | 7/8 |
| batch writes | -6.5% | 5/8 |
| individual writes | -0.9% | 4/8 |
| bulk load | +1.5% | 2/8 |
| read / removal / retain / extract_if / pop / compaction phases | within noise | 2/8-6/8 |

`uncompacted size` (4.00 GiB) and `compacted size` (1.28 GiB) are identical between the two builds.

One caveat worth flagging for review: **the branch path accounts for all of the measured gain.** `nosync writes` inserts fresh random keys, so the leaf same-size path never fires there. The phases that isolate the leaf path show nothing beyond noise. A supplementary microbenchmark covering same-size overwrites (which `redb_benchmark` does not exercise, since every insert phase uses fresh random keys) put single-key `Durability::None` overwrites at -18.2% with codex faster in 6/6 pairs, against -15.7% for the branch path alone; the difference is in the right direction but inside the noise. So the leaf half is sound but not independently demonstrated.

## On-disk output

Each build is deterministic (same binary twice produces a byte-identical file), but the two builds' files differ in 1,269 bytes out of 134,746,112 (0.0009%), across 7 leaf pages, entirely in dead space past each page's live region. Logical contents are identical (same 200,303 entries, same order-sensitive hash). The cause is that a rebuild wrote into a freshly allocated page and so zeroed the tail left behind by an earlier `remove`, while a copy carries those stale bytes forward.

## Verification

- `cargo test --all-features`: 419 passed, 0 failed
- `cargo clippy --all --all-targets --all-features` with `-D warnings`: clean
- `cargo fmt --check`: clean
- libFuzzer `fuzz_redb`, two sessions (10 min, plus 7 min with `-len_control=0` for max-length inputs): 535,400 executions, 0 crashes

The leaf path returns an old value that borrows the page it just replaced, so the page must be deferred to `freed` rather than released immediately - correct only for a page this transaction did not allocate. `sufficient_replace_inplace_space()` is always satisfied when the value length is unchanged, so an uncommitted page cannot get past the in-place path above; a `debug_assert!` records that invariant, and it did not fire across the test suite or the fuzz runs.

Adapted from Codex's `agent/copy-and-patch-only`, with the invariant assertion added, the `insert_reserve` test's original assertion restored (the original diff replaced it rather than adding to it, leaving the first reserve's value unverified), and the changelog entry reworded to state user-facing impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sg5WmwKjQ1GuLP5tnHpHmk)_