### PR TITLE
Call StorageBackend::close() when opening a database fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,9 @@
   leaf page, instead of splitting the full one in half and leaving space behind that no later
   insert can use. A table loaded in key order occupies about half as many pages as before, and
   loads faster.
+* `StorageBackend::close()` is now also called when opening a database fails, so that a backend
+  can release what it holds on that path. Previously it was called only for a database that
+  finished opening.
 
 ### redb-derive (unreleased)
 * Fix the derived implementations calling inherent methods named `fixed_width`, `from_bytes`,

--- a/src/db.rs
+++ b/src/db.rs
@@ -64,8 +64,8 @@ pub trait StorageBackend: 'static + Debug + Send + Sync {
     /// Release any resources held by the backend
     ///
     /// Note: redb will not access the backend after calling this method and will call it exactly
-    /// once when the database is closed: when the [`Database`] is dropped, or, if a
-    /// [`WriteTransaction`] was live at that point, when that transaction completes
+    /// once: when the [`Database`] is dropped, or, if a [`WriteTransaction`] was live at that
+    /// point, when that transaction completes, or if opening the database fails
     fn close(&self) -> core::result::Result<(), io::Error> {
         Ok(())
     }

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -126,6 +126,16 @@ struct CheckedBackend {
     closed: AtomicBool,
 }
 
+// Covers the open paths that fail before there is a Database to drop. Drop cannot report the
+// error, but the open is already failing.
+impl Drop for CheckedBackend {
+    fn drop(&mut self) {
+        if !self.closed.load(Ordering::Acquire) {
+            let _ = self.file.close();
+        }
+    }
+}
+
 impl CheckedBackend {
     fn new(file: Box<dyn StorageBackend>) -> Self {
         Self {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -484,6 +484,71 @@ fn close_called_exactly_once_on_shutdown_io_error() {
     }
 }
 
+// close() is also called when opening fails, before there is a Database to drop.
+#[test]
+fn close_called_exactly_once_when_open_fails() {
+    use std::sync::atomic::AtomicU64;
+
+    #[derive(Debug)]
+    struct CountingBackend {
+        data: Vec<u8>,
+        len_fails: bool,
+        close_calls: Arc<AtomicU64>,
+    }
+
+    impl StorageBackend for CountingBackend {
+        fn len(&self) -> Result<u64, std::io::Error> {
+            if self.len_fails {
+                return Err(std::io::Error::other("injected fault"));
+            }
+            Ok(self.data.len() as u64)
+        }
+
+        fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
+            let start = usize::try_from(offset).unwrap();
+            out.copy_from_slice(&self.data[start..start + out.len()]);
+            Ok(())
+        }
+
+        fn set_len(&self, _len: u64) -> Result<(), std::io::Error> {
+            Ok(())
+        }
+
+        fn sync_data(&self) -> Result<(), std::io::Error> {
+            Ok(())
+        }
+
+        fn write(&self, _offset: u64, _data: &[u8]) -> Result<(), std::io::Error> {
+            Ok(())
+        }
+
+        fn close(&self) -> Result<(), std::io::Error> {
+            self.close_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    // Not a redb database, so the magic number check rejects it
+    let close_calls = Arc::new(AtomicU64::new(0));
+    let backend = CountingBackend {
+        data: vec![0xAB; 4096],
+        len_fails: false,
+        close_calls: close_calls.clone(),
+    };
+    assert!(Database::builder().create_with_backend(backend).is_err());
+    assert_eq!(close_calls.load(Ordering::SeqCst), 1);
+
+    // Fails earlier still, on the first call the backend receives
+    let close_calls = Arc::new(AtomicU64::new(0));
+    let backend = CountingBackend {
+        data: Vec::new(),
+        len_fails: true,
+        close_calls: close_calls.clone(),
+    };
+    assert!(Database::builder().create_with_backend(backend).is_err());
+    assert_eq!(close_calls.load(Ordering::SeqCst), 1);
+}
+
 #[test]
 fn mixed_durable_commit() {
     let tmpfile = create_tempfile();


### PR DESCRIPTION
Split out of #1372 at your request, so that one stays documentation only.

`close()` is documented to be called exactly once, but that only held for a database that finished opening. `TransactionalMemory::new` takes the backend and hands it to `PagedCachedFile`, and every error between there and `Database::new` constructing `db` returns with the backend dropped and never closed:

- a magic number that does not match (`page_manager.rs`, "Not a redb database")
- an empty file when `create` was not requested
- any `?` on the repair path, `begin_writable()`, or the header read
- the persistent savepoint restore below `db.rs:1213` -- this one *does* close today, since `db` is live and its `Drop` runs, which is what makes the current behaviour inconsistent rather than merely absent

A backend that releases a file lock, powers down a device, or frees a peripheral in `close()` never got the chance on any of the others.

### The fix

`CheckedBackend` owns the `Box<dyn StorageBackend>` and already tracks whether it has been closed, so closing from its `Drop` covers all of those at once:

```rust
impl Drop for CheckedBackend {
    fn drop(&mut self) {
        if !self.closed.load(Ordering::Acquire) {
            let _ = self.file.close();
        }
    }
}
```

That is one place instead of the twenty-odd early returns, and it covers any added later for free. `close()` sets the flag, so a database that shuts down normally still closes exactly once -- `close_called_exactly_once_on_shutdown_io_error` is what pins that half, and it still passes.

The error is discarded. `Drop` cannot return it, and on the paths this affects the open is already failing with an error worth more than "the close also failed".

### Testing

`close_called_exactly_once_when_open_fails` covers a backend rejected for its magic number and one whose very first `len()` fails. It fails without the `Drop` impl, so it is not vacuous.

Full suite passes with `--all-features`, `cargo clippy --all --all-targets --all-features` is clean, `cargo fmt --check` and the ASCII check pass.

Once this lands, the `close()` note in #1372 can drop its "not guaranteed if opening the database failed" caveat.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7DhuGXp5hmdwuRSRFYGtV)_