### PR TITLE
Mark a multi-process database directory (2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,13 @@
 
 ## 4.2.0 - 2026-XX-XX
 * Add `MultiProcessDatabase` behind the new `experimental-multiprocess` feature. It stores a
-  database in a directory, alongside the lock file that coordinates the processes using it, and
-  takes its exclusion from that lock file rather than from a lock on the database file. This is the
+  database in a directory -- `data.redb` beside a `write.lock` and a `metadata` marker -- and takes
+  its exclusion from the lock file rather than from a lock on the database file. The marker carries
+  a magic number and a format version, so a directory is recognized as one of these rather than
+  guessed at, and a directory written by a later redb is refused rather than misread. This is the
   first step of an incomplete feature: only one process may have the database open, so it has no
-  advantage over `Database` yet.
+  advantage over `Database` yet, and the directory layout may change incompatibly while the feature
+  is experimental.
 * `Durability::None` commits are about 2x faster.
 * Commits now flush table root updates in a deterministic order, removing a source of
   nondeterminism that could make identical operation sequences produce differing database files

--- a/docs/design.md
+++ b/docs/design.md
@@ -506,6 +506,7 @@ directory rather than a single file:
 |------|----------|
 | `data.redb` | the database, in the ordinary redb file format |
 | `write.lock` | empty; held exclusively by the process that has the database open |
+| `metadata` | a magic number and a format version, so that a directory can be recognized |
 
 The point of the directory is to move exclusion off the database file. An ordinary `Database` takes
 an exclusive advisory lock on the file itself, which is what stops a second process opening it --
@@ -535,3 +536,54 @@ running; tying it to the backend gives it exactly the lifetime of the open file.
 
 A platform without file locking cannot support any of this safely, so opening fails there rather
 than warning and continuing as `Database` does.
+
+`metadata` is what makes a directory recognizable as one of these, and what gives the layout a
+version to change later. It holds a magic number and a format version, and is checked on the way in:
+a marker from a version this build does not know is refused rather than guessed at, and so is a
+`metadata` file that is not a marker at all -- pointing `create()` at a directory that already has
+one is a mistake, and overwriting whatever was there would be a destructive way to report it.
+Reading is bounded to the marker's own length plus one byte, since a mistyped path can point at a
+directory whose `metadata` is any size at all, and a file that merely starts with the marker is not
+one.
+
+The marker must be an ordinary file, checked before it is opened. `File::open` follows a symlink, so
+one aimed at a valid marker elsewhere would otherwise vouch for a directory holding nothing of
+redb's, and it blocks on a FIFO rather than failing, so a directory holding one under this name
+could hang the call instead of being refused. That closes the door rather than locking it: between
+the check and the open the entry could be replaced, and doing better needs `O_NOFOLLOW`, which `std`
+does not expose portably.
+
+Being that strict is only safe because the marker is written under a temporary name and renamed into
+place, so it is either absent or complete and never something in between. A `create()` that dies
+partway through leaves the directory recoverable rather than wedged, and the next one finishes the
+job. The directory is fsynced after the rename so the entry survives a crash, as is the *parent*
+directory, on every `create()` -- syncing entries inside a directory whose own entry was never
+flushed would lose the lot. That happens unconditionally rather than only when this call created the
+directory, because finding it already there says nothing about whether anyone flushed it: a process
+that made it and died before syncing leaves an entry the next process would wrongly assume durable,
+and nothing can serialize that window, since the lock lives inside the directory and so cannot cover
+the directory's own creation. The guarantee stops there: the database
+directory's own entry is made durable, not an arbitrary prefix of the path it was reached by. If
+`create()` had to make ancestors of it along the way, those are the caller's directories, and their
+durability is the same concern any other file placed in them would have.
+
+Both syncs are best-effort about a directory this process cannot open. Flushing one needs read
+permission on it, while everything else here needs only the ability to traverse it and to change its
+entries, so a directory that is searchable but not readable -- the database directory or its parent
+-- would otherwise turn `create()` into an error on a database `open()` handles perfectly well. One
+that cannot be opened cannot be made durable by any other means either, so skipping the fsync gives
+up nothing that failing the call would have saved.
+
+All of this directory flushing holds on Unix only. Off it, `std` exposes no directory handle to
+sync, and no way to make the rename itself write-through, so this is a known gap rather than a
+solved problem: a power loss just after `create()` returned can lose the marker while keeping the
+database file, leaving a directory the next `open()` refuses until someone calls `create()` again.
+No data is lost, but it is a failure the caller has no way to anticipate.
+
+The marker goes in last, once the database file has turned out to be usable, so that a `create()`
+pointed at a directory which turns out not to hold a database fails without having converted it into
+one of these on the way out. It is only written when the directory does not already carry one: it
+was validated on the way in, under the lock, so a marker that is there is byte-for-byte what would
+be written, and rewriting it would fail in a directory whose entries cannot be changed even though
+everything the caller asked for is already in place. `create()` is open-or-create, and should not
+become an error where `open()` would have worked.

--- a/src/multi_process/locks.rs
+++ b/src/multi_process/locks.rs
@@ -8,11 +8,17 @@ use crate::tree_store::file_backend::FileBackend;
 use crate::{DatabaseError, StorageBackend, StorageError};
 use std::fs::{File, OpenOptions, TryLockError};
 use std::io;
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
 
 const DATA_FILE_NAME: &str = "data.redb";
 const WRITE_LOCK_FILE_NAME: &str = "write.lock";
+const METADATA_FILE_NAME: &str = "metadata";
+const METADATA_TMP_FILE_NAME: &str = "metadata.tmp";
+
+const MAGIC: [u8; 8] = [b'r', b'e', b'd', b'b', b'M', b'P', b'r', b'o'];
+const FORMAT_VERSION: u32 = 1;
+const METADATA_LEN: usize = 12;
 
 /// Maps the "this platform has no file locks" case to an error. A multi-process database has no way
 /// to be safe without them, so unlike [`crate::Database`] it refuses to open rather than warning
@@ -38,6 +44,84 @@ fn open_or_create(path: &Path) -> Result<File, io::Error> {
         .open(path)
 }
 
+/// Flushes a directory itself, so that an entry a rename just created is durable.
+///
+/// Without this a crash just after `create()` returned could lose the marker while keeping the
+/// database file, leaving a directory that `open()` refuses until someone thinks to call `create()`
+/// again.
+///
+/// A directory this process cannot open is left alone rather than reported. Opening one in order to
+/// flush it needs read permission, while everything else here needs only the ability to traverse it
+/// and to change its entries, so a directory that is searchable but not readable would otherwise
+/// turn `create()` into an error on a database that `open()` handles perfectly well. There is no
+/// other way to reach the same fsync either, so failing the call buys nothing that skipping it does
+/// not: the durability gap is there in both cases, and only one of them also loses the database.
+#[cfg(unix)]
+fn sync_dir(root: &Path) -> Result<(), DatabaseError> {
+    let dir = match File::open(root) {
+        Ok(dir) => dir,
+        Err(err) if err.kind() == ErrorKind::PermissionDenied => return Ok(()),
+        Err(err) => return Err(StorageError::Io(err).into()),
+    };
+    dir.sync_all().map_err(StorageError::Io)?;
+
+    Ok(())
+}
+
+/// Off Unix there is no directory handle to sync, and `std` offers no way to ask for the equivalent
+/// -- making the rename itself write-through needs `MOVEFILE_WRITE_THROUGH`, which `fs::rename` does
+/// not pass and which cannot be reached without a platform crate.
+///
+/// So this is a real gap rather than a case that does not need handling: on Windows a power loss
+/// just after `create()` returned can lose the marker while keeping the database file, and the next
+/// `open()` refuses the directory until someone calls `create()` again. Recoverable, and no data is
+/// lost, but it is a failure the caller cannot anticipate.
+#[cfg(not(unix))]
+fn sync_dir(_root: &Path) -> Result<(), DatabaseError> {
+    Ok(())
+}
+
+/// The directory a path lives in, as something openable. `Path::parent` gives an empty path for a
+/// bare relative name, which is not a directory anything can open.
+fn parent_of(path: &Path) -> PathBuf {
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+        _ => PathBuf::from("."),
+    }
+}
+
+/// Flushes the directory holding the database directory.
+fn sync_parent(root: &Path) -> Result<(), DatabaseError> {
+    // Canonicalized first: `Path::parent` is purely lexical, so for a path ending in `..` it names
+    // a child of the real directory rather than its parent, and the fsync would flush the wrong one
+    let root = std::fs::canonicalize(root).map_err(StorageError::Io)?;
+    sync_dir(&parent_of(&root))
+}
+
+/// Refuses anything that is not an ordinary file under one of this database's own names.
+///
+/// The opens that follow all traverse symlinks, so a planted one would be read or written through
+/// to whatever it points at, outside the directory entirely -- and a `metadata` symlink aimed at a
+/// valid marker elsewhere would vouch for a directory holding nothing of redb's. It also keeps
+/// `File::open` away from anything that would block rather than return: opening a FIFO read-only
+/// waits for a writer, so a directory holding one under a name redb trusts could hang the call
+/// instead of failing it. A missing file is fine -- that is the case where one is about to be made.
+///
+/// This closes the door rather than locking it: between the check and the open, the entry could be
+/// replaced. Doing better needs `O_NOFOLLOW`, which is not portable through `std`.
+fn require_regular_file(path: &Path) -> Result<(), DatabaseError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() => Ok(()),
+        Ok(_) => Err(StorageError::Io(io::Error::new(
+            ErrorKind::InvalidData,
+            "a multi-process database directory may hold only ordinary files",
+        ))
+        .into()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(StorageError::Io(err).into()),
+    }
+}
+
 /// The paths that make up a multi-process database directory.
 pub(super) struct DatabaseDir {
     root: PathBuf,
@@ -58,13 +142,29 @@ impl DatabaseDir {
         self.root.join(WRITE_LOCK_FILE_NAME)
     }
 
+    fn metadata_file(&self) -> PathBuf {
+        self.root.join(METADATA_FILE_NAME)
+    }
+
+    fn metadata_tmp_file(&self) -> PathBuf {
+        self.root.join(METADATA_TMP_FILE_NAME)
+    }
+
     /// Takes the write lock, which excludes every other process from the database. Held for as
     /// long as this process has it open.
     ///
-    /// Taken before anything else in the directory is opened, so that a process which gets it has
-    /// the directory to itself -- including while it is being created. The lock file is only made
-    /// when the database is being created: its absence is what tells `open()` that this directory
-    /// is not a multi-process database.
+    /// Taken before anything in the directory is read or written, so that a process which gets it
+    /// has the directory to itself -- including while it is being created. The lock file is only
+    /// made when the database is being created: an `open()` that is going to fail because the
+    /// directory holds something else should not leave a lock file in it on the way out.
+    ///
+    /// A `create()` that fails validation has necessarily made one already, since the lock is what
+    /// serializes two processes creating the same directory and so cannot wait until the directory
+    /// has been read. Unlinking it on the way out would be worse than leaving it: another process
+    /// can be waiting on the lock on that same file, and unlinking would leave it holding a lock on
+    /// an unlinked inode while a third creates a fresh `write.lock` and locks it successfully. An
+    /// empty lock file means nothing on its own -- the marker is what makes a directory one of
+    /// these -- so it is left in place.
     fn acquire_write_lock(&self, create: bool) -> Result<File, DatabaseError> {
         let path = self.write_lock_file();
         let file = if create {
@@ -92,9 +192,24 @@ impl DatabaseDir {
 
     /// Opens the directory, creating it if `create` is set, and returns a backend for the database
     /// file that holds the write lock for as long as the database is open.
+    ///
+    /// A directory being created is not marked as one of these yet -- the caller does that with
+    /// [`Self::write_metadata`], once the database file has turned out to be usable.
     pub(super) fn open(&self, create: bool) -> Result<Box<dyn StorageBackend>, DatabaseError> {
         if create {
             std::fs::create_dir_all(&self.root).map_err(StorageError::Io)?;
+            // Everything below syncs entries *inside* this directory, which does not help if the
+            // directory's own entry in its parent is lost -- a crash after create() returned would
+            // take the whole database with it.
+            //
+            // Done on every create(), not only when this call was the one that made the directory.
+            // A process that created it and died before getting here leaves an entry that is not
+            // durable, and the next process would have no way to tell: finding the directory
+            // already there says nothing about whether anyone flushed it. Nothing can serialize
+            // that window either, since the lock this type uses lives *inside* the directory and
+            // so cannot cover the directory's own creation. One fsync per create() is not worth
+            // the risk of skipping
+            sync_parent(&self.root)?;
         } else if !self.root.is_dir() {
             return Err(StorageError::Io(io::Error::new(
                 ErrorKind::NotFound,
@@ -104,6 +219,8 @@ impl DatabaseDir {
         }
 
         let write_lock = self.acquire_write_lock(create)?;
+        self.read_metadata(create)?;
+
         let data = OpenOptions::new()
             .read(true)
             .write(true)
@@ -122,15 +239,127 @@ impl DatabaseDir {
 
         Ok(Box::new(DirectoryBackend { data, write_lock }))
     }
+
+    /// Writes the marker that says this directory holds a multi-process database.
+    ///
+    /// Called only once the database file has been opened and initialized, so that a `create()`
+    /// pointed at a directory holding something that is not a redb database fails without having
+    /// converted it into one of these on the way.
+    ///
+    /// Written under a temporary name and renamed into place, so that the marker is either absent
+    /// or complete and never something in between. A `create()` that dies partway through leaves
+    /// the directory as it found it, and the next one finishes the job -- whereas a half-written
+    /// marker would be indistinguishable from a file that is simply not ours, and so would wedge
+    /// the directory for good.
+    pub(super) fn write_metadata(&self) -> Result<(), DatabaseError> {
+        let mut contents = [0u8; METADATA_LEN];
+        contents[0..8].copy_from_slice(&MAGIC);
+        contents[8..12].copy_from_slice(&FORMAT_VERSION.to_le_bytes());
+
+        let tmp = self.metadata_tmp_file();
+        // Removed and then created afresh rather than truncated in place: `File::create` follows a
+        // symlink left under this name and writes through it to whatever it points at, and blocks
+        // on a FIFO rather than failing. Unlinking first means neither is ever opened
+        match std::fs::remove_file(&tmp) {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(err) => return Err(StorageError::Io(err).into()),
+        }
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)
+            .map_err(StorageError::Io)?;
+        file.write_all(&contents).map_err(StorageError::Io)?;
+        file.sync_all().map_err(StorageError::Io)?;
+        drop(file);
+        std::fs::rename(&tmp, self.metadata_file()).map_err(StorageError::Io)?;
+        sync_dir(&self.root)?;
+
+        Ok(())
+    }
+
+    /// Writes the marker only if the directory does not already carry one.
+    ///
+    /// [`Self::read_metadata`] validated it on the way in, under the write lock, so a marker that
+    /// is there is this database's own and byte-for-byte what would be written. Rewriting it costs
+    /// a create and a rename, and fails outright in a directory whose entries cannot be changed
+    /// even though everything the caller asked for is already in place -- `create()` is
+    /// open-or-create, and should not turn into an error where `open()` would have worked.
+    pub(super) fn write_metadata_if_missing(&self) -> Result<(), DatabaseError> {
+        if self.metadata_file().exists() {
+            // The marker needs no rewriting, but this call may still have created the lock file or
+            // the database file in a directory that was missing them, and `write_metadata` is
+            // where the directory would otherwise be flushed
+            return sync_dir(&self.root);
+        }
+
+        self.write_metadata()
+    }
+
+    /// Checks that this directory holds a multi-process database, tolerating a missing marker when
+    /// one is being created.
+    ///
+    /// A directory holding anything else is refused rather than taken over, even by `create()`:
+    /// pointing this at a directory that already has a `metadata` file in it is a mistake, and
+    /// overwriting whatever was there would be a destructive way to report it. That is safe to be
+    /// strict about only because [`Self::write_metadata`] cannot leave a marker half-written.
+    ///
+    /// The caller must hold the write lock, which is what makes this safe against another process
+    /// creating the same directory.
+    fn read_metadata(&self, create: bool) -> Result<(), DatabaseError> {
+        let path = self.metadata_file();
+        require_regular_file(&path)?;
+        let file = match File::open(&path) {
+            Ok(file) => file,
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                if !create {
+                    return Err(StorageError::Io(io::Error::new(
+                        ErrorKind::NotFound,
+                        "not a multi-process database directory",
+                    ))
+                    .into());
+                }
+                return Ok(());
+            }
+            Err(err) => return Err(StorageError::Io(err).into()),
+        };
+
+        // One byte past the marker, which is enough to tell a marker from a longer file without
+        // reading it: a mistyped path can point at a directory whose `metadata` is any size at all,
+        // and none of it is worth allocating for
+        let mut bytes = Vec::with_capacity(METADATA_LEN + 1);
+        file.take((METADATA_LEN + 1) as u64)
+            .read_to_end(&mut bytes)
+            .map_err(StorageError::Io)?;
+
+        if bytes.len() != METADATA_LEN || bytes[0..8] != MAGIC {
+            return Err(StorageError::Io(io::Error::new(
+                ErrorKind::InvalidData,
+                "not a multi-process database directory",
+            ))
+            .into());
+        }
+        let version = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        if version != FORMAT_VERSION {
+            return Err(StorageError::Io(io::Error::new(
+                ErrorKind::InvalidData,
+                format!("unsupported multi-process database version: {version}"),
+            ))
+            .into());
+        }
+
+        Ok(())
+    }
 }
 
-/// The database file, plus the write lock that has to outlive it.
+/// The database file, plus the write lock that keeps other processes out of the directory it lives
+/// in.
 ///
-/// The lock is held here rather than alongside the [`crate::Database`] because a live write
-/// transaction keeps the database open past the point where the handle is dropped. A lock released
-/// when the handle went away would let another process start writing while that transaction was
-/// still running. Tying it to the backend gives it exactly the lifetime of the open file: redb
-/// calls `close()` once, when it has really finished.
+/// The lock is held here, rather than alongside the [`crate::Database`], because a live write
+/// transaction keeps the database open past the point where the `Database` is dropped. Tying the
+/// lock to the backend gives it exactly the lifetime of the open file: it is released by `close()`,
+/// which redb calls once, when the database has really finished with the file.
 #[derive(Debug)]
 struct DirectoryBackend {
     data: FileBackend,
@@ -168,12 +397,22 @@ impl StorageBackend for DirectoryBackend {
 mod test {
     use super::*;
 
+    /// The whole create sequence, which is split between here and the caller: the marker is
+    /// written only once [`crate::Database`] has accepted the database file. These tests are about
+    /// the lock and the marker rather than the database, so they stand in for that middle step by
+    /// doing nothing.
+    fn create(dir: &DatabaseDir) -> Box<dyn StorageBackend> {
+        let backend = dir.open(true).unwrap();
+        dir.write_metadata().unwrap();
+        backend
+    }
+
     #[test]
     fn the_write_lock_excludes_other_handles() {
         let tmpdir = tempfile::tempdir().unwrap();
         let dir = DatabaseDir::new(tmpdir.path().join("db"));
 
-        let first = dir.open(true).unwrap();
+        let first = create(&dir);
         assert!(matches!(
             dir.open(false),
             Err(DatabaseError::DatabaseAlreadyOpen)
@@ -186,11 +425,114 @@ mod test {
     }
 
     #[test]
-    fn a_directory_without_a_lock_file_is_not_a_database() {
+    fn a_directory_without_the_marker_is_not_a_database() {
         let tmpdir = tempfile::tempdir().unwrap();
         let path = tmpdir.path().join("db");
         std::fs::create_dir(&path).unwrap();
+        // A lock file on its own is not enough -- the marker is what says the directory is one of
+        // these, so it has to be what this turns on rather than the lock file's absence
+        std::fs::write(path.join(WRITE_LOCK_FILE_NAME), []).unwrap();
+        let dir = DatabaseDir::new(&path);
+        assert!(dir.open(false).is_err());
 
-        assert!(DatabaseDir::new(&path).open(false).is_err());
+        // An empty file where the marker should be is rejected too, rather than being read as a
+        // database with a zero version
+        std::fs::write(path.join(METADATA_FILE_NAME), []).unwrap();
+        assert!(dir.open(false).is_err());
+    }
+
+    /// A `create()` that died while writing the marker leaves the partial copy under the temporary
+    /// name and no marker at all, which the next `create()` finishes rather than tripping over.
+    #[test]
+    fn a_marker_that_never_landed_is_written_again() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        let dir = DatabaseDir::new(&path);
+        create(&dir).close().unwrap();
+
+        std::fs::remove_file(path.join(METADATA_FILE_NAME)).unwrap();
+        std::fs::write(path.join(METADATA_TMP_FILE_NAME), &MAGIC[0..4]).unwrap();
+
+        create(&dir).close().unwrap();
+        assert_eq!(
+            METADATA_LEN,
+            std::fs::read(path.join(METADATA_FILE_NAME)).unwrap().len()
+        );
+    }
+
+    /// The flip side of recovering from an interrupted create: because the marker is never left
+    /// half-written, a `metadata` file that is not a marker belongs to something else, and
+    /// `create()` must refuse rather than overwrite it.
+    #[test]
+    fn a_directory_belonging_to_something_else_is_left_alone() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        std::fs::create_dir(&path).unwrap();
+        std::fs::write(path.join(METADATA_FILE_NAME), b"someone else's").unwrap();
+
+        assert!(DatabaseDir::new(&path).open(true).is_err());
+        assert_eq!(
+            b"someone else's",
+            &std::fs::read(path.join(METADATA_FILE_NAME)).unwrap()[..]
+        );
+    }
+
+    /// A `metadata` file that starts with the marker but keeps going is not a marker. The read is
+    /// bounded to the marker's length plus one byte, so a directory whose `metadata` is enormous
+    /// costs nothing to reject.
+    #[test]
+    fn an_oversized_marker_is_rejected() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        let dir = DatabaseDir::new(&path);
+        create(&dir).close().unwrap();
+
+        let mut contents = std::fs::read(path.join(METADATA_FILE_NAME)).unwrap();
+        assert_eq!(METADATA_LEN, contents.len());
+        contents.extend_from_slice(&[0u8; 4096]);
+        std::fs::write(path.join(METADATA_FILE_NAME), contents).unwrap();
+
+        assert!(dir.open(false).is_err());
+        assert!(dir.open(true).is_err());
+    }
+
+    /// A marker has to be an ordinary file, not a symlink pointing at one somewhere else -- which
+    /// would otherwise vouch for a directory holding nothing of redb's, since `File::open` follows
+    /// the link. The same check keeps the open away from a FIFO, which would block rather than
+    /// fail.
+    #[cfg(unix)]
+    #[test]
+    fn a_marker_that_is_a_symlink_is_not_a_marker() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let real = tmpdir.path().join("real");
+        let dir = DatabaseDir::new(&real);
+        create(&dir).close().unwrap();
+
+        let borrowed = tmpdir.path().join("borrowed");
+        std::fs::create_dir(&borrowed).unwrap();
+        std::fs::write(borrowed.join(WRITE_LOCK_FILE_NAME), []).unwrap();
+        std::os::unix::fs::symlink(
+            real.join(METADATA_FILE_NAME),
+            borrowed.join(METADATA_FILE_NAME),
+        )
+        .unwrap();
+
+        let borrowed = DatabaseDir::new(&borrowed);
+        assert!(borrowed.open(false).is_err());
+        assert!(borrowed.open(true).is_err());
+    }
+
+    #[test]
+    fn a_marker_from_a_later_version_is_rejected() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        let dir = DatabaseDir::new(&path);
+        create(&dir).close().unwrap();
+
+        let mut contents = [0u8; METADATA_LEN];
+        contents[0..8].copy_from_slice(&MAGIC);
+        contents[8..12].copy_from_slice(&(FORMAT_VERSION + 1).to_le_bytes());
+        std::fs::write(path.join(METADATA_FILE_NAME), contents).unwrap();
+        assert!(dir.open(false).is_err());
     }
 }

--- a/src/multi_process/mod.rs
+++ b/src/multi_process/mod.rs
@@ -148,10 +148,11 @@ impl MultiProcessBuilder {
     }
 
     fn open_inner(&self, path: &Path, create: bool) -> Result<MultiProcessDatabase, DatabaseError> {
-        let backend = DatabaseDir::new(path).open(create)?;
+        let dir = DatabaseDir::new(path);
+        let backend = dir.open(create)?;
         // `create` alone decides whether an empty database file may be initialized, exactly as it
-        // does for a Database, so a create() that made the directory but died before initializing
-        // the database file can be redone
+        // does for a Database: an existing one is recognized by its contents rather than by the
+        // directory's marker, so a create() that died before initializing the file can be redone
         let inner = Database::new(
             backend,
             create,
@@ -160,6 +161,11 @@ impl MultiProcessBuilder {
             self.cache_size,
             &self.repair_callback,
         )?;
+        if create {
+            // Last, so that a create() pointed at a directory which turns out not to hold a
+            // database fails without having marked it as one of these on the way out
+            dir.write_metadata_if_missing()?;
+        }
 
         Ok(MultiProcessDatabase { inner })
     }

--- a/tests/multi_process_tests.rs
+++ b/tests/multi_process_tests.rs
@@ -71,6 +71,7 @@ fn create_makes_a_directory() {
 
     assert!(path.join("data.redb").is_file());
     assert!(path.join("write.lock").is_file());
+    assert!(path.join("metadata").is_file());
 }
 
 #[test]
@@ -133,8 +134,7 @@ fn opening_something_that_is_not_a_database_fails() {
     std::fs::create_dir(&empty).unwrap();
     assert!(MultiProcessDatabase::open(&empty).is_err());
 
-    // A directory holding a plain redb database is not one of these either -- there is no lock
-    // file in it, which is all that identifies one at this step
+    // A directory holding a plain redb database is not one of these either -- it has no marker
     let plain = dir.path().join("plain");
     std::fs::create_dir(&plain).unwrap();
     drop(Database::create(plain.join("data.redb")).unwrap());
@@ -161,9 +161,9 @@ fn the_builder_configures_the_database() {
     assert_eq!(Some(1), read(&db, 0));
 }
 
-/// A create() that made the directory but died before the database file was initialized must not
-/// leave the directory permanently unopenable: a later create() finishes the job, exactly as it
-/// would for a `Database` whose file was created and then not written to.
+/// A create() that made the directory and the marker but died before the database file was
+/// initialized must not leave the directory permanently unopenable: a later create() finishes the
+/// job, exactly as it would for a `Database` whose file was created and then not written to.
 #[test]
 fn an_interrupted_create_can_be_redone() {
     let dir = tempdir();
@@ -174,6 +174,29 @@ fn an_interrupted_create_can_be_redone() {
     let db = MultiProcessDatabase::create(&path).unwrap();
     write(&db, 0, 1);
     assert_eq!(Some(1), read(&db, 0));
+}
+
+/// `Path::parent` is lexical, so a path ending in `..` names a child of the real directory rather
+/// than its parent. Deciding which directory to fsync on that would flush the wrong one, and the
+/// database directory's own entry would not be durable after `create()` returned.
+#[test]
+fn a_path_that_walks_back_up_still_works() {
+    let dir = tempdir();
+    let nested = dir.path().join("a").join("b");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let path = nested.join("..").join("db");
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 1);
+    assert_eq!(Some(1), read(&db, 0));
+    drop(db);
+
+    // the database is where the path actually pointed, not where a lexical reading would put it
+    assert!(dir.path().join("a").join("db").join("data.redb").is_file());
+    assert_eq!(
+        Some(1),
+        read(&MultiProcessDatabase::open(&path).unwrap(), 0)
+    );
 }
 
 /// The write lock is invisible to a process that reaches past the directory and opens the database
@@ -313,4 +336,32 @@ fn a_process_that_dies_releases_the_lock() {
     assert_eq!(Some(9), read(&db, 0));
     write(&db, 0, 10);
     assert_eq!(Some(10), read(&db, 0));
+}
+
+/// A directory can be searchable and writable without being readable, and everything this type does
+/// in one apart from flushing the directory itself works there. `create()` is open-or-create, so it
+/// should behave the way `open()` does rather than failing on a database that is already complete.
+#[test]
+#[cfg(unix)]
+fn a_directory_that_cannot_be_read_still_opens() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempdir();
+    let path = db_path(&dir);
+    {
+        let db = MultiProcessDatabase::create(&path).unwrap();
+        write(&db, 0, 7);
+    }
+
+    let readable = std::fs::metadata(&path).unwrap().permissions();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o311)).unwrap();
+
+    let opened = MultiProcessDatabase::open(&path).map(|db| read(&db, 0));
+    let created = MultiProcessDatabase::create(&path).map(|db| read(&db, 0));
+
+    // Restored before the assertions, so that a failure does not also leave the directory
+    // unreadable for whatever has to clean it up
+    std::fs::set_permissions(&path, readable).unwrap();
+    assert_eq!(Some(7), opened.unwrap());
+    assert_eq!(Some(7), created.unwrap());
 }


### PR DESCRIPTION
Second of three. **Based on #1359** -- review that one first; this diff is only the marker.

| | what | added |
|---|---|---|
| 1/3 | #1359 -- the directory and the write lock | 730 |
| **2/3** | this PR -- the `metadata` marker | 479 |
| 3/3 | #1362 -- refusing directories that are not redb&#39;s | 610 |

---

After #1359 the only thing identifying one of these directories is that it has a `write.lock` in it. That means any directory someone has ever pointed `MultiProcessDatabase` at looks like a database, and the layout has no version to change later.

This adds the third file:

| file | contents |
|------|----------|
| `metadata` | magic number and format version, so a directory can be recognized as one of these |

## What it buys

* **Recognition.** A directory holding a plain redb database at `data.redb` is no longer mistaken for one of these, and neither is a directory that merely has a lock file in it.
* **A version to change.** A marker written by a later redb is refused rather than guessed at, which is what makes the layout extensible -- #1362 and the releases after it change what lives in the directory.
* **Refusing what isn&#39;t ours.** A `metadata` file that is not a marker means the directory is somebody else&#39;s, and it is refused rather than taken over, even by `create()`. Pointing `create()` at a directory that already has one is a mistake, and overwriting whatever was there would be a destructive way to report it.

## Why the marker is written the way it is

Being that strict about a foreign `metadata` file is only safe if a marker of redb&#39;s own can never be *half* written -- otherwise a `create()` interrupted mid-write would leave something that is not a marker, and the directory would be wedged for good by the rule above. So it goes in under a temporary name and is renamed into place: either absent or complete, never in between.

It is also fsynced, along with the directory holding it, and along with the *parent* directory. Syncing entries inside a directory whose own entry was never flushed loses the whole database, and a marker lost after `create()` returned leaves a database `open()` refuses until someone thinks to call `create()` again.

The parent sync happens on **every** `create()`, not only the one that made the directory. Finding the directory already there says nothing about whether anyone flushed it -- a process that created it and died before the fsync leaves an entry the next process would wrongly assume durable -- and nothing can serialize that window, since the lock lives inside the directory and so cannot cover the directory&#39;s own creation.

Both of those syncs are best-effort about a directory this process cannot open. Flushing one needs *read* permission, while everything else here needs only the ability to traverse it and change its entries, so a directory that is searchable but not readable would otherwise turn `create()` into an error on a database `open()` handles perfectly well. One that cannot be opened cannot be made durable by any other means either.

A `create()` on a directory that already carries a valid marker does not rewrite it. `read_metadata` validated it on the way in, under the lock, so it is byte-for-byte what would be written; rewriting costs a create and a rename and fails outright where the directory&#39;s entries cannot be changed, turning open-or-create into an error for no benefit.

Reading it is bounded to the marker&#39;s own length plus one byte. A mistyped path can point at a directory whose `metadata` is any size at all, and a file that merely *starts* with the marker is not one.

Finally, the marker goes in **last**, once `Database` has accepted the database file, so a `create()` pointed at a directory that turns out not to hold a database fails without having marked it on the way out. That is the beginning of the rule #1362 finishes: a call that fails never leaves a marker behind.

## Testing

5 new unit tests -- an empty `metadata` is not read as version zero, an oversized one is refused, a later format version is refused, a `metadata` symlink is not a marker, and a foreign `metadata` file is left byte-for-byte intact -- plus 2 new integration tests: a path ending in `..` still syncs the right parent directory, and a database directory that is searchable but not readable still opens. 15 integration tests and 7 unit tests in total.

`cargo build`, `cargo clippy --all-targets` and the full test suite pass with `--all-features` and with default features, and clippy is checked against `x86_64-pc-windows-msvc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJFSfcturbVcnPqY5CNzQv

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJFSfcturbVcnPqY5CNzQv)_