### PR TITLE
Hold the multi-process byte ranges in the existing open modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # redb - Changelog
 
 ## 5.0.0 - 2026-XX-XX
+* On Linux and macOS, opening a database now takes byte-range locks on the database file --
+  exclusive for a writable `Database`, shared for a `ReadOnlyDatabase` -- alongside the
+  whole-file lock on Linux, and in place of it on macOS, where the two kinds of lock conflict
+  with each other. These are the ranges the multi-process locking protocol will coordinate
+  through, so another process's byte-range locks on a database file now conflict with opening it.
 * Under the `experimental-api-5` feature flag, turning off the `std` feature now builds redb as a
   `no_std` crate, for embedded targets. `alloc` is still required, as is `panic = "abort"` and a
   target with atomic compare-and-swap -- Cortex-M3 and above, but not Cortex-M0. The file backend

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ uuid = { version= "1.17.0", optional = true }
 [target.'cfg(target_os = "wasi")'.dependencies]
 libc = "0.2.174"
 
+# For the byte-range file locks in the multi-process locking protocol. std exposes only
+# whole-file locks, and the layout of struct flock differs between Linux and Apple platforms
+[target.'cfg(any(target_os = "linux", target_vendor = "apple"))'.dependencies]
+libc = "0.2.174"
+
 # Common test/bench dependencies
 [dev-dependencies]
 rand = "0.10.1"

--- a/docs/design.md
+++ b/docs/design.md
@@ -490,15 +490,17 @@ The following concurrency modes are supported, and their locking protocol is des
 ## Read-only
 
 In this mode, multiple processes may open the database. Each takes a shared lock on the entire database file.
-On platforms that support both whole-file and range locks, both must be held, since some platforms
-such as Linux namespace them separately.
+On platforms that namespace whole-file and range locks separately, such as Linux, both must be
+held. On platforms where the two share one lock table and conflict with each other, such as macOS,
+only the range lock is taken.
 
 ## Single process
 
 In this mode, only a single process may open the database. The process takes an exclusive lock on
 the entire database file.
-On platforms that support both whole-file and range locks, both must be held, since some platforms
-such as Linux namespace them separately.
+On platforms that namespace whole-file and range locks separately, such as Linux, both must be
+held. On platforms where the two share one lock table and conflict with each other, such as macOS,
+only the range lock is taken.
 
 ## Multi-process with a single writer process
 

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -11,10 +11,110 @@ use std::os::unix::fs::FileExt;
 #[cfg(windows)]
 use std::os::windows::fs::FileExt;
 
