### PR TITLE
Report backend failures through crate::io::Error

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,3 +1,4 @@
+use crate::io;
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
 #[cfg(not(redb_no_std))]
 use crate::tree_store::ReadOnlyBackend;
@@ -21,7 +22,6 @@ use alloc::sync::Arc;
 use core::marker::PhantomData;
 #[cfg(not(redb_no_std))]
 use std::fs::{File, OpenOptions};
-use std::io;
 #[cfg(not(redb_no_std))]
 use std::path::Path;
 
@@ -39,6 +39,8 @@ use log::{debug, warn};
 
 #[allow(clippy::len_without_is_empty)]
 /// Implements persistent storage for a database.
+///
+/// Failures are reported as [`io::Error`], which is [`std::io::Error`] whenever std is available.
 pub trait StorageBackend: 'static + Debug + Send + Sync {
     /// Gets the current length of the storage.
     fn len(&self) -> core::result::Result<u64, io::Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use crate::io;
 use crate::sync::PoisonError;
 use crate::tree_store::{FILE_FORMAT_VERSION3, MAX_VALUE_LENGTH};
 use crate::{ReadTransaction, TypeName};
@@ -6,7 +7,6 @@ use alloc::format;
 use alloc::string::String;
 use core::fmt::{Display, Formatter};
 use core::panic;
