### PR TITLE
Import core and alloc paths instead of std

### DIFF
--- a/src/complex_types.rs
+++ b/src/complex_types.rs
@@ -1,4 +1,6 @@
 use crate::types::{TypeName, Value};
+use alloc::format;
+use alloc::vec::Vec;
 
 // Encode len as a varint and store it at the end of output
 pub(super) fn encode_varint_len(len: usize, output: &mut Vec<u8>) {

--- a/src/db.rs
+++ b/src/db.rs
@@ -9,13 +9,18 @@ use crate::{
     StorageError, TableError,
 };
 use crate::{ReadTransaction, Result, WriteTransaction};
-use std::fmt::{Debug, Display, Formatter};
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::string::String;
+use alloc::string::ToString;
+use core::fmt::{Debug, Display, Formatter};
 
+use alloc::sync::Arc;
+use core::marker::PhantomData;
 use std::fs::{File, OpenOptions};
-use std::marker::PhantomData;
+use std::io;
 use std::path::Path;
-use std::sync::Arc;
-use std::{io, thread};
+use std::thread;
 
 use crate::error::TransactionError;
 use crate::sealed::{Sealed, SealedInApi5};
@@ -32,30 +37,30 @@ use log::{debug, warn};
 /// Implements persistent storage for a database.
 pub trait StorageBackend: 'static + Debug + Send + Sync {
     /// Gets the current length of the storage.
-    fn len(&self) -> std::result::Result<u64, io::Error>;
+    fn len(&self) -> core::result::Result<u64, io::Error>;
 
     /// Reads the specified array of bytes from the storage.
     ///
     /// If `out.len()` + `offset` exceeds the length of the storage an appropriate `Error` must be returned.
-    fn read(&self, offset: u64, out: &mut [u8]) -> std::result::Result<(), io::Error>;
+    fn read(&self, offset: u64, out: &mut [u8]) -> core::result::Result<(), io::Error>;
 
     /// Sets the length of the storage.
     ///
     /// New positions in the storage must be initialized to zero.
-    fn set_len(&self, len: u64) -> std::result::Result<(), io::Error>;
+    fn set_len(&self, len: u64) -> core::result::Result<(), io::Error>;
 
     /// Syncs all buffered data with the persistent storage.
-    fn sync_data(&self) -> std::result::Result<(), io::Error>;
+    fn sync_data(&self) -> core::result::Result<(), io::Error>;
 
     /// Writes the specified array to the storage.
-    fn write(&self, offset: u64, data: &[u8]) -> std::result::Result<(), io::Error>;
+    fn write(&self, offset: u64, data: &[u8]) -> core::result::Result<(), io::Error>;
 
     /// Release any resources held by the backend
     ///
     /// Note: redb will not access the backend after calling this method and will call it exactly
     /// once when the database is closed: when the [`Database`] is dropped, or, if a
     /// [`WriteTransaction`] was live at that point, when that transaction completes
-    fn close(&self) -> std::result::Result<(), io::Error> {
+    fn close(&self) -> core::result::Result<(), io::Error> {
         Ok(())
     }
 }
@@ -155,7 +160,7 @@ impl<K: Key + 'static, V: Value + 'static> Clone for TableDefinition<'_, K, V> {
 impl<K: Key + 'static, V: Value + 'static> Copy for TableDefinition<'_, K, V> {}
 
 impl<K: Key + 'static, V: Value + 'static> Display for TableDefinition<'_, K, V> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "{}<{}, {}>",
@@ -215,7 +220,7 @@ impl<K: Key + 'static, V: Key + 'static> Clone for MultimapTableDefinition<'_, K
 impl<K: Key + 'static, V: Key + 'static> Copy for MultimapTableDefinition<'_, K, V> {}
 
 impl<K: Key + 'static, V: Key + 'static> Display for MultimapTableDefinition<'_, K, V> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "{}<{}, {}>",
@@ -1439,7 +1444,7 @@ impl Builder {
     #[cfg(any(fuzzing, test))]
     pub fn set_page_size(&mut self, size: usize) -> &mut Self {
         assert!(size.is_power_of_two());
-        self.page_size = std::cmp::max(size, 512);
+        self.page_size = core::cmp::max(size, 512);
         self
     }
 
@@ -1541,8 +1546,8 @@ impl Builder {
     }
 }
 
-impl std::fmt::Debug for Database {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Database {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Database").finish()
     }
 }
@@ -1554,10 +1559,10 @@ mod test {
         CommitError, Database, DatabaseError, Durability, ReadableTable, StorageBackend,
         StorageError, TableDefinition, TransactionError,
     };
+    use alloc::sync::Arc;
+    use core::sync::atomic::{AtomicU64, Ordering};
     use std::fs::File;
     use std::io::{ErrorKind, Read, Seek, SeekFrom};
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     #[derive(Debug)]
     struct FailingBackend {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,12 @@
 use crate::tree_store::{FILE_FORMAT_VERSION3, MAX_VALUE_LENGTH};
 use crate::{ReadTransaction, TypeName};
-use std::fmt::{Display, Formatter};
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::string::String;
+use core::fmt::{Display, Formatter};
+use std::io;
+use std::panic;
 use std::sync::PoisonError;
-use std::{io, panic};
 
 /// General errors directly from the storage layer
 #[derive(Debug)]
@@ -49,7 +53,7 @@ impl From<StorageError> for Error {
 }
 
 impl Display for StorageError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             StorageError::Corrupted(msg) => {
                 write!(f, "DB corrupted: {msg}")
@@ -87,7 +91,7 @@ impl Display for StorageError {
     }
 }
 
-impl std::error::Error for StorageError {}
+impl core::error::Error for StorageError {}
 
 /// Errors related to opening tables
 #[derive(Debug)]
@@ -168,7 +172,7 @@ impl From<StorageError> for TableError {
 }
 
 impl Display for TableError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             TableError::TypeDefinitionChanged {
                 name,
@@ -211,7 +215,7 @@ impl Display for TableError {
     }
 }
 
-impl std::error::Error for TableError {}
+impl core::error::Error for TableError {}
 
 /// Errors related to opening a database
 #[derive(Debug)]
@@ -254,7 +258,7 @@ impl From<StorageError> for DatabaseError {
 }
 
 impl Display for DatabaseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             DatabaseError::UpgradeRequired(actual) => {
                 write!(
@@ -279,7 +283,7 @@ impl Display for DatabaseError {
     }
 }
 
-impl std::error::Error for DatabaseError {}
+impl core::error::Error for DatabaseError {}
 
 /// Errors related to savepoints
 #[derive(Debug)]
@@ -317,7 +321,7 @@ impl From<StorageError> for SavepointError {
 }
 
 impl Display for SavepointError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             SavepointError::InvalidSavepoint => {
                 write!(f, "Savepoint is invalid or cannot be created.")
@@ -333,7 +337,7 @@ impl Display for SavepointError {
     }
 }
 
-impl std::error::Error for SavepointError {}
+impl core::error::Error for SavepointError {}
 
 /// Errors related to compaction
 #[derive(Debug)]
@@ -367,7 +371,7 @@ impl From<StorageError> for CompactionError {
 }
 
 impl Display for CompactionError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             CompactionError::PersistentSavepointExists => {
                 write!(
@@ -392,7 +396,7 @@ impl Display for CompactionError {
     }
 }
 
-impl std::error::Error for CompactionError {}
+impl core::error::Error for CompactionError {}
 
 /// Errors related to transactions
 #[derive(Debug)]
@@ -411,7 +415,7 @@ impl From<SetDurabilityError> for Error {
 }
 
 impl Display for SetDurabilityError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             SetDurabilityError::PersistentSavepointModified => {
                 write!(
@@ -423,7 +427,7 @@ impl Display for SetDurabilityError {
     }
 }
 
-impl std::error::Error for SetDurabilityError {}
+impl core::error::Error for SetDurabilityError {}
 
 /// Errors related to transactions
 #[derive(Debug)]
@@ -462,7 +466,7 @@ impl From<StorageError> for TransactionError {
 }
 
 impl Display for TransactionError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             TransactionError::Storage(storage) => storage.fmt(f),
             TransactionError::ReadTransactionStillInUse(_) => {
@@ -472,7 +476,7 @@ impl Display for TransactionError {
     }
 }
 
-impl std::error::Error for TransactionError {}
+impl core::error::Error for TransactionError {}
 
 /// Errors related to committing transactions
 #[derive(Debug)]
@@ -509,7 +513,7 @@ impl From<StorageError> for CommitError {
 }
 
 impl Display for CommitError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             CommitError::Storage(storage) => storage.fmt(f),
             CommitError::TransactionPoisoned => {
@@ -519,7 +523,7 @@ impl Display for CommitError {
     }
 }
 
-impl std::error::Error for CommitError {}
+impl core::error::Error for CommitError {}
 
 /// Superset of all other errors that can occur. Convenience enum so that users can convert all errors into a single type
 #[derive(Debug)]
@@ -599,7 +603,7 @@ impl From<io::Error> for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::Corrupted(msg) => {
                 write!(f, "DB corrupted: {msg}")
@@ -724,4 +728,4 @@ impl Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}

--- a/src/key_range.rs
+++ b/src/key_range.rs
@@ -1,8 +1,9 @@
 use crate::sealed::Sealed;
 use crate::tree_store::encode_bounds;
 use crate::types::Key;
-use std::borrow::Borrow;
-use std::ops::{Bound, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::ops::{Bound, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
 /// A range of keys, accepted by the range taking methods of a table
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,11 @@ compile_error!(
      it is on by default, so add features = [\"std\"] if you set default-features = false."
 );
 
+// Everything redb needs from the standard library that is not core is imported through `alloc`, so
+// that the crate can eventually be built without std. `alloc` is a subset of `std`, so this is a
+// no-op for std builds.
+extern crate alloc;
+
 pub use db::{
     Builder, CacheStats, Database, MultimapTableDefinition, MultimapTableHandle, ReadOnlyDatabase,
     ReadableDatabase, RepairSession, StorageBackend, TableDefinition, TableHandle,
@@ -98,7 +103,7 @@ pub use transactions::{DatabaseStats, Durability, ReadTransaction, WriteTransact
 pub use tree_store::{AccessGuard, AccessGuardMut, AccessGuardMutInPlace, Savepoint};
 pub use types::{Key, MutInPlaceValue, TypeName, Value};
 
-pub type Result<T = (), E = StorageError> = std::result::Result<T, E>;
+pub type Result<T = (), E = StorageError> = core::result::Result<T, E>;
 
 pub mod backends;
 mod complex_types;

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -18,13 +18,19 @@ use crate::tree_store::{
 };
 use crate::types::{Key, Value};
 use crate::{AccessGuard, MultimapTableHandle, Result, StorageError, WriteTransaction};
-use std::borrow::Borrow;
-use std::marker::PhantomData;
-use std::mem;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::marker::PhantomData;
+use core::mem;
 #[cfg(not(feature = "experimental-api-5"))]
-use std::ops::RangeBounds;
-use std::ops::{Bound, Range, RangeFull};
-use std::sync::{Arc, Mutex};
+use core::ops::RangeBounds;
+use core::ops::{Bound, Range, RangeFull};
+use std::sync::Mutex;
 
 pub(crate) struct LeafKeyIter<'a, V: Key + 'static> {
     // Kept alive so any Drop side-effects on `data` (e.g. `remove_on_drop`) still run.

--- a/src/table.rs
+++ b/src/table.rs
@@ -16,13 +16,17 @@ use crate::tree_store::{
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, AccessGuardMut, StorageError, WriteTransaction};
 use crate::{Result, TableHandle};
-use std::borrow::Borrow;
-use std::fmt::{Debug, Formatter};
-use std::marker::PhantomData;
-use std::ops::Bound;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::fmt::{Debug, Formatter};
+use core::marker::PhantomData;
+use core::ops::Bound;
 #[cfg(not(feature = "experimental-api-5"))]
-use std::ops::RangeBounds;
-use std::sync::{Arc, Mutex};
+use core::ops::RangeBounds;
+use std::sync::Mutex;
 use std::thread;
 
 /// Informational storage stats about a table
@@ -562,7 +566,7 @@ fn debug_helper<K: Key + 'static, V: Value + 'static>(
     len: Result<u64>,
     first: Result<Option<(AccessGuard<K>, AccessGuard<V>)>>,
     last: Result<Option<(AccessGuard<K>, AccessGuard<V>)>>,
-) -> std::fmt::Result {
+) -> core::fmt::Result {
     write!(f, "Table [ name: \"{name}\", ")?;
     if let Ok(len) = len {
         if len == 0 {
@@ -600,7 +604,7 @@ fn debug_helper<K: Key + 'static, V: Value + 'static>(
 }
 
 impl<K: Key + 'static, V: Value + 'static> Debug for Table<'_, K, V> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         debug_helper(f, &self.name, self.len(), self.first(), self.last())
     }
 }
@@ -1021,7 +1025,7 @@ impl<K: Key + 'static, V: Value + 'static> ReadableTable<K, V> for ReadOnlyTable
 impl<K: Key, V: Value> Sealed for ReadOnlyTable<K, V> {}
 
 impl<K: Key + 'static, V: Value + 'static> Debug for ReadOnlyTable<K, V> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         debug_helper(f, &self.name, self.len(), self.first(), self.last())
     }
 }

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -1,13 +1,16 @@
 use crate::tree_store::TransactionalMemory;
 use crate::{Key, Result, Savepoint, TypeName, Value};
+use alloc::collections::BTreeSet;
+use alloc::collections::btree_map::BTreeMap;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::mem;
+use core::mem::size_of;
 #[cfg(feature = "logging")]
 use log::debug;
-use std::cmp::Ordering;
-use std::collections::btree_map::BTreeMap;
-use std::collections::{BTreeSet, HashMap};
-use std::mem;
-use std::mem::size_of;
-use std::sync::{Arc, Condvar, Mutex};
+use std::collections::HashMap;
+use std::sync::{Condvar, Mutex};
 
 #[derive(Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub(crate) struct TransactionId(u64);
@@ -360,8 +363,8 @@ impl TransactionTracker {
             .unwrap()
             .valid_savepoints
             .range((
-                std::ops::Bound::Excluded(id),
-                std::ops::Bound::Unbounded::<SavepointId>,
+                core::ops::Bound::Excluded(id),
+                core::ops::Bound::Unbounded::<SavepointId>,
             ))
             .map(|(x, _)| *x)
             .collect()

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -18,18 +18,26 @@ use crate::{
     TableError, TableHandle, TransactionError, TypeName, UntypedMultimapTableHandle,
     UntypedTableHandle,
 };
+use alloc::boxed::Box;
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::cmp::min;
+use core::fmt::{Debug, Display, Formatter};
+use core::marker::PhantomData;
+use core::mem::size_of;
+use core::ops::{RangeBounds, RangeFull};
+use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg(feature = "logging")]
 use log::{debug, warn};
-use std::borrow::Borrow;
-use std::cmp::min;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::fmt::{Debug, Display, Formatter};
-use std::marker::PhantomData;
-use std::mem::size_of;
-use std::ops::{RangeBounds, RangeFull};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::{panic, thread};
+use std::collections::{HashMap, HashSet};
+use std::panic;
+use std::sync::Mutex;
+use std::thread;
 
 const MAX_PAGES_PER_COMPACTION: usize = 1_000_000;
 const NEXT_SAVEPOINT_TABLE: SystemTableDefinition<(), SavepointId> =
@@ -127,7 +135,7 @@ impl MutInPlaceValue for PageList<'_> {
     }
 
     fn from_bytes_mut(data: &mut [u8]) -> &mut Self::BaseRefType {
-        unsafe { &mut *(std::ptr::from_mut::<[u8]>(data) as *mut PageListMut) }
+        unsafe { &mut *(core::ptr::from_mut::<[u8]>(data) as *mut PageListMut) }
     }
 }
 
@@ -179,14 +187,14 @@ impl Value for TransactionIdWithPagination {
 }
 
 impl Key for TransactionIdWithPagination {
-    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+    fn compare(data1: &[u8], data2: &[u8]) -> core::cmp::Ordering {
         let value1 = Self::from_bytes(data1);
         let value2 = Self::from_bytes(data2);
 
         match value1.transaction_id.cmp(&value2.transaction_id) {
-            std::cmp::Ordering::Greater => std::cmp::Ordering::Greater,
-            std::cmp::Ordering::Equal => value1.pagination_id.cmp(&value2.pagination_id),
-            std::cmp::Ordering::Less => std::cmp::Ordering::Less,
+            core::cmp::Ordering::Greater => core::cmp::Ordering::Greater,
+            core::cmp::Ordering::Equal => value1.pagination_id.cmp(&value2.pagination_id),
+            core::cmp::Ordering::Less => core::cmp::Ordering::Less,
         }
     }
 }
@@ -252,7 +260,7 @@ impl Value for AllocatorStateKey {
 }
 
 impl Key for AllocatorStateKey {
-    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+    fn compare(data1: &[u8], data2: &[u8]) -> core::cmp::Ordering {
         Self::from_bytes(data1).cmp(&Self::from_bytes(data2))
     }
 }
@@ -291,7 +299,7 @@ impl<K: Key + 'static, V: Value + 'static> Clone for SystemTableDefinition<'_, K
 impl<K: Key + 'static, V: Value + 'static> Copy for SystemTableDefinition<'_, K, V> {}
 
 impl<K: Key + 'static, V: Value + 'static> Display for SystemTableDefinition<'_, K, V> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "{}<{}, {}>",
@@ -837,7 +845,7 @@ impl SavepointTransactionState {
         // deallocate_savepoint above has already removed them; for ephemeral,
         // the user's Savepoint handle still owns the live_read_transactions
         // refcount and will release it on drop.
-        tracker.invalidate_savepoints(std::mem::take(&mut self.invalidated));
+        tracker.invalidate_savepoints(core::mem::take(&mut self.invalidated));
         // Persistent savepoints created during this transaction stay live:
         // drop them from our bookkeeping without releasing tracker state.
         self.created_persistent.clear();
@@ -1275,7 +1283,7 @@ impl WriteTransaction {
     /// Calling this method invalidates all [`Savepoint`]s created after savepoint
     pub fn restore_savepoint(&mut self, savepoint: &Savepoint) -> Result<(), SavepointError> {
         // Reject a Savepoint that is from a different Database
-        if std::ptr::from_ref(self.transaction_tracker.as_ref()) != savepoint.db_address() {
+        if core::ptr::from_ref(self.transaction_tracker.as_ref()) != savepoint.db_address() {
             return Err(SavepointError::InvalidSavepoint);
         }
 
@@ -2715,7 +2723,7 @@ impl ReadTransaction {
 }
 
 impl Debug for ReadTransaction {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.write_str("ReadTransaction")
     }
 }

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -17,14 +17,19 @@ use crate::tree_store::{
 };
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, Result};
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::cmp::max;
+use core::marker::PhantomData;
+use core::ops::Bound;
+use core::ops::RangeBounds;
 #[cfg(feature = "logging")]
 use log::trace;
-use std::borrow::Borrow;
-use std::cmp::max;
-use std::collections::{Bound, HashMap};
-use std::marker::PhantomData;
-use std::ops::RangeBounds;
-use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 pub(crate) struct BtreeStats {
     pub(crate) tree_height: u32,

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -4,13 +4,15 @@ use crate::tree_store::page_store::{
 use crate::tree_store::{PageAllocator, PageNumber, PageTracker};
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{Result, StorageError};
-use std::borrow::Borrow;
-use std::cmp::Ordering;
-use std::collections::VecDeque;
-use std::marker::PhantomData;
-use std::mem::size_of;
-use std::ops::Range;
-use std::sync::Arc;
+use alloc::collections::VecDeque;
+use alloc::format;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::cmp::Ordering;
+use core::marker::PhantomData;
+use core::mem::size_of;
+use core::ops::Range;
 use std::thread;
 
 pub(crate) const LEAF: u8 = 1;

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -9,12 +9,17 @@ use crate::tree_store::page_store::{Page, PageHint, PageImpl};
 use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageResolver, PageTracker};
 use crate::types::{Key, Value};
 use crate::{Result, StorageError};
-use std::cmp::Ordering;
-use std::collections::Bound;
-use std::collections::Bound::{Excluded, Included, Unbounded};
-use std::marker::PhantomData;
-use std::ops::Range;
-use std::sync::{Arc, Mutex};
+#[cfg(feature = "experimental_cursor")]
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::marker::PhantomData;
+use core::ops::Bound;
+use core::ops::Bound::{Excluded, Included, Unbounded};
+use core::ops::Range;
+use std::sync::Mutex;
 
 #[derive(Clone)]
 struct Branch {
@@ -1307,7 +1312,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> CursorMut<'a, 'b, K, V> {
     // Takes the pending batch in ascending order; backward scans record their
     // batch in decreasing order.
     fn take_removals_ascending(&mut self) -> Vec<usize> {
-        let mut removed_indexes = std::mem::take(&mut self.state.removed_indexes);
+        let mut removed_indexes = core::mem::take(&mut self.state.removed_indexes);
         if removed_indexes.first() > removed_indexes.last() {
             removed_indexes.reverse();
         }
@@ -1957,7 +1962,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> BtreeCursorMut<'a, K, V> {
         &mut self,
         operation: impl FnOnce(&mut CursorMut<'a, '_, K, V>) -> Result<R>,
     ) -> Result<R> {
-        let mut cursor = self.tree.cursor(std::mem::take(&mut self.state));
+        let mut cursor = self.tree.cursor(core::mem::take(&mut self.state));
         let result = operation(&mut cursor);
         self.state = cursor.into_state();
         self.tree.drain_freed();
@@ -2180,7 +2185,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
         let mut state = self.seek_end(direction)?;
         if matches!(self.end_ref(direction), EndState::Pending(_)) {
             let EndState::Pending(batch) =
-                std::mem::replace(self.end_mut(direction), EndState::Parked(Unbounded))
+                core::mem::replace(self.end_mut(direction), EndState::Parked(Unbounded))
             else {
                 unreachable!();
             };
@@ -2246,7 +2251,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
             EndState::Pending(ParkedBatch {
                 bound,
                 leaf_bytes: position.leaf.page.to_arc(),
-                removed_indexes: std::mem::take(&mut state.removed_indexes),
+                removed_indexes: core::mem::take(&mut state.removed_indexes),
             })
         };
         let result = if state.leaf_run_rewrite.is_some() {
@@ -2315,7 +2320,7 @@ impl<'a, K: Key + 'static, V: Value + 'static> RangeMut<'a, K, V> {
         operation: impl FnOnce(&mut CursorMut<'a, '_, K, V>) -> Result<R>,
     ) -> Result<R> {
         let end = self.end_mut(direction);
-        let EndState::Live(state) = std::mem::replace(end, EndState::Parked(Unbounded)) else {
+        let EndState::Live(state) = core::mem::replace(end, EndState::Parked(Unbounded)) else {
             unreachable!("end must be live");
         };
         let mut cursor = self.tree.cursor(state);

--- a/src/tree_store/btree_cursor_range.rs
+++ b/src/tree_store/btree_cursor_range.rs
@@ -5,10 +5,11 @@ use crate::tree_store::page_store::PageHint;
 use crate::tree_store::{PageNumber, PageResolver};
 use crate::types::{Key, Value};
 use Bound::{Excluded, Included, Unbounded};
-use std::borrow::Borrow;
-use std::cmp::Ordering;
-use std::collections::Bound;
-use std::ops::RangeBounds;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::cmp::Ordering;
+use core::ops::Bound;
+use core::ops::RangeBounds;
 
 #[derive(Clone)]
 enum Slot<C> {

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -5,10 +5,12 @@ use crate::tree_store::page_store::{Page, PageHint, PageImpl};
 use crate::tree_store::{PageNumber, PageResolver};
 use crate::types::{Key, Value};
 use Bound::{Excluded, Included, Unbounded};
-use std::borrow::Borrow;
-use std::collections::Bound;
-use std::marker::PhantomData;
-use std::ops::{Range, RangeBounds};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::marker::PhantomData;
+use core::ops::Bound;
+use core::ops::{Range, RangeBounds};
 
 pub(crate) struct EntryGuard<K: Key, V: Value> {
     page: PageImpl,

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -14,10 +14,12 @@ use crate::tree_store::{
 };
 use crate::types::{Key, Value};
 use crate::{AccessGuard, Result};
-use std::cmp::{max, min};
-use std::marker::PhantomData;
-use std::ops::Range;
-use std::sync::Arc;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::{max, min};
+use core::marker::PhantomData;
+use core::ops::Range;
 
 #[derive(Debug)]
 enum DeletionResult {
@@ -512,7 +514,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         // propagating; a matching stored separator proves the
                         // bound unchanged, which None expresses upward.
                         let carried = if stored.is_none() {
-                            std::mem::take(&mut nodes[0].2)
+                            core::mem::take(&mut nodes[0].2)
                         } else {
                             None
                         };

--- a/src/tree_store/extract_if.rs
+++ b/src/tree_store/extract_if.rs
@@ -2,8 +2,10 @@ use crate::tree_store::btree_cursor::RangeMut;
 use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageTracker};
 use crate::types::{Key, Value};
 use crate::{AccessGuard, Result, StorageError};
-use std::collections::Bound;
-use std::sync::{Arc, Mutex};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::ops::Bound;
+use std::sync::Mutex;
 
 type ExtractItem<'a, K, V> = (AccessGuard<'a, K>, AccessGuard<'a, V>);
 type AdvanceInner<T, R> = fn(&mut T) -> Result<Option<R>>;

--- a/src/tree_store/multimap_btree.rs
+++ b/src/tree_store/multimap_btree.rs
@@ -9,12 +9,15 @@ use crate::tree_store::{
     PageResolver, PageTracker, RawBtree,
 };
 use crate::types::{Key, TypeName, Value};
-use std::cmp::max;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::max;
+use core::marker::PhantomData;
+use core::mem::size_of;
+use core::ops::Range;
 use std::collections::HashMap;
-use std::marker::PhantomData;
-use std::mem::size_of;
-use std::ops::Range;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 pub(crate) fn multimap_btree_stats(
     root: Option<PageNumber>,
@@ -476,8 +479,8 @@ pub(crate) struct DynamicCollection<V: Key> {
     data: [u8],
 }
 
-impl<V: Key> std::fmt::Debug for DynamicCollection<V> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<V: Key> core::fmt::Debug for DynamicCollection<V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("DynamicCollection")
             .field("data", &&self.data)
             .finish()
@@ -519,7 +522,7 @@ impl<V: Key> Value for &DynamicCollection<V> {
 
 impl<V: Key> DynamicCollection<V> {
     pub(crate) fn new(data: &[u8]) -> &Self {
-        unsafe { &*(std::ptr::from_ref::<[u8]>(data) as *const DynamicCollection<V>) }
+        unsafe { &*(core::ptr::from_ref::<[u8]>(data) as *const DynamicCollection<V>) }
     }
 
     pub(crate) fn collection_type(&self) -> DynamicCollectionType {
@@ -596,7 +599,7 @@ impl UntypedDynamicCollection {
     }
 
     fn new(data: &[u8]) -> &Self {
-        unsafe { &*(std::ptr::from_ref::<[u8]>(data) as *const UntypedDynamicCollection) }
+        unsafe { &*(core::ptr::from_ref::<[u8]>(data) as *const UntypedDynamicCollection) }
     }
 
     fn make_subtree_data(header: BtreeHeader) -> Vec<u8> {

--- a/src/tree_store/page_store/backends.rs
+++ b/src/tree_store/page_store/backends.rs
@@ -1,4 +1,6 @@
 use crate::StorageBackend;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use std::io;
 use std::io::Error;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};

--- a/src/tree_store/page_store/base.rs
+++ b/src/tree_store/page_store/base.rs
@@ -2,19 +2,19 @@ use crate::Result;
 use crate::tree_store::page_store::cached_file::WritablePage;
 use crate::tree_store::page_store::fast_hash::PageNumberHashSet;
 use crate::tree_store::page_store::page_manager::MAX_MAX_PAGE_ORDER;
-use std::cmp::Ordering;
+use alloc::sync::Arc;
+use core::cmp::Ordering;
+use core::fmt::{Debug, Formatter};
+use core::hash::{Hash, Hasher};
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::Range;
+use core::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 #[cfg(debug_assertions)]
 use std::collections::HashMap;
 #[cfg(debug_assertions)]
 use std::collections::HashSet;
-use std::fmt::{Debug, Formatter};
-use std::hash::{Hash, Hasher};
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::Range;
-use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
 pub(crate) const MAX_VALUE_LENGTH: usize = 3 * 1024 * 1024 * 1024;
 pub(crate) const MAX_PAIR_LENGTH: usize = 3 * 1024 * 1024 * 1024 + 768 * 1024 * 1024;
@@ -164,7 +164,7 @@ impl PageNumber {
 }
 
 impl Debug for PageNumber {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "r{}.{}/{}",
@@ -193,7 +193,7 @@ impl PageImpl {
 }
 
 impl Debug for PageImpl {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!("PageImpl: page_number={:?}", self.page_number))
     }
 }

--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -1,5 +1,7 @@
 use crate::tree_store::page_store::xxh3_checksum;
-use std::mem::size_of;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::mem::size_of;
 
 const HEIGHT_OFFSET: usize = 0;
 const END_OFFSETS: usize = HEIGHT_OFFSET + size_of::<u32>();

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -1,10 +1,10 @@
 use crate::tree_store::PageNumber;
 use crate::tree_store::page_store::bitmap::BtreeBitmap;
 use crate::tree_store::page_store::page_manager::MAX_MAX_PAGE_ORDER;
-use std::cmp::min;
+use core::cmp::min;
+use core::mem::size_of;
 #[cfg(test)]
 use std::collections::HashSet;
-use std::mem::size_of;
 
 const MAX_ORDER_OFFSET: usize = 0;
 const PADDING: usize = 3;

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -1,18 +1,22 @@
 use crate::tree_store::page_store::base::PageHint;
 use crate::tree_store::page_store::lru_cache::LRUCache;
 use crate::{CacheStats, DatabaseError, Result, StorageBackend, StorageError};
-use std::ops::{Index, IndexMut};
-use std::slice::SliceIndex;
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::ops::{Index, IndexMut};
+use core::slice::SliceIndex;
 #[cfg(feature = "cache_metrics")]
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard, RwLock};
+use core::sync::atomic::AtomicU64;
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Mutex, MutexGuard, RwLock};
 
 // Allocates an `Arc<[u8]>` in one step. `Arc::<[u8]>::from(vec![0; len])` would
 // allocate the Vec and then allocate a new Arc and memcpy into it.
 fn zero_filled_arc(len: usize) -> Arc<[u8]> {
     // This is documented to do a single allocation: https://doc.rust-lang.org/std/sync/struct.Arc.html#iterators-of-known-length
-    std::iter::repeat_n(0u8, len).collect()
+    core::iter::repeat_n(0u8, len).collect()
 }
 
 pub(super) struct WritablePage {
@@ -840,8 +844,8 @@ mod test {
     use crate::backends::InMemoryBackend;
     use crate::tree_store::PageHint;
     use crate::tree_store::page_store::cached_file::PagedCachedFile;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use alloc::sync::Arc;
+    use core::sync::atomic::{AtomicU64, Ordering};
 
     #[derive(Debug)]
     struct CountingBackend {

--- a/src/tree_store/page_store/fast_hash.rs
+++ b/src/tree_store/page_store/fast_hash.rs
@@ -1,6 +1,6 @@
 use crate::tree_store::PageNumber;
+use core::hash::{BuildHasherDefault, Hasher};
 use std::collections::{HashMap, HashSet};
-use std::hash::{BuildHasherDefault, Hasher};
 
 // See "Computationally easy, spectrally good multipliers for congruential pseudorandom number generators" by Steele & Vigna
 const K: u64 = 0xf135_7aea_2e62_a9c5;

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -138,7 +138,7 @@ fn read_exact_at(file: &File, mut buf: &mut [u8], mut offset: u64) -> io::Result
             libc::pread(
                 file.as_raw_fd(),
                 buf.as_mut_ptr() as _,
-                std::cmp::min(buf.len(), libc::ssize_t::MAX as _),
+                core::cmp::min(buf.len(), libc::ssize_t::MAX as _),
                 offset as _,
             )
         };
@@ -174,7 +174,7 @@ fn write_all_at(file: &File, mut buf: &[u8], mut offset: u64) -> io::Result<()> 
             libc::pwrite(
                 file.as_raw_fd(),
                 buf.as_ptr() as _,
-                std::cmp::min(buf.len(), libc::ssize_t::MAX as _),
+                core::cmp::min(buf.len(), libc::ssize_t::MAX as _),
                 offset as _,
             )
         };

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -6,7 +6,9 @@ use crate::tree_store::page_store::page_manager::{
     FILE_FORMAT_VERSION1, FILE_FORMAT_VERSION2, FILE_FORMAT_VERSION3, xxh3_checksum,
 };
 use crate::{DatabaseError, Result, StorageError};
-use std::mem::size_of;
+use alloc::format;
+use alloc::string::ToString;
+use core::mem::size_of;
 
 // Database layout:
 //
@@ -576,11 +578,11 @@ mod test {
     };
     use crate::{Database, DatabaseError, StorageBackend};
     use crate::{ReadableDatabase, StorageError};
+    use alloc::sync::Arc;
+    use core::mem::size_of;
+    use core::sync::atomic::{AtomicU8, AtomicU64, Ordering};
     use std::fs::OpenOptions;
     use std::io::{Error, ErrorKind, Read, Seek, SeekFrom, Write};
-    use std::mem::size_of;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 
     const X: TableDefinition<&str, &str> = TableDefinition::new("x");
 
@@ -855,7 +857,7 @@ mod test {
         let primary_txn_id =
             super::get_u64(&header[primary_offset + super::TRANSACTION_ID_OFFSET..]);
         let id_offset = secondary_offset + super::TRANSACTION_ID_OFFSET;
-        header[id_offset..id_offset + std::mem::size_of::<u64>()]
+        header[id_offset..id_offset + core::mem::size_of::<u64>()]
             .copy_from_slice(&(primary_txn_id + 1).to_le_bytes());
         corrupt_slot_checksum(&mut header, secondary_offset);
 
@@ -1036,20 +1038,20 @@ mod test {
     // allocating it -- used to simulate an externally created (e.g. sparse) file.
     #[derive(Clone, Debug, Default)]
     struct LenOverrideBackend {
-        data: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
-        fake_len: std::sync::Arc<std::sync::atomic::AtomicU64>,
+        data: alloc::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+        fake_len: alloc::sync::Arc<core::sync::atomic::AtomicU64>,
     }
 
     impl LenOverrideBackend {
         fn set_fake_len(&self, len: u64) {
             self.fake_len
-                .store(len, std::sync::atomic::Ordering::Release);
+                .store(len, core::sync::atomic::Ordering::Release);
         }
     }
 
     impl StorageBackend for LenOverrideBackend {
         fn len(&self) -> Result<u64, std::io::Error> {
-            let fake = self.fake_len.load(std::sync::atomic::Ordering::Acquire);
+            let fake = self.fake_len.load(core::sync::atomic::Ordering::Acquire);
             if fake == 0 {
                 Ok(self.data.lock().unwrap().len() as u64)
             } else {
@@ -1392,7 +1394,7 @@ mod test {
         // Test that magic number is not valid utf-8
         #[allow(invalid_from_utf8)]
         {
-            assert!(std::str::from_utf8(&MAGICNUMBER).is_err());
+            assert!(core::str::from_utf8(&MAGICNUMBER).is_err());
         }
         // Test there is a octet with high-bit set
         assert!(MAGICNUMBER.iter().any(|x| *x & 0x80 != 0));

--- a/src/tree_store/page_store/layout.rs
+++ b/src/tree_store/page_store/layout.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 fn round_up_to_multiple_of(value: u64, multiple: u64) -> u64 {
     if value.is_multiple_of(multiple) {

--- a/src/tree_store/page_store/lru_cache.rs
+++ b/src/tree_store/page_store/lru_cache.rs
@@ -1,6 +1,6 @@
 use crate::tree_store::page_store::fast_hash::FastHashMapU64;
-use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, Ordering};
+use alloc::collections::VecDeque;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 #[derive(Default)]
 pub struct LRUCache<T> {

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -14,17 +14,20 @@ use crate::tree_store::page_store::{PageImpl, PageMut, hash128_with_seed};
 use crate::tree_store::{Page, PageNumber, PageTracker};
 use crate::{CacheStats, StorageBackend};
 use crate::{DatabaseError, Result, StorageError};
-use std::cmp::{max, min};
-use std::collections::BTreeMap;
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::{max, min};
+use core::convert::TryInto;
+use core::marker::PhantomData;
+use core::mem;
 #[cfg(debug_assertions)]
 use std::collections::HashMap;
 #[cfg(debug_assertions)]
 use std::collections::HashSet;
-use std::convert::TryInto;
 use std::io::ErrorKind;
-use std::marker::PhantomData;
-use std::mem;
-use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
 

--- a/src/tree_store/page_store/region.rs
+++ b/src/tree_store/page_store/region.rs
@@ -3,8 +3,10 @@ use crate::tree_store::page_store::bitmap::BtreeBitmap;
 use crate::tree_store::page_store::buddy_allocator::BuddyAllocator;
 use crate::tree_store::page_store::layout::DatabaseLayout;
 use crate::tree_store::page_store::page_manager::{INITIAL_REGIONS, MAX_MAX_PAGE_ORDER};
-use std::cmp::{self, max};
-use std::mem::size_of;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::{self, max};
+use core::mem::size_of;
 
 // Tracks the page orders that MAY BE free in each region. This data structure is optimistic, so
 // a region may not actually have a page free for a given order

--- a/src/tree_store/page_store/savepoint.rs
+++ b/src/tree_store/page_store/savepoint.rs
@@ -2,9 +2,13 @@ use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker}
 use crate::tree_store::page_store::page_manager::FILE_FORMAT_VERSION3;
 use crate::tree_store::{BtreeHeader, TransactionalMemory};
 use crate::{Result, StorageError, TypeName, Value};
-use std::fmt::Debug;
-use std::mem::size_of;
-use std::sync::Arc;
+use alloc::format;
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt::Debug;
+use core::mem::size_of;
 
 // on-disk format:
 // * 1 byte: version
@@ -66,7 +70,7 @@ impl Savepoint {
     }
 
     pub(crate) fn db_address(&self) -> *const TransactionTracker {
-        std::ptr::from_ref(self.transaction_tracker.as_ref())
+        core::ptr::from_ref(self.transaction_tracker.as_ref())
     }
 
     pub(crate) fn set_persistent(&mut self) {
@@ -216,7 +220,7 @@ impl Value for SerializedSavepoint<'_> {
 mod test {
     use super::*;
     use crate::transaction_tracker::{TransactionId, TransactionTracker};
-    use std::sync::Arc;
+    use alloc::sync::Arc;
 
     #[test]
     fn corrupted_record_errors() {

--- a/src/tree_store/page_store/xxh3.rs
+++ b/src/tree_store/page_store/xxh3.rs
@@ -22,7 +22,7 @@
 
 // Copied from xxh3 crate, commit hash e91f09d1e930e179c11d5cfda6d14284bfb006f8
 
-use std::mem::size_of;
+use core::mem::size_of;
 
 const STRIPE_LENGTH: usize = 64;
 const SECRET_CONSUME_RATE: usize = 8;
@@ -165,9 +165,9 @@ unsafe fn scramble_accumulators_avx2(
 ) {
     unsafe {
         #[cfg(target_arch = "x86")]
-        use std::arch::x86::*;
+        use core::arch::x86::*;
         #[cfg(target_arch = "x86_64")]
-        use std::arch::x86_64::*;
+        use core::arch::x86_64::*;
 
         #[allow(clippy::cast_possible_truncation)]
         let simd_prime = _mm256_set1_epi32(PRIME32[0] as i32);
@@ -198,9 +198,9 @@ unsafe fn scramble_accumulators_neon(
     secret: &[u8],
 ) {
     #[cfg(target_arch = "aarch64")]
-    use std::arch::aarch64::*;
+    use core::arch::aarch64::*;
     #[cfg(target_arch = "arm")]
-    use std::arch::arm::*;
+    use core::arch::arm::*;
 
     unsafe {
         let prime = vdup_n_u32(PRIME32[0].try_into().unwrap());
@@ -294,9 +294,9 @@ fn gen_secret_generic(seed: u64) -> [u8; DEFAULT_SECRET.len()] {
 unsafe fn gen_secret_avx2(seed: u64) -> [u8; DEFAULT_SECRET.len()] {
     unsafe {
         #[cfg(target_arch = "x86")]
-        use std::arch::x86::*;
+        use core::arch::x86::*;
         #[cfg(target_arch = "x86_64")]
-        use std::arch::x86_64::*;
+        use core::arch::x86_64::*;
 
         #[allow(clippy::cast_possible_wrap)]
         let xxh_i64 = 0u64.wrapping_sub(seed) as i64;
@@ -321,9 +321,9 @@ unsafe fn gen_secret_avx2(seed: u64) -> [u8; DEFAULT_SECRET.len()] {
 #[cfg(target_arch = "aarch64")]
 unsafe fn accumulate_stripe_neon(accumulators: &mut [u64; 8], data: &[u8], secret: &[u8]) {
     #[cfg(target_arch = "aarch64")]
-    use std::arch::aarch64::*;
+    use core::arch::aarch64::*;
     #[cfg(target_arch = "arm")]
-    use std::arch::arm::*;
+    use core::arch::arm::*;
 
     unsafe {
         let accum_ptr = accumulators.as_mut_ptr();
@@ -355,9 +355,9 @@ unsafe fn accumulate_stripe_neon(accumulators: &mut [u64; 8], data: &[u8], secre
 unsafe fn accumulate_stripe_avx2(accumulators: &mut [u64; 8], data: &[u8], secret: &[u8]) {
     unsafe {
         #[cfg(target_arch = "x86")]
-        use std::arch::x86::*;
+        use core::arch::x86::*;
         #[cfg(target_arch = "x86_64")]
-        use std::arch::x86_64::*;
+        use core::arch::x86_64::*;
 
         let data_ptr = data.as_ptr();
         let secret_ptr = secret.as_ptr();

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -12,12 +12,19 @@ use crate::tree_store::{
 };
 use crate::types::{Key, Value};
 use crate::{DatabaseStats, Result};
-use std::cmp::max;
-use std::collections::{BTreeMap, HashMap};
-use std::mem::size_of;
-use std::ops::RangeFull;
-use std::sync::{Arc, Mutex};
-use std::{mem, thread};
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::max;
+use core::mem;
+use core::mem::size_of;
+use core::ops::RangeFull;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::thread;
 
 #[derive(Debug)]
 #[repr(transparent)]
@@ -347,7 +354,8 @@ impl TableTreeMut {
     }
 
     pub(crate) fn flush_table_root_updates(&mut self) -> Result<&mut Self> {
-        for (name, (new_root, new_length, dirty)) in std::mem::take(&mut self.pending_table_updates)
+        for (name, (new_root, new_length, dirty)) in
+            core::mem::take(&mut self.pending_table_updates)
         {
             // Bypass .get_table() since the table types are dynamic
             let mut definition = self.tree.get(&name.as_str())?.unwrap().value();

--- a/src/tree_store/table_tree_base.rs
+++ b/src/tree_store/table_tree_base.rs
@@ -2,9 +2,13 @@ use crate::tree_store::btree::{PagePath, UntypedBtree, UntypedBtreeMut};
 use crate::tree_store::multimap_btree::{UntypedMultiBtree, relocate_subtrees};
 use crate::tree_store::{BtreeHeader, PageAllocator, PageHint, PageNumber, PageResolver};
 use crate::{Key, Result, TableError, TypeName, Value};
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::mem::size_of;
 use std::collections::HashMap;
-use std::mem::size_of;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 // Forward compatibility feature in case alignment can be supported in the future
 // See https://github.com/cberner/redb/issues/360

--- a/src/tuple_types.rs
+++ b/src/tuple_types.rs
@@ -1,7 +1,10 @@
 use crate::complex_types::{decode_varint_len, encode_varint_len};
 use crate::types::{Key, TypeName, Value};
-use std::borrow::Borrow;
-use std::cmp::Ordering;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::cmp::Ordering;
 
 fn serialize_tuple_elements_variable<const N: usize>(
     is_fixed_width: [bool; N],

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,12 @@
-use std::cmp::Ordering;
-use std::convert::TryInto;
-use std::fmt::Debug;
-use std::mem::size_of;
+use alloc::format;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::convert::TryInto;
+use core::fmt::Debug;
+use core::mem::size_of;
 #[cfg(feature = "chrono_v0_4")]
 mod chrono_v0_4;
 #[cfg(feature = "uuid")]
@@ -96,7 +101,7 @@ impl TypeName {
 
     pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
         let classification = TypeClassification::from_byte(bytes[0]);
-        let name = std::str::from_utf8(&bytes[1..]).unwrap().to_string();
+        let name = core::str::from_utf8(&bytes[1..]).unwrap().to_string();
 
         Self {
             classification,
@@ -561,7 +566,7 @@ impl Value for &str {
     where
         Self: 'a,
     {
-        std::str::from_utf8(data).unwrap()
+        core::str::from_utf8(data).unwrap()
     }
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a str
@@ -602,7 +607,7 @@ impl Value for String {
     where
         Self: 'a,
     {
-        std::str::from_utf8(data).unwrap().to_string()
+        core::str::from_utf8(data).unwrap().to_string()
     }
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a str
@@ -619,8 +624,8 @@ impl Value for String {
 
 impl Key for String {
     fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
-        let str1 = std::str::from_utf8(data1).unwrap();
-        let str2 = std::str::from_utf8(data2).unwrap();
+        let str1 = core::str::from_utf8(data1).unwrap();
+        let str2 = core::str::from_utf8(data2).unwrap();
         str1.cmp(str2)
     }
 }
@@ -667,12 +672,12 @@ macro_rules! le_value {
         impl Value for $t {
             type SelfType<'a> = $t;
             type AsBytes<'a>
-                = [u8; std::mem::size_of::<$t>()]
+                = [u8; core::mem::size_of::<$t>()]
             where
                 Self: 'a;
 
             fn fixed_width() -> Option<usize> {
-                Some(std::mem::size_of::<$t>())
+                Some(core::mem::size_of::<$t>())
             }
 
             fn from_bytes<'a>(data: &'a [u8]) -> $t
@@ -684,7 +689,7 @@ macro_rules! le_value {
 
             fn as_bytes<'a, 'b: 'a>(
                 value: &'a Self::SelfType<'b>,
-            ) -> [u8; std::mem::size_of::<$t>()]
+            ) -> [u8; core::mem::size_of::<$t>()]
             where
                 Self: 'a,
                 Self: 'b,

--- a/src/types/chrono_v0_4.rs
+++ b/src/types/chrono_v0_4.rs
@@ -58,7 +58,7 @@ impl Value for NaiveDate {
     }
 }
 impl Key for NaiveDate {
-    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+    fn compare(data1: &[u8], data2: &[u8]) -> core::cmp::Ordering {
         let date1 = date_from_bytes(data1);
         let date2 = date_from_bytes(data2);
         date1.cmp(&date2)
@@ -115,7 +115,7 @@ impl Value for NaiveTime {
     }
 }
 impl Key for NaiveTime {
-    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+    fn compare(data1: &[u8], data2: &[u8]) -> core::cmp::Ordering {
         let time1 = time_from_bytes(data1);
         let time2 = time_from_bytes(data2);
         time1.cmp(&time2)
@@ -186,7 +186,7 @@ impl Value for NaiveDateTime {
     }
 }
 impl Key for NaiveDateTime {
-    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+    fn compare(data1: &[u8], data2: &[u8]) -> core::cmp::Ordering {
         let date_time1 = NaiveDateTime::from_bytes(data1);
         let date_time2 = NaiveDateTime::from_bytes(data2);
         date_time1.cmp(&date_time2)
@@ -265,7 +265,7 @@ impl Value for DateTime<FixedOffset> {
     }
 }
 impl Key for DateTime<FixedOffset> {
-    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+    fn compare(data1: &[u8], data2: &[u8]) -> core::cmp::Ordering {
         let datetime1 = DateTime::<FixedOffset>::from_bytes(data1);
         let datetime2 = DateTime::<FixedOffset>::from_bytes(data2);
         datetime1.cmp(&datetime2)
@@ -311,7 +311,7 @@ impl Value for FixedOffset {
     }
 }
 impl Key for FixedOffset {
-    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+    fn compare(data1: &[u8], data2: &[u8]) -> core::cmp::Ordering {
         let offset1 = FixedOffset::from_bytes(data1);
         let offset2 = FixedOffset::from_bytes(data2);
         offset1.local_minus_utc().cmp(&offset2.local_minus_utc())
@@ -363,7 +363,7 @@ mod tests {
         );
         assert_eq!(
             NaiveDate::compare(&bytes, &bytes),
-            std::cmp::Ordering::Equal,
+            core::cmp::Ordering::Equal,
             "Bytes should compare equal to themselves"
         );
         let date_from_bytes = NaiveDate::from_bytes(&bytes);
@@ -380,7 +380,7 @@ mod tests {
         );
         assert_eq!(
             NaiveTime::compare(&bytes, &bytes),
-            std::cmp::Ordering::Equal,
+            core::cmp::Ordering::Equal,
             "Bytes should compare equal to themselves"
         );
         let time_from_bytes = NaiveTime::from_bytes(&bytes);
@@ -399,7 +399,7 @@ mod tests {
         );
         assert_eq!(
             NaiveDateTime::compare(&bytes, &bytes),
-            std::cmp::Ordering::Equal,
+            core::cmp::Ordering::Equal,
             "Bytes should compare equal to themselves"
         );
         let datetime_from_bytes = NaiveDateTime::from_bytes(&bytes);
@@ -416,7 +416,7 @@ mod tests {
         );
         assert_eq!(
             FixedOffset::compare(&bytes, &bytes),
-            std::cmp::Ordering::Equal,
+            core::cmp::Ordering::Equal,
             "Bytes should compare equal to themselves"
         );
         let offset_from_bytes = FixedOffset::from_bytes(&bytes);
@@ -438,7 +438,7 @@ mod tests {
             );
             assert_eq!(
                 DateTime::<FixedOffset>::compare(&bytes, &bytes),
-                std::cmp::Ordering::Equal,
+                core::cmp::Ordering::Equal,
                 "Bytes should compare equal to themselves"
             );
             let datetime_from_bytes = DateTime::<FixedOffset>::from_bytes(&bytes);

--- a/src/types/uuid.rs
+++ b/src/types/uuid.rs
@@ -1,5 +1,5 @@
 use crate::{Key, TypeName, Value};
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 use uuid::Uuid;
 
 impl Value for Uuid {


### PR DESCRIPTION
First step towards `no_std` support (#1099).

Everything redb uses from the standard library that also exists in `core` or `alloc` is now imported from there, and the items that the std prelude supplies but the core prelude does not (`Vec`, `Box`, `String`, `ToString`, `format!`, `vec!`) are imported explicitly. `alloc` is a subset of `std`, so this is a no-op for std builds; it's a prerequisite for ever setting `#[no_std]`.

The change is mechanical:

* `std::{cmp,mem,ops,fmt,hash,marker,ptr,slice,str,iter,convert,arch,result,error,borrow::Borrow,sync::atomic}` -> `core::...`
* `std::sync::Arc` -> `alloc::sync::Arc`, `std::collections::{BTreeMap,BTreeSet,VecDeque,btree_map}` -> `alloc::collections::...`
* `std::collections::Bound` -> `core::ops::Bound` (`std::collections::Bound` is just a re-export)
* `impl std::error::Error` -> `impl core::error::Error` (same trait; `std::error::Error` has been a re-export of the core trait since 1.81, and redb only uses the default method bodies)
* `extern crate alloc;` added in `lib.rs`

What is deliberately *not* touched here, because it has no `core`/`alloc` equivalent and needs real work: `std::io`, `std::fs`, `std::path`, `std::os`, `std::sync::{Mutex,RwLock,Condvar,PoisonError}`, `std::thread`, `std::panic`, and `std::collections::{HashMap,HashSet}`. Those come in follow-up PRs.

No behaviour change and no public API change. `cargo test --all-features` passes, and `cargo clippy --all-targets` is clean with default, `--all-features`, `--no-default-features`, `experimental-api-5`, `experimental_cursor`, and `logging`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7DhuGXp5hmdwuRSRFYGtV)_