### PR TITLE
Gate the file-backed API on std

### DIFF
--- a/src/backends.rs
+++ b/src/backends.rs
@@ -1,2 +1,3 @@
 pub use crate::tree_store::InMemoryBackend;
+#[cfg(not(redb_no_std))]
 pub use crate::tree_store::file_backend::FileBackend;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,9 @@
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
+#[cfg(not(redb_no_std))]
+use crate::tree_store::ReadOnlyBackend;
 use crate::tree_store::{
     AllocationPolicy, BtreeHeader, InternalTableDefinition, PAGE_SIZE, PageHint, PageNumber,
-    PageResolver, ReadOnlyBackend, ShrinkPolicy, TableTree, TableType, TransactionalMemory,
+    PageResolver, ShrinkPolicy, TableTree, TableType, TransactionalMemory,
 };
 use crate::types::{Key, Value};
 use crate::{
@@ -17,10 +19,11 @@ use core::fmt::{Debug, Display, Formatter};
 
 use alloc::sync::Arc;
 use core::marker::PhantomData;
+#[cfg(not(redb_no_std))]
 use std::fs::{File, OpenOptions};
 use std::io;
+#[cfg(not(redb_no_std))]
 use std::path::Path;
-use std::thread;
 
 use crate::error::TransactionError;
 use crate::sealed::{Sealed, SealedInApi5};
@@ -29,6 +32,7 @@ use crate::transactions::{
     DATA_FREED_TABLE, PageList, SYSTEM_FREED_TABLE, SystemTableDefinition,
     TransactionIdWithPagination,
 };
+#[cfg(not(redb_no_std))]
 use crate::tree_store::file_backend::FileBackend;
 #[cfg(feature = "logging")]
 use log::{debug, warn};
@@ -375,6 +379,8 @@ pub trait ReadableDatabase: SealedInApi5 {
     fn cache_stats(&self) -> CacheStats;
 }
 
+// Unavailable without std: every route to one goes through a path, and the file-backed API is
+// gated out below.
 /// A redb database opened in read-only mode
 ///
 /// Use [`Self::begin_read`] to get a [`ReadTransaction`] object that can be used to read from the database
@@ -415,13 +421,16 @@ pub trait ReadableDatabase: SealedInApi5 {
 /// # Ok(())
 /// # }
 /// ```
+#[cfg(not(redb_no_std))]
 pub struct ReadOnlyDatabase {
     mem: Arc<TransactionalMemory>,
     transaction_tracker: Arc<TransactionTracker>,
 }
 
+#[cfg(not(redb_no_std))]
 impl Sealed for ReadOnlyDatabase {}
 
+#[cfg(not(redb_no_std))]
 impl ReadableDatabase for ReadOnlyDatabase {
     fn begin_read(&self) -> Result<ReadTransaction, TransactionError> {
         let id = self
@@ -440,8 +449,10 @@ impl ReadableDatabase for ReadOnlyDatabase {
     }
 }
 
+#[cfg(not(redb_no_std))]
 impl ReadOnlyDatabase {
     /// Opens an existing redb database.
+    #[cfg(not(redb_no_std))]
     pub fn open(path: impl AsRef<Path>) -> Result<ReadOnlyDatabase, DatabaseError> {
         Builder::new().open_read_only(path)
     }
@@ -557,11 +568,13 @@ impl Database {
     /// * if the file does not exist, or is an empty file, a new database will be initialized in it
     /// * if the file is a valid redb database, it will be opened
     /// * otherwise this function will return an error
+    #[cfg(not(redb_no_std))]
     pub fn create(path: impl AsRef<Path>) -> Result<Database, DatabaseError> {
         Self::builder().create(path)
     }
 
     /// Opens an existing redb database.
+    #[cfg(not(redb_no_std))]
     pub fn open(path: impl AsRef<Path>) -> Result<Database, DatabaseError> {
         Self::builder().open(path)
     }
@@ -1335,7 +1348,7 @@ fn ensure_allocator_state_table_and_trim(
 // transaction can be started concurrently and the commit in here cannot block on the
 // write-transaction slot.
 fn close_database(transaction_tracker: &Arc<TransactionTracker>, mem: &Arc<TransactionalMemory>) {
-    if !thread::panicking()
+    if !crate::panicking()
         && ensure_allocator_state_table_and_trim(transaction_tracker, mem).is_err()
     {
         #[cfg(feature = "logging")]
@@ -1468,6 +1481,7 @@ impl Builder {
     /// * if the file does not exist, or is an empty file, a new database will be initialized in it
     /// * if the file is a valid redb database, it will be opened
     /// * otherwise this function will return an error
+    #[cfg(not(redb_no_std))]
     pub fn create(&self, path: impl AsRef<Path>) -> Result<Database, DatabaseError> {
         let file = OpenOptions::new()
             .read(true)
@@ -1487,6 +1501,7 @@ impl Builder {
     }
 
     /// Opens an existing redb database.
+    #[cfg(not(redb_no_std))]
     pub fn open(&self, path: impl AsRef<Path>) -> Result<Database, DatabaseError> {
         let file = OpenOptions::new().read(true).write(true).open(path)?;
 
@@ -1505,6 +1520,7 @@ impl Builder {
     /// If the file has been opened for writing (i.e. as a [`Database`]) [`DatabaseError::DatabaseAlreadyOpen`]
     /// will be returned on platforms which support file locks (macOS, Windows, Linux). On other platforms,
     /// the caller MUST avoid calling this method when the database is open for writing.
+    #[cfg(not(redb_no_std))]
     pub fn open_read_only(
         &self,
         path: impl AsRef<Path>,
@@ -1522,6 +1538,7 @@ impl Builder {
     /// Open an existing or create a new database in the given `file`.
     ///
     /// The file must be empty or contain a valid database.
+    #[cfg(not(redb_no_std))]
     pub fn create_file(&self, file: File) -> Result<Database, DatabaseError> {
         Database::new(
             Box::new(FileBackend::new(file)?),

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,8 +5,8 @@ use alloc::boxed::Box;
 use alloc::format;
 use alloc::string::String;
 use core::fmt::{Display, Formatter};
+use core::panic;
 use std::io;
-use std::panic;
 
 /// General errors directly from the storage layer
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,10 +74,12 @@ compile_error!(
 // no-op for std builds.
 extern crate alloc;
 
+#[cfg(not(redb_no_std))]
+pub use db::ReadOnlyDatabase;
 pub use db::{
-    Builder, CacheStats, Database, MultimapTableDefinition, MultimapTableHandle, ReadOnlyDatabase,
-    ReadableDatabase, RepairSession, StorageBackend, TableDefinition, TableHandle,
-    UntypedMultimapTableHandle, UntypedTableHandle,
+    Builder, CacheStats, Database, MultimapTableDefinition, MultimapTableHandle, ReadableDatabase,
+    RepairSession, StorageBackend, TableDefinition, TableHandle, UntypedMultimapTableHandle,
+    UntypedTableHandle,
 };
 pub use error::{
     CommitError, CompactionError, DatabaseError, Error, SavepointError, SetDurabilityError,
@@ -120,6 +122,19 @@ mod transactions;
 mod tree_store;
 mod tuple_types;
 mod types;
+
+// Whether the current thread is unwinding from a panic. redb's Drop impls use it to soften
+// assertions that would otherwise turn a panic into an abort. A no_std program aborts on panic
+// rather than unwinding, so its Drop impls never run while panicking.
+#[cfg(not(redb_no_std))]
+pub(crate) fn panicking() -> bool {
+    std::thread::panicking()
+}
+
+#[cfg(redb_no_std)]
+pub(crate) fn panicking() -> bool {
+    false
+}
 
 #[cfg(test)]
 fn create_tempfile() -> tempfile::NamedTempFile {

--- a/src/table.rs
+++ b/src/table.rs
@@ -27,7 +27,6 @@ use core::marker::PhantomData;
 use core::ops::Bound;
 #[cfg(not(feature = "experimental-api-5"))]
 use core::ops::RangeBounds;
-use std::thread;
 
 /// Informational storage stats about a table
 #[derive(Debug)]
@@ -106,7 +105,7 @@ impl<'txn> RetainPanicGuard<'txn> {
 
 impl Drop for RetainPanicGuard<'_> {
     fn drop(&mut self) {
-        if !self.disarmed && thread::panicking() {
+        if !self.disarmed && crate::panicking() {
             self.transaction.poison();
         }
     }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -35,11 +35,10 @@ use core::marker::PhantomData;
 use core::mem;
 use core::mem::size_of;
 use core::ops::{RangeBounds, RangeFull};
+use core::panic;
 use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg(feature = "logging")]
 use log::{debug, warn};
-use std::panic;
-use std::thread;
 
 const MAX_PAGES_PER_COMPACTION: usize = 1_000_000;
 const NEXT_SAVEPOINT_TABLE: SystemTableDefinition<(), SavepointId> =
@@ -2545,7 +2544,7 @@ impl WriteTransaction {
 
 impl Drop for WriteTransaction {
     fn drop(&mut self) {
-        if !self.completed && !thread::panicking() && !self.mem.storage_failure() {
+        if !self.completed && !crate::panicking() && !self.mem.storage_failure() {
             #[allow(unused_variables)]
             if let Err(error) = self.abort_inner() {
                 #[cfg(feature = "logging")]

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -13,7 +13,6 @@ use core::cmp::Ordering;
 use core::marker::PhantomData;
 use core::mem::size_of;
 use core::ops::Range;
-use std::thread;
 
 pub(crate) const LEAF: u8 = 1;
 pub(crate) const BRANCH: u8 = 2;
@@ -260,7 +259,7 @@ impl<V: Value + 'static> Drop for AccessGuard<'_, V> {
                     let mut mutator =
                         LeafMutator::new(mut_page.memory_mut(), fixed_key_size, V::fixed_width());
                     mutator.remove(position);
-                } else if !thread::panicking() {
+                } else if !crate::panicking() {
                     unreachable!();
                 }
             }
@@ -1203,7 +1202,7 @@ impl<'a> RawLeafBuilder<'a> {
 
 impl Drop for RawLeafBuilder<'_> {
     fn drop(&mut self) {
-        if !thread::panicking() {
+        if !crate::panicking() {
             assert_eq!(self.pairs_written, self.num_pairs);
             assert_eq!(
                 self.key_section_start() + self.provisioned_key_bytes,
@@ -2204,7 +2203,7 @@ impl<'b> RawBranchBuilder<'b> {
 
 impl Drop for RawBranchBuilder<'_> {
     fn drop(&mut self) {
-        if !thread::panicking() {
+        if !crate::panicking() {
             assert_eq!(self.keys_written, self.num_keys);
         }
     }

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -22,12 +22,15 @@ pub(crate) use btree_cursor_range::BtreeCursorRange;
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, encode_bounds};
 pub(crate) use extract_if::BtreeExtractIf;
 pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multimap_btree_stats};
+#[cfg(not(redb_no_std))]
 pub(crate) use page_store::ReadOnlyBackend;
+#[cfg(not(redb_no_std))]
+pub use page_store::file_backend;
 pub(crate) use page_store::{
     AllocationPolicy, FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page,
     PageAllocator, PageHint, PageNumber, PageNumberHashMap, PageNumberHashSet, PageResolver,
     PageTracker, SerializedSavepoint, ShrinkPolicy, TransactionalMemory,
 };
-pub use page_store::{InMemoryBackend, Savepoint, file_backend};
+pub use page_store::{InMemoryBackend, Savepoint};
 pub(crate) use table_tree::{PageListMut, TableTree, TableTreeMut};
 pub(crate) use table_tree_base::{InternalTableDefinition, TableType};

--- a/src/tree_store/page_store/backends.rs
+++ b/src/tree_store/page_store/backends.rs
@@ -1,21 +1,26 @@
 use crate::StorageBackend;
 use crate::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+#[cfg(not(redb_no_std))]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use std::io;
+#[cfg(not(redb_no_std))]
 use std::io::Error;
 
+#[cfg(not(redb_no_std))]
 #[derive(Debug)]
 pub(crate) struct ReadOnlyBackend {
     inner: Box<dyn StorageBackend>,
 }
 
+#[cfg(not(redb_no_std))]
 impl ReadOnlyBackend {
     pub fn new(inner: Box<dyn StorageBackend>) -> Self {
         Self { inner }
     }
 }
 
+#[cfg(not(redb_no_std))]
 impl StorageBackend for ReadOnlyBackend {
     fn len(&self) -> Result<u64, Error> {
         self.inner.len()

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -4,6 +4,7 @@ mod bitmap;
 mod buddy_allocator;
 mod cached_file;
 mod fast_hash;
+#[cfg(not(redb_no_std))]
 pub mod file_backend;
 mod header;
 mod layout;
@@ -15,6 +16,7 @@ mod savepoint;
 mod xxh3;
 
 pub use backends::InMemoryBackend;
+#[cfg(not(redb_no_std))]
 pub(crate) use backends::ReadOnlyBackend;
 pub(crate) use base::{MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTracker};
 pub(crate) use fast_hash::{PageNumberHashMap, PageNumberHashSet};

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -25,7 +25,6 @@ use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem;
 use std::io::ErrorKind;
-use std::thread;
 
 // The region header is optional in the v3 file format
 // It's an artifact of the v2 file format, so we initialize new databases without headers to save space
@@ -1583,7 +1582,7 @@ impl TransactionalMemory {
     }
 
     fn flush_shutdown_header(&self) -> Result {
-        if self.storage.check_io_errors().is_ok() && !thread::panicking() {
+        if self.storage.check_io_errors().is_ok() && !crate::panicking() {
             let mut state = self.state.lock()?;
             // Clearing the flag asserts that this process left the file consistent, which requires
             // an allocator state describing what it wrote. Without one there is nothing to assert.

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -23,7 +23,6 @@ use core::cmp::max;
 use core::mem;
 use core::mem::size_of;
 use core::ops::RangeFull;
-use std::thread;
 
 #[derive(Debug)]
 #[repr(transparent)]
@@ -799,7 +798,7 @@ impl TableTreeMut {
 
 impl Drop for TableTreeMut {
     fn drop(&mut self) {
-        if thread::panicking() {
+        if crate::panicking() {
             return;
         }
         assert!(self.allocated_pages.is_empty());


### PR DESCRIPTION
Fourth step towards `no_std` support (#1099). #1365 has landed, so this now targets `master` directly and is a single commit.

`std::fs` and `std::path` have no counterpart without std, so in a no_std build the following are `cfg`'d out: the `file_backend` module and `backends::FileBackend`; `Database::create`/`Database::open`; and `Builder::create`/`open`/`open_read_only`/`create_file`. What remains is `Builder::create_with_backend()`, which is how an embedded caller supplies its own storage anyway, plus `InMemoryBackend`.

`ReadOnlyDatabase` goes too. Every route to one went through a path, so it has no constructor in a no_std build; the type, its `ReadableDatabase` impl and its re-export are `cfg`'d out rather than left unconstructable. `ReadOnlyBackend`, which exists only to wrap a backend for it, follows.

`thread::panicking()`, which several `Drop` impls consult to soften their assertions, moves behind `crate::panicking()`. It is `false` without std; the last PR of the series (#1369) restricts that build to `panic = "abort"`, where nothing unwinds and no `Drop` impl runs during a panic, so that answer is correct rather than assumed. `std::panic::Location` also becomes `core::panic::Location` -- the same type, `std`'s is a re-export.

`cargo test --all-features` passes, `cargo clippy --all --all-targets` is clean with and without `--all-features`, the `wasm32-unknown-unknown` checks CI runs are clean, and the no_std side is clean in debug and release with no warnings (CI builds it with `--deny warnings`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7DhuGXp5hmdwuRSRFYGtV)_