### PR TITLE
Refuse directories that are not this database's own (3/3)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -587,3 +587,77 @@ was validated on the way in, under the lock, so a marker that is there is byte-f
 be written, and rewriting it would fail in a directory whose entries cannot be changed even though
 everything the caller asked for is already in place. `create()` is open-or-create, and should not
 become an error where `open()` would have worked.
+
+## What a call that fails leaves behind
+
+The rule the rest of this follows is that **a call which fails never leaves a marker behind**, so a
+directory that is not a multi-process database is never turned into one by a call that did not
+succeed. Three things follow.
+
+An existing directory with no marker at all is only accepted by `create()` if everything in it is a
+*regular file* named like something `create()` itself writes -- `data.redb`, `data.redb.tmp`,
+`write.lock`, `metadata`, `metadata.tmp`. That is what an interrupted create looks like; a directory
+with anything else in it is a mistyped path, and turning it into a database would be the same kind
+of surprise as overwriting a `metadata` file. The check applies *only* when the marker is absent: a
+directory that is already a database opens whatever else has appeared in it, or a stray `.DS_Store`
+would be enough to lock its owner out. Since it needs no lock, `create()` runs it before taking one,
+so the mistyped-path case leaves nothing behind at all.
+
+Every one of these names must be an ordinary file -- `data.redb`, `write.lock` and `metadata` alike,
+wherever they are checked. All of the opens traverse symlinks, so one planted under a name redb
+trusts would be written through to whatever it points at, outside the directory entirely, and a
+`metadata` symlink pointing at a valid marker elsewhere would vouch for a directory holding nothing
+of redb's. The temporary files are unlinked and created afresh rather than truncated in place, for
+the same reason. This closes the door rather than locking it: between the check and the open an
+entry could be replaced, and doing better needs `O_NOFOLLOW`, which `std` does not offer portably.
+
+`data.redb` gets the same temporary-name treatment as the marker, for the same reason. redb writes a
+new database's header with the magic number zeroed, flushes, and only then writes the magic, so that
+a crash during initialization leaves a file it will refuse rather than half a database. That refusal
+is what makes the state dangerous here: under its own name, a file that is neither empty nor a
+database is indistinguishable from something this call was pointed at by mistake, so refusing it
+forever is the only safe reading, and the directory is wedged. Initialized under `data.redb.tmp` and
+renamed into place once `Database` has accepted it, the same file is unambiguously an unfinished
+attempt of this database's own, which the next `create()` throws away and redoes. `data.redb`
+therefore exists only when it is a database that was finished.
+
+Two things follow from `data.redb` meaning "a database that was finished". A file with nothing in it
+does not qualify, so an empty one is discarded and redone through the temporary name rather than
+initialized where it lies -- otherwise the header bytes would land under the final name and a crash
+before the magic number was written would produce exactly the file this indirection exists to avoid.
+And "is the name free?" has to be asked with `symlink_metadata` rather than `Path::exists`, which
+follows the link and so reports a dangling symlink as an absent file: deciding on that would let the
+promoting rename replace a symlink instead of the regular-file check refusing it.
+
+An empty `data.redb` is only wreckage if nobody is holding it. A process that reached past the
+directory could have created and locked it a moment ago, and unlinking it would leave that process
+writing to an inode nothing points at while this one publishes a different database, so the file's
+own lock is taken before it is discarded and a held one gives `DatabaseAlreadyOpen` instead. That
+lock is held across the unlink rather than released before it: the unlink succeeds whether or not
+someone has taken the file in between, so letting go first would reopen the window it exists to
+close.
+
+The corollary is that a temporary file is only ever moved into place by the call that wrote it.
+Which name the database file was opened under is carried forward from the open rather than worked
+out again from what is on disk, because a `data.redb.tmp` present at the end is this call's own only
+if this call made it, and nothing about the file itself says so. Promoting on mere presence would
+replace a good database with wreckage and leave the handle just returned writing to an inode nothing
+points at.
+
+A call that opened the database under its own name therefore promotes nothing, and clears any
+temporary it finds -- but only once `Database` has accepted the file. On the way out rather than the
+way in, so that a `create()` pointed by mistake at a directory that turns out not to hold a database
+fails without having deleted a file it did not put there. The temporary name is redb's, so a
+directory holding one gets past the check below, but that is not a licence to remove it before there
+is any evidence the directory is redb's too.
+
+`open()` creates nothing whatsoever, down to not making the lock file in a directory it is about to
+reject, and `create()` does the same for the case it can check without the lock. It cannot do so in
+general: the lock has to be taken before the directory is read, because it is the only thing
+serializing two processes creating the same directory at once, so a `create()` that gets as far as
+validating the database file has already made an empty `write.lock`. Removing it on the way out
+would be worse than leaving it. Another process can have opened that same file and be waiting on the
+lock; unlinking it and releasing would leave that process holding a lock on an unlinked inode while
+a third creates a fresh `write.lock` and locks it successfully, so both would believe they had the
+directory. An inert empty file is the smaller cost, and it is inert precisely because the marker is
+what confers meaning.

