### PR TITLE
Take locks through crate::sync

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use crate::sync::PoisonError;
 use crate::tree_store::{FILE_FORMAT_VERSION3, MAX_VALUE_LENGTH};
 use crate::{ReadTransaction, TypeName};
 use alloc::boxed::Box;
@@ -6,7 +7,6 @@ use alloc::string::String;
 use core::fmt::{Display, Formatter};
 use std::io;
 use std::panic;
-use std::sync::PoisonError;
 
 /// General errors directly from the storage layer
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ mod error;
 mod key_range;
 mod multimap_table;
 mod sealed;
+mod sync;
 mod table;
 mod transaction_tracker;
 mod transactions;

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -3,6 +3,7 @@ use crate::KeyRange;
 use crate::db::TransactionGuard;
 use crate::multimap_table::DynamicCollectionType::{Inline, SubtreeV2};
 use crate::sealed::Sealed;
+use crate::sync::Mutex;
 #[cfg(feature = "experimental-api-5")]
 use crate::table::bound_to_bytes;
 use crate::table::{OwnedAccessGuard, ReadableTableMetadata, TableStats};
@@ -30,7 +31,6 @@ use core::mem;
 #[cfg(not(feature = "experimental-api-5"))]
 use core::ops::RangeBounds;
 use core::ops::{Bound, Range, RangeFull};
