### PR TITLE
Bound the btree descent depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
   could be slower than writing from a single thread; they now scale with the number of threads.
 * Fix a panic when opening a database containing a corrupted persistent savepoint record;
   `StorageError::Corrupted` is now returned instead.
+* Fix a process abort when reading a database file whose branch pages form a cycle, or an
+  arbitrarily long chain. Descending the tree recursed until the stack overflowed, which aborts the
+  process rather than failing; `StorageError::Corrupted` is now returned instead.
 * Fix a process abort when reading a database file containing a corrupted page number. Such a page
   could attempt a multi-terabyte allocation, which aborts the process rather than failing;
   `StorageError::Corrupted` is now returned instead.

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -1,7 +1,7 @@
 use crate::db::TransactionGuard;
 use crate::tree_store::btree_base::{
     AccessGuardMut, BRANCH, BranchAccessor, BranchMutator, BtreeHeader, Checksum, DEFERRED, LEAF,
-    LeafAccessor, LeafPageMut, branch_checksum, leaf_checksum,
+    LeafAccessor, LeafPageMut, MAX_BTREE_DEPTH, branch_checksum, leaf_checksum,
 };
 #[cfg(feature = "experimental-api-5")]
 use crate::tree_store::btree_cursor::BtreeCursor;
@@ -16,7 +16,7 @@ use crate::tree_store::{
     PageAllocator, PageHint, PageNumber, PageNumberHashMap, PageResolver, PageTracker,
 };
 use crate::types::{Key, MutInPlaceValue, Value};
-use crate::{AccessGuard, Result};
+use crate::{AccessGuard, Result, StorageError};
 use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec;
@@ -67,6 +67,10 @@ impl PagePath {
         &self.path[..self.path.len() - 1]
     }
 
+    pub(crate) fn depth(&self) -> usize {
+        self.path.len()
+    }
+
     pub(crate) fn page_number(&self) -> PageNumber {
         self.path[self.path.len() - 1]
     }