--- a/src/multi_process/locks.rs
+++ b/src/multi_process/locks.rs
@@ -15,6 +15,7 @@ const DATA_FILE_NAME: &str = "data.redb";
 const WRITE_LOCK_FILE_NAME: &str = "write.lock";
 const METADATA_FILE_NAME: &str = "metadata";
 const METADATA_TMP_FILE_NAME: &str = "metadata.tmp";
+const DATA_TMP_FILE_NAME: &str = "data.redb.tmp";
 
 const MAGIC: [u8; 8] = [b'r', b'e', b'd', b'b', b'M', b'P', b'r', b'o'];
 const FORMAT_VERSION: u32 = 1;
@@ -98,6 +99,12 @@ fn sync_parent(root: &Path) -> Result<(), DatabaseError> {
     sync_dir(&parent_of(&root))
 }
 
+/// Whether a name is taken, by anything at all -- including a symlink that resolves to nothing,
+/// which `Path::exists` reports as absent because it follows the link.
+fn occupied(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok()
+}
+
 /// Refuses anything that is not an ordinary file under one of this database's own names.
 ///
 /// The opens that follow all traverse symlinks, so a planted one would be read or written through
@@ -120,6 +127,19 @@ fn require_regular_file(path: &Path) -> Result<(), DatabaseError> {
         Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
         Err(err) => Err(StorageError::Io(err).into()),
     }
+}
+
+/// Which name [`DatabaseDir::open`] put the database file under.
+///
+/// Carried from the open to [`DatabaseDir::promote_data`] rather than worked out again from what is
+/// on disk. A temporary file that is there at the end of a `create()` is this call's own only if
+/// this call made it, and nothing about the file itself says so.
+#[derive(Clone, Copy)]
+pub(super) enum DataLocation {
+    /// `data.redb`, which is where a database that was already finished lives.
+    Final,
+    /// `data.redb.tmp`, which is where one being initialized lives until it is renamed into place.
+    Temporary,
 }
 
 /// The paths that make up a multi-process database directory.
@@ -150,6 +170,10 @@ impl DatabaseDir {
         self.root.join(METADATA_TMP_FILE_NAME)
     }
 
+    fn data_tmp_file(&self) -> PathBuf {
+        self.root.join(DATA_TMP_FILE_NAME)
+    }
+
     /// Takes the write lock, which excludes every other process from the database. Held for as
     /// long as this process has it open.
     ///