-use std::sync::Mutex;
 
 pub(crate) struct LeafKeyIter<'a, V: Key + 'static> {
     // Kept alive so any Drop side-effects on `data` (e.g. `remove_on_drop`) still run.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,416 @@
+// The synchronization primitives redb locks with. std's are used whenever it is available; builds
+// without it get the spinning implementations below.
+
+#[cfg(not(redb_no_std))]
+pub(crate) use std::sync::{
+    Condvar, Mutex, MutexGuard, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard,
+};
+
+#[cfg(redb_no_std)]
+pub(crate) use spin::{
+    Condvar, Mutex, MutexGuard, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard,
+};
+
+// Compiled for test builds as well, so that the tests below run as part of the normal test suite
+// rather than only in the no_std configuration. Nothing outside this module uses it in that case,
+// so the parts the tests do not reach are expected to be unused there.
+#[cfg(any(redb_no_std, test))]
+#[cfg_attr(not(redb_no_std), allow(dead_code))]
+mod spin {
+    use core::cell::UnsafeCell;
+    use core::fmt::{Debug, Formatter};
+    use core::hint;
+    use core::marker::PhantomData;
+    use core::ops::{Deref, DerefMut};
+    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    // Stand-ins for the std synchronization primitives, for targets that have no operating system
+    // to block on. Their APIs mirror std's -- including the LockResult wrapper -- so that redb's
+    // call sites are identical in both builds.
+    //
+    // A waiter spins instead of parking, which only makes progress if the holder is running on
+    // another core. That is the same requirement the rest of redb already has: a single-threaded
+    // program never contends for these locks, because it cannot hold two of redb's handles at
+    // once, and redb never takes a lock from an interrupt handler.
+    //
+    // Nothing here poisons. Poisoning exists to stop a later thread from trusting state that a
+    // panicking thread left half-updated, which requires unwinding past the guard; a no_std
+    // program aborts instead. LockResult is kept anyway, so that redb's error path stays in the
+    // type system and the std build keeps its poisoning behavior.
+
+    /// Mirrors [`std::sync::PoisonError`]. These locks never poison, so this is never returned.
+    pub(crate) struct PoisonError<T> {
+        guard: T,
+    }
+
+    impl<T> PoisonError<T> {
+        pub(crate) fn into_inner(self) -> T {
+            self.guard
+        }
+    }
+
+    // Hand-written, because std's is also available for guards that are not Debug.
+    impl<T> Debug for PoisonError<T> {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            f.write_str("PoisonError { .. }")
+        }
+    }
+
+    pub(crate) type LockResult<G> = Result<G, PoisonError<G>>;
+
+    /// The lock is held by someone else. Mirrors [`std::sync::TryLockError::WouldBlock`].
+    #[derive(Debug)]
+    pub(crate) struct WouldBlock;
+
+    pub(crate) type TryLockResult<G> = Result<G, WouldBlock>;
+
+    pub(crate) struct Mutex<T: ?Sized> {
+        locked: AtomicBool,
+        data: UnsafeCell<T>,
+    }
+
+    // Safety: `locked` serializes all access to `data`, so the mutex transfers ownership of the
+    // data between threads and shares nothing else.
+    unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
+    unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
+
+    impl<T> Mutex<T> {
+        pub(crate) const fn new(data: T) -> Self {
+            Self {
+                locked: AtomicBool::new(false),
+                data: UnsafeCell::new(data),
+            }
+        }
+    }
+
+    impl<T: ?Sized> Mutex<T> {
+        pub(crate) fn lock(&self) -> LockResult<MutexGuard<'_, T>> {
+            loop {
+                if !self.locked.swap(true, Ordering::Acquire) {
+                    return Ok(MutexGuard {
+                        mutex: self,
+                        _not_send_or_sync: PhantomData,
+                    });
+                }
+                // Spin on a plain load, so that the contended case does not keep bouncing the
+                // cache line between cores
+                while self.locked.load(Ordering::Relaxed) {
+                    hint::spin_loop();
+                }
+            }
+        }
+
+        pub(crate) fn try_lock(&self) -> TryLockResult<MutexGuard<'_, T>> {
+            if self.locked.swap(true, Ordering::Acquire) {
+                Err(WouldBlock)
+            } else {
+                Ok(MutexGuard {
+                    mutex: self,
+                    _not_send_or_sync: PhantomData,
+                })
+            }
+        }
+    }
+
+    impl<T: Default> Default for Mutex<T> {
+        fn default() -> Self {
+            Self::new(T::default())
+        }
+    }
+
+    impl<T: ?Sized + Debug> Debug for Mutex<T> {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            match self.try_lock() {
+                Ok(guard) => f.debug_struct("Mutex").field("data", &&*guard).finish(),
+                Err(_) => f.write_str("Mutex { <locked> }"),
+            }
+        }
+    }
+
+    pub(crate) struct MutexGuard<'a, T: ?Sized> {
+        mutex: &'a Mutex<T>,
+        // `&Mutex<T>` is the guard's only real field, and `Mutex<T>` is `Sync` for `T: Send`, so
+        // the auto impls would make the guard `Sync` -- and `Send` -- whenever `T: Send`. Two
+        // threads sharing one guard could then reach `&T` concurrently through `Deref` for a `T`
+        // that is not `Sync`, which is a data race. Opt out of both auto impls and restate std's
+        // bounds below.
+        _not_send_or_sync: PhantomData<*const ()>,
+    }
+
+    // Safety: sharing the guard is exactly sharing the `&T` that `Deref` hands out, which is sound
+    // when `T: Sync`. Matches `std::sync::MutexGuard`, which is also never `Send`.
+    unsafe impl<T: ?Sized + Sync> Sync for MutexGuard<'_, T> {}
+
+    impl<T: ?Sized> Deref for MutexGuard<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &T {
+            // Safety: the guard's existence proves the lock is held
+            unsafe { &*self.mutex.data.get() }
+        }
+    }
+
+    impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
+        fn deref_mut(&mut self) -> &mut T {
+            // Safety: the guard's existence proves the lock is held exclusively
+            unsafe { &mut *self.mutex.data.get() }
+        }
+    }
+
+    impl<T: ?Sized> Drop for MutexGuard<'_, T> {
+        fn drop(&mut self) {
+            self.mutex.locked.store(false, Ordering::Release);
+        }
+    }
+
+    impl<T: ?Sized + Debug> Debug for MutexGuard<'_, T> {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            Debug::fmt(&**self, f)
+        }
+    }
+
+    // `state` while a writer holds the lock. Any other value is the number of readers.
+    const WRITER: usize = usize::MAX;
+
+    pub(crate) struct RwLock<T: ?Sized> {
+        state: AtomicUsize,
+        data: UnsafeCell<T>,
+    }
+
+    // Safety: `state` grants either one writer or any number of readers, so `&mut T` is never
+    // handed out concurrently with any other access.
+    unsafe impl<T: ?Sized + Send> Send for RwLock<T> {}
+    unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
+
+    impl<T> RwLock<T> {
+        pub(crate) const fn new(data: T) -> Self {
+            Self {
+                state: AtomicUsize::new(0),
+                data: UnsafeCell::new(data),
+            }
+        }
+    }
+
+    impl<T: ?Sized> RwLock<T> {
+        pub(crate) fn read(&self) -> LockResult<RwLockReadGuard<'_, T>> {
+            loop {
+                let state = self.state.load(Ordering::Relaxed);
+                // WRITER - 1 readers is not reachable in practice, but wrapping into WRITER would
+                // hand this reader the lock as a writer
+                if state >= WRITER - 1 {
+                    hint::spin_loop();
+                    continue;
+                }
+                if self
+                    .state
+                    .compare_exchange_weak(state, state + 1, Ordering::Acquire, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    return Ok(RwLockReadGuard { lock: self });
+                }
+                hint::spin_loop();
+            }
+        }
+
+        pub(crate) fn write(&self) -> LockResult<RwLockWriteGuard<'_, T>> {
+            while self
+                .state
+                .compare_exchange_weak(0, WRITER, Ordering::Acquire, Ordering::Relaxed)
+                .is_err()
+            {
+                hint::spin_loop();
+            }
+            Ok(RwLockWriteGuard { lock: self })
+        }
+    }
+
+    impl<T: Default> Default for RwLock<T> {
+        fn default() -> Self {
+            Self::new(T::default())
+        }
+    }
+
+    impl<T: ?Sized + Debug> Debug for RwLock<T> {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            f.debug_struct("RwLock")
+                .field("data", &&*self.read().unwrap())
+                .finish()
+        }
+    }
+
+    // The read and write guards need no equivalent of `MutexGuard`'s marker: `RwLock<T>` is `Sync`
+    // only for `T: Send + Sync`, so the auto impls already give the guards `T: Sync`, which is the
+    // bound std uses.
+    pub(crate) struct RwLockReadGuard<'a, T: ?Sized> {
+        lock: &'a RwLock<T>,
+    }
+
+    impl<T: ?Sized> Deref for RwLockReadGuard<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &T {
+            // Safety: the guard's existence proves no writer holds the lock
+            unsafe { &*self.lock.data.get() }
+        }
+    }
+
+    impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
+        fn drop(&mut self) {
+            self.lock.state.fetch_sub(1, Ordering::Release);
+        }
+    }
+
+    pub(crate) struct RwLockWriteGuard<'a, T: ?Sized> {
+        lock: &'a RwLock<T>,
+    }
+
+    impl<T: ?Sized> Deref for RwLockWriteGuard<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &T {
+            // Safety: the guard's existence proves the lock is held exclusively
+            unsafe { &*self.lock.data.get() }
+        }
+    }
+
+    impl<T: ?Sized> DerefMut for RwLockWriteGuard<'_, T> {
+        fn deref_mut(&mut self) -> &mut T {
+            // Safety: the guard's existence proves the lock is held exclusively
+            unsafe { &mut *self.lock.data.get() }
+        }
+    }
+
+    impl<T: ?Sized> Drop for RwLockWriteGuard<'_, T> {
+        fn drop(&mut self) {
+            self.lock.state.store(0, Ordering::Release);
+        }
+    }
+
+    /// Mirrors [`std::sync::Condvar`], for the single mutex it is paired with.
+    #[derive(Default)]
+    pub(crate) struct Condvar {
+        // Bumped by every notification. A waiter reads it while still holding the mutex, so a
+        // notification that lands after the read but before the guard is dropped is not lost.
+        notifications: AtomicUsize,
+    }
+
+    impl Condvar {
+        pub(crate) const fn new() -> Self {
+            Self {
+                notifications: AtomicUsize::new(0),
+            }
+        }
+
+        pub(crate) fn wait<'a, T: ?Sized>(
+            &self,
+            guard: MutexGuard<'a, T>,
+        ) -> LockResult<MutexGuard<'a, T>> {
+            let mutex = guard.mutex;
+            let seen = self.notifications.load(Ordering::Relaxed);
+            drop(guard);
+            while self.notifications.load(Ordering::Acquire) == seen {
+                hint::spin_loop();
+            }
+            mutex.lock()
+        }
+
+        pub(crate) fn notify_one(&self) {
+            self.notifications.fetch_add(1, Ordering::Release);
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::{Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+        use std::sync::Arc;
+        use std::thread;
+
+        // The guards must stay `Sync` for data that is `Sync`. The bound they must *not* have is
+        // `T: Send`, which would let two threads reach `&T` at once for a `T` like `Cell`; that
+        // direction cannot be asserted here, and is held by the explicit impl on `MutexGuard`.
+        const _: () = {
+            const fn assert_sync<T: Sync>() {}
+            assert_sync::<MutexGuard<'_, u64>>();
+            assert_sync::<RwLockReadGuard<'_, u64>>();
+            assert_sync::<RwLockWriteGuard<'_, u64>>();
+        };
+
+        #[test]
+        fn mutex_is_exclusive() {
+            let counter = Arc::new(Mutex::new(0u64));
+            thread::scope(|s| {
+                for _ in 0..4 {
+                    let counter = counter.clone();
+                    s.spawn(move || {
+                        for _ in 0..10000 {
+                            *counter.lock().unwrap() += 1;
+                        }
+                    });
+                }
+            });
+            assert_eq!(*counter.lock().unwrap(), 40000);
+        }
+
+        #[test]
+        fn mutex_try_lock() {
+            let mutex = Mutex::new(7u64);
+            let guard = mutex.lock().unwrap();
+            assert!(mutex.try_lock().is_err());
+            drop(guard);
+            assert_eq!(*mutex.try_lock().unwrap(), 7);
+        }
+
+        #[test]
+        fn mutex_debug() {
+            let mutex = Mutex::new(7u64);
+            assert!(format!("{mutex:?}").contains('7'));
+            let guard = mutex.lock().unwrap();
+            assert!(format!("{mutex:?}").contains("locked"));
+            drop(guard);
+        }
+
+        #[test]
+        fn rwlock_readers_are_concurrent() {
+            let lock = RwLock::new(5u64);
+            let first = lock.read().unwrap();
+            let second = lock.read().unwrap();
+            assert_eq!(*first + *second, 10);
+        }
+
+        #[test]
+        fn rwlock_writer_is_exclusive() {
+            let lock = Arc::new(RwLock::new(0u64));
+            thread::scope(|s| {
+                for _ in 0..4 {
+                    let lock = lock.clone();
+                    s.spawn(move || {
+                        for _ in 0..1000 {
+                            *lock.write().unwrap() += 1;
+                            assert!(*lock.read().unwrap() > 0);
+                        }
+                    });
+                }
+            });
+            assert_eq!(*lock.read().unwrap(), 4000);
+        }
+
+        #[test]
+        fn condvar_wakes_waiter() {
+            let ready = Arc::new((Mutex::new(false), Condvar::new()));
+            let waiter = ready.clone();
+            thread::scope(|s| {
+                s.spawn(move || {
+                    let (mutex, condvar) = &*waiter;
+                    let mut ready = mutex.lock().unwrap();
+                    while !*ready {
+                        ready = condvar.wait(ready).unwrap();
+                    }
+                });
+
+                let (mutex, condvar) = &*ready;
+                *mutex.lock().unwrap() = true;
+                condvar.notify_one();
+            });
+        }
+    }
+}