-use std::io;
 
 /// General errors directly from the storage layer
 #[derive(Debug)]

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,94 @@
+//! The error type that [`StorageBackend`](crate::StorageBackend) reports failures with.
+//!
+//! On builds with std this is a re-export of [`std::io::Error`], so a backend written against this
+//! module is also a backend written against `std::io`. Builds without std get the stand-in below.
+
+#[cfg(not(redb_no_std))]
+pub use std::io::Error;
+
+#[cfg(redb_no_std)]
+pub use no_std::Error;
+
+// The kinds redb attaches to the errors it raises itself. std's `ErrorKind` carries them where it
+// is available, so a std build's errors are unchanged; without std the kind is dropped and only
+// the message survives. Keeping these in one place means that if the stand-in ever grows a kind,
+// only this module changes.
+pub(crate) fn invalid_data(message: &str) -> Error {
+    #[cfg(not(redb_no_std))]
+    {
+        Error::new(std::io::ErrorKind::InvalidData, message)
+    }
+    #[cfg(redb_no_std)]
+    {
+        Error::other(message)
+    }
+}
+
+pub(crate) fn invalid_input(message: &str) -> Error {
+    #[cfg(not(redb_no_std))]
+    {
+        Error::new(std::io::ErrorKind::InvalidInput, message)
+    }
+    #[cfg(redb_no_std)]
+    {
+        Error::other(message)
+    }
+}
+
+// Compiled for test builds as well, so that the tests below run as part of the normal test suite
+// rather than only in the no_std configuration.
+#[cfg(any(redb_no_std, test))]
+#[cfg_attr(not(redb_no_std), allow(dead_code))]
+mod no_std {
+    use alloc::string::String;
+    use core::fmt::{Debug, Display, Formatter};
+
+    /// A stand-in for [`std::io::Error`], for targets without std.
+    ///
+    /// It carries a message, which is what a storage backend has to say about a failure that redb
+    /// cannot say for it. std's classifying `ErrorKind` has no counterpart here: redb never reads
+    /// one back in this configuration, and the kinds it would list are a guess at what an embedded
+    /// backend reports. The type is `non_exhaustive` and its only constructor is
+    /// [`other`](Self::other) -- named after [`std::io::Error::other`] -- so that a kind, or
+    /// anything else, can be added later without breaking callers.
+    #[derive(Debug)]
+    #[non_exhaustive]
+    pub struct Error {
+        message: String,
+    }
+
+    impl Error {
+        /// Creates an error described by `message`.
+        pub fn other(message: impl Into<String>) -> Self {
+            Self {
+                message: message.into(),
+            }
+        }
+    }
+
+    impl Display for Error {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            f.write_str(&self.message)
+        }
+    }
+
+    impl core::error::Error for Error {}
+
+    #[cfg(test)]
+    mod test {
+        use super::Error;
+        use alloc::format;
+
+        #[test]
+        fn display_is_the_message() {
+            let error = Error::other("Index out-of-range.");
+            assert_eq!(format!("{error}"), "Index out-of-range.");
+        }
+
+        #[test]
+        fn accepts_an_owned_message() {
+            let error = Error::other(format!("page {} is out of range", 7));
+            assert_eq!(format!("{error}"), "page 7 is out of range");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,13 @@ pub mod backends;
 mod complex_types;
 mod db;
 mod error;
+// Public only where it is needed: without std a backend author has to be able to name these types
+// to implement `StorageBackend`. With std they are re-exports of `std::io`, which the caller
+// already has, so the module stays private and redb adds no public surface.
+#[cfg(redb_no_std)]
+pub mod io;
+#[cfg(not(redb_no_std))]
+mod io;
 #[cfg(feature = "experimental-api-5")]
 mod key_range;
 mod multimap_table;

--- a/src/tree_store/page_store/backends.rs
+++ b/src/tree_store/page_store/backends.rs
@@ -1,11 +1,11 @@
 use crate::StorageBackend;
+use crate::io;
+#[cfg(not(redb_no_std))]
+use crate::io::Error;
 use crate::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 #[cfg(not(redb_no_std))]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use std::io;
-#[cfg(not(redb_no_std))]
-use std::io::Error;
 
 #[cfg(not(redb_no_std))]
 #[derive(Debug)]
@@ -53,7 +53,7 @@ pub struct InMemoryBackend(RwLock<Vec<u8>>);
 
 impl InMemoryBackend {
     fn out_of_range() -> io::Error {
-        io::Error::new(io::ErrorKind::InvalidInput, "Index out-of-range.")
+        io::invalid_input("Index out-of-range.")
     }
 }
 

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1,3 +1,4 @@
+use crate::io;
 use crate::sync::Mutex;
 use crate::transaction_tracker::TransactionId;
 use crate::transactions::{AllocatorStateKey, AllocatorStateTree, AllocatorStateTreeMut};
@@ -24,7 +25,6 @@ use core::cmp::{max, min};
 use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem;
-use std::io::ErrorKind;
 
 // The region header is optional in the v3 file format
 // It's an artifact of the v2 file format, so we initialize new databases without headers to save space
@@ -535,12 +535,18 @@ impl TransactionalMemory {
         if initial_storage_len > 0 {
             // File already exists check that the magic number matches
             if magic_number != MAGICNUMBER {
-                return Err(StorageError::Io(ErrorKind::InvalidData.into()).into());
+                return Err(StorageError::Io(io::invalid_data(
+                    "Not a redb database: magic number mismatch",
+                ))
+                .into());
             }
         } else {
             // File is empty, check that we're allowed to initialize a new database (i.e. the caller is Database::create() and not open())
             if !allow_initialize {
-                return Err(StorageError::Io(ErrorKind::InvalidData.into()).into());
+                return Err(StorageError::Io(io::invalid_data(
+                    "Database file is empty and creating a new database was not requested",
+                ))
+                .into());
             }
         }
 


### PR DESCRIPTION
Fifth step towards `no_std` support (#1099). #1366 has landed, so this now targets `master` directly and is a single commit.

`StorageBackend` reports failures as `std::io::Error`, which does not exist without std. The new `crate::io` re-exports std's `Error` whenever std is available, so the trait's signatures, `StorageError::Io`, `Error::Io` and every existing implementation of `StorageBackend` are byte-for-byte unchanged there. Without std it supplies a stand-in.

The module is `pub` **only in no_std builds**, where a backend author has to be able to name the type to implement the trait. With std the type is a re-export of `std::io::Error`, which the caller already has, so the module is private and this PR adds no public API at all to a std build -- including one with `experimental-api-5` on.

### The stand-in carries a message and nothing else

```rust
#[derive(Debug)]
#[non_exhaustive]
pub struct Error { message: String }

impl Error {
    pub fn other(message: impl Into<String>) -> Self { ... }
}
```

There is no `ErrorKind`. redb's internals want exactly one bit from a backend -- did the operation fail -- and `cached_file.rs` proves it: every one of the five methods is wrapped identically, latching `io_failed` on any error and passing the error through with `map_err(StorageError::from)`. Nothing reads a kind back in a build where the stand-in exists, so a classifying enum would have been a vocabulary invented for nobody. (redb *does* read `ErrorKind` in five places, but all of them are in the file backend or in `#[cfg(test)]` code, none of which exists without std.)

Room is left to change that: the struct is `non_exhaustive` so fields can be added, and the sole constructor is named `other` after `std::io::Error::other`, which leaves `new(kind, message)` free for exactly std's signature should a kind ever be wanted.

The kinds redb attaches to its *own* errors are unaffected. Two crate-private helpers in `crate::io` hold the one cfg:

```rust
pub(crate) fn invalid_data(message: &str) -> Error {
    #[cfg(not(redb_no_std))] { Error::new(std::io::ErrorKind::InvalidData, message) }
    #[cfg(redb_no_std)]      { Error::other(message) }
}
```

so a std build's error kinds are exactly what they were -- `open_empty_file` and `open_missing_file`, which assert on `InvalidData` and `NotFound`, both still pass -- while no_std gets the message. Three call sites go through them, and two of those gained real text where they previously had a bare kind: "Not a redb database: magic number mismatch" and "Database file is empty and creating a new database was not requested".

### Why a concrete type rather than an associated `Error`

The `embedded-io` convention is an error *trait* plus `type Error` per implementor. That does not fit here: redb stores backends as `Box<dyn StorageBackend>` in eight places and `Database` is deliberately not generic, so an associated type would only be usable as `Box<dyn StorageBackend<Error = X>>` for one fixed `X` -- today's design with extra ceremony. Making `Database` generic over the backend instead would push a type parameter through `Database`, `ReadTransaction`, `WriteTransaction` and the savepoint machinery (30 `Arc<TransactionalMemory>` sites across four files), which is a far larger break than the error type it would fix.

Like `sync::spin`, the module is compiled for test builds too, so the stand-in's tests run in the normal test suite rather than only in the configuration CI cannot execute.

`cargo test --all-features` passes, `cargo clippy --all --all-targets` is clean with and without `--all-features`, `cargo doc` is clean, `wasm32-unknown-unknown --no-default-features` is clean, and so is the no_std side.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7DhuGXp5hmdwuRSRFYGtV)_