@@ -167,6 +191,10 @@ impl DatabaseDir {
     /// these -- so it is left in place.
     fn acquire_write_lock(&self, create: bool) -> Result<File, DatabaseError> {
         let path = self.write_lock_file();
+        // Before opening, for the same reason as the marker and the database file: `create(true)`
+        // would otherwise follow a symlink left under this name and make its target, and the
+        // directory lock would then be taken on a file whose identity was never checked
+        require_regular_file(&path)?;
         let file = if create {
             open_or_create(&path)
         } else {
@@ -191,12 +219,23 @@ impl DatabaseDir {
     }
 
     /// Opens the directory, creating it if `create` is set, and returns a backend for the database
-    /// file that holds the write lock for as long as the database is open.
+    /// file that holds the write lock for as long as the database is open, along with which of the
+    /// two names that file is under.
     ///
     /// A directory being created is not marked as one of these yet -- the caller does that with
     /// [`Self::write_metadata`], once the database file has turned out to be usable.
-    pub(super) fn open(&self, create: bool) -> Result<Box<dyn StorageBackend>, DatabaseError> {
+    pub(super) fn open(
+        &self,
+        create: bool,
+    ) -> Result<(Box<dyn StorageBackend>, DataLocation), DatabaseError> {
         if create {
+            // Checked here as well as under the lock further down, which is the authoritative one.
+            // Doing it first means the overwhelmingly common case -- a mistyped path -- is refused
+            // without even the lock file having been made, and doing it only when there is no
+            // marker keeps it away from directories that are already databases
+            if !self.metadata_file().exists() {
+                self.reject_foreign_directory()?;
+            }
             std::fs::create_dir_all(&self.root).map_err(StorageError::Io)?;
             // Everything below syncs entries *inside* this directory, which does not help if the
             // directory's own entry in its parent is lost -- a crash after create() returned would
@@ -221,12 +260,73 @@ impl DatabaseDir {
         let write_lock = self.acquire_write_lock(create)?;
         self.read_metadata(create)?;
 
+        // A database being made for the first time is initialized under a temporary name and
+        // renamed into place by `promote_data`, the same way the marker is. redb deliberately
+        // writes the header with the magic number zeroed, flushes, and only then writes the magic,
+        // so a crash partway through initialization leaves a file that is not empty and not a
+        // database either -- and `Database::new` refuses such a file whether or not `create` is
+        // set. Under its own name that file would be indistinguishable from something this call
+        // was pointed at by mistake, and refusing it forever is the only safe reading. Under the
+        // temporary name it is unambiguously an unfinished attempt of ours, so it can be thrown
+        // away and redone
+        let (path, location) = if create {
+            // `symlink_metadata` rather than `exists()`, which follows the link and so reports a
+            // dangling symlink as an absent file -- the question here is whether the name is
+            // occupied at all, since one that is gets checked by `require_regular_file` below
+            // instead of being quietly replaced by the promoting rename
+            match std::fs::symlink_metadata(self.data_file()) {
+                // A database file with nothing in it got as far as being created and no further,
+                // so it is discarded and redone under the temporary name. Initializing it in place
+                // would put the header bytes under the final name, and a crash in the window
+                // before the magic number is written leaves exactly the file this indirection
+                // exists to avoid -- one that is neither empty nor a database, under a name that
+                // must then be refused forever
+                Ok(metadata) if metadata.is_file() && metadata.len() == 0 => {
+                    // Empty means an attempt that got as far as creating the file -- but only if
+                    // nobody is holding it. A process that reached past the directory could have
+                    // created and locked it a moment ago, and unlinking it would leave that
+                    // process writing to an inode nothing points at while this one publishes a
+                    // different database. Taking the lock first turns that into the same
+                    // `DatabaseAlreadyOpen` a second handle would get
+                    let existing = OpenOptions::new()
+                        .read(true)
+                        .write(true)
+                        .open(self.data_file())
+                        .map_err(StorageError::Io)?;
+                    match existing.try_lock() {
+                        Ok(()) => {}
+                        Err(TryLockError::WouldBlock) => {
+                            return Err(DatabaseError::DatabaseAlreadyOpen);
+                        }
+                        Err(TryLockError::Error(err)) => return Err(lock_unsupported(err)),
+                    }
+                    // Still held across the unlink. Dropping the handle first would reopen the
+                    // window the lock is here to close: a direct opener could take the file in
+                    // between, and the unlink would succeed anyway, leaving it writing to an inode
+                    // nothing points at
+                    std::fs::remove_file(self.data_file()).map_err(StorageError::Io)?;
+                    drop(existing);
+                    self.discard_data_tmp()?;
+                    (self.data_tmp_file(), DataLocation::Temporary)
+                }
+                Ok(_) => (self.data_file(), DataLocation::Final),
+                Err(err) if err.kind() == ErrorKind::NotFound => {
+                    self.discard_data_tmp()?;
+                    (self.data_tmp_file(), DataLocation::Temporary)
+                }
+                Err(err) => return Err(StorageError::Io(err).into()),
+            }
+        } else {
+            (self.data_file(), DataLocation::Final)
+        };
+
+        require_regular_file(&path)?;
         let data = OpenOptions::new()
             .read(true)
             .write(true)
             .create(create)
             .truncate(false)
-            .open(self.data_file())
+            .open(path)
             .map_err(StorageError::Io)?;
         // The ordinary exclusive lock, the same one a Database takes. The write lock above is what
         // other multi-process handles look at, but a process that reaches past the directory and
@@ -237,7 +337,56 @@ impl DatabaseDir {
         // the lock they have to replace
         let data = FileBackend::new(data)?;
 
-        Ok(Box::new(DirectoryBackend { data, write_lock }))
+        Ok((Box::new(DirectoryBackend { data, write_lock }), location))
+    }
+
+    /// Moves a freshly initialized database file into place, if this call was the one that made it.
+    ///
+    /// Called once [`crate::Database`] has accepted the file, so that `data.redb` exists only when
+    /// it is a database that was finished. `location` is what [`Self::open`] did, rather than
+    /// something read back off disk: which name the database file is under is a fact this call
+    /// established, and the presence of a temporary file says nothing about who left it there.
+    ///
+    /// The write lock is still held, so nothing can be looking at either name.
+    pub(super) fn promote_data(&self, location: DataLocation) -> Result<(), DatabaseError> {
+        let tmp = self.data_tmp_file();
+        if matches!(location, DataLocation::Final) {
+            // The database was opened under its own name, so anything under the temporary one is
+            // the wreckage of an earlier attempt -- a database that was finished is at `data.redb`
+            // -- and clearing it is what keeps a later call from moving it over a good database.
+            //
+            // Done here rather than on the way in, so that a `create()` pointed at a directory
+            // that turns out not to hold a database fails without having deleted a file it did not
+            // put there. Everything above this point leaves the directory as it found it
+            return self.discard_data_tmp();
+        }
+        // This call initialized the temporary, which it does only when there was no database file.
+        // One appearing in the meantime means something reached past the directory and made it,
+        // and renaming over it would destroy a database this call never opened -- so this fails
+        // rather than finishing
+        if occupied(&self.data_file()) {
+            return Err(StorageError::Io(io::Error::new(
+                ErrorKind::AlreadyExists,
+                "the database file appeared while it was being initialized",
+            ))
+            .into());
+        }
+        std::fs::rename(&tmp, self.data_file()).map_err(StorageError::Io)?;
+        sync_dir(&self.root)?;
+
+        Ok(())
+    }
+
+    /// Throws away a temporary database file left by an earlier attempt.
+    ///
+    /// Unlinks rather than truncates, so a symlink left under this name is removed rather than
+    /// followed and written through.
+    fn discard_data_tmp(&self) -> Result<(), DatabaseError> {
+        match std::fs::remove_file(self.data_tmp_file()) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(StorageError::Io(err).into()),
+        }
     }
 
     /// Writes the marker that says this directory holds a multi-process database.
@@ -297,6 +446,50 @@ impl DatabaseDir {
         self.write_metadata()
     }
 
+    /// Refuses a directory that holds anything this database did not put there.
+    ///
+    /// Only consulted when there is no marker: a directory with one is this database's, and a stray
+    /// file appearing next to it -- `.DS_Store`, an editor's scratch file -- must not stop it
+    /// opening. Without a marker the only reason to accept a directory that already exists is that
+    /// a `create()` was interrupted partway through, and such a directory holds nothing but the
+    /// files `create()` itself makes. Anything else is a path this call was pointed at by mistake.
+    fn reject_foreign_directory(&self) -> Result<(), DatabaseError> {
+        let entries = match std::fs::read_dir(&self.root) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(StorageError::Io(err).into()),
+        };
+
+        for entry in entries {
+            let entry = entry.map_err(StorageError::Io)?;
+            let name = entry.file_name();
+            let named_like_ours = [
+                DATA_FILE_NAME,
+                DATA_TMP_FILE_NAME,
+                WRITE_LOCK_FILE_NAME,
+                METADATA_FILE_NAME,
+                METADATA_TMP_FILE_NAME,
+            ]
+            .iter()
+            .any(|known| name == *known);
+            // The name is not enough. `file_type()` reports the entry itself rather than what it
+            // points at, so a symlink wearing one of these names is caught here -- otherwise
+            // opening `data.redb` with `create` would follow it and initialize a database over
+            // whatever it pointed at, somewhere outside this directory entirely
+            let ours = named_like_ours && entry.file_type().map_err(StorageError::Io)?.is_file();
+            if !ours {
+                return Err(StorageError::Io(io::Error::new(
+                    ErrorKind::AlreadyExists,
+                    "refusing to create a multi-process database in a directory that holds files \
+                     it did not write",
+                ))
+                .into());
+            }
+        }
+
+        Ok(())
+    }
+
     /// Checks that this directory holds a multi-process database, tolerating a missing marker when
     /// one is being created.
     ///
@@ -320,7 +513,7 @@ impl DatabaseDir {
                     ))
                     .into());
                 }
-                return Ok(());
+                return self.reject_foreign_directory();
             }
             Err(err) => return Err(StorageError::Io(err).into()),
         };