+// The multi-process locking protocol (see docs/design.md) coordinates processes through
+// byte-range locks on the database file, at offsets far past any possible end of file. On
+// Unix those are a separate namespace from the whole-file flock() that std's file locks
+// take, so the two kinds of lock cannot see each other; a single-process or read-only
+// handle must hold the entire byte range as well, so that it and a multi-process handle
+// refuse each other. Windows needs nothing extra: std's whole-file lock is itself a range
+// lock over every byte.
+//
+// Open file description locks, never POSIX record locks: a record lock belongs to the
+// process, and is released when any descriptor for the file is closed anywhere in it --
+// which a library embedded in an arbitrary program cannot rule out.
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+mod range_lock {
+    use std::fs::File;
+    use std::io;
+    use std::os::unix::io::AsRawFd;
+
+    // The lock-type constants are c_int on Linux and already c_short on the Apple platforms
+    #[cfg(target_os = "linux")]
+    fn lock_type(kind: libc::c_int) -> libc::c_short {
+        kind.try_into().unwrap()
+    }
+
+    #[cfg(target_vendor = "apple")]
+    fn lock_type(kind: libc::c_short) -> libc::c_short {
+        kind
+    }
+
+    fn flock_struct(kind: libc::c_short, start: u64, len: u64) -> libc::flock {
+        // Zeroed rather than written field by field: the layout of struct flock differs
+        // between Linux and the Apple platforms, and libc carries the right one for each
+        let mut lock: libc::flock = unsafe { std::mem::zeroed() };
+        lock.l_type = kind;
+        lock.l_whence = libc::SEEK_SET.try_into().unwrap();
+        lock.l_start = libc::off_t::try_from(start).unwrap();
+        lock.l_len = libc::off_t::try_from(len).unwrap();
+        lock
+    }
+
+    /// `Ok(true)`: acquired. `Ok(false)`: a conflicting lock is held elsewhere.
+    fn try_lock(file: &File, start: u64, len: u64, exclusive: bool) -> io::Result<bool> {
+        let kind = lock_type(if exclusive {
+            libc::F_WRLCK
+        } else {
+            libc::F_RDLCK
+        });
+        let mut lock = flock_struct(kind, start, len);
+        let rc = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_OFD_SETLK, &raw mut lock) };
+        if rc == 0 {
+            return Ok(true);
+        }
+        let err = io::Error::last_os_error();
+        match err.raw_os_error() {
+            Some(libc::EAGAIN | libc::EACCES) => Ok(false),
+            _ => Err(err),
+        }
+    }
+
+    fn unlock(file: &File, start: u64, len: u64) -> io::Result<()> {
+        let mut lock = flock_struct(lock_type(libc::F_UNLCK), start, len);
+        let rc = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_OFD_SETLK, &raw mut lock) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    /// Locks every offset the file can address. A length of zero means "to the largest
+    /// possible offset", and is the only way to say it: an explicit length cannot reach the
+    /// last addressable byte, because the offsets fcntl takes are signed.
+    pub(super) fn try_lock_all(file: &File, exclusive: bool) -> io::Result<bool> {
+        try_lock(file, 0, 0, exclusive)
+    }
+
+    pub(super) fn unlock_all(file: &File) -> io::Result<()> {
+        unlock(file, 0, 0)
+    }
+
+    /// The filesystem does not support range locks (fcntl on a kernel or filesystem
+    /// without them reports `EINVAL` or a not-supported error)
+    pub(super) fn unsupported(err: &io::Error) -> bool {
+        matches!(err.raw_os_error(), Some(code) if code == libc::EINVAL
+            || code == libc::ENOTSUP
+            || code == libc::EOPNOTSUPP)
+    }
+
+    #[cfg(test)]
+    pub(super) fn try_lock_byte(file: &File, offset: u64, exclusive: bool) -> io::Result<bool> {
+        try_lock(file, offset, 1, exclusive)
+    }
+
+    #[cfg(test)]
+    pub(super) fn unlock_byte(file: &File, offset: u64) -> io::Result<()> {
+        unlock(file, offset, 1)
+    }
+}
+
 /// Stores a database as a file on-disk.
 #[derive(Debug)]
 pub struct FileBackend {
     lock_supported: bool,
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+    range_lock_supported: bool,
     file: File,
 }
 
@@ -25,6 +125,59 @@ impl FileBackend {
     }
 
     pub(crate) fn new_internal(file: File, read_only: bool) -> Result<Self, DatabaseError> {
+        // On the Apple platforms the whole-file flock and the fcntl range locks share one
+        // lock table and conflict with each other, even taken through the same file
+        // description, so the two cannot be held together the way they are on Linux. Only
+        // the range lock is taken there: sharing the table is exactly what makes it
+        // conflict with everything else -- the ranges of the multi-process protocol and
+        // the whole-file locks of older redb versions alike. The whole-file lock remains
+        // as the fallback for a filesystem that does not support range locks, where the
+        // conflict cannot arise
+        #[cfg(target_vendor = "apple")]
+        let mut lock_supported = false;
+
+        #[cfg(not(target_vendor = "apple"))]
+        let lock_supported = Self::try_whole_file_lock(&file, read_only)?;
+
+        // The byte ranges of the multi-process locking protocol, held exclusively by a
+        // writable handle, the way it locks the file itself, and shared by a read-only
+        // one. On Linux the flock above cannot conflict with them -- flock() and fcntl()
+        // locks ignore each other there -- so they are held in addition. A conflict means
+        // a multi-process handle has the database open
+        #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+        let range_lock_supported = match range_lock::try_lock_all(&file, !read_only) {
+            Ok(true) => true,
+            Ok(false) => return Err(DatabaseError::DatabaseAlreadyOpen),
+            Err(err) if range_lock::unsupported(&err) => {
+                #[cfg(feature = "logging")]
+                warn!(
+                    "Byte-range locks not supported by this filesystem. You must ensure that the database file is not opened for multi-process access"
+                );
+
+                // Nothing is held yet on an Apple platform, so a database on such a
+                // filesystem must fall back to the whole-file lock, keeping two ordinary
+                // handles excluding each other the way they always have
+                #[cfg(target_vendor = "apple")]
+                {
+                    lock_supported = Self::try_whole_file_lock(&file, read_only)?;
+                }
+
+                false
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+        Ok(Self {
+            lock_supported,
+            #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+            range_lock_supported,
+            file,
+        })
+    }
+
+    /// Takes the whole-file lock, shared or exclusive. `Ok(false)` means the platform does
+    /// not support file locks at all, which is reported once rather than failing the open.
+    fn try_whole_file_lock(file: &File, read_only: bool) -> Result<bool, DatabaseError> {
         let result = if read_only {
             file.try_lock_shared()
         } else {
@@ -32,10 +185,7 @@ impl FileBackend {
         };
 
         match result {
-            Ok(()) => Ok(Self {
-                file,
-                lock_supported: true,
-            }),
+            Ok(()) => Ok(true),
             Err(TryLockError::WouldBlock) => Err(DatabaseError::DatabaseAlreadyOpen),
             Err(TryLockError::Error(err)) if err.kind() == io::ErrorKind::Unsupported => {
                 #[cfg(feature = "logging")]
@@ -43,10 +193,7 @@ impl FileBackend {
                     "File locks not supported on this platform. You must ensure that only a single process opens the database file, at a time"
                 );
 
-                Ok(Self {
-                    file,
-                    lock_supported: false,
-                })
+                Ok(false)
             }
             Err(TryLockError::Error(err)) => Err(err.into()),
         }
@@ -127,6 +274,10 @@ impl StorageBackend for FileBackend {
     }
 
     fn close(&self) -> Result<(), io::Error> {
+        #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+        if self.range_lock_supported {
+            range_lock::unlock_all(&self.file)?;
+        }
         if self.lock_supported {
             self.file.unlock()?;
         }
@@ -204,4 +355,98 @@ fn write_all_at(file: &File, mut buf: &[u8], mut offset: u64) -> io::Result<()> 
         }
     }
     Ok(())
+}
+
+#[cfg(all(test, any(target_os = "linux", target_vendor = "apple")))]
+mod range_lock_tests {
+    use super::{FileBackend, range_lock};
+    use crate::StorageBackend;
+    use std::fs::{File, OpenOptions};
+    use std::path::Path;
+
+    // The offsets docs/design.md assigns: the header lock over the super-header bytes, the
+    // fixed coordination bytes at BASE, the active transaction range above TXN_BASE, and
+    // the last byte the range can address. Holding "the entire file" must cover every one
+    const BASE: u64 = 1 << 62;
+    const PROTOCOL_OFFSETS: [u64; 6] = [0, 319, BASE, BASE + 2, BASE + 1024 + 12345, (1 << 63) - 1];
+
+    fn reopen(path: &Path) -> File {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap()
+    }
+
+    /// A shared probe answers "could a reader-side lock land here", an exclusive probe
+    /// "could a writer-side lock land here". The probe's own lock is released right away.
+    fn byte_is_free(file: &File, offset: u64, exclusive: bool) -> bool {
+        let acquired = range_lock::try_lock_byte(file, offset, exclusive).unwrap();
+        if acquired {
+            range_lock::unlock_byte(file, offset).unwrap();
+        }
+        acquired
+    }
+
+    #[test]
+    fn a_writable_backend_holds_every_protocol_byte_exclusively() {
+        let tmpfile = crate::create_tempfile();
+        let backend = FileBackend::new_internal(reopen(tmpfile.path()), false).unwrap();
+
+        let observer = reopen(tmpfile.path());
+        for offset in PROTOCOL_OFFSETS {
+            assert!(!byte_is_free(&observer, offset, false), "offset {offset}");
+            assert!(!byte_is_free(&observer, offset, true), "offset {offset}");
+        }
+
+        // ... and releases them all at close
+        backend.close().unwrap();
+        for offset in PROTOCOL_OFFSETS {
+            assert!(byte_is_free(&observer, offset, true), "offset {offset}");
+        }
+    }
+
+    #[test]
+    fn a_read_only_backend_shares_the_protocol_bytes() {
+        let tmpfile = crate::create_tempfile();
+        let backend = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
+
+        let observer = reopen(tmpfile.path());
+        for offset in PROTOCOL_OFFSETS {
+            assert!(byte_is_free(&observer, offset, false), "offset {offset}");
+            assert!(!byte_is_free(&observer, offset, true), "offset {offset}");
+        }
+        backend.close().unwrap();
+    }
+
+    #[test]
+    fn a_held_protocol_byte_reads_as_already_open() {
+        let tmpfile = crate::create_tempfile();
+        let holder = reopen(tmpfile.path());
+        assert!(range_lock::try_lock_byte(&holder, BASE, true).unwrap());
+
+        // Both kinds of handle are refused while any part of the range is held, which is
+        // what stands in for a multi-process handle having the database open
+        assert!(matches!(
+            FileBackend::new_internal(reopen(tmpfile.path()), false),
+            Err(crate::DatabaseError::DatabaseAlreadyOpen)
+        ));
+        assert!(matches!(
+            FileBackend::new_internal(reopen(tmpfile.path()), true),
+            Err(crate::DatabaseError::DatabaseAlreadyOpen)
+        ));
+
+        range_lock::unlock_byte(&holder, BASE).unwrap();
+        let backend = FileBackend::new_internal(reopen(tmpfile.path()), false).unwrap();
+        backend.close().unwrap();
+    }
+
+    #[test]
+    fn read_only_backends_share_with_each_other() {
+        let tmpfile = crate::create_tempfile();
+        let first = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
+        let second = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
+        first.close().unwrap();
+        second.close().unwrap();
+    }
 }


