### PR TITLE
Report malformed freed-page records instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
   could be slower than writing from a single thread; they now scale with the number of threads.
 * Fix a panic when opening a database containing a corrupted persistent savepoint record;
   `StorageError::Corrupted` is now returned instead.
+* Fix a panic while repairing a database file containing a malformed freed-page record, which left
+  the file permanently unopenable because both `Database::open` and `check_integrity()` run the same
+  repair. `StorageError::Corrupted` is now returned instead.
 * Fix a process abort when reading a database file whose branch pages form a cycle, or an
   arbitrarily long chain. Descending the tree recursed until the stack overflowed, which aborts the
   process rather than failing; `StorageError::Corrupted` is now returned instead.

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -262,7 +262,7 @@ impl BuddyAllocator {
                 if processed_pages + order_size > self.len() {
                     break;
                 }
-                self.record_alloc_inner(page, order);
+                assert!(self.record_alloc_inner(page, order));
                 processed_pages += order_size;
             }
             // Allocate the remaining space, at the highest order
@@ -270,7 +270,7 @@ impl BuddyAllocator {
                 let order_size = 2u32.pow(order.into());
                 while processed_pages + order_size <= self.len() {
                     let page = processed_pages / order_size;
-                    self.record_alloc_inner(page, order);
+                    assert!(self.record_alloc_inner(page, order));
                     processed_pages += order_size;
                 }
             }
@@ -389,19 +389,33 @@ impl BuddyAllocator {
         }
     }
 