@@ -397,12 +590,13 @@ impl StorageBackend for DirectoryBackend {
 mod test {
     use super::*;
 
-    /// The whole create sequence, which is split between here and the caller: the marker is
-    /// written only once [`crate::Database`] has accepted the database file. These tests are about
-    /// the lock and the marker rather than the database, so they stand in for that middle step by
-    /// doing nothing.
+    /// The whole create sequence, which is split between here and the caller: the database file is
+    /// moved into place and the marker written only once [`crate::Database`] has accepted the file.
+    /// These tests are about the lock and the marker rather than the database, so they stand in for
+    /// that middle step by doing nothing -- the file they promote is simply empty.
     fn create(dir: &DatabaseDir) -> Box<dyn StorageBackend> {
-        let backend = dir.open(true).unwrap();
+        let (backend, location) = dir.open(true).unwrap();
+        dir.promote_data(location).unwrap();
         dir.write_metadata().unwrap();
         backend
     }
@@ -421,7 +615,7 @@ mod test {
         // Closing the backend is what releases the lock, since that is when redb has finished
         // with the file
         first.close().unwrap();
-        let _second = dir.open(false).unwrap();
+        let _second = dir.open(false).unwrap().0;
     }
 
     #[test]
@@ -520,6 +714,59 @@ mod test {
         let borrowed = DatabaseDir::new(&borrowed);
         assert!(borrowed.open(false).is_err());
         assert!(borrowed.open(true).is_err());
+    }
+
+    /// A database file with nothing in it never gets initialized under its own name: doing so
+    /// would put the header bytes there, and a crash before the magic number was written would
+    /// leave a file that has to be refused forever. It is discarded and redone under the temporary
+    /// name like any other unfinished attempt.
+    #[test]
+    fn an_empty_data_file_is_redone_through_the_temporary_name() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        let dir = DatabaseDir::new(&path);
+        create(&dir).close().unwrap();
+        std::fs::write(path.join(DATA_FILE_NAME), []).unwrap();
+
+        let (backend, location) = dir.open(true).unwrap();
+        assert!(!path.join(DATA_FILE_NAME).exists());
+        assert!(path.join(DATA_TMP_FILE_NAME).is_file());
+
+        // ... and promoting puts it back under the name it belongs under
+        dir.promote_data(location).unwrap();
+        assert!(path.join(DATA_FILE_NAME).is_file());
+        assert!(!path.join(DATA_TMP_FILE_NAME).exists());
+        backend.close().unwrap();
+    }
+
+    /// An empty database file is only wreckage if nobody is holding it. One that a process
+    /// reached past the directory to create and lock is live, and unlinking it would leave that
+    /// process writing to an inode nothing points at.
+    #[test]
+    fn an_empty_data_file_someone_is_holding_is_not_discarded() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        let dir = DatabaseDir::new(&path);
+        create(&dir).close().unwrap();
+        std::fs::write(path.join(DATA_FILE_NAME), []).unwrap();
+
+        let held = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path.join(DATA_FILE_NAME))
+            .unwrap();
+        held.try_lock().unwrap();
+
+        assert!(matches!(
+            dir.open(true),
+            Err(DatabaseError::DatabaseAlreadyOpen)
+        ));
+        assert!(path.join(DATA_FILE_NAME).is_file());
+
+        // ... and once it is let go, the empty file is wreckage again
+        held.unlock().unwrap();
+        drop(held);
+        dir.open(true).unwrap().0.close().unwrap();
     }
 
     #[test]

--- a/src/multi_process/mod.rs
+++ b/src/multi_process/mod.rs
@@ -149,7 +149,7 @@ impl MultiProcessBuilder {
 
     fn open_inner(&self, path: &Path, create: bool) -> Result<MultiProcessDatabase, DatabaseError> {
         let dir = DatabaseDir::new(path);
-        let backend = dir.open(create)?;
+        let (backend, location) = dir.open(create)?;
         // `create` alone decides whether an empty database file may be initialized, exactly as it
         // does for a Database: an existing one is recognized by its contents rather than by the
         // directory's marker, so a create() that died before initializing the file can be redone
@@ -162,8 +162,10 @@ impl MultiProcessBuilder {
             &self.repair_callback,
         )?;
         if create {
-            // Last, so that a create() pointed at a directory which turns out not to hold a
-            // database fails without having marked it as one of these on the way out
+            // Both last, and in this order, so that a create() pointed somewhere that turns out
+            // not to hold a database fails without having left either a database file or a marker
+            // behind
+            dir.promote_data(location)?;
             dir.write_metadata_if_missing()?;
         }
 

--- a/tests/multi_process_tests.rs
+++ b/tests/multi_process_tests.rs
@@ -240,6 +240,236 @@ fn an_ordinary_database_cannot_open_the_data_file() {
     );
 }
 
+/// A directory that already holds something else is a mistyped path, not a database waiting to be
+/// made. The only reason to accept an existing directory without a marker is an interrupted
+/// `create()`, and such a directory holds nothing but the files `create()` itself writes.
+#[test]
+fn create_refuses_a_directory_holding_other_files() {
+    let dir = tempdir();
+    let path = dir.path().join("not-a-db");
+    std::fs::create_dir(&path).unwrap();
+    std::fs::write(path.join("notes.txt"), b"hello").unwrap();
+
+    assert!(MultiProcessDatabase::create(&path).is_err());
+
+    // Nothing at all this time -- the check runs before the lock file would be made
+    assert_eq!(1, std::fs::read_dir(&path).unwrap().count());
+}
+
+/// The names `create()` will adopt have to be its own files and not symlinks wearing those names.
+/// Opening `data.redb` with `create` set follows a symlink, so without this a directory planted
+/// with one would have a database initialized over whatever it pointed at.
+#[cfg(unix)]
+#[test]
+fn create_refuses_a_directory_of_symlinks() {
+    let dir = tempdir();
+    let outside = dir.path().join("precious");
+    std::fs::write(&outside, b"not redb's to touch").unwrap();
+
+    for name in ["data.redb", "metadata.tmp"] {
+        let path = dir.path().join(format!("planted-{name}"));
+        std::fs::create_dir(&path).unwrap();
+        std::os::unix::fs::symlink(&outside, path.join(name)).unwrap();
+
+        assert!(MultiProcessDatabase::create(&path).is_err());
+        assert_eq!(
+            b"not redb's to touch",
+            &std::fs::read(&outside).unwrap()[..],
+            "followed the {name} symlink"
+        );
+    }
+}
+
+/// A symlink that resolves to nothing is still a symlink, and `Path::exists` reports it as an
+/// absent file. Deciding on that would have `create()` treat the name as free and let the
+/// promoting rename replace it, so the check has to ask whether the name is taken rather than
+/// whether it resolves.
+#[cfg(unix)]
+#[test]
+fn create_refuses_a_dangling_data_file_symlink() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    drop(MultiProcessDatabase::create(&path).unwrap());
+
+    std::fs::remove_file(path.join("data.redb")).unwrap();
+    std::os::unix::fs::symlink(dir.path().join("nowhere"), path.join("data.redb")).unwrap();
+
+    assert!(MultiProcessDatabase::create(&path).is_err());
+    assert!(MultiProcessDatabase::open(&path).is_err());
+    // and the symlink is still a symlink, not a database written over the top of it
+    assert!(
+        std::fs::symlink_metadata(path.join("data.redb"))
+            .unwrap()
+            .is_symlink()
+    );
+}
+
+/// ... but only when there is no marker. A directory that is already a database stays openable
+/// whatever else turns up in it, or a stray `.DS_Store` would be enough to lock its owner out.
+#[test]
+fn a_stray_file_does_not_stop_an_existing_database_opening() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    drop(MultiProcessDatabase::create(&path).unwrap());
+    std::fs::write(path.join(".DS_Store"), b"junk").unwrap();
+
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    write(&db, 0, 1);
+    drop(db);
+
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    assert_eq!(Some(1), read(&db, 0));
+}
+
+/// The file-type rule covers a directory that is already a database too, not just the recovery
+/// path. `create()` on an existing database still rewrites the marker, and a `metadata` that is a
+/// symlink would vouch for a directory holding nothing of redb's.
+#[cfg(unix)]
+#[test]
+fn symlinks_are_refused_in_a_directory_that_has_a_marker() {
+    let dir = tempdir();
+    let outside = dir.path().join("precious");
+    std::fs::write(&outside, b"not redb's to touch").unwrap();
+
+    // Rewriting the marker must not be written through a planted temporary
+    let rewritten = db_path(&dir);
+    drop(MultiProcessDatabase::create(&rewritten).unwrap());
+    std::os::unix::fs::symlink(&outside, rewritten.join("metadata.tmp")).unwrap();
+    drop(MultiProcessDatabase::create(&rewritten).unwrap());
+    assert_eq!(
+        b"not redb's to touch",
+        &std::fs::read(&outside).unwrap()[..]
+    );
+
+    // And a marker that is a symlink is not a marker, however valid the bytes it points at
+    let borrowed = dir.path().join("borrowed");
+    std::fs::create_dir(&borrowed).unwrap();
+    std::os::unix::fs::symlink(rewritten.join("metadata"), borrowed.join("metadata")).unwrap();
+    std::fs::write(borrowed.join("data.redb"), []).unwrap();
+    assert!(MultiProcessDatabase::open(&borrowed).is_err());
+    assert!(MultiProcessDatabase::create(&borrowed).is_err());
+
+    // The lock file is held to the same rule: the directory lock is worth nothing if it is taken
+    // on a file that turned out to be a pointer somewhere else
+    let relinked = dir.path().join("relinked");
+    drop(MultiProcessDatabase::create(&relinked).unwrap());
+    std::fs::remove_file(relinked.join("write.lock")).unwrap();
+    std::os::unix::fs::symlink(&outside, relinked.join("write.lock")).unwrap();
+    assert!(MultiProcessDatabase::open(&relinked).is_err());
+    assert!(MultiProcessDatabase::create(&relinked).is_err());
+    assert_eq!(
+        b"not redb's to touch",
+        &std::fs::read(&outside).unwrap()[..]
+    );
+}
+
+/// `open()` does not create anything, and that has to hold for a directory that exists but is not
+/// one of these: it must be left exactly as it was found rather than gaining a lock file on the
+/// way to the error.
+#[test]
+fn open_does_not_touch_a_directory_it_rejects() {
+    let dir = tempdir();
+    let path = dir.path().join("not-a-db");
+    std::fs::create_dir(&path).unwrap();
+    std::fs::write(path.join("notes.txt"), b"hello").unwrap();
+
+    assert!(MultiProcessDatabase::open(&path).is_err());
+    assert_eq!(1, std::fs::read_dir(&path).unwrap().count());
+}
+
+/// The marker is what makes a directory one of these, so `create()` must not install it in a
+/// directory it then fails on -- that would convert someone else's directory as a side effect of
+/// refusing it, and every later open would read it as a database.
+///
+/// Unlike `open()`, `create()` cannot leave the directory completely untouched: the lock has to be
+/// taken before the directory can be read, so an empty `write.lock` is already there by the time
+/// validation fails. That file means nothing without a marker beside it, and unlinking it would
+/// break the exclusion it provides, so the guarantee is about the marker rather than about the
+/// directory being pristine.
+#[test]
+fn create_does_not_mark_a_directory_it_rejects() {
+    let dir = tempdir();
+    let path = dir.path().join("not-a-db");
+    std::fs::create_dir(&path).unwrap();
+    std::fs::write(path.join("data.redb"), b"this is not a redb database").unwrap();
+
+    assert!(MultiProcessDatabase::create(&path).is_err());
+    assert!(!path.join("metadata").exists());
+
+    // ... and the file it refused to read is still there, byte for byte
+    assert_eq!(
+        b"this is not a redb database",
+        &std::fs::read(path.join("data.redb")).unwrap()[..]
+    );
+
+    // Nothing beyond the lock file it had to take to check at all
+    let mut left: Vec<_> = std::fs::read_dir(&path)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    left.sort();
+    assert_eq!(vec!["data.redb", "write.lock"], left);
+
+    // ... and having refused it once, it refuses it again rather than reading its own lock file as
+    // evidence that the directory is one of these
+    assert!(MultiProcessDatabase::create(&path).is_err());
+    assert!(MultiProcessDatabase::open(&path).is_err());
+}
+
+/// redb writes a new database's header with the magic number zeroed, flushes, and only then writes
+/// the magic, so a crash during initialization leaves a file that is neither empty nor a database.
+/// `Database::new` refuses such a file whether or not `create` is set, so under the name
+/// `data.redb` it would wedge the directory for good -- indistinguishable from a file this call was
+/// pointed at by mistake. Initializing under a temporary name is what keeps the two apart.
+#[test]
+fn an_initialization_that_crashed_partway_can_be_redone() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    drop(MultiProcessDatabase::create(&path).unwrap());
+
+    // Exactly what such a crash leaves: no marker, no data.redb, and a temporary file that is not
+    // empty and has no magic number
+    std::fs::remove_file(path.join("metadata")).unwrap();
+    std::fs::rename(path.join("data.redb"), path.join("data.redb.tmp")).unwrap();
+    let mut partial = std::fs::read(path.join("data.redb.tmp")).unwrap();
+    partial[0..9].fill(0);
+    std::fs::write(path.join("data.redb.tmp"), &partial).unwrap();
+
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 1);
+    assert_eq!(Some(1), read(&db, 0));
+    drop(db);
+
+    assert!(path.join("data.redb").is_file());
+    assert!(!path.join("data.redb.tmp").exists());
+}
+
+/// A temporary file only ever means "an attempt that did not finish", so one sitting next to a
+/// database that *did* finish must not be moved over it. Promoting on the mere presence of a
+/// temporary would swap a good database for wreckage, and leave the handle this call returns
+/// writing to an inode nothing points at any more.
+#[test]
+fn a_stale_temporary_does_not_replace_the_database() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 42);
+    drop(db);
+
+    std::fs::write(path.join("data.redb.tmp"), b"stale wreckage").unwrap();
+
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    assert_eq!(Some(42), read(&db, 0));
+    write(&db, 1, 43);
+    drop(db);
+
+    // ... and what this call wrote is in the database the directory actually points at
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(42), read(&db, 0));
+    assert_eq!(Some(43), read(&db, 1));
+    assert!(!path.join("data.redb.tmp").exists());
+}
+
 // --------------------------------------------------------------------------------------------
 // Tests that need a real process
 // --------------------------------------------------------------------------------------------