@@ -113,6 +117,11 @@ impl UntypedBtree {
     where
         F: FnMut(&PagePath) -> Result,
     {
+        if path.depth() > MAX_BTREE_DEPTH {
+            return Err(crate::StorageError::Corrupted(
+                "Btree exceeded maximum depth".to_string(),
+            ));
+        }
         visitor(&path)?;
         let page = self.mem.get_page(path.page_number(), self.hint)?;
 
@@ -950,7 +959,7 @@ impl RawBtree {
         expected_checksum: Checksum,
         visited: &mut Vec<PageNumber>,
     ) -> Result<bool> {
-        if visited.contains(&page_number) {
+        if visited.len() >= MAX_BTREE_DEPTH || visited.contains(&page_number) {
             return Ok(false);
         }
         visited.push(page_number);
@@ -1083,42 +1092,54 @@ impl<K: Key, V: Value> Btree<K, V> {
 
     // Returns the value for the queried key, if present
     fn get_helper(&self, page: &PageImpl, query: &[u8]) -> Result<Option<AccessGuard<'static, V>>> {
-        let node_mem = page.memory();
-        match node_mem[0] {
-            LEAF => {
-                let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
-                if let Some(entry_index) = accessor.find_key::<K>(query) {
-                    let (start, end) = accessor.value_range(entry_index).unwrap();
-                    let guard = AccessGuard::with_page(page.clone(), start..end);
-                    Ok(Some(guard))
-                } else {
-                    Ok(None)
+        let mut descended: Option<PageImpl> = None;
+        for _ in 0..MAX_BTREE_DEPTH {
+            let page = descended.as_ref().unwrap_or(page);
+            let child_page = match page.memory()[0] {
+                LEAF => {
+                    let accessor =
+                        LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
+                    return Ok(accessor.find_key::<K>(query).map(|entry_index| {
+                        let (start, end) = accessor.value_range(entry_index).unwrap();
+                        AccessGuard::with_page(page.clone(), start..end)
+                    }));
                 }
-            }
-            BRANCH => {
-                let accessor = BranchAccessor::new(page, K::fixed_width());
-                let (_, child_page) = accessor.child_for_key::<K>(query);
-                let child_page = self.mem.get_page(child_page, self.hint)?;
-                self.get_helper(&child_page, query)
-            }
-            _ => unreachable!(),
+                BRANCH => {
+                    let accessor = BranchAccessor::new(page, K::fixed_width());
+                    accessor.child_for_key::<K>(query).1
+                }
+                _ => unreachable!(),
+            };
+            descended = Some(self.mem.get_page(child_page, self.hint)?);
         }
+        Err(StorageError::Corrupted(
+            "Btree exceeded maximum depth".to_string(),
+        ))
     }
 
     pub(crate) fn first(
         &self,
     ) -> Result<Option<(AccessGuard<'static, K>, AccessGuard<'static, V>)>> {
         if let Some(ref root) = self.cached_root {
-            self.first_helper(root.clone())
+            self.first_helper(root.clone(), 0)
         } else {
             Ok(None)
         }
     }
 
+    // Recursive, unlike the other descents: consuming the leaf page into the returned guards is a
+    // move out of the loop variable, which costs a conditional drop flag and measurably worse
+    // codegen. Bounded by depth instead.
     fn first_helper(
         &self,
         page: PageImpl,
+        depth: usize,
     ) -> Result<Option<(AccessGuard<'static, K>, AccessGuard<'static, V>)>> {
+        if depth > MAX_BTREE_DEPTH {
+            return Err(StorageError::Corrupted(
+                "Btree exceeded maximum depth".to_string(),
+            ));
+        }
         let node_mem = page.memory();
         match node_mem[0] {
             LEAF => {
@@ -1131,7 +1152,7 @@ impl<K: Key, V: Value> Btree<K, V> {
             BRANCH => {
                 let accessor = BranchAccessor::new(&page, K::fixed_width());
                 let child_page = accessor.child_page(0).unwrap();
-                self.first_helper(self.mem.get_page(child_page, self.hint)?)
+                self.first_helper(self.mem.get_page(child_page, self.hint)?, depth + 1)
             }
             _ => unreachable!(),
         }
@@ -1141,16 +1162,23 @@ impl<K: Key, V: Value> Btree<K, V> {
         &self,
     ) -> Result<Option<(AccessGuard<'static, K>, AccessGuard<'static, V>)>> {
         if let Some(ref root) = self.cached_root {
-            self.last_helper(root.clone())
+            self.last_helper(root.clone(), 0)
         } else {
             Ok(None)
         }
     }
 
+    // Recursive for the same reason as first_helper()
     fn last_helper(
         &self,
         page: PageImpl,
+        depth: usize,
     ) -> Result<Option<(AccessGuard<'static, K>, AccessGuard<'static, V>)>> {
+        if depth > MAX_BTREE_DEPTH {
+            return Err(StorageError::Corrupted(
+                "Btree exceeded maximum depth".to_string(),
+            ));
+        }
         let node_mem = page.memory();
         match node_mem[0] {
             LEAF => {
@@ -1164,7 +1192,7 @@ impl<K: Key, V: Value> Btree<K, V> {
             BRANCH => {
                 let accessor = BranchAccessor::new(&page, K::fixed_width());
                 let child_page = accessor.child_page(accessor.count_children() - 1).unwrap();
-                self.last_helper(self.mem.get_page(child_page, self.hint)?)
+                self.last_helper(self.mem.get_page(child_page, self.hint)?, depth + 1)
             }
             _ => unreachable!(),
         }

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -18,6 +18,12 @@ use std::thread;
 pub(crate) const LEAF: u8 = 1;
 pub(crate) const BRANCH: u8 = 2;
 
+// Descending a btree recurses once per level, so a corrupted file whose branch pages form a cycle,
+// or a crafted chain of them, overflows the stack -- which aborts rather than unwinding. No real
+// tree comes close to this depth: the page format addresses 4PiB, and branches hold enough children
+// that even a minimally filled tree over it is only tens of levels deep.
+pub(crate) const MAX_BTREE_DEPTH: usize = 128;
+
 pub(super) type Checksum = u128;
 // Dummy value. Final value will be computed during commit
 pub(super) const DEFERRED: Checksum = 999;

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -1,7 +1,7 @@
 use crate::AccessGuard;
 use crate::tree_store::btree_base::{
-    BRANCH, BranchAccessor, LEAF, LeafAccessor, OwnedEntryBuffer, leaf_below_merge_threshold,
-    leaf_fits_one_page, retained_after_removals,
+    BRANCH, BranchAccessor, LEAF, LeafAccessor, MAX_BTREE_DEPTH, OwnedEntryBuffer,
+    leaf_below_merge_threshold, leaf_fits_one_page, retained_after_removals,
 };
 use crate::tree_store::btree_iters::EntryGuard;
 use crate::tree_store::btree_mutator::MutateHelper;
@@ -141,32 +141,38 @@ fn descend_to_position<K: Key + 'static, V: Value + 'static, F>(
 where
     F: FnMut(PageNumber) -> Result<PageImpl>,
 {
-    match page.memory()[0] {
-        LEAF => {
-            let (position, len) = {
-                let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
-                (
-                    lower_bound_entry::<K>(&accessor, position),
-                    accessor.num_pairs(),
-                )
-            };
-            Ok(Leaf {
-                page,
-                position,
-                len,
-            })
-        }
-        BRANCH => {
-            let (child_index, child_page) = {
+    let mut page = page;
+    loop {
+        let (child_index, child_page) = match page.memory()[0] {
+            LEAF => {
+                let (leaf_position, len) = {
+                    let accessor =
+                        LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
+                    (
+                        lower_bound_entry::<K>(&accessor, position),
+                        accessor.num_pairs(),
+                    )
+                };
+                return Ok(Leaf {
+                    page,
+                    position: leaf_position,
+                    len,
+                });
+            }
+            BRANCH => {
                 let accessor = BranchAccessor::new(&page, K::fixed_width());
                 let child_index = child_to_visit::<K>(&accessor, position);
                 (child_index, accessor.child_page(child_index).unwrap())
-            };
-            path.push(Branch::new(page, child_index));
-            let child = get_page(child_page)?;
-            descend_to_position::<K, V, F>(child, position, path, get_page)
+            }
+            _ => unreachable!(),
+        };
+        if path.len() >= MAX_BTREE_DEPTH {
+            return Err(StorageError::Corrupted(
+                "Btree exceeded maximum depth".to_string(),
+            ));
         }
-        _ => unreachable!(),
+        path.push(Branch::new(page, child_index));
+        page = get_page(child_page)?;
     }
 }
 

--- a/tests/corrupted_btree_descent.rs
+++ b/tests/corrupted_btree_descent.rs
@@ -1,0 +1,144 @@
+//! A corrupted branch pointer must not send the btree descent into unbounded recursion. That
+//! overflows the stack, which aborts the process rather than unwinding, so it cannot be reported
+//! as an error or caught by the caller. See https://github.com/cberner/redb/issues/1332
+
+use redb::{ReadOnlyDatabase, ReadableDatabase, ReadableTable, StorageError, TableDefinition};
+use std::path::Path;
+
+const T: TableDefinition<u64, u64> = TableDefinition::new("t");
+const BRANCH: u8 = 2;
+const PAGE_SIZE: usize = 4096;
+
+fn create_tempfile() -> tempfile::NamedTempFile {
+    if cfg!(target_os = "wasi") {
+        tempfile::NamedTempFile::new_in("/tmp").unwrap()
+    } else {
+        tempfile::NamedTempFile::new().unwrap()
+    }
+}
+
+// In u64 because a full region is 4GiB, which overflows a 32 bit usize (wasm32)
+fn region_size(data: &[u8]) -> u64 {
+    let region_header_pages = u64::from(u32::from_le_bytes(data[16..20].try_into().unwrap()));
+    let region_max_data_pages = u64::from(u32::from_le_bytes(data[20..24].try_into().unwrap()));
+    (region_header_pages + region_max_data_pages) * PAGE_SIZE as u64
+}
+
+// Offsets of every page that looks like a branch. Some belong to the system tree, and some are
+// stale pages left by earlier commits; the caller sorts out which are usable.
+fn branch_page_offsets(data: &[u8]) -> Vec<usize> {
+    let mut offsets = vec![];
+    // The super-header occupies the first page
+    let mut offset = PAGE_SIZE;
+    while offset + PAGE_SIZE <= data.len() {
+        let page = &data[offset..offset + PAGE_SIZE];
+        let num_keys = u16::from_le_bytes([page[2], page[3]]) as usize;
+        if page[0] == BRANCH && num_keys > 0 && 8 + 24 * (num_keys + 1) <= PAGE_SIZE {
+            offsets.push(offset);
+        }
+        offset += PAGE_SIZE;
+    }
+    offsets
+}
+
+// Points every child pointer of a branch page at the branch page itself, so that a descent in any
+// direction hits the cycle. Reads do not verify checksums, so the stale checksum does not matter.
+fn make_self_referential(data: &mut [u8], offset: usize) {
+    let region_size = region_size(data);
+    let relative = (offset - PAGE_SIZE) as u64;
+    let region = relative / region_size;
+    let index = (relative % region_size) / PAGE_SIZE as u64;
+    // order 0, so the page number is just the region and index
+    let self_reference = (region << 20) | index;
+
+    let page = &mut data[offset..offset + PAGE_SIZE];
+    let num_keys = u16::from_le_bytes([page[2], page[3]]) as usize;
+    // Child pointers follow the per-child checksums, which follow an 8 byte header
+    let children = 8 + 16 * (num_keys + 1);
+    for i in 0..=num_keys {
+        let child = children + 8 * i;
+        page[child..child + 8].copy_from_slice(&self_reference.to_le_bytes());
+    }
+}
+
+fn opens_cleanly(path: &Path) -> bool {
+    let Ok(db) = ReadOnlyDatabase::open(path) else {
+        return false;
+    };
+    let Ok(txn) = db.begin_read() else {
+        return false;
+    };
+    txn.open_table(T).is_ok()
+}
+
+// Opened read-only, because a debug-assertions build of the writable open walks every page while
+// seeding its allocator assertions, and rejects the cycle there. This test is about the descent
+// itself, which the read-only open reaches without that walk.
+#[test]
+fn cyclic_branch_pointer_is_reported_rather_than_overflowing_the_stack() {
+    let tmpfile = create_tempfile();
+    {
+        let db = redb::Database::create(tmpfile.path()).unwrap();
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(T).unwrap();
+            // Enough entries that the table's tree has branch pages
+            for i in 0..5_000u64 {
+                table.insert(&i, &i).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    let pristine = std::fs::read(tmpfile.path()).unwrap();
+    let candidates = branch_page_offsets(&pristine);
+    assert!(
+        !candidates.is_empty(),
+        "no branch page was found to corrupt"
+    );
+
+    // Keep the branch pages that are not in the system tree, which opening the database walks
+    let mut usable = vec![];
+    for &offset in &candidates {
+        let mut data = pristine.clone();
+        make_self_referential(&mut data, offset);
+        std::fs::write(tmpfile.path(), &data).unwrap();
+        if opens_cleanly(tmpfile.path()) {
+            usable.push(offset);
+        }
+    }
+    assert!(
+        !usable.is_empty(),
+        "every branch page was in the system tree"
+    );
+
+    // Corrupt all of them at once, so any descent into the table hits a cycle immediately
+    let mut data = pristine.clone();
+    for &offset in &usable {
+        make_self_referential(&mut data, offset);
+    }
+    std::fs::write(tmpfile.path(), &data).unwrap();
+
+    let db = ReadOnlyDatabase::open(tmpfile.path()).unwrap();
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(T).unwrap();
+
+    // Each of these descends from the root, and must give up rather than recurse forever
+    assert!(matches!(table.get(&0u64), Err(StorageError::Corrupted(_))));
+    assert!(matches!(table.first(), Err(StorageError::Corrupted(_))));
+    assert!(matches!(table.last(), Err(StorageError::Corrupted(_))));
+    // The cursors build lazily, so the descent may be reported by the first step instead
+    match table.range(0u64..) {
+        Err(StorageError::Corrupted(_)) => {}
+        Ok(mut range) => assert!(matches!(
+            range.next(),
+            Some(Err(StorageError::Corrupted(_)))
+        )),
+        Err(err) => panic!("expected Corrupted, got {err:?}"),
+    }
+    match table.iter() {
+        Err(StorageError::Corrupted(_)) => {}
+        Ok(mut iter) => assert!(matches!(iter.next(), Some(Err(StorageError::Corrupted(_))))),
+        Err(err) => panic!("expected Corrupted, got {err:?}"),
+    }
+}


### PR DESCRIPTION
Fixes #1332

Descending a btree recursed once per level, with no bound. A corrupted file whose branch pages form a cycle, or a crafted chain of them, drove the recursion until the stack overflowed -- which aborts the process rather than unwinding, so it could not be reported as an error or caught by the caller.

The cycle detection added in 88868bf covers `RawBtree::verify_checksum_helper` and `UntypedBtree::visit_pages_helper`, but not the ordinary descent paths. A long *acyclic* chain defeats it everywhere, including those two.

## Approach

`get_helper()` and `descend_to_position()` were tail recursive, so they become bounded loops. That removes the stack growth entirely rather than merely limiting it, and measured *faster* than the recursion it replaced.

`first_helper()` and `last_helper()` stay recursive with a depth parameter. They were tail recursive too and were loops in an earlier revision, but they consume the leaf page into the guards they return -- `AccessGuard::with_page(page, value_range)` -- which is a move out of the loop-carried variable. That forces a conditional drop flag: a stack slot plus a branch on the exit paths, nearly free in instructions but not in IPC, and costly in a function this short. See the benchmark section.

`verify_checksum_helper()` and `visit_pages_helper()` fan out over several children, so a loop does not fit; they stay recursive and check against `MAX_BTREE_DEPTH`. Both already carry a path stack (`visited` and `PagePath`), pushed and popped per level, so the check is just its length -- no new state, no new parameter.

`MAX_BTREE_DEPTH` is 128, far above any real tree: the page format addresses 4PiB, and branches hold enough children that even a minimally filled tree over it is only tens of levels deep.

## Performance

These are callgrind instruction counts, taken as the difference between 100k and 300k operation runs so all fixed setup cancels. Wall-clock is not measurable on the host I have: a 75% noise band (796-1394 ns/op for identical work) with drift that biases whichever binary runs second, and ABBA-paired blocks still gave ±3.7% and ±7.9% stdev straddling zero.

Against this PR's original base (ea8dfcf):

| op | baseline | all-loops (earlier revision) | this PR |
|---|---|---|---|
| `get()` | 1994.92 | 1989.92 (-0.251%) | **1989.92 (-0.251%)** |
| short `range()` | 3543.96 | 3442.96 (-2.850%) | **3454.96 (-2.511%)** |
| `first()` | 862.00 | 862.00 (+0.000%) | **875.00 (+1.508%)** |
| `last()` | 877.00 | 877.00 (+0.000%) | **890.00 (+1.482%)** |

**Why `first`/`last` are not loops.** An independent benchmark run on real hardware (8-vCPU EPYC Milan) found the all-loops revision regressed `first()` by 6.25% and `last()` by 7.45% in *cycles*, with instruction counts unchanged -- an IPC effect, which instruction counting cannot see. The table above reproduces the instruction half exactly: +0.000% for those two. Reverting them to bounded recursion costs +13 instructions per call and restores the original code shape. That same run measured the loops as clear wins elsewhere: -3.2% cycles for `get`, -7.5% for one-element `range`, -10.9% for cursor descent, with no change to whole-suite throughput, write scaling, memory, or database size.

I have not been able to confirm that the revert recovers the lost IPC, since cycles are not measurable on my host -- it is reasoned from the codegen difference, not measured.

Choosing loops over a depth counter for `get` was itself a measurement:

| variant | `get` instr/op | vs baseline |
|---|---|---|
| recursive + depth parameter | 2009.92 | +0.651% |
| recursive + countdown parameter | 2009.92 | +0.651% (LLVM emits identical code) |
| loop + bound | 1991.92 | -0.250% |

## Test

`tests/corrupted_btree_descent.rs` builds a table with branch pages, points every child pointer of its branch pages at the page itself, and checks that `get`, `first`, `last`, `range` and `iter` all return `Corrupted`.

It opens the database **read-only** on purpose: a debug-assertions build of the writable open walks every page while seeding its allocator assertions and would reject the cycle there via the pre-existing check, so the test would pass without this change. The read-only open reaches the descent directly, which makes the test load-bearing in both profiles. Without the fix it dies with `thread ... has overflowed its stack / fatal runtime error: stack overflow, aborting` (SIGABRT), matching the issue report.

Three wrinkles the test works around: the user root in a commit slot is the *table tree* root (a single leaf for one table), not the table's own root, so the data-tree branch pages are found by testing which ones do not break the system tree; `last()` descends the rightmost spine, so every child pointer is corrupted rather than just the first; and the region geometry is computed in `u64` because a full 4GiB region overflows a 32 bit `usize` under wasm32, which `just test_wasi` runs.

## Not covered

The mutator (`insert_helper` / `delete_helper`), `UntypedBtreeMut::relocate` (`compact()`), `btree_stats`, and `AllPageNumbersBtreeIter` are left alone. They are reached only after a file is already trusted, and are not on the paths that decide whether a file is intact.

Two notes for whoever picks those up. The mutators are not tail recursive -- they do work on the way back up as pages split and merge -- so they would need a real depth parameter rather than becoming loops for free. And `AllPageNumbersBtreeIter` is not recursive at all: it keeps an explicit `pending` stack, so a cycle grows the heap rather than the call stack, and it needs a visited set or a page-count bound rather than a depth cap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeaXwvRvuCWemNbNU9Jjaq)_