-    // `page_number` must be free
-    pub(crate) fn record_alloc(&mut self, page_number: u32, order: u8) {
-        assert!(order <= self.max_order);
+    // `page_number` must be free. Returns false if it cannot be marked allocated: the order is too
+    // large for this region, the page is out of range, or the space is already in use. Rebuilding
+    // the allocator state feeds this page numbers read from the file, where any of the three means
+    // the file is corrupt; the callers that compute page numbers themselves assert instead.
+    #[must_use]
+    pub(crate) fn record_alloc(&mut self, page_number: u32, order: u8) -> bool {
         // Split parent pages as necessary, and update the free index
-        self.record_alloc_inner(page_number, order);
+        self.record_alloc_inner(page_number, order)
     }
 
-    pub(crate) fn record_alloc_inner(&mut self, page_number: u32, order: u8) {
+    #[must_use]
+    pub(crate) fn record_alloc_inner(&mut self, page_number: u32, order: u8) -> bool {
+        // Marking a page that is already allocated walks up the orders looking for a free parent to
+        // split, so running off the top is how a duplicate or overlapping page number shows up
+        if order > self.max_order {
+            return false;
+        }
         let allocator = self.get_order_free_mut(order);
+        if page_number >= allocator.len() {
+            return false;
+        }
         if allocator.get(page_number) {
             // Need to split parent page
             let upper_page = next_higher_order(page_number);
-            self.record_alloc_inner(upper_page, order + 1);
+            if !self.record_alloc_inner(upper_page, order + 1) {
+                return false;
+            }
             let allocator = self.get_order_free_mut(order);
 
             let (free1, free2) = (upper_page * 2, upper_page * 2 + 1);
@@ -414,6 +428,8 @@ impl BuddyAllocator {
         } else {
             allocator.set(page_number);
         }
+
+        true
     }
 
     /// data must have been initialized by `Self::init_new()`
@@ -466,7 +482,7 @@ mod test {
         assert_eq!(allocator.count_allocated_pages(), 0);
 
         for page in 0..num_pages {
-            allocator.record_alloc(page, 0);
+            assert!(allocator.record_alloc(page, 0));
         }
         assert_eq!(allocator.count_allocated_pages(), num_pages);
 

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -804,9 +804,31 @@ impl TransactionalMemory {
     pub(crate) fn mark_page_allocated(&self, page_number: PageNumber) -> Result<()> {
         Self::check_page_order(page_number)?;
         let mut state = self.state.lock()?;
-        let region_index = page_number.region;
-        let allocator = state.get_region_mut(region_index);
-        allocator.record_alloc(page_number.page_index, page_number.page_order);
+        // Unlike the read path, this is only reached while rebuilding the allocator state, and the
+        // state lock is already held, so validating against the layout costs nothing here
+        let layout = state.header.layout();
+        if page_number.region >= layout.num_regions() {
+            return Err(StorageError::Corrupted(format!(
+                "Page {page_number:?} is in region {}, but the database has {} region(s)",
+                page_number.region,
+                layout.num_regions()
+            )));
+        }
+        let region_pages = u64::from(layout.region_layout(page_number.region).num_pages());
+        // Cannot overflow: page_index is at most 2^32, and the order was bounded above
+        let end_page = (u64::from(page_number.page_index) + 1) << page_number.page_order;
+        if end_page > region_pages {
+            return Err(StorageError::Corrupted(format!(
+                "Page {page_number:?} extends past the end of its region, which has {region_pages} pages"
+            )));
+        }
+
+        let allocator = state.get_region_mut(page_number.region);
+        if !allocator.record_alloc(page_number.page_index, page_number.page_order) {
+            return Err(StorageError::Corrupted(format!(
+                "Page {page_number:?} overlaps a page that is already allocated"
+            )));
+        }
         #[cfg(debug_assertions)]
         assert!(self.allocated_pages.lock().unwrap().insert(page_number));
 
@@ -1683,6 +1705,56 @@ mod test {
         // The poison stays set, so later accesses fail rather than trust the state
         assert!(mem.state.is_poisoned());
         assert!(mem.get_last_committed_transaction_id().is_err());
+    }
+
+    // Rebuilding the allocator state feeds mark_page_allocated() page numbers straight out of the
+    // freed tables, which no page walk ever reads. A corrupted entry has to be reported rather than
+    // indexing the region allocators, tripping the bitmap's bounds assertion, or walking the buddy
+    // allocator past its maximum order. See https://github.com/cberner/redb/issues/1333
+    #[test]
+    fn mark_page_allocated_rejects_corrupt_page_numbers() {
+        use super::{MAX_PAGE_INDEX, TransactionalMemory};
+        use crate::StorageError;
+        use crate::tree_store::page_store::base::MAX_REGIONS;
+        use crate::tree_store::{InMemoryBackend, PageNumber};
+
+        let page_size = 4096;
+        let mem = TransactionalMemory::new(
+            Box::new(InMemoryBackend::new()),
+            true,
+            page_size,
+            Some(64 * page_size as u64),
+            0,
+            false,
+        )
+        .unwrap();
+        mem.reset_allocator_state().unwrap();
+
+        let corrupt = [
+            // Past the end of the layout, which would index the region allocators out of bounds
+            PageNumber::new(MAX_REGIONS - 1, 0, 0),
+            // Past the end of its region, which the bitmap asserts on
+            PageNumber::new(0, MAX_PAGE_INDEX, 0),
+            // An order no region can have
+            PageNumber::from_le_bytes((31u64 << 59).to_le_bytes()),
+        ];
+        for page in corrupt {
+            assert!(
+                matches!(
+                    mem.mark_page_allocated(page),
+                    Err(StorageError::Corrupted(_))
+                ),
+                "{page:?} was not rejected"
+            );
+        }
+
+        // Naming the same page twice walks the allocator up past its maximum order looking for a
+        // parent to split
+        mem.mark_page_allocated(PageNumber::new(0, 0, 0)).unwrap();
+        assert!(matches!(
+            mem.mark_page_allocated(PageNumber::new(0, 0, 0)),
+            Err(StorageError::Corrupted(_))
+        ));
     }
 
     // A page order read from a corrupted file can be far larger than any real page, which the read


### PR DESCRIPTION
Fixes #1333

Rebuilding the allocator state marks every page named by the freed tables as allocated, using page numbers read straight from the file. A malformed one panicked in four different ways, all release-active:

* an out of range **region** indexed `region_allocators` out of bounds (`page_manager.rs:318`)
* an out of range **page index** tripped `BtreeBitmap::get`'s `assert!(bit < self.len)`
* an **order** larger than the region's own `max_order` tripped `record_alloc`'s assertion -- the order check added in #1368 bounds it to `MAX_MAX_PAGE_ORDER`, but a region's maximum is `min(20, log2(capacity))`, so a small or trailing region is lower
* the **same page named twice** walked `record_alloc_inner` up past `max_order`, indexing `self.free[order]` out of bounds

This is on the untrusted side of the line: it is reached only from `Database::open` on an uncleanly shut down file, or from `check_integrity()`. Both run the same repair, so an affected file was permanently unopenable with no way to recover from inside the library.

## Changes

**Validate in `mark_page_allocated()`.** Region and extent are checked against the layout. Unlike the read path -- where this was dropped in #1368 because it needed the `state` lock on `get_page` -- this is repair-only and *already holds that lock*, so the layout is right there and the check is free.

**`record_alloc()` reports failure instead of asserting.** It bounds the order and page index at each level of the split walk, which also catches the duplicate case: marking a page that is already allocated walks up looking for a free parent to split, so running off the top is exactly how a duplicate or overlapping entry shows up. Modifications happen after the recursive call returns, so a rejected page leaves the allocator untouched. The two internal callers in `resize_to` compute their own page numbers, so they assert.

## Tests

`mark_page_allocated_rejects_corrupt_page_numbers` covers the bad region, bad index, bad order and duplicate-page cases. Verified load-bearing: with the validation stripped it panics at `page_manager.rs:318`, the region index, exactly the first site the issue names.

Full suite green, fmt and clippy clean.

## Deliberately left for a follow up

Earlier revisions of this PR also reworked the *saved* allocator state on the quick-repair open path -- replacing the `unreachable!()` in `AllocatorStateKey::from_bytes`, rejecting a partial state whose region keys had been corrupted, and discarding a half-built state if the rebuild unwound. That went through several rounds of review churn and is a distinct problem from the freed-page records this issue reports, so it has been cut back out. What was found there, for the follow up:

* `AllocatorStateKey::from_bytes` has `_ => unreachable!()`, reachable from a corrupt table because `Key::compare` parses every stored key a lookup passes.
* Simply not panicking there is not enough: an unrecognized discriminant sorts below `Region(0)` and so drops out of `load_allocator_state()`'s scan, leaving a region unaccounted for that `resize_to()` refills as free -- a silent version of the same bug. Rejecting the snapshot in `is_valid_allocator_state()` is what fixes that, and a region count alone is not sufficient; the numbering has to be checked too.
* `is_valid_allocator_state` unwraps a `try_into` on a transaction id whose length might not be 8. Every rejection there should be `Ok(false)`, not an error, so the caller falls back to the full repair -- the table is a cache the repair rebuilds without reading.
* `rebuild_allocator_state()` installs an all-free state and marks pages as it walks, so unwinding out of it leaves a half-built one in which live pages look free. Any guard for this must fire on panic only: `repair_live_state()` deliberately keeps going after a corrupt live rebuild, and invalidating on the `Err` path panics `check_integrity()`.
* `BuddyAllocator::from_bytes` slices untrusted bytes unguarded (`data[metadata..]`, `data[data_start..data_end]`) on that same path.

Thanks to the Codex reviews for finding the second and fourth of those.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeaXwvRvuCWemNbNU9Jjaq)_