@@ -364,4 +594,47 @@ fn a_directory_that_cannot_be_read_still_opens() {
     std::fs::set_permissions(&path, readable).unwrap();
     assert_eq!(Some(7), opened.unwrap());
     assert_eq!(Some(7), created.unwrap());
+}
+
+/// A `create()` that is going to fail must fail without having deleted anything. The temporary name
+/// is redb's, so a directory holding one gets past the foreign-directory check, but a `create()`
+/// pointed there by mistake still has no business removing a file it did not put there.
+#[test]
+fn a_failed_create_leaves_a_temporary_file_alone() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    std::fs::create_dir(&path).unwrap();
+    // Under redb's own names, but not redb's: a mistyped path, not a database
+    std::fs::write(path.join("data.redb"), b"not a database").unwrap();
+    std::fs::write(path.join("data.redb.tmp"), b"someone else's file").unwrap();
+
+    assert!(MultiProcessDatabase::create(&path).is_err());
+    assert_eq!(
+        b"someone else's file".to_vec(),
+        std::fs::read(path.join("data.redb.tmp")).unwrap()
+    );
+}
+
+/// The other half of that: once the database *has* been accepted, a temporary file next to it is
+/// the wreckage of an earlier attempt and is cleared, so that a later `create()` can never find one
+/// to move over a database that was finished.
+#[test]
+fn a_successful_create_clears_a_stale_temporary_file() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    {
+        let db = MultiProcessDatabase::create(&path).unwrap();
+        write(&db, 0, 7);
+    }
+    std::fs::write(path.join("data.redb.tmp"), b"wreckage").unwrap();
+
+    {
+        let db = MultiProcessDatabase::create(&path).unwrap();
+        assert_eq!(Some(7), read(&db, 0));
+    }
+    assert!(!path.join("data.redb.tmp").exists());
+
+    // And the database is still the one that was there, rather than whatever the temporary held
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(7), read(&db, 0));
 }


