### PR TITLE
Generate a lockfile in test_wasi when one is missing

### DIFF
--- a/justfile
+++ b/justfile
@@ -61,6 +61,9 @@ clear_podman_cache:
 
 test_wasi:
     rustup install nightly-2025-07-26 --target wasm32-wasip1-threads
+    # cargo pkgid below needs a lockfile, which a fresh checkout of a library does not have. Only
+    # created when missing, so that running this does not re-resolve an existing one.
+    [ -f Cargo.lock ] || cargo generate-lockfile
     # Uses cargo pkgid because "redb" is ambiguous with the test dependency on an old version of redb
     cargo +nightly-2025-07-26 test -p $(cargo pkgid) --target=wasm32-wasip1-threads -- --nocapture
     cargo +nightly-2025-07-26 test -p redb-derive --target=wasm32-wasip1-threads -- --nocapture


### PR DESCRIPTION
`just test_wasi` does not work on a fresh checkout. `Cargo.lock` is gitignored, as it is for most libraries, so a new clone has none, and `cargo pkgid` then exits before the tests run:

```
$ cargo pkgid
error: a Cargo.lock must exist for this command
```

CI does not hit it because the wasm step earlier in the job runs `cargo generate-lockfile` first, so the recipe only fails when invoked directly -- which is the way it is meant to be used.

Same fix as #1369 applied to `build_no_std`, and same guard:

```
[ -f Cargo.lock ] || cargo generate-lockfile
```

The guard is the part that matters. A bare `cargo generate-lockfile` re-resolves -- on this repo it reports `Adding syn v2.0.119 (available: v3.0.3)` -- so running the recipe unconditionally would quietly rewrite the lockfile of anyone who already had one. Verified both ways: with the lockfile moved aside it is created and `cargo pkgid` then resolves; with one present the file is byte-identical afterwards.

Dropping `cargo pkgid` is not an alternative, for the reason the existing comment gives: `cargo test -p redb` is ambiguous with the 2.6.0 dev-dependency on redb.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7DhuGXp5hmdwuRSRFYGtV)_