--- a/src/table.rs
+++ b/src/table.rs
@@ -2,6 +2,7 @@
 use crate::KeyRange;
 use crate::db::TransactionGuard;
 use crate::sealed::Sealed;
+use crate::sync::Mutex;
 #[cfg(feature = "experimental-api-5")]
 use crate::tree_store::BtreeCursor;
 #[cfg(feature = "experimental_cursor")]
@@ -26,7 +27,6 @@ use core::marker::PhantomData;
 use core::ops::Bound;
 #[cfg(not(feature = "experimental-api-5"))]
 use core::ops::RangeBounds;
-use std::sync::Mutex;
 use std::thread;
 
 /// Informational storage stats about a table

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -1,3 +1,4 @@
+use crate::sync::{Condvar, Mutex};
 use crate::tree_store::TransactionalMemory;
 use crate::{Key, Result, Savepoint, TypeName, Value};
 use alloc::collections::BTreeSet;
@@ -9,7 +10,6 @@ use core::mem;
 use core::mem::size_of;
 #[cfg(feature = "logging")]
 use log::debug;
-use std::sync::{Condvar, Mutex};
 
 #[derive(Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub(crate) struct TransactionId(u64);

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2,6 +2,7 @@ use crate::db::TransactionGuard;
 use crate::error::CommitError;
 use crate::multimap_table::ReadOnlyUntypedMultimapTable;
 use crate::sealed::Sealed;