### PR DESCRIPTION
Third of three. **Based on #1361, which is based on #1359** -- review those first; this diff is only the hardening.

| | what | added |
|---|---|---|
| 1/3 | #1359 -- the directory and the write lock | 730 |
| 2/3 | #1361 -- the `metadata` marker | 479 |
| **3/3** | this PR -- refusing directories that are not redb&#39;s | 610 |

---

Everything here is about `create()` and `open()` being pointed somewhere that is not a database, and about surviving being interrupted partway through. It is almost entirely the product of review on the original combined PR, which is why it is worth reading as its own change: five rules, each with a test.

**A call that fails never leaves a marker behind.** #1361 started this by writing the marker last. This finishes it, so a directory that is not a multi-process database is never turned into one by a call that did not succeed.

**A directory redb did not write is never adopted.** An existing directory with no marker is accepted by `create()` only if everything in it is named like something `create()` itself writes. That is what an interrupted create looks like; anything else is a mistyped path. The check applies only when the marker is absent -- a directory that is already a database opens whatever else has appeared in it, or a stray `.DS_Store` would lock its owner out. Since it needs no lock, `create()` runs it *before* taking one, so the mistyped-path case leaves nothing behind at all.

**Only ordinary files are trusted, under every one of redb&#39;s names.** Every open here traverses symlinks, so a planted one would be written through to whatever it points at, outside the directory entirely -- and a `metadata` symlink aimed at a valid marker elsewhere would vouch for a directory holding nothing of redb&#39;s. Temporary files are unlinked and created afresh rather than truncated in place. This closes the door rather than locking it: doing better needs `O_NOFOLLOW`, which `std` does not offer portably, and `docs/design.md` says so rather than implying more than is true.

