### PR TITLE
Record the collection horizon in the commit slots

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -733,6 +733,7 @@ impl Database {
                 next_transaction_id,
                 true,
                 ShrinkPolicy::Never,
+                None,
             )?;
             // Reserve the id, or the next write transaction would commit with the same one,
             // which crash recovery could then resolve to the wrong slot
@@ -1198,6 +1199,7 @@ impl Database {
                 next_transaction_id,
                 true,
                 ShrinkPolicy::Never,
+                None,
             )?;
         }
 
@@ -1598,6 +1600,43 @@ mod test {
     use core::sync::atomic::{AtomicU64, Ordering};
     use std::fs::File;
     use std::io::{ErrorKind, Read, Seek, SeekFrom};
+
+    #[test]
+    fn collection_horizon_advances_and_persists() {
+        let tmpfile = crate::create_tempfile();
+        let table: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+
+        let db = Database::create(tmpfile.path()).unwrap();
+        let value = [0u8; 512];
+        for _ in 0..5 {
+            let txn = db.begin_write().unwrap();
+            {
+                let mut t = txn.open_table(table).unwrap();
+                for key in 0..64u64 {
+                    t.insert(&key, value.as_slice()).unwrap();
+                }
+            }
+            txn.commit().unwrap();
+        }
+        // Overwriting commits free and reprocess pages, so the published horizon has moved
+        let horizon = db.mem.collection_horizon();
+        assert!(horizon.raw_id() > 0);
+        drop(db);
+
+        // The horizon rides in the commit slots, so a reopen reads it back, and every commit
+        // only ever advances it -- the close itself included, which commits the allocator
+        // state and moves the watermark with it
+        let db = Database::open(tmpfile.path()).unwrap();
+        assert!(db.mem.collection_horizon() >= horizon);
+        let horizon = db.mem.collection_horizon();
+        let txn = db.begin_write().unwrap();
+        {
+            let mut t = txn.open_table(table).unwrap();
+            t.insert(&0, value.as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+        assert!(db.mem.collection_horizon() >= horizon);
+    }
 
     #[derive(Debug)]
     struct FailingBackend {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2040,12 +2040,18 @@ impl WriteTransaction {
         };
 
         let page_allocator = self.page_allocator();
+        // Freed pages were processed through free_until_transaction above, so pages freed
+        // strictly before it may now be reused: that boundary, inclusive, is the collection
+        // horizon this commit publishes
         self.mem.commit(
             user_root,
             system_root,
             self.transaction_id,
             self.two_phase_commit,
             self.shrink_policy,
+            Some(TransactionId::new(
+                free_until_transaction.raw_id().saturating_sub(1),
+            )),
         )?;
         // All of this transaction's allocations are durable; discard the per-txn tracker.
         let _ = page_allocator.take_allocated_since_commit();

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -73,6 +73,9 @@ const USER_ROOT_OFFSET: usize = _UNUSED_OFFSET + size_of::<u8>() + PADDING;
 const SYSTEM_ROOT_OFFSET: usize = USER_ROOT_OFFSET + BtreeHeader::serialized_size();
 const _UNUSED2_OFFSET: usize = SYSTEM_ROOT_OFFSET + BtreeHeader::serialized_size();
 const TRANSACTION_ID_OFFSET: usize = _UNUSED2_OFFSET + BtreeHeader::serialized_size();
+// The last 8 bytes of what was padding before the collection horizon was recorded, kept
+// directly ahead of the transaction id per the layout in docs/design.md
+const COLLECTION_HORIZON_OFFSET: usize = TRANSACTION_ID_OFFSET - size_of::<u64>();
 const TRANSACTION_LAST_FIELD: usize = TRANSACTION_ID_OFFSET + size_of::<u64>();
 
 const SLOT_CHECKSUM_OFFSET: usize = TRANSACTION_SIZE - size_of::<Checksum>();
@@ -405,17 +408,23 @@ impl DatabaseHeader {
         &self.transaction_slots[self.primary_slot ^ 1]
     }
 
-    // Overwrite the secondary slot with a newly committed transaction.
+    // Overwrite the secondary slot with a newly committed transaction. `collection_horizon`
+    // is the newest transaction this commit processed freed pages through, or `None` for a
+    // commit that processed none; the stored horizon never moves backwards either way, since
+    // reuse that an earlier commit made visible cannot be taken back
     pub(super) fn write_secondary_slot(
         &mut self,
         transaction_id: TransactionId,
         user_root: Option<BtreeHeader>,
         system_root: Option<BtreeHeader>,
+        collection_horizon: Option<TransactionId>,
     ) {
+        let floor = self.transaction_slots[self.primary_slot].collection_horizon;
         let slot = &mut self.transaction_slots[self.primary_slot ^ 1];
         slot.transaction_id = transaction_id;
         slot.user_root = user_root;
         slot.system_root = system_root;
+        slot.collection_horizon = floor.max(collection_horizon.unwrap_or(floor));
         slot.corrupt_bytes = None;
     }
 
@@ -461,6 +470,12 @@ pub(super) struct TransactionHeader {
     pub(super) user_root: Option<BtreeHeader>,
     pub(super) system_root: Option<BtreeHeader>,
     pub(super) transaction_id: TransactionId,
+    // The newest transaction whose freed pages have been processed for reuse. A page can only
+    // change after it is freed and reused, so this is the watermark a page cache is valid
+    // against: entries cached at or before it may be stale. It only ever advances. Nothing in a
+    // single process consults it -- the in-memory tracker knows more -- but the multi-process
+    // protocol reads it from the file, so every commit keeps it current
+    pub(super) collection_horizon: TransactionId,
     // When present, the original on-disk bytes of a slot whose checksum did not verify. They are
     // written back verbatim, so a slot that failed verification keeps its invalid checksum instead
     // of being re-serialized as if it were valid. `None` once the slot holds a new commit.
@@ -474,6 +489,7 @@ impl TransactionHeader {
             user_root: None,
             system_root: None,
             transaction_id,
+            collection_horizon: TransactionId::new(0),
             corrupt_bytes: None,
         }
     }
@@ -519,12 +535,15 @@ impl TransactionHeader {
             None
         };
         let transaction_id = TransactionId::new(get_u64(&data[TRANSACTION_ID_OFFSET..]));
+        // Zero in files from before the field existed: nothing recorded, the safe floor
+        let collection_horizon = TransactionId::new(get_u64(&data[COLLECTION_HORIZON_OFFSET..]));
 
         let result = Self {
             version,
             user_root,
             system_root,
             transaction_id,
+            collection_horizon,
             corrupt_bytes: if corrupted {
                 Some(data[..TRANSACTION_SIZE].try_into().unwrap())
             } else {
@@ -553,6 +572,8 @@ impl TransactionHeader {
             result[SYSTEM_ROOT_OFFSET..(SYSTEM_ROOT_OFFSET + BtreeHeader::serialized_size())]
                 .copy_from_slice(&header.to_le_bytes());
         }
+        result[COLLECTION_HORIZON_OFFSET..(COLLECTION_HORIZON_OFFSET + size_of::<u64>())]
+            .copy_from_slice(&self.collection_horizon.raw_id().to_le_bytes());
         result[TRANSACTION_ID_OFFSET..(TRANSACTION_ID_OFFSET + size_of::<u64>())]
             .copy_from_slice(&self.transaction_id.raw_id().to_le_bytes());
         let checksum = xxh3_checksum(&result[..SLOT_CHECKSUM_OFFSET]);
@@ -565,10 +586,12 @@ impl TransactionHeader {
 
 #[cfg(test)]
 mod test {
+    use super::{COLLECTION_HORIZON_OFFSET, TRANSACTION_SIZE, TransactionHeader};
     #[cfg(feature = "experimental-api-5")]
     use crate::ReadableTable;
     use crate::backends::FileBackend;
     use crate::db::TableDefinition;
+    use crate::transaction_tracker::TransactionId;
     use crate::tree_store::page_store::base::MAX_REGIONS;
     use crate::tree_store::page_store::header::{
         DB_HEADER_SIZE, GOD_BYTE_OFFSET, MAGICNUMBER, NUM_FULL_REGIONS_OFFSET, PAGE_SIZE_OFFSET,
@@ -1512,5 +1535,30 @@ mod test {
             || *x == 0x0B
             || (0x0E <= *x && *x <= 0x1F)
             || (0x7F <= *x && *x <= 0x9F)));
+    }
+
+    #[test]
+    fn collection_horizon_roundtrips_and_is_checksummed() {
+        let mut slot = TransactionHeader::new(TransactionId::new(7));
+        slot.collection_horizon = TransactionId::new(5);
+        let bytes = slot.to_bytes();
+
+        let (parsed, corrupted) = TransactionHeader::from_bytes(&bytes).unwrap();
+        assert!(!corrupted);
+        assert_eq!(parsed.collection_horizon, TransactionId::new(5));
+        assert_eq!(parsed.transaction_id, TransactionId::new(7));
+
+        // The horizon sits inside the checksummed region: a torn write of it must invalidate
+        // the slot rather than parse as a different horizon
+        let mut torn = bytes;
+        torn[COLLECTION_HORIZON_OFFSET] ^= 0xFF;
+        let (_, corrupted) = TransactionHeader::from_bytes(&torn).unwrap();
+        assert!(corrupted);
+
+        // Files from before the field existed hold zeros there
+        let empty = TransactionHeader::new(TransactionId::new(1)).to_bytes();
+        let (parsed, _) = TransactionHeader::from_bytes(&empty).unwrap();
+        assert_eq!(parsed.collection_horizon, TransactionId::new(0));
+        assert_eq!(empty.len(), TRANSACTION_SIZE);
     }
 }

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1056,6 +1056,7 @@ impl TransactionalMemory {
         transaction_id: TransactionId,
         two_phase: bool,
         shrink_policy: ShrinkPolicy,
+        collection_horizon: Option<TransactionId>,
     ) -> Result {
         // All mutable pages must be dropped, this ensures that when a transaction completes
         // no more writes can happen to the pages it allocated. Thus it is safe to make them visible
@@ -1082,7 +1083,7 @@ impl TransactionalMemory {
         );
 
         let old_transaction_id = header.secondary_slot().transaction_id;
-        header.write_secondary_slot(transaction_id, data_root, system_root);
+        header.write_secondary_slot(transaction_id, data_root, system_root, collection_horizon);
 
         self.write_header(&header)?;
 
@@ -1141,7 +1142,7 @@ impl TransactionalMemory {
         let mut state = self.state.lock().unwrap();
         state
             .header
-            .write_secondary_slot(transaction_id, data_root, system_root);
+            .write_secondary_slot(transaction_id, data_root, system_root, None);
         state.read_from_secondary = true;
 
         Ok(())
@@ -1277,6 +1278,18 @@ impl TransactionalMemory {
 
     pub(crate) fn get_durable_system_root(&self) -> Option<BtreeHeader> {
         self.state.lock().unwrap().header.primary_slot().system_root
+    }
+
+    // The collection horizon the latest durable commit published. Nothing outside the
+    // multi-process protocol needs it, and that protocol reads it from the file
+    #[cfg(test)]
+    pub(crate) fn collection_horizon(&self) -> TransactionId {
+        self.state
+            .lock()
+            .unwrap()
+            .header
+            .primary_slot()
+            .collection_horizon
     }
 
     pub(crate) fn free(&self, page: PageNumber, allocated: &PageTracker) {


### PR DESCRIPTION
Second PR of the multi-process implementation on the revised design. **Based on #1375** -- review that one first; this diff is only the horizon field. No new public API, no file format version change.

The multi-process protocol invalidates a process's page cache by watermark: a page can only change after it is freed and reused, reuse begins when a commit processes the freed-page records, and the newest transaction so processed is the `collection horizon transaction id` of `docs/design.md`. This PR makes every commit keep that watermark current in the file, so the protocol built on it in later PRs reads a value that has always been maintained.

* The field lives in each commit slot's previously-padding bytes, directly ahead of the transaction id, per the design layout. Sitting inside the checksummed region gives it the crash story of the roots it travels with: it becomes visible exactly at the flip that publishes the reuse it describes, a torn write fails the slot checksum, and repair falling back to the other slot gets the horizon matching that slot's roots.
* Durable commits record the boundary their freed-page processing reached; commits that process none (repair, shutdown) carry the stored value forward. The stored horizon only ever advances.
* Files from before the field read as zero, the safe floor. The format version is unchanged: the bytes were padding under the same checksum, and old versions ignore them. The version advances later, when a database is opened for multi-process access -- the point where an older redb, unaware of range locks, must be refused and where an unmaintained horizon is initialized rather than trusted.
* Single-process handles never consult the stored value; the in-memory tracker knows strictly more.

Tests: a slot-level roundtrip that also proves a torn horizon write fails the slot checksum and that pre-field files parse as zero, and a database-level test that the horizon advances with commits, survives reopen, and never regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJFSfcturbVcnPqY5CNzQv