### PR TITLE
Validate page order when reading a page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
   could be slower than writing from a single thread; they now scale with the number of threads.
 * Fix a panic when opening a database containing a corrupted persistent savepoint record;
   `StorageError::Corrupted` is now returned instead.
+* Fix a process abort when reading a database file containing a corrupted page number. Such a page
+  could attempt a multi-terabyte allocation, which aborts the process rather than failing;
+  `StorageError::Corrupted` is now returned instead.
 * Add an experimental cursor API, behind the `experimental_cursor` feature flag:
   `Table::lower_bound_mut()` and `Table::upper_bound_mut()` return a `CursorMut` pointing at a gap
   between entries, modeled on the standard library's `BTreeMap` cursors. Inserting sorted data

--- a/src/db.rs
+++ b/src/db.rs
@@ -995,11 +995,22 @@ impl Database {
         Ok(())
     }
 
+    // Whether the primary slot's trees verify. A Corrupted error counts as "they do not", so that
+    // a torn slot carrying an invalid page number falls back to the secondary like any other bad
+    // primary, rather than aborting the repair. Other errors (e.g. I/O) still propagate.
+    fn primary_verifies(mem: &Arc<TransactionalMemory>) -> Result<bool> {
+        match Self::verify_primary_checksums(mem.clone()) {
+            Ok(verified) => Ok(verified),
+            Err(StorageError::Corrupted(_)) => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
     fn do_repair(
         mem: &mut Arc<TransactionalMemory>, // Only &mut to ensure exclusivity
         repair_callback: &(dyn Fn(&mut RepairSession) + 'static),
     ) -> Result<[Option<BtreeHeader>; 2], DatabaseError> {
-        if !Self::verify_primary_checksums(mem.clone())? {
+        if !Self::primary_verifies(mem)? {
             if mem.used_two_phase_commit() {
                 return Err(DatabaseError::Storage(StorageError::Corrupted(
                     "Primary is corrupted despite 2-phase commit".to_string(),
@@ -1018,7 +1029,7 @@ impl Database {
             // have poisoned it with pages that just got rolled back by repair_primary_corrupted(), since
             // that rolls back a partially committed transaction.
             mem.clear_read_cache();
-            if !Self::verify_primary_checksums(mem.clone())? {
+            if !Self::primary_verifies(mem)? {
                 return Err(DatabaseError::Storage(StorageError::Corrupted(
                     "Failed to repair database. All roots are corrupted".to_string(),
                 )));
@@ -1064,10 +1075,7 @@ impl Database {
                 untracked,
                 PageResolver::new(mem.clone()),
             )?;
-            tables.visit_all_pages(|path| {
-                mem.mark_page_allocated(path.page_number());
-                Ok(())
-            })?;
+            tables.visit_all_pages(|path| mem.mark_page_allocated(path.page_number()))?;
             Self::with_recounted_length(root, tables.count_tables()?)
         };
 
@@ -1087,26 +1095,21 @@ impl Database {
                 untracked,
                 PageResolver::new(mem.clone()),
             )?;
-            system_tables.visit_all_pages(|path| {
-                mem.mark_page_allocated(path.page_number());
-                Ok(())
-            })?;
+            system_tables.visit_all_pages(|path| mem.mark_page_allocated(path.page_number()))?;
             Self::with_recounted_length(root, system_tables.count_tables()?)
         };
 
         Self::visit_freed_tree(system_root, DATA_FREED_TABLE, mem.clone(), |page| {
-            mem.mark_page_allocated(page);
-            Ok(())
+            mem.mark_page_allocated(page)
         })?;
         Self::visit_freed_tree(system_root, SYSTEM_FREED_TABLE, mem.clone(), |page| {
-            mem.mark_page_allocated(page);
-            Ok(())
+            mem.mark_page_allocated(page)
         })?;
         // Non-durable commits hold their data-freed records in memory rather than in
         // DATA_FREED_TABLE, so the walk above does not reach those pages. They are still allocated
         // until a commit processes the records, so mark them like any other freed-table page.
         for page in mem.unpersisted_data_freed_pages() {
-            mem.mark_page_allocated(page);
+            mem.mark_page_allocated(page)?;
         }
         #[cfg(debug_assertions)]
         {

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -1032,6 +1032,109 @@ mod test {
         );
     }
 
+    // Re-checksums the slot, so the page number is indistinguishable from one redb wrote itself
+    fn overwrite_root_page_order(path: &std::path::Path, root_offset: usize, order: u8) {
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+        let mut header = [0u8; DB_HEADER_SIZE];
+        file.read_exact(&mut header).unwrap();
+
+        let slot = primary_slot_offset(header[GOD_BYTE_OFFSET]);
+        // The page number is the first field of the serialized BtreeHeader
+        let offset = slot + root_offset;
+        let root = super::get_u64(&header[offset..]);
+        let root = (root & !(0b1_1111 << 59)) | (u64::from(order) << 59);
+        header[offset..offset + size_of::<u64>()].copy_from_slice(&root.to_le_bytes());
+        let checksum = super::xxh3_checksum(&header[slot..slot + super::SLOT_CHECKSUM_OFFSET]);
+        let checksum_offset = slot + super::SLOT_CHECKSUM_OFFSET;
+        header[checksum_offset..checksum_offset + size_of::<super::Checksum>()]
+            .copy_from_slice(&checksum.to_le_bytes());
+
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.write_all(&header).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    // An oversized page order sizes a multi-terabyte read buffer, whose failed allocation aborts
+    // the process. See https://github.com/cberner/redb/issues/1331
+    #[test]
+    fn oversized_root_page_order_is_reported_as_corruption() {
+        let tmpfile = crate::create_tempfile();
+        create_database_with_one_table(tmpfile.path());
+        overwrite_root_page_order(tmpfile.path(), super::USER_ROOT_OFFSET, 31);
+
+        // Debug builds walk the data tree while opening; release builds reach it via the check
+        let err = match Database::create(tmpfile.path()) {
+            Ok(mut db) => db.check_integrity().unwrap_err(),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(err, DatabaseError::Storage(StorageError::Corrupted(_))),
+            "expected Corrupted, got {err:?}"
+        );
+    }
+
+    fn patch_god_byte(path: &std::path::Path, patch: impl FnOnce(&mut u8)) {
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+        let mut header = [0u8; DB_HEADER_SIZE];
+        file.read_exact(&mut header).unwrap();
+        patch(&mut header[GOD_BYTE_OFFSET]);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.write_all(&header).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    // A torn commit slot can carry an invalid page number. Repair must treat that as a bad primary
+    // and fall back to the secondary, as it does for a checksum mismatch.
+    #[test]
+    fn repair_falls_back_to_secondary_on_invalid_primary_root() {
+        let tmpfile = crate::create_tempfile();
+        {
+            let db = Database::create(tmpfile.path()).unwrap();
+            for (key, value) in [("k", "v"), ("k2", "v2")] {
+                let txn = db.begin_write().unwrap();
+                txn.open_table(X).unwrap().insert(key, value).unwrap();
+                txn.commit().unwrap();
+            }
+        }
+        // Give the primary slot a root with an impossible order, leaving its checksum valid, then
+        // mark the file as a crashed 1-phase commit so that a full repair runs
+        overwrite_root_page_order(tmpfile.path(), super::USER_ROOT_OFFSET, 31);
+        patch_god_byte(tmpfile.path(), |god_byte| {
+            *god_byte |= RECOVERY_REQUIRED;
+            *god_byte &= !TWO_PHASE_COMMIT;
+        });
+
+        let db = Database::create(tmpfile.path()).unwrap();
+        let txn = db.begin_read().unwrap();
+        let table = txn.open_table(X).unwrap();
+        assert_eq!(table.get("k").unwrap().unwrap().value(), "v");
+        assert_eq!(table.get("k2").unwrap().unwrap().value(), "v2");
+    }
+
+    // The read-only open walks the system tree to load the allocator state
+    #[test]
+    fn oversized_system_root_page_order_is_reported_as_corruption_read_only() {
+        let tmpfile = crate::create_tempfile();
+        create_database_with_one_table(tmpfile.path());
+        overwrite_root_page_order(tmpfile.path(), super::SYSTEM_ROOT_OFFSET, 31);
+
+        let Err(err) = crate::ReadOnlyDatabase::open(tmpfile.path()) else {
+            panic!("expected the open to fail");
+        };
+        assert!(
+            matches!(err, DatabaseError::Storage(StorageError::Corrupted(_))),
+            "expected Corrupted, got {err:?}"
+        );
+    }
+
     // A backend that can report a `len()` larger than the data it actually holds, without
     // allocating it -- used to simulate an externally created (e.g. sparse) file.
     #[derive(Clone, Debug, Default)]

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -638,6 +638,17 @@ impl TransactionalMemory {
         })
     }
 
+    // An order read from a corrupted file would otherwise size a multi-terabyte read buffer, whose
+    // failed allocation aborts the process instead of returning an error.
+    fn check_page_order(page: PageNumber) -> Result<()> {
+        if page.page_order > MAX_MAX_PAGE_ORDER {
+            return Err(StorageError::Corrupted(format!(
+                "Page {page:?} has order greater than the maximum of {MAX_MAX_PAGE_ORDER}"
+            )));
+        }
+        Ok(())
+    }
+
     pub(crate) fn cache_stats(&self) -> CacheStats {
         self.storage.cache_stats()
     }
@@ -790,13 +801,18 @@ impl TransactionalMemory {
         self.state.lock().unwrap().allocators.is_some()
     }
 
-    pub(crate) fn mark_page_allocated(&self, page_number: PageNumber) {
-        let mut state = self.state.lock().unwrap();
+    // The freed tables name pages that no page walk ever reads, so this is the only place those
+    // page numbers are validated.
+    pub(crate) fn mark_page_allocated(&self, page_number: PageNumber) -> Result<()> {
+        Self::check_page_order(page_number)?;
+        let mut state = self.state.lock()?;
         let region_index = page_number.region;
         let allocator = state.get_region_mut(region_index);
         allocator.record_alloc(page_number.page_index, page_number.page_order);
         #[cfg(debug_assertions)]
         assert!(self.allocated_pages.lock().unwrap().insert(page_number));
+
+        Ok(())
     }
 
     fn write_header(&self, header: &DatabaseHeader) -> Result {
@@ -1059,6 +1075,7 @@ impl TransactionalMemory {
     }
 
     pub(crate) fn get_page(&self, page_number: PageNumber, hint: PageHint) -> Result<PageImpl> {
+        Self::check_page_order(page_number)?;
         let range = page_number.address_range(
             self.page_size.into(),
             self.region_size,
@@ -1092,6 +1109,7 @@ impl TransactionalMemory {
 
     // NOTE: the caller must ensure that the read cache has been invalidated or stale reads my occur
     pub(crate) fn get_page_mut<'txn>(&self, page_number: PageNumber) -> Result<PageMut<'txn>> {
+        Self::check_page_order(page_number)?;
         #[cfg(debug_assertions)]
         {
             assert!(
@@ -1667,6 +1685,47 @@ mod test {
         // The poison stays set, so later accesses fail rather than trust the state
         assert!(mem.state.is_poisoned());
         assert!(mem.get_last_committed_transaction_id().is_err());
+    }
+
+    // A page order read from a corrupted file can be far larger than any real page, which the read
+    // path would use to size its buffer.
+    #[test]
+    fn oversized_page_order_is_rejected() {
+        use super::TransactionalMemory;
+        use crate::StorageError;
+        use crate::tree_store::page_store::base::PageHint;
+        use crate::tree_store::{InMemoryBackend, Page, PageNumber, PageTracker};
+
+        let page_size = 4096;
+        let mem = TransactionalMemory::new(
+            Box::new(InMemoryBackend::new()),
+            true,
+            page_size,
+            Some(64 * page_size as u64),
+            0,
+            false,
+        )
+        .unwrap();
+        mem.reset_allocator_state().unwrap();
+
+        let valid = mem.allocate_helper(1, false).unwrap();
+        let valid_page = valid.get_page_number();
+        drop(valid);
+
+        // order = 31, which would be read as a 2^31 page (8TiB) allocation
+        let bad_order = PageNumber::from_le_bytes((31u64 << 59).to_le_bytes());
+
+        assert!(matches!(
+            mem.get_page(bad_order, PageHint::None),
+            Err(StorageError::Corrupted(_))
+        ));
+        assert!(matches!(
+            mem.mark_page_allocated(bad_order),
+            Err(StorageError::Corrupted(_))
+        ));
+        mem.get_page(valid_page, PageHint::None).unwrap();
+
+        mem.free(valid_page, &PageTracker::ignore());
     }
 
     // Freeing pages that buddy-merge into a higher order must re-mark the region tracker at the


### PR DESCRIPTION
Fixes #1331

A `PageNumber` read from disk carries a 5-bit order field, but nothing validated it against `MAX_MAX_PAGE_ORDER`. An order of 31 made `get_page()` compute a 2^31 page span and allocate a buffer for it -- 8TiB with the default page size -- before any I/O or bounds check. That allocation fails, which aborts the process, so it cannot be reported as an error.

## Approach

`check_page_order()` rejects `page.page_order > MAX_MAX_PAGE_ORDER` with `StorageError::Corrupted`, and is called from `get_page()`, `get_page_mut()` and `mark_page_allocated()`.

The check is unconditional. An earlier revision of this PR gated it on a `pedantic_checks` flag that only opening and `check_integrity()` turned on, on the theory that validation did not belong on the read path. That was worth doing when the check also validated the region and page index against the layout, since reading the layout meant taking the `state` lock; once it narrowed to a comparison against a constant, the flag cost about as much to consult as the check it guarded -- an `Acquire` load is `ldarb` on aarch64 -- and both are noise next to the cache lookup and possible file read that follow in `get_page()`. Removing it also made the fix work everywhere rather than only during open, which is what the reported reproduction needs: a cleanly shut down file whose data-page pointer is corrupt now returns `Corrupted` on the read instead of aborting.

`mark_page_allocated()` is now fallible. Freed-table entries are page numbers stored inside leaf values, and repair hands them straight to the buddy allocator without ever reading them through `get_page`, so this is the only place they are validated. An out-of-range order previously indexed `self.free[31]` out of bounds.

## Repair must still fall back to the secondary

`do_repair()` goes through a `primary_verifies()` helper that maps `Corrupted` to "the primary does not verify" and lets other errors (e.g. I/O) propagate. A torn commit slot can easily carry a bogus page order, and the secondary is what recovery exists to fall back to; without this, such a file would report corruption instead of recovering.

## Tests

Each test was confirmed to reproduce the original failure with the check removed, so they are load-bearing rather than merely passing.

* `oversized_root_page_order_is_reported_as_corruption` -- patches the primary slot's user-root order bits to 31 and re-checksums the slot, so the corruption is indistinguishable from something redb wrote itself. Without the check it aborts with `memory allocation of 8796093022224 bytes failed` / SIGABRT, matching the issue report.
* `oversized_system_root_page_order_is_reported_as_corruption_read_only` -- the same, through `ReadOnlyDatabase::open`.
* `repair_falls_back_to_secondary_on_invalid_primary_root` -- gives the primary slot a root with order 31, re-checksums it so the slot still verifies, and marks the file as a crashed 1-phase commit. Without `primary_verifies()` it reports `Corrupted`; with it, both committed keys are recovered from the secondary.
* `oversized_page_order_is_rejected` -- unit coverage for `get_page()` and `mark_page_allocated()`, plus a page that really is in the file still reading.

## Note on scope

Only the order field is validated. A corrupted region or page index is not rejected: those produce an addressable-but-wrong page or a read past EOF, both of which already surface as errors rather than aborting the process. Validating them would require reading the layout under the `state` lock on every page read.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeaXwvRvuCWemNbNU9Jjaq)_