**An interrupted `create()` can always be finished.** This is the substantial one. redb deliberately writes a new database&#39;s header with the magic zeroed, flushes, and only then writes the magic (`page_manager.rs`), so a crash during initialization leaves `data.redb` neither empty nor a database -- and `Database::new` refuses such a file whether or not `create` is set. Under its own name that file is indistinguishable from something the call was pointed at by mistake, so refusing it forever is the only safe reading, and the directory is wedged permanently. So `data.redb` gets the marker&#39;s treatment: initialized as `data.redb.tmp` and renamed into place once `Database` has accepted it. Both guarantees then hold at once, where before they were in tension -- a junk `data.redb` is still refused rather than overwritten, and a genuine partial create is still redone.

An empty `data.redb` is a case of this: it got as far as being created and no further, so it is discarded and redone through the temporary name rather than initialized where it lies. It is only wreckage if nobody is holding it, though -- a process that reached past the directory could have created and locked it a moment ago -- so its own lock is taken first, and held across the unlink, with a held one giving `DatabaseAlreadyOpen` instead.

**A temporary is only promoted by the call that wrote it.** Which name the database file was opened under is carried forward from the open rather than worked out again from what is on disk: a `data.redb.tmp` present at the end is this call&#39;s own only if this call made it, and nothing about the file itself says so. Promoting on mere presence would replace a good database with wreckage and leave the handle just returned writing to an inode nothing points at.

A call that opened the database under its own name therefore promotes nothing, and clears any temporary it finds -- but only once `Database` has accepted the file, not on the way in. The temporary name is redb&#39;s, so a directory holding one gets past the foreign-directory check, and a `create()` pointed there by mistake must fail without having deleted a file it did not put there.

## Known gap

During the *first* `create()` of a directory, `data.redb` does not exist yet, so a process reaching past the directory API could create and lock that path in the window before the temporary is promoted. `write.lock` still excludes every `MultiProcessDatabase` throughout, and promotion fails rather than renaming over a file that appeared -- but that check is check-then-act, and closing it properly needs a no-replace publish. The options and their costs are laid out [on this thread](https://github.com/cberner/redb/pull/1362#discussion_r3768038324); none is free, so it is a question rather than a change. The lock on `data.redb` is a courtesy to direct openers in any case, and the later releases in this series have to revisit it regardless, since on Windows a shared range denies the holder&#39;s own writes.

## Testing

11 new integration tests and 2 new unit tests, each pinning one of the rules above -- including a symlink planted under every name redb trusts, asserting the target is byte-for-byte intact afterwards; a reconstruction of the exact crash state (no marker, no `data.redb`, a `data.redb.tmp` that is non-empty with its magic zeroed); and both directions of the temporary rule, that a failed `create()` leaves someone else&#39;s `data.redb.tmp` alone and a successful one clears a stale temporary.

26 integration tests and 9 unit tests in total. `cargo build`, `cargo clippy --all-targets` and the full test suite pass with `--all-features` and with default features, and clippy is checked against `x86_64-pc-windows-msvc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJFSfcturbVcnPqY5CNzQv

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJFSfcturbVcnPqY5CNzQv)_