### PR TITLE
Document StorageBackend's error and concurrency contracts

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -41,6 +41,17 @@ use log::{debug, warn};
 /// Implements persistent storage for a database.
 ///
 /// Failures are reported as [`io::Error`], which is [`std::io::Error`] whenever std is available.
+///
+/// An error from [`len`](Self::len), [`read`](Self::read), [`set_len`](Self::set_len) or
+/// [`sync_data`](Self::sync_data) takes the database out of service: redb records it and never
+/// retries, so a call that starts after that fails with [`StorageError::PreviousIo`] instead of
+/// reaching the backend. [`write`](Self::write) is the same except on cache writeback redb
+/// issues as best effort, which a backend cannot distinguish, so it should assume every error it
+/// returns is permanent and retry transient conditions -- a short read, a busy device, an
+/// interrupted system call -- internally.
+///
+/// Methods take `&self` and may be called concurrently, hence the `Send + Sync` bound; a backend
+/// over storage that is not inherently shareable supplies its own interior mutability.
 pub trait StorageBackend: 'static + Debug + Send + Sync {
     /// Gets the current length of the storage.
     fn len(&self) -> core::result::Result<u64, io::Error>;
@@ -66,6 +77,9 @@ pub trait StorageBackend: 'static + Debug + Send + Sync {
     /// Note: redb will not access the backend after calling this method and will call it exactly
     /// once: when the [`Database`] is dropped, or, if a [`WriteTransaction`] was live at that
     /// point, when that transaction completes, or if opening the database fails
+    ///
+    /// It is called even after another method has failed, so a backend can rely on it to release
+    /// whatever it holds.
     fn close(&self) -> core::result::Result<(), io::Error> {
         Ok(())
     }


### PR DESCRIPTION
Documentation only; no behaviour change. The `close()` fix that briefly lived here was split out into #1374, which has now merged.

**Errors are permanent.** `TransactionalMemory` latches `io_failed` on a failure from any of the five methods, and a call that starts after that fails with `StorageError::PreviousIo` instead of reaching the backend. redb never retries and never inspects the error -- its entire use of the return value is `is_err()`. So a backend that surfaces a transient condition rather than looping on it takes the database out of service over something that would have cleared on the next attempt; redb's own file backend loops on `ErrorKind::Interrupted` for exactly this reason. The one path that does not latch is best-effort cache writeback, which reaches the backend as an ordinary `write` and so cannot be distinguished from any other.

The barrier is scoped to when a call *starts*: `check_failure()` runs before the inner call with no lock spanning the two, so a thread already past the check still reaches the backend. Promising otherwise would describe a quiescent barrier that the lock-free design does not provide.

**Methods take `&self` and may be called concurrently**, which is what the `Send + Sync` bound is for: the backend is a plain `Box` field with no lock around it, so tables of a single `WriteTransaction` modified from different threads reach it concurrently.

Rebased onto master after #1374 merged. The `close()` note dropped its "not guaranteed if opening the database failed" caveat, which that PR made false, and shrank to the half master does not already state -- master's own line now covers the failed-open case.

`cargo doc` is clean with all intra-doc links resolving, `cargo clippy --all --all-targets --all-features` is clean, `cargo fmt --check` passes, and the ASCII check passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7DhuGXp5hmdwuRSRFYGtV)_