+use crate::sync::Mutex;
 use crate::table::ReadOnlyUntypedTable;
 use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker};
 #[cfg(debug_assertions)]
@@ -38,7 +39,6 @@ use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg(feature = "logging")]
 use log::{debug, warn};
 use std::panic;
-use std::sync::Mutex;
 use std::thread;
 
 const MAX_PAGES_PER_COMPACTION: usize = 1_000_000;

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -1,4 +1,5 @@
 use crate::db::TransactionGuard;
+use crate::sync::Mutex;
 use crate::tree_store::btree_base::{
     AccessGuardMut, BRANCH, BranchAccessor, BranchMutator, BtreeHeader, Checksum, DEFERRED, LEAF,
     LeafAccessor, LeafPageMut, branch_checksum, leaf_checksum,
@@ -28,7 +29,6 @@ use core::ops::Bound;
 use core::ops::RangeBounds;
 #[cfg(feature = "logging")]
 use log::trace;
-use std::sync::Mutex;
 
 pub(crate) struct BtreeStats {
     pub(crate) tree_height: u32,

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -1,4 +1,5 @@
 use crate::AccessGuard;
+use crate::sync::Mutex;
 use crate::tree_store::btree_base::{
     BRANCH, BranchAccessor, LEAF, LeafAccessor, OwnedEntryBuffer, leaf_below_merge_threshold,
     leaf_fits_one_page, retained_after_removals,
@@ -19,7 +20,6 @@ use core::marker::PhantomData;
 use core::ops::Bound;
 use core::ops::Bound::{Excluded, Included, Unbounded};
 use core::ops::Range;
-use std::sync::Mutex;
 
 #[derive(Clone)]
 struct Branch {

--- a/src/tree_store/extract_if.rs
+++ b/src/tree_store/extract_if.rs
@@ -1,3 +1,4 @@
+use crate::sync::Mutex;
 use crate::tree_store::btree_cursor::RangeMut;
 use crate::tree_store::{BtreeHeader, PageAllocator, PageNumber, PageTracker};
 use crate::types::{Key, Value};
@@ -5,7 +6,6 @@ use crate::{AccessGuard, Result, StorageError};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::ops::Bound;
-use std::sync::Mutex;
 
 type ExtractItem<'a, K, V> = (AccessGuard<'a, K>, AccessGuard<'a, V>);
 type AdvanceInner<T, R> = fn(&mut T) -> Result<Option<R>>;

--- a/src/tree_store/multimap_btree.rs
+++ b/src/tree_store/multimap_btree.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use crate::sync::Mutex;
 use crate::tree_store::btree::{PagePath, UntypedBtree, UntypedBtreeMut, btree_stats};
 use crate::tree_store::btree_base::{
     BRANCH, BranchAccessor, BranchMutator, Checksum, DEFERRED, LEAF, LeafAccessor, LeafPageMut,
@@ -16,7 +17,6 @@ use core::cmp::max;
 use core::marker::PhantomData;
 use core::mem::size_of;
 use core::ops::Range;
-use std::sync::Mutex;
 
 pub(crate) fn multimap_btree_stats(
     root: Option<PageNumber>,

--- a/src/tree_store/page_store/backends.rs
+++ b/src/tree_store/page_store/backends.rs
@@ -1,9 +1,9 @@
 use crate::StorageBackend;
+use crate::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use std::io;
 use std::io::Error;
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 #[derive(Debug)]
 pub(crate) struct ReadOnlyBackend {

--- a/src/tree_store/page_store/base.rs
+++ b/src/tree_store/page_store/base.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use crate::sync::Mutex;
 use crate::tree_store::page_store::cached_file::WritablePage;
 #[cfg(debug_assertions)]
 use crate::tree_store::page_store::fast_hash::PageNumberHashMap;
@@ -12,7 +13,6 @@ use core::marker::PhantomData;
 use core::mem;
 use core::ops::Range;
 use core::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
-use std::sync::Mutex;
 
 pub(crate) const MAX_VALUE_LENGTH: usize = 3 * 1024 * 1024 * 1024;
 pub(crate) const MAX_PAIR_LENGTH: usize = 3 * 1024 * 1024 * 1024 + 768 * 1024 * 1024;

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -1,3 +1,4 @@
+use crate::sync::{Mutex, MutexGuard, RwLock};
 use crate::tree_store::page_store::base::PageHint;
 use crate::tree_store::page_store::lru_cache::LRUCache;
 use crate::{CacheStats, DatabaseError, Result, StorageBackend, StorageError};
@@ -10,7 +11,6 @@ use core::slice::SliceIndex;
 #[cfg(feature = "cache_metrics")]
 use core::sync::atomic::AtomicU64;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Mutex, MutexGuard, RwLock};
 
 // Allocates an `Arc<[u8]>` in one step. `Arc::<[u8]>::from(vec![0; len])` would
 // allocate the Vec and then allocate a new Arc and memcpy into it.

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1,3 +1,4 @@
+use crate::sync::Mutex;
 use crate::transaction_tracker::TransactionId;
 use crate::transactions::{AllocatorStateKey, AllocatorStateTree, AllocatorStateTreeMut};
 use crate::tree_store::btree_base::{BtreeHeader, Checksum};
@@ -24,7 +25,6 @@ use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem;
 use std::io::ErrorKind;
-use std::sync::Mutex;
 use std::thread;
 
 // The region header is optional in the v3 file format
@@ -787,12 +787,12 @@ impl TransactionalMemory {
     pub(crate) fn invalidate_allocator_state(&self) {
         self.state
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .unwrap_or_else(crate::sync::PoisonError::into_inner)
             .allocators = None;
         #[cfg(debug_assertions)]
         self.allocated_pages
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .unwrap_or_else(crate::sync::PoisonError::into_inner)
             .clear();
     }
 

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -1,5 +1,6 @@
 use crate::db::TransactionGuard;
 use crate::error::TableError;
+use crate::sync::Mutex;
 use crate::tree_store::btree::{PagePath, UntypedBtreeMut, btree_stats};
 use crate::tree_store::btree_base::BtreeHeader;
 use crate::tree_store::multimap_btree::{
@@ -22,7 +23,6 @@ use core::cmp::max;
 use core::mem;
 use core::mem::size_of;
 use core::ops::RangeFull;
-use std::sync::Mutex;
 use std::thread;
 
 #[derive(Debug)]

--- a/src/tree_store/table_tree_base.rs
+++ b/src/tree_store/table_tree_base.rs
@@ -1,3 +1,4 @@
+use crate::sync::Mutex;
 use crate::tree_store::btree::{PagePath, UntypedBtree, UntypedBtreeMut};
 use crate::tree_store::multimap_btree::{UntypedMultiBtree, relocate_subtrees};
 use crate::tree_store::{
@@ -9,7 +10,6 @@ use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::mem::size_of;
-use std::sync::Mutex;
 
 // Forward compatibility feature in case alignment can be supported in the future
 // See https://github.com/cberner/redb/issues/360


### PR DESCRIPTION
Third step towards `no_std` support (#1099). #1364 has landed, so this now targets `master` directly and is a single commit.

`Mutex`, `RwLock` and `Condvar` have no `core`/`alloc` counterpart, so a no_std build needs its own. The new `crate::sync` re-exports std's whenever std is available, and otherwise resolves to the spinning implementations in `sync::spin`, whose APIs mirror std's -- including the `LockResult` wrapper and `PoisonError::into_inner` -- so every call site is character-for-character identical in both builds. The only churn outside `src/sync.rs` is `use std::sync::...` becoming `use crate::sync::...`.

`file_backend/fallback.rs` and the test-only mutexes in `header.rs`/`db.rs` deliberately keep using `std::sync`: they are std-only code either way.

### The two ways the spinning locks differ from std's

* **They spin instead of parking.** That only makes progress if the lock holder is running on another core -- which is the requirement redb's locks already have, since a single-threaded program cannot hold two of redb's handles at once and redb never takes a lock from an interrupt handler.
* **They never poison.** Poisoning exists to stop a later thread from trusting state that a panicking thread left half-updated, and that requires unwinding past the guard; a no_std program aborts instead. `LockResult` is kept anyway so redb's error path (`StorageError::LockPoisoned`, the `.lock()?` sites) stays in the type system and the std build is unchanged.

The guards restate std's auto-trait bounds rather than inheriting them. `MutexGuard`'s only real field is `&Mutex<T>`, and `Mutex<T>` is `Sync` for `T: Send`, so the auto impl would make the guard `Sync` for `T: Send` where std's bound is `T: Sync` -- two threads could then share one guard and reach `&T` concurrently for a `T` like `Cell`. It carries a `PhantomData<*const ()>` to opt out, with `unsafe impl<T: ?Sized + Sync> Sync` restated explicitly, which also leaves it `!Send` as std's is. The `RwLock` guards need no marker, because `RwLock<T>: Sync` already requires `T: Send + Sync`; there is a comment saying so. (Caught by the Codex review.)

### On depending on `spin` instead

I kept redb dependency-free rather than hand-rolling for its own sake, but it is worth recording that `spin` would not be a clean swap:

* It has **no `Condvar`**. It ships `Mutex`, `RwLock`, `Once`, `LazyLock` and `Barrier`; `transaction_tracker.rs` blocks a writer on a condition variable, so that would stay hand-written either way.
* It has **no poisoning and no `LockResult`** -- its `.lock()` returns the guard directly. The 156 `.lock()?` / `.lock().unwrap()` sites depend on the std-shaped `Result`, so `src/sync.rs` would still exist to define `LockResult`/`PoisonError` and wrap every guard.
* Cargo cannot enable it automatically for this build either. Features are additive, so "depend on `spin` when `std` is off" is not expressible, and `[target.'cfg(not(feature = "std"))'.dependencies]` is explicitly unsupported -- cargo warns and adds the dependency anyway, including on default std builds. It would have to be either an unconditional dependency for every user, or an extra feature no_std callers must remember.

So the swap would replace roughly 120 lines of locking logic and leave the condvar and the whole `LockResult` layer in place. Still a real gain in dropping the `unsafe`, and worth revisiting; not the clear win it looks like from outside.

### Testing

`sync::spin` is compiled for test builds as well, so its unit tests (mutual exclusion under 4 threads, `try_lock`, concurrent readers, exclusive writer, condvar wakeup) run in the normal test suite rather than only in a configuration CI cannot execute. A `const _` assertion pins that the guards stay `Sync` for `Sync` data.

Beyond those, I locally forced `crate::sync` to resolve to the spinning implementations in a std test build and ran the whole suite against them: all 316 integration tests, the 6 doc tests, and 102 of the 103 lib tests pass. The one failure is `invalidate_allocator_state_tolerates_poison`, which asserts std's poisoning semantics directly and cannot hold for a non-poisoning lock. That override is not part of this PR.

Otherwise: `cargo test --all-features` passes, `cargo clippy --all --all-targets` is clean with and without `--all-features`, and the no_std side (`-p redb --no-default-features --features experimental-api-5`, `compile_error!` temporarily lifted) is clean in debug and release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7DhuGXp5hmdwuRSRFYGtV)_