### PR TITLE
Use alloc collections in place of the std hash collections

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,16 @@
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(fuzzing)");
+    println!("cargo:rustc-check-cfg=cfg(redb_no_std)");
+
+    // Building without the standard library is only offered under the redb 5 API preview. Cargo
+    // features cannot express "experimental-api-5 and not std", so it is computed here and used as
+    // `cfg(redb_no_std)` throughout the crate. Turning "std" off without "experimental-api-5" keeps
+    // the std build, so that 4.x dependents who set `default-features = false` are unaffected.
+    if std::env::var_os("CARGO_FEATURE_EXPERIMENTAL_API_5").is_some()
+        && std::env::var_os("CARGO_FEATURE_STD").is_none()
+    {
+        println!("cargo:rustc-cfg=redb_no_std");
+    }
 
     if std::env::var("CARGO_CFG_FUZZING").is_ok()
         && std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,10 +60,10 @@
 //! [lmdb]: https://www.lmdb.tech/doc/
 //! [design]: https://github.com/cberner/redb/blob/master/docs/design.md
 
-// The "std" feature is a placeholder: no_std is not supported yet. Enforce it under the redb 5
-// flag, so that turning it off there fails loudly instead of producing a build that still links
-// against the standard library.
-#[cfg(all(feature = "experimental-api-5", not(feature = "std")))]
+// `redb_no_std` is set by build.rs when the redb 5 API preview is enabled and "std" is not. It is
+// not a complete build mode yet, so it still fails loudly rather than silently producing a build
+// that links against the standard library.
+#[cfg(redb_no_std)]
 compile_error!(
     "redb requires the standard library: no_std is not supported yet. Enable the \"std\" feature; \
      it is on by default, so add features = [\"std\"] if you set default-features = false."

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -9,7 +9,6 @@ use core::mem;
 use core::mem::size_of;
 #[cfg(feature = "logging")]
 use log::debug;
-use std::collections::HashMap;
 use std::sync::{Condvar, Mutex};
 
 #[derive(Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, Debug)]
@@ -91,7 +90,7 @@ struct State {
     // Therefore, we hold a read transaction on their nearest durable ancestor
     //
     // Maps non-durable transaction id -> durable ancestor
-    pending_non_durable_commits: HashMap<TransactionId, TransactionId>,
+    pending_non_durable_commits: BTreeMap<TransactionId, TransactionId>,
     // Non-durable commits which have NOT been processed in the freed table
     unprocessed_freed_non_durable_commits: BTreeSet<TransactionId>,
     // Set when the Database was dropped while a write transaction was live. That transaction
@@ -115,7 +114,7 @@ impl TransactionTracker {
                 live_write_transaction: None,
                 valid_savepoints: BTreeMap::default(),
                 persistent_savepoints: BTreeSet::default(),
-                pending_non_durable_commits: HashMap::default(),
+                pending_non_durable_commits: BTreeMap::default(),
                 unprocessed_freed_non_durable_commits: BTreeSet::default(),
                 deferred_close: None,
             }),

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -4,11 +4,13 @@ use crate::multimap_table::ReadOnlyUntypedMultimapTable;
 use crate::sealed::Sealed;
 use crate::table::ReadOnlyUntypedTable;
 use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker};
+#[cfg(debug_assertions)]
+use crate::tree_store::PageNumberHashSet;
 use crate::tree_store::{
     AllocationPolicy, Btree, BtreeHeader, BtreeMut, InternalTableDefinition, MAX_PAIR_LENGTH,
-    MAX_VALUE_LENGTH, Page, PageAllocator, PageHint, PageListMut, PageNumber, PageResolver,
-    PageTracker, SerializedSavepoint, ShrinkPolicy, TableTree, TableTreeMut, TableType,
-    TransactionalMemory,
+    MAX_VALUE_LENGTH, Page, PageAllocator, PageHint, PageListMut, PageNumber, PageNumberHashMap,
+    PageResolver, PageTracker, SerializedSavepoint, ShrinkPolicy, TableTree, TableTreeMut,
+    TableType, TransactionalMemory,
 };
 use crate::types::{Key, Value};
 use crate::{
@@ -29,12 +31,12 @@ use core::borrow::Borrow;
 use core::cmp::min;
 use core::fmt::{Debug, Display, Formatter};
 use core::marker::PhantomData;
+use core::mem;
 use core::mem::size_of;
 use core::ops::{RangeBounds, RangeFull};
 use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg(feature = "logging")]
 use log::{debug, warn};