### PR DESCRIPTION
First PR of the multi-process implementation, rebuilt on the revised design in `docs/design.md` (single file, byte-range locks). No new public API.

The multi-process locking protocol coordinates processes through byte-range locks on the database file. Per the design's "Single process" and "Read-only" modes, the existing open paths now hold the entire byte range: exclusively for a writable `Database`, shared for a `ReadOnlyDatabase`, released at close. A conflict on the range reports `DatabaseAlreadyOpen`, which is what will refuse an ordinary open while a future multi-process handle has the file open, and vice versa.

Details:
* On Linux the range locks are held in addition to the whole-file lock: `flock()` and `fcntl()` locks are separate namespaces there and cannot see each other. On the Apple platforms the two share one lock table and conflict with each other -- even through the same file description, which macOS CI demonstrated by refusing every open that tried to hold both -- so the range lock is taken alone there; the shared table is exactly what makes it conflict with everything else, including the whole-file locks of older redb versions. The design doc's mode sections are updated to state both cases.
* Open file description locks (`F_OFD_SETLK`), never POSIX record locks: a record lock is dropped when any descriptor for the file closes anywhere in the process, which a library embedded in an arbitrary program cannot rule out. This adds the `libc` dependency on Linux and the Apple platforms.
* The whole range is locked with `l_len = 0` ("to the largest possible offset"): an explicit length cannot reach the last addressable byte, because the offsets `fcntl` takes are signed.
* Windows needs no change: std's whole-file lock is a `LockFileEx` over every byte, so it already conflicts with any range the protocol will lock.
* Other platforms keep the whole-file lock alone; the multi-process modes will not be offered there. A filesystem that refuses range locks degrades the same way an unsupported whole-file lock always has: the database opens, with a logged warning.
* Unit tests probe the protocol's actual byte map (the header lock bytes, the coordination bytes at `2^62`, the active transaction range, and the last addressable byte) through a second file description, in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJFSfcturbVcnPqY5CNzQv