### PR TITLE
Build without std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,17 @@ jobs:
             $command --no-default-features
             rustup target remove wasm32-unknown-unknown
 
+      - name: Compile (`no_std`, `thumbv7em-none-eabihf`)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+            rustup target add thumbv7em-none-eabihf
+            # Uses cargo pkgid because "redb" is ambiguous with the test dependency on an old version of redb
+            cargo check -p $(cargo pkgid) --target thumbv7em-none-eabihf --no-default-features --features experimental-api-5
+            # The features that are supported alongside no_std. cache_metrics needs 64-bit atomics,
+            # and chrono_v0_4/uuid need std, so all three are refused at compile time instead.
+            cargo check -p $(cargo pkgid) --target thumbv7em-none-eabihf --no-default-features --features experimental-api-5,logging,experimental_cursor
+            rustup target remove thumbv7em-none-eabihf
+
       - name: Clippy (default features)
         run: cargo clippy --all --all-targets -- -Dwarnings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # redb - Changelog
 
 ## 5.0.0 - 2026-XX-XX
+* Under the `experimental-api-5` feature flag, turning off the `std` feature now builds redb as a
+  `no_std` crate, for embedded targets. `alloc` is still required, as is `panic = "abort"` and a
+  target with atomic compare-and-swap -- Cortex-M3 and above, but not Cortex-M0. The file backend
+  and everything that opens a database from a path or a `File` are unavailable in that mode, as is
+  `ReadOnlyDatabase`; storage is supplied through `Builder::create_with_backend()`, and
+  `StorageBackend` reports failures as `redb::io::Error`, a module redb makes public only in that
+  mode; with std it stays private and the type is `std::io::Error`, as before. The `cache_metrics`,
+  `chrono_v0_4` and `uuid` features are unavailable there: the first needs 64-bit atomics, and the
+  other two link against the standard library. Leaving `experimental-api-5` off keeps the std build
+  regardless of the `std` feature, as before.
 * Behind the `experimental-api-5` feature flag, the range taking methods --
   `ReadableTable::range()`, `ReadOnlyTable::range_owned()`, `Table::retain_in()`,
   `Table::extract_from_if()`, and their multimap equivalents -- take a `KeyRange` instead of a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,9 @@ redb-derive = { path = "./crates/redb-derive" }
 
 [features]
 default = ["std"]
-# Enables linking against the Rust standard library. Currently a no-op, since building without it
-# is not supported yet; it exists so that dependents can opt out ahead of a future no_std mode
+# Enables linking against the Rust standard library. Turning it off requires "experimental-api-5",
+# and builds redb as a no_std crate; alloc is still required. Without "experimental-api-5" it is a
+# no-op, so that dependents who already set default-features = false keep the std build
 std = []
 # Enables log messages
 logging = ["dep:log"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ are any future changes to it.
 * Crash-safe by default
 * Savepoints and rollbacks
 
+## `no_std`
+
+Turning off the `std` feature, with `experimental-api-5` on, builds redb without the standard
+library. It needs `alloc`, `panic = "abort"`, and a target with atomic compare-and-swap -- Cortex-M3
+and above, but not Cortex-M0. There is no filesystem, so storage is supplied by implementing
+`StorageBackend` and passing it to `Builder::create_with_backend()`. The `cache_metrics`,
+`chrono_v0_4` and `uuid` features are unavailable.
+
 ## Development
 
 [`just`](https://github.com/casey/just) and rootless

--- a/justfile
+++ b/justfile
@@ -59,6 +59,14 @@ test_all_no_sandbox: pre_all_no_sandbox
 clear_podman_cache:
     podman volume rm --force redb-sandbox-target
 
+build_no_std:
+    rustup target add thumbv7em-none-eabihf
+    # cargo pkgid below needs a lockfile, which a fresh checkout of a library does not have. Only
+    # created when missing, so that running this does not re-resolve an existing one.
+    [ -f Cargo.lock ] || cargo generate-lockfile
+    # Uses cargo pkgid because "redb" is ambiguous with the test dependency on an old version of redb
+    cargo check -p $(cargo pkgid) --target thumbv7em-none-eabihf --no-default-features --features experimental-api-5
+
 test_wasi:
     rustup install nightly-2025-07-26 --target wasm32-wasip1-threads
     # cargo pkgid below needs a lockfile, which a fresh checkout of a library does not have. Only

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(redb_no_std, no_std)]
 #![deny(clippy::all, clippy::pedantic, clippy::disallowed_methods)]
 #![allow(
     clippy::if_not_else,
@@ -57,21 +58,16 @@
 //! }
 //! ```
 //!
+//! # Crate features
+//!
+//! - `std`: enabled by default. With `experimental-api-5` on, disable it to build redb as a
+//!   `no_std` crate; see the README for what that mode requires and leaves out.
+//!
 //! [lmdb]: https://www.lmdb.tech/doc/
 //! [design]: https://github.com/cberner/redb/blob/master/docs/design.md
 
-// `redb_no_std` is set by build.rs when the redb 5 API preview is enabled and "std" is not. It is
-// not a complete build mode yet, so it still fails loudly rather than silently producing a build
-// that links against the standard library.
-#[cfg(redb_no_std)]
-compile_error!(
-    "redb requires the standard library: no_std is not supported yet. Enable the \"std\" feature; \
-     it is on by default, so add features = [\"std\"] if you set default-features = false."
-);
-
-// Everything redb needs from the standard library that is not core is imported through `alloc`, so
-// that the crate can eventually be built without std. `alloc` is a subset of `std`, so this is a
-// no-op for std builds.
+// Everything redb uses beyond core comes through `alloc`, a subset of std, so this is a no-op for
+// std builds.
 extern crate alloc;
 
 #[cfg(not(redb_no_std))]
@@ -130,9 +126,24 @@ mod tree_store;
 mod tuple_types;
 mod types;
 
-// Whether the current thread is unwinding from a panic. redb's Drop impls use it to soften
-// assertions that would otherwise turn a panic into an abort. A no_std program aborts on panic
-// rather than unwinding, so its Drop impls never run while panicking.
+// core cannot tell whether the current thread is unwinding, and redb's Drop impls consult that in
+// opposite ways, so neither constant is safe to assume. Restricted to panic = "abort" instead,
+// where nothing unwinds and panicking() below is vacuously correct.
+#[cfg(all(redb_no_std, panic = "unwind"))]
+compile_error!(
+    "redb without the standard library requires panic = \"abort\": it cannot detect unwinding, \
+     and its Drop impls depend on being able to. Set panic = \"abort\" in the profile, or enable \
+     the \"std\" feature."
+);
+
+// Rejected here rather than at the AtomicU64 use site, so that the error names the feature
+// responsible instead of an unresolved import.
+#[cfg(all(feature = "cache_metrics", not(target_has_atomic = "64")))]
+compile_error!(
+    "the \"cache_metrics\" feature requires a target with 64-bit atomics: its counters are \
+     AtomicU64. Disable the feature on this target."
+);
+
 #[cfg(not(redb_no_std))]
 pub(crate) fn panicking() -> bool {
     std::thread::panicking()

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -543,6 +543,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
     }
 
     #[allow(dead_code)]
+    #[cfg(not(redb_no_std))]
     pub(crate) fn print_debug(&self, include_values: bool) -> Result {
         self.tree.print_debug(include_values)
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -134,6 +134,7 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
     }
 
     #[allow(dead_code)]
+    #[cfg(not(redb_no_std))]
     pub(crate) fn print_debug(&self, include_values: bool) -> Result {
         self.tree.print_debug(include_values)
     }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -5,7 +5,7 @@ use crate::sealed::Sealed;
 use crate::sync::Mutex;
 use crate::table::ReadOnlyUntypedTable;
 use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker};
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, not(redb_no_std)))]
 use crate::tree_store::PageNumberHashSet;
 use crate::tree_store::{
     AllocationPolicy, Btree, BtreeHeader, BtreeMut, InternalTableDefinition, MAX_PAIR_LENGTH,
@@ -1013,7 +1013,7 @@ impl WriteTransaction {
                 .is_some())
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(all(debug_assertions, not(redb_no_std)))]
     pub fn print_allocated_page_debug(&self) {
         let mut all_allocated = PageNumberHashSet::from_iter(self.mem.all_allocated_pages());
 
@@ -2499,6 +2499,7 @@ impl WriteTransaction {
     }
 
     #[allow(dead_code)]
+    #[cfg(not(redb_no_std))]
     pub(crate) fn print_debug(&self) -> Result {
         // Flush any pending updates to make sure we get the latest root
         let mut tables = self.tables.lock().unwrap();

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -561,6 +561,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
     }
 
     #[allow(dead_code)]
+    #[cfg(not(redb_no_std))]
     pub(crate) fn print_debug(&self, include_values: bool) -> Result {
         self.read_tree()?.print_debug(include_values)
     }
@@ -1239,6 +1240,7 @@ impl<K: Key, V: Value> Btree<K, V> {
     }
 
     #[allow(dead_code)]
+    #[cfg(not(redb_no_std))]
     pub(crate) fn print_debug(&self, include_values: bool) -> Result {
         if let Some(p) = self.root.map(|x| x.root) {
             let mut pages = vec![self.mem.get_page(p, self.hint)?];

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -483,6 +483,7 @@ impl<'a> LeafAccessor<'a> {
         }
     }
 
+    #[cfg(not(redb_no_std))]
     pub(super) fn print_node<K: Key, V: Value>(&self, include_value: bool) {
         let mut i = 0;
         while let Some(entry) = self.entry(i) {
@@ -1795,6 +1796,7 @@ impl<'a: 'b, 'b, T: Page + 'a> BranchAccessor<'a, 'b, T> {
         }
     }
 
+    #[cfg(not(redb_no_std))]
     pub(super) fn print_node<K: Key>(&self) {
         eprint!(
             "Internal[ (page={:?}), child_0={:?}",

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -12,6 +12,7 @@ use crate::types::{Key, Value};
 use crate::{Result, StorageError};
 #[cfg(feature = "experimental_cursor")]
 use alloc::boxed::Box;
+use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -3,6 +3,8 @@ use crate::tree_store::page_store::bitmap::BtreeBitmap;
 #[cfg(test)]
 use crate::tree_store::page_store::fast_hash::PageNumberHashSet;
 use crate::tree_store::page_store::page_manager::MAX_MAX_PAGE_ORDER;
+use alloc::vec;
+use alloc::vec::Vec;
 use core::cmp::min;
 use core::mem::size_of;
 

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -18,6 +18,7 @@ use crate::{CacheStats, StorageBackend};
 use crate::{DatabaseError, Result, StorageError};
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
+use alloc::format;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -681,6 +682,7 @@ impl TransactionalMemory {
     }
 
     #[cfg(debug_assertions)]
+    #[cfg_attr(redb_no_std, expect(dead_code))]
     pub(crate) fn all_allocated_pages(&self) -> Vec<PageNumber> {
         self.allocated_pages
             .lock()
@@ -691,6 +693,7 @@ impl TransactionalMemory {
     }
 
     #[cfg(debug_assertions)]
+    #[cfg_attr(redb_no_std, expect(dead_code))]
     pub(crate) fn debug_check_allocator_consistency(&self) {
         let state = self.state.lock().unwrap();
         let allocators = state.allocators();

--- a/src/tree_store/page_store/xxh3.rs
+++ b/src/tree_store/page_store/xxh3.rs
@@ -60,7 +60,7 @@ pub fn hash64_with_seed(data: &[u8], seed: u64) -> u64 {
     if data.len() <= 240 {
         hash64_0to240(data, &DEFAULT_SECRET, seed)
     } else {
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), not(redb_no_std)))]
         {
             if is_x86_feature_detected!("avx2") {
                 unsafe {
@@ -87,7 +87,7 @@ pub fn hash128_with_seed(data: &[u8], seed: u64) -> u128 {
     if data.len() <= 240 {
         hash128_0to240(data, &DEFAULT_SECRET, seed)
     } else {
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), not(redb_no_std)))]
         if is_x86_feature_detected!("avx2") {
             unsafe {
                 return hash128_large_avx2(data, seed);

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -274,7 +274,7 @@ impl TableTreeMut {
         self.pending_table_updates.clear();
     }
 
-    #[cfg_attr(not(debug_assertions), expect(dead_code))]
+    #[cfg_attr(any(not(debug_assertions), redb_no_std), expect(dead_code))]
     pub(crate) fn visit_all_pages<F>(&self, mut visitor: F) -> Result
     where
         F: FnMut(&PagePath) -> Result,


### PR DESCRIPTION
Last step for `no_std` support (#1099). Rebased onto master after #1374 merged; a single commit, no longer stacked.

`#[no_std]` goes on, and the `compile_error!` that rejected the mode comes off. With `experimental-api-5` on and `std` off, redb is now a `no_std` crate. With `experimental-api-5` off it links against the standard library whatever `std` is set to, exactly as before.

The four earlier PRs had already moved everything to `core`/`alloc`, so what was left was the handful of places that still reached for std directly:

* The debug-printing helpers (`print_debug`, `print_node`, `print_allocated_page_debug`) write to stdout/stderr, so they are `cfg`'d out. Their `#[allow(dead_code)]`-style callees get their existing `cfg_attr` predicates widened to match.
* xxh3's AVX2 dispatch uses `is_x86_feature_detected!`, which lives in std. It is compiled out and xxh3 falls back to its generic path there; the AVX2 code itself is untouched.
* `buddy_allocator.rs` was missing two `alloc` imports, and `page_manager.rs` one (`alloc::format`, for the `check_page_order` message added by `e6a753e` -- `format!` is in the std prelude but not core's, so it is invisible until `#[no_std]` is on).

### The no_std build requires `panic = "abort"`

`crate::panicking()` has no answer without std, and redb's `Drop` impls consult it in **opposite** ways: most do `if !panicking() { assert!(...) }` to avoid turning a panic into an abort, while `RetainPanicGuard` poisons a transaction whose `retain` predicate panicked. So neither constant is safe -- returning `false` silently drops the poisoning, returning `true` silently drops the assertions.

Rather than pick, the build that raises the question is refused:

```rust
#[cfg(all(redb_no_std, panic = "unwind"))]
compile_error!("redb without the standard library requires panic = \"abort\": ...");
```

Under `panic = "abort"` nothing unwinds, no `Drop` impl runs during a panic, and `panicking() == false` is vacuously correct. Bare-metal targets are `panic = "abort"` already, so this costs the intended users nothing; what it catches is a std application on a host target setting `default-features = false, features = ["experimental-api-5"]`, which would otherwise get a redb that unwinds but never poisons. (Thanks to the Codex review for spotting that case.)

### What the target has to provide

| target | |
|---|---|
| `thumbv7em-none-eabihf` | Cortex-M4F/M7, i.e. the STM32 case the issue asks about. 32-bit, checked by CI |
| `aarch64-unknown-none` | |
| `x86_64-unknown-none` | |

All three build clean in debug and release with `--deny warnings`.

The requirement is **atomic compare-and-swap**, which the spinlocks in `crate::sync` need. Cortex-M3 and above have it. Cortex-M0 (`thumbv6m-none-eabi`) reports no `target_has_atomic` at all and is not supported; that would need a different locking strategy, not a small change.

64-bit atomics are *not* required. `thumbv7em-none-eabihf` has only 8/16/32/ptr atomics and builds fine, because the only `AtomicU64`s in the crate are the five cache counters in `cached_file.rs`, all behind `#[cfg(feature = "cache_metrics")]`.

### Feature combinations that are not supported

| feature | no_std | |
|---|---|---|
| `logging` | ✅ | `log` does not enable std by default; covered by CI |
| `experimental_cursor` | ✅ | covered by CI |
| `cache_metrics` | ❌ | counters are `AtomicU64`; refused by `compile_error!` on targets without 64-bit atomics |
| `chrono_v0_4` | ❌ | chrono does not declare `#[no_std]` |
| `uuid` | ❌ | links against std unless its own default features are off |

`cache_metrics` is guarded in `lib.rs`, keyed on `not(target_has_atomic = "64")` rather than on `redb_no_std`, since the requirement belongs to the target. The other two are not guarded: cargo builds a dependency before the crate depending on it, so chrono or uuid fails to find std before redb's own lib is compiled and a `compile_error!` here would never be reached. Making them work is a `default-features = false` plus weak re-enables on redb's `std` feature; that changes dependency resolution for existing std users, so it is left as a separate decision. Both are documented as unavailable. (Both of these came out of the Codex review.)

Also in this PR: a `Compile (no_std, thumbv7em-none-eabihf)` CI step next to the existing wasm one -- building the bare configuration and the supported-features one -- a `just build_no_std` recipe, `CHANGELOG.md` entries, a `## no_std` section in the README with a one-line `# Crate features` pointer to it from the crate docs, and an updated description of the `std` feature in `Cargo.toml`.

`cargo test --all-features` passes, `cargo clippy --all --all-targets` is clean with and without `--all-features`, `cargo doc` is clean with and without the flag, `cargo fmt --check` and the ASCII check pass, and the `wasm32-unknown-unknown` checks CI runs are unaffected.

### Not covered

The no_std build is compile-checked, not run. There is no test suite for it: redb's tests need `std` (tempfile, threads, the file backend), and the CI runners have no bare-metal target to execute on. What that risk actually covers is small, though -- the two pieces of behaviour that genuinely differ between the builds are `sync::spin` and `io::Error`, and both have unit tests that run in the normal suite, plus I ran the entire suite against the spinlocks (see #1365).

One consequence worth noting while this is in flight: until this PR lands, the `compile_error!` means CI never builds the no_std configuration, so a commit landing on master that uses a std-prelude macro (`format!`, `vec!`) or `HashMap` will rebase onto it cleanly and break the no_std build silently. That is exactly what `e6a753e` did, and why `page_manager.rs` needs the import above. I rebuild the bare-metal targets on every rebase rather than trusting a conflict-free rebase -- including this one, after #1374.

Fixes: #1099

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7DhuGXp5hmdwuRSRFYGtV)_