-use std::collections::{HashMap, HashSet};
 use std::panic;
 use std::sync::Mutex;
 use std::thread;
@@ -602,7 +604,7 @@ impl SystemNamespace {
 }
 
 struct TableNamespace {
-    open_tables: HashMap<String, &'static panic::Location<'static>>,
+    open_tables: BTreeMap<String, &'static panic::Location<'static>>,
     allocated_pages: Arc<PageTracker>,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
     table_tree: TableTreeMut,
@@ -626,7 +628,7 @@ impl TableNamespace {
             allocated.clone(),
         );
         Self {
-            open_tables: HashMap::default(),
+            open_tables: BTreeMap::default(),
             table_tree,
             freed_pages,
             allocated_pages: allocated,
@@ -802,7 +804,7 @@ impl TableNamespace {
 // Transaction-local savepoint lifecycle state.
 #[derive(Default)]
 struct SavepointTransactionState {
-    created_persistent: HashSet<(SavepointId, TransactionId)>,
+    created_persistent: BTreeSet<(SavepointId, TransactionId)>,
     deleted_persistent: Vec<(SavepointId, TransactionId)>,
     invalidated: BTreeSet<SavepointId>,
 }
@@ -855,7 +857,7 @@ impl SavepointTransactionState {
         // Persistent savepoints created during this transaction: their
         // on-disk entries will be rolled back by rollback_uncommitted_writes(),
         // but the shared tracker registration must be released explicitly.
-        for (savepoint, transaction) in self.created_persistent.drain() {
+        for (savepoint, transaction) in mem::take(&mut self.created_persistent) {
             tracker.deallocate_savepoint(savepoint, transaction);
         }
         // Deleted-persistent entries will be rolled back on disk, so the
@@ -1014,8 +1016,7 @@ impl WriteTransaction {
 
     #[cfg(debug_assertions)]
     pub fn print_allocated_page_debug(&self) {
-        let mut all_allocated: HashSet<PageNumber> =
-            HashSet::from_iter(self.mem.all_allocated_pages());
+        let mut all_allocated = PageNumberHashSet::from_iter(self.mem.all_allocated_pages());
 
         self.mem.debug_check_allocator_consistency();
 
@@ -2175,7 +2176,7 @@ impl WriteTransaction {
         let page_allocator = table_tree.page_allocator().clone();
 
         // Calculate how many of them can be relocated to lower pages, starting from the last page
-        let mut relocation_map = HashMap::new();
+        let mut relocation_map = PageNumberHashMap::default();
         for path in highest_pages.into_values().rev() {
             if relocation_map.contains_key(&path.page_number()) {
                 continue;

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -13,7 +13,7 @@ use crate::tree_store::btree_mutator::MutateHelper;
 use crate::tree_store::page_store::{Page, PageImpl, PageMut};
 use crate::tree_store::{
     AccessGuardMutInPlace, AllPageNumbersBtreeIter, BtreeCursorRange, BtreeExtractIf,
-    PageAllocator, PageHint, PageNumber, PageResolver, PageTracker,
+    PageAllocator, PageHint, PageNumber, PageNumberHashMap, PageResolver, PageTracker,
 };
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, Result};
@@ -28,7 +28,6 @@ use core::ops::Bound;
 use core::ops::RangeBounds;
 #[cfg(feature = "logging")]
 use log::trace;
-use std::collections::HashMap;
 use std::sync::Mutex;
 
 pub(crate) struct BtreeStats {
@@ -278,7 +277,7 @@ impl UntypedBtreeMut {
 
     pub(crate) fn relocate(
         &mut self,
-        relocation_map: &HashMap<PageNumber, PageNumber>,
+        relocation_map: &PageNumberHashMap<PageNumber>,
     ) -> Result<bool> {
         if let Some(root) = self.get_root()
             && let Some((new_root, new_checksum)) =
@@ -294,7 +293,7 @@ impl UntypedBtreeMut {
     fn relocate_helper(
         &mut self,
         page_number: PageNumber,
-        relocation_map: &HashMap<PageNumber, PageNumber>,
+        relocation_map: &PageNumberHashMap<PageNumber>,
     ) -> Result<Option<(PageNumber, Checksum)>> {
         let old_page = self.page_allocator.get_page(page_number, PageHint::None)?;
         let mut new_page = if let Some(new_page_number) = relocation_map.get(&page_number) {
@@ -425,7 +424,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
 
     pub(crate) fn relocate(
         &mut self,
-        relocation_map: &HashMap<PageNumber, PageNumber>,
+        relocation_map: &PageNumberHashMap<PageNumber>,
     ) -> Result<bool> {
         let mut tree = UntypedBtreeMut::new(
             self.get_root(),

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -25,8 +25,8 @@ pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multim
 pub(crate) use page_store::ReadOnlyBackend;
 pub(crate) use page_store::{
     AllocationPolicy, FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page,
-    PageAllocator, PageHint, PageNumber, PageNumberHashSet, PageResolver, PageTracker,
-    SerializedSavepoint, ShrinkPolicy, TransactionalMemory,
+    PageAllocator, PageHint, PageNumber, PageNumberHashMap, PageNumberHashSet, PageResolver,
+    PageTracker, SerializedSavepoint, ShrinkPolicy, TransactionalMemory,
 };
 pub use page_store::{InMemoryBackend, Savepoint, file_backend};
 pub(crate) use table_tree::{PageListMut, TableTree, TableTreeMut};

--- a/src/tree_store/multimap_btree.rs
+++ b/src/tree_store/multimap_btree.rs
@@ -6,7 +6,7 @@ use crate::tree_store::btree_base::{
 use crate::tree_store::multimap_btree::DynamicCollectionType::{Inline, SubtreeV2};
 use crate::tree_store::{
     AllPageNumbersBtreeIter, BtreeHeader, BtreeStats, Page, PageAllocator, PageHint, PageNumber,
-    PageResolver, PageTracker, RawBtree,
+    PageNumberHashMap, PageResolver, PageTracker, RawBtree,
 };
 use crate::types::{Key, TypeName, Value};
 use alloc::sync::Arc;
@@ -16,7 +16,6 @@ use core::cmp::max;
 use core::marker::PhantomData;
 use core::mem::size_of;
 use core::ops::Range;
-use std::collections::HashMap;
 use std::sync::Mutex;
 
 pub(crate) fn multimap_btree_stats(
@@ -204,7 +203,7 @@ pub(super) fn relocate_subtrees(
     value_size: Option<usize>,
     page_allocator: PageAllocator,
     freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-    relocation_map: &HashMap<PageNumber, PageNumber>,
+    relocation_map: &PageNumberHashMap<PageNumber>,
 ) -> Result<(PageNumber, Checksum)> {
     let old_page = page_allocator.get_page(root.0, PageHint::None)?;
     let mut new_page = if let Some(new_page_number) = relocation_map.get(&root.0) {

--- a/src/tree_store/page_store/base.rs
+++ b/src/tree_store/page_store/base.rs
@@ -1,5 +1,7 @@
 use crate::Result;
 use crate::tree_store::page_store::cached_file::WritablePage;
+#[cfg(debug_assertions)]
+use crate::tree_store::page_store::fast_hash::PageNumberHashMap;
 use crate::tree_store::page_store::fast_hash::PageNumberHashSet;
 use crate::tree_store::page_store::page_manager::MAX_MAX_PAGE_ORDER;
 use alloc::sync::Arc;
@@ -10,10 +12,6 @@ use core::marker::PhantomData;
 use core::mem;
 use core::ops::Range;
 use core::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
-#[cfg(debug_assertions)]
-use std::collections::HashMap;
-#[cfg(debug_assertions)]
-use std::collections::HashSet;
 use std::sync::Mutex;
 
 pub(crate) const MAX_VALUE_LENGTH: usize = 3 * 1024 * 1024 * 1024;
@@ -183,7 +181,7 @@ pub struct PageImpl {
     pub(super) mem: Arc<[u8]>,
     pub(super) page_number: PageNumber,
     #[cfg(debug_assertions)]
-    pub(super) open_pages: Arc<Mutex<HashMap<PageNumber, u64>>>,
+    pub(super) open_pages: Arc<Mutex<PageNumberHashMap<u64>>>,
 }
 
 impl PageImpl {
@@ -248,7 +246,7 @@ pub(crate) struct PageMut<'txn> {
     pub(super) page_number: PageNumber,
     pub(super) _lifetime: PhantomData<&'txn ()>,
     #[cfg(debug_assertions)]
-    pub(super) open_pages: Arc<Mutex<HashSet<PageNumber>>>,
+    pub(super) open_pages: Arc<Mutex<PageNumberHashSet>>,
 }
 
 impl PageMut<'_> {

--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -390,10 +390,10 @@ impl U64GroupedBitmap {
 #[cfg(test)]
 mod test {
     use crate::tree_store::page_store::bitmap::BtreeBitmap;
+    use alloc::collections::BTreeSet;
     use rand::prelude::IteratorRandom;
     use rand::rngs::StdRng;
     use rand::{RngExt, SeedableRng};
-    use std::collections::HashSet;
 
     #[test]
     fn alloc() {
@@ -523,7 +523,7 @@ mod test {
         for i in 0..num_pages {
             allocator.clear(i);
         }
-        let mut allocated = HashSet::new();
+        let mut allocated = BTreeSet::new();
 
         for _ in 0..(num_pages * 2) {
             if rng.random_bool(0.75) {

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -1,10 +1,10 @@
 use crate::tree_store::PageNumber;
 use crate::tree_store::page_store::bitmap::BtreeBitmap;
+#[cfg(test)]
+use crate::tree_store::page_store::fast_hash::PageNumberHashSet;
 use crate::tree_store::page_store::page_manager::MAX_MAX_PAGE_ORDER;
 use core::cmp::min;
 use core::mem::size_of;
-#[cfg(test)]
-use std::collections::HashSet;
 
 const MAX_ORDER_OFFSET: usize = 0;
 const PADDING: usize = 3;
@@ -198,14 +198,14 @@ impl BuddyAllocator {
         #[cfg(test)]
         // Check the result against the free index to be sure it matches
         {
-            let mut free_check = HashSet::new();
+            let mut free_check = PageNumberHashSet::default();
             for i in 0..self.len() {
                 if self.find_free_order(i).is_none() {
                     free_check.insert(PageNumber::new(region, i, 0));
                 }
             }
 
-            let mut check_result = HashSet::new();
+            let mut check_result = PageNumberHashSet::default();
             for page in allocated_pages {
                 check_result.extend(page.to_order0());
             }

--- a/src/tree_store/page_store/fast_hash.rs
+++ b/src/tree_store/page_store/fast_hash.rs
@@ -1,35 +1,92 @@
-use crate::tree_store::PageNumber;
-use core::hash::{BuildHasherDefault, Hasher};
-use std::collections::{HashMap, HashSet};
+// The lookup tables that redb uses on hot paths, all keyed by an integer. `alloc` has no hash map,
+// so builds without std substitute the ordered collections. That costs O(log n) lookups, but the
+// iteration order of these tables is never observable, so nothing else changes.
+#[cfg(not(redb_no_std))]
+mod hash {
+    use crate::tree_store::PageNumber;
+    use core::hash::{BuildHasherDefault, Hasher};
+    use std::collections::{HashMap, HashSet};
 
-// See "Computationally easy, spectrally good multipliers for congruential pseudorandom number generators" by Steele & Vigna
-const K: u64 = 0xf135_7aea_2e62_a9c5;
+    // See "Computationally easy, spectrally good multipliers for congruential pseudorandom number generators" by Steele & Vigna
+    const K: u64 = 0xf135_7aea_2e62_a9c5;
 
-pub(crate) type FastHashMapU64<V> = HashMap<u64, V, BuildHasherDefault<FastHasher64>>;
-pub(crate) type PageNumberHashMap<V> = HashMap<PageNumber, V, BuildHasherDefault<FastHasher64>>;
-pub(crate) type PageNumberHashSet = HashSet<PageNumber, BuildHasherDefault<FastHasher64>>;
+    pub(crate) type FastHashMapU64<V> = HashMap<u64, V, BuildHasherDefault<FastHasher64>>;
+    pub(crate) type PageNumberHashMap<V> = HashMap<PageNumber, V, BuildHasherDefault<FastHasher64>>;
+    pub(crate) type PageNumberHashSet = HashSet<PageNumber, BuildHasherDefault<FastHasher64>>;
 
-#[derive(Copy, Clone, Default, Eq, PartialEq)]
-pub(crate) struct FastHasher64 {
-    hash: u64,
+    #[derive(Copy, Clone, Default, Eq, PartialEq)]
+    pub(crate) struct FastHasher64 {
+        hash: u64,
+    }
+
+    impl Hasher for FastHasher64 {
+        fn finish(&self) -> u64 {
+            #[cfg(target_pointer_width = "64")]
+            const ROTATE: u32 = 26;
+            #[cfg(target_pointer_width = "32")]
+            const ROTATE: u32 = 15;
+
+            self.hash.rotate_left(ROTATE)
+        }
+
+        fn write(&mut self, _bytes: &[u8]) {
+            unreachable!("Only hashing 8 bytes is supported");
+        }
+
+        fn write_u64(&mut self, x: u64) {
+            debug_assert_eq!(self.hash, 0);
+            self.hash = x.wrapping_mul(K);
+        }
+    }
 }
 
-impl Hasher for FastHasher64 {
-    fn finish(&self) -> u64 {
-        #[cfg(target_pointer_width = "64")]
-        const ROTATE: u32 = 26;
-        #[cfg(target_pointer_width = "32")]
-        const ROTATE: u32 = 15;
+#[cfg(redb_no_std)]
+mod hash {
+    use crate::tree_store::PageNumber;
+    use alloc::collections::{BTreeMap, BTreeSet};
 
-        self.hash.rotate_left(ROTATE)
+    pub(crate) type FastHashMapU64<V> = BTreeMap<u64, V>;
+    pub(crate) type PageNumberHashMap<V> = BTreeMap<PageNumber, V>;
+    pub(crate) type PageNumberHashSet = BTreeSet<PageNumber>;
+}
+
+pub(crate) use hash::{FastHashMapU64, PageNumberHashMap, PageNumberHashSet};
+
+// Releases the spare capacity of one of the tables above. The ordered fallbacks hold none, so it
+// is a no-op for them.
+pub(crate) trait Shrink {
+    fn shrink(&mut self);
+}
+
+#[cfg(not(redb_no_std))]
+mod shrink {
+    use super::Shrink;
+    use core::hash::{BuildHasher, Hash};
+    use std::collections::{HashMap, HashSet};
+
+    impl<K: Eq + Hash, V, S: BuildHasher> Shrink for HashMap<K, V, S> {
+        fn shrink(&mut self) {
+            self.shrink_to_fit();
+        }
     }
 
-    fn write(&mut self, _bytes: &[u8]) {
-        unreachable!("Only hashing 8 bytes is supported");
+    impl<K: Eq + Hash, S: BuildHasher> Shrink for HashSet<K, S> {
+        fn shrink(&mut self) {
+            self.shrink_to_fit();
+        }
+    }
+}
+
+#[cfg(redb_no_std)]
+mod shrink {
+    use super::Shrink;
+    use alloc::collections::{BTreeMap, BTreeSet};
+
+    impl<K, V> Shrink for BTreeMap<K, V> {
+        fn shrink(&mut self) {}
     }
 
-    fn write_u64(&mut self, x: u64) {
-        debug_assert_eq!(self.hash, 0);
-        self.hash = x.wrapping_mul(K);
+    impl<K> Shrink for BTreeSet<K> {
+        fn shrink(&mut self) {}
     }
 }

--- a/src/tree_store/page_store/lru_cache.rs
+++ b/src/tree_store/page_store/lru_cache.rs
@@ -1,4 +1,4 @@
-use crate::tree_store::page_store::fast_hash::FastHashMapU64;
+use crate::tree_store::page_store::fast_hash::{FastHashMapU64, Shrink};
 use alloc::collections::VecDeque;
 use core::sync::atomic::{AtomicBool, Ordering};
 
@@ -95,7 +95,7 @@ impl<T> LRUCache<T> {
     }
 
     pub(crate) fn clear(&mut self) {
-        self.cache.shrink_to_fit();
+        self.cache.shrink();
         self.cache.clear();
         self.lru_queue.shrink_to_fit();
         self.lru_queue.clear();

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -17,7 +17,7 @@ mod xxh3;
 pub use backends::InMemoryBackend;
 pub(crate) use backends::ReadOnlyBackend;
 pub(crate) use base::{MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTracker};
-pub(crate) use fast_hash::PageNumberHashSet;
+pub(crate) use fast_hash::{PageNumberHashMap, PageNumberHashSet};
 pub(crate) use header::PAGE_SIZE;
 pub(crate) use page_manager::{
     AllocationPolicy, FILE_FORMAT_VERSION3, PageAllocator, PageResolver, ShrinkPolicy,

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -4,7 +4,7 @@ use crate::tree_store::btree_base::{BtreeHeader, Checksum};
 use crate::tree_store::page_store::base::{MAX_PAGE_INDEX, PageHint};
 use crate::tree_store::page_store::buddy_allocator::BuddyAllocator;
 use crate::tree_store::page_store::cached_file::PagedCachedFile;
-use crate::tree_store::page_store::fast_hash::{PageNumberHashMap, PageNumberHashSet};
+use crate::tree_store::page_store::fast_hash::{PageNumberHashMap, PageNumberHashSet, Shrink};
 use crate::tree_store::page_store::header::{
     DB_HEADER_SIZE, DatabaseHeader, MAGICNUMBER, TransactionHeader, UnrepairedDatabaseHeader,
 };
@@ -23,10 +23,6 @@ use core::cmp::{max, min};
 use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem;
-#[cfg(debug_assertions)]
-use std::collections::HashMap;
-#[cfg(debug_assertions)]
-use std::collections::HashSet;
 use std::io::ErrorKind;
 use std::sync::Mutex;
 use std::thread;
@@ -363,7 +359,7 @@ struct UnpersistedState {
 impl UnpersistedState {
     fn clear(&mut self) {
         self.pages.clear();
-        self.pages.shrink_to_fit();
+        self.pages.shrink();
         self.allocations.clear();
         self.allocation_txn.clear();
         self.data_freed.clear();
@@ -490,10 +486,10 @@ pub(crate) struct TransactionalMemory {
     state: Mutex<InMemoryState>,
     // The number of PageMut which are outstanding
     #[cfg(debug_assertions)]
-    open_dirty_pages: Arc<Mutex<HashSet<PageNumber>>>,
+    open_dirty_pages: Arc<Mutex<PageNumberHashSet>>,
     // Reference counts of PageImpls that are outstanding
     #[cfg(debug_assertions)]
-    read_page_ref_counts: Arc<Mutex<HashMap<PageNumber, u64>>>,
+    read_page_ref_counts: Arc<Mutex<PageNumberHashMap<u64>>>,
     // Set of all allocated pages for debugging assertions
     #[cfg(debug_assertions)]
     allocated_pages: Arc<Mutex<PageNumberHashSet>>,
@@ -630,9 +626,9 @@ impl TransactionalMemory {
             storage,
             state: Mutex::new(state),
             #[cfg(debug_assertions)]
-            open_dirty_pages: Arc::new(Mutex::new(HashSet::new())),
+            open_dirty_pages: Arc::new(Mutex::new(PageNumberHashSet::default())),
             #[cfg(debug_assertions)]
-            read_page_ref_counts: Arc::new(Mutex::new(HashMap::new())),
+            read_page_ref_counts: Arc::new(Mutex::new(PageNumberHashMap::default())),
             #[cfg(debug_assertions)]
             allocated_pages: Arc::new(Mutex::new(PageNumberHashSet::default())),
             page_size: page_size.try_into().unwrap(),

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -7,8 +7,8 @@ use crate::tree_store::multimap_btree::{
 };
 use crate::tree_store::{
     Btree, BtreeCursorRange, BtreeMut, InternalTableDefinition, PageAllocator, PageHint,
-    PageNumber, PageNumberHashSet, PageResolver, PageTracker, RawBtree, TableType,
-    multimap_btree_stats,
+    PageNumber, PageNumberHashMap, PageNumberHashSet, PageResolver, PageTracker, RawBtree,
+    TableType, multimap_btree_stats,
 };
 use crate::types::{Key, Value};
 use crate::{DatabaseStats, Result};
@@ -22,7 +22,6 @@ use core::cmp::max;
 use core::mem;
 use core::mem::size_of;
 use core::ops::RangeFull;
-use std::collections::HashMap;
 use std::sync::Mutex;
 use std::thread;
 
@@ -694,7 +693,7 @@ impl TableTreeMut {
 
     pub(crate) fn relocate_tables(
         &mut self,
-        relocation_map: &HashMap<PageNumber, PageNumber>,
+        relocation_map: &PageNumberHashMap<PageNumber>,
     ) -> Result {
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;

--- a/src/tree_store/table_tree_base.rs
+++ b/src/tree_store/table_tree_base.rs
@@ -1,13 +1,14 @@
 use crate::tree_store::btree::{PagePath, UntypedBtree, UntypedBtreeMut};
 use crate::tree_store::multimap_btree::{UntypedMultiBtree, relocate_subtrees};
-use crate::tree_store::{BtreeHeader, PageAllocator, PageHint, PageNumber, PageResolver};
+use crate::tree_store::{
+    BtreeHeader, PageAllocator, PageHint, PageNumber, PageNumberHashMap, PageResolver,
+};
 use crate::{Key, Result, TableError, TypeName, Value};
 use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::mem::size_of;
-use std::collections::HashMap;
 use std::sync::Mutex;
 
 // Forward compatibility feature in case alignment can be supported in the future
@@ -236,7 +237,7 @@ impl InternalTableDefinition {
         &mut self,
         page_allocator: PageAllocator,
         freed_pages: Arc<Mutex<Vec<PageNumber>>>,
-        relocation_map: &HashMap<PageNumber, PageNumber>,
+        relocation_map: &PageNumberHashMap<PageNumber>,
     ) -> Result<Option<BtreeHeader>> {
         let original_root = self.private_get_root();
         let relocated_root = match self {


### PR DESCRIPTION
Second step towards `no_std` support (#1099). #1363 has landed, so this now targets `master` directly and is a single commit.

`alloc` has no hash map, so a build without std needs a substitute for the tables the page store and the transaction bookkeeping keep in memory.

* The three aliases in `fast_hash.rs` (`FastHashMapU64`, `PageNumberHashMap`, `PageNumberHashSet`) resolve to `BTreeMap`/`BTreeSet` when std is unavailable, and keep the `FastHasher64`-backed hash tables otherwise. This is the only place where the two builds diverge.
* The remaining ad-hoc `HashMap`/`HashSet` uses are gone: the `PageNumber`-keyed ones (relocation maps, open-page tracking, `print_allocated_page_debug`) now go through those aliases, and the few that are not (`open_tables`, `pending_non_durable_commits`, `created_persistent`) become `BTreeMap`/`BTreeSet` outright -- they hold a handful of entries and sit next to fields that were already ordered collections.
* `HashMap::shrink_to_fit` has no `BTreeMap` counterpart, so the two call sites go through a small `Shrink` trait that is a no-op for the ordered fallbacks.

redb never relies on the iteration order of any of these, so switching to an ordered container cannot change behaviour -- only lookup cost, which becomes `O(log n)` in the no_std build. If that turns out to matter for the hot tables, `hashbrown` behind the same cfg would be the drop-in fix; I kept the dependency list untouched for now.

### How the build mode is selected

"Is this a no_std build" is `experimental-api-5 && !std`, which Cargo features cannot express, so `build.rs` computes it and emits `cfg(redb_no_std)`. Turning `std` off *without* the redb 5 preview keeps the std build, so 4.x dependents that set `default-features = false` (and the existing `wasm32-unknown-unknown --no-default-features` CI check) are unaffected. The `compile_error!` that rejects the incomplete no_std mode is unchanged in behaviour; it just keys off the new cfg, and goes away in the last PR of the series.

I verified both sides compile by temporarily lifting that `compile_error!` and running `cargo check`/`cargo clippy` for `-p redb --no-default-features --features experimental-api-5`, in debug and release. `cargo test --all-features` passes, `cargo clippy --all --all-targets` is clean with and without `--all-features`, and `cargo doc` is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7DhuGXp5hmdwuRSRFYGtV)_