### PR TITLE
Update the post-commit epilogue's pages in place

### DIFF
--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1672,6 +1672,14 @@ impl WriteTransaction {
         let (user_root, allocated_pages, data_freed) =
             self.tables.lock().unwrap().table_tree.flush_and_close()?;
 
+        // From here a durable commit is irreversible: it either completes or leaves the allocator
+        // state invalidated, so nothing rolls back what it claims. That is what lets it take over
+        // the epilogue's pages, which no durable root names and it is about to supersede.
+        if self.durability == InternalDurability::Immediate {
+            let pages = self.mem.take_post_commit_allocations();
+            self.page_allocator().adopt_unpersisted(pages);
+        }
+
         // A non-durable commit keeps its freed-page records in memory rather than writing them to
         // DATA_FREED_TABLE, which would mutate the system tree on every commit. durable_commit()
         // writes the accumulated records out.
@@ -2066,6 +2074,8 @@ impl WriteTransaction {
         };
 
         let epilogue_allocations = page_allocator.take_allocated_since_commit();
+        self.mem
+            .record_post_commit_allocations(epilogue_allocations.iter().copied());
         self.mem.non_durable_commit(
             user_root,
             system_root,

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -191,6 +191,17 @@ impl PageAllocator {
         self.allocated_since_commit.take_all()
     }
 
+    // Takes ownership of pages an earlier transaction allocated, so this one can update them in
+    // place. Only sound once this transaction can no longer abort, since rollback_all() frees
+    // whatever is adopted. The page leaves the unpersisted set: it is an ordinary uncommitted page
+    // from here, and the copy-on-write that may free it does not maintain that set.
+    pub(crate) fn adopt_unpersisted(&self, pages: impl IntoIterator<Item = PageNumber>) {
+        for page in pages {
+            assert!(self.mem.claim_unpersisted(page));
+            self.allocated_since_commit.insert(page);
+        }
+    }
+
     /// Reverses every allocation made since the last commit: drains the
     /// allocated-since-commit set and frees each page.
     pub(crate) fn rollback_all(&self) {
@@ -354,6 +365,10 @@ struct UnpersistedState {
     // here for the same reason as `allocations` -- the commits that freed them are volatile, so a
     // crash that loses the records also rolls back the commits they describe.
     data_freed: BTreeMap<TransactionId, Vec<PageNumber>>,
+    // System-tree pages allocated by the post-commit epilogue, which the next durable commit may
+    // take over once it is irreversible. Always a subset of `pages`, so a reused page number is
+    // never mistaken for the allocation that held it before.
+    post_commit_allocations: PageNumberHashSet,
 }
 
 impl UnpersistedState {
@@ -363,6 +378,7 @@ impl UnpersistedState {
         self.allocations.clear();
         self.allocation_txn.clear();
         self.data_freed.clear();
+        self.post_commit_allocations.clear();
     }
 
     fn contains(&self, page: PageNumber) -> bool {
@@ -379,6 +395,8 @@ impl UnpersistedState {
         if !self.pages.remove(&page) {
             return false;
         }
+        // Keeps the subset invariant; see the field.
+        self.post_commit_allocations.remove(&page);
         if let Some(txn) = self.allocation_txn.remove(&page) {
             let pages = self
                 .allocations
@@ -1279,6 +1297,11 @@ impl TransactionalMemory {
         self.storage.cancel_pending_write(address_range.start, len);
     }
 
+    // Drops the page from the unpersisted set without freeing it. Returns whether it was there.
+    pub(crate) fn claim_unpersisted(&self, page: PageNumber) -> bool {
+        self.unpersisted.lock().unwrap().claim(page)
+    }
+
     // Frees the page if no durable commit has occurred, since it was allocated. Returns true, if the page was freed
     pub(crate) fn free_if_unpersisted(&self, page: PageNumber, allocated: &PageTracker) -> bool {
         if self.unpersisted.lock().unwrap().claim(page) {
@@ -1307,6 +1330,21 @@ impl TransactionalMemory {
         &self,
     ) -> BTreeMap<TransactionId, PageNumberHashSet> {
         self.unpersisted.lock().unwrap().take_allocations()
+    }
+
+    pub(crate) fn record_post_commit_allocations(
+        &self,
+        pages: impl IntoIterator<Item = PageNumber>,
+    ) {
+        self.unpersisted
+            .lock()
+            .unwrap()
+            .post_commit_allocations
+            .extend(pages);
+    }
+
+    pub(crate) fn take_post_commit_allocations(&self) -> PageNumberHashSet {
+        mem::take(&mut self.unpersisted.lock().unwrap().post_commit_allocations)
     }
 
     // Returns all unpersisted data-tree pages allocated strictly after `transaction_id`. Used

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -177,6 +177,35 @@ impl StorageBackend for SharedInMemoryBackend {
     }
 }
 
+#[derive(Debug)]
+struct WriteCountingBackend {
+    inner: InMemoryBackend,
+    writes: Arc<AtomicU64>,
+}
+
+impl StorageBackend for WriteCountingBackend {
+    fn len(&self) -> Result<u64, std::io::Error> {
+        self.inner.len()
+    }
+
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
+        self.inner.read(offset, out)
+    }
+
+    fn set_len(&self, len: u64) -> Result<(), std::io::Error> {
+        self.inner.set_len(len)
+    }
+
+    fn sync_data(&self) -> Result<(), std::io::Error> {
+        self.inner.sync_data()
+    }
+
+    fn write(&self, offset: u64, data: &[u8]) -> Result<(), std::io::Error> {
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        self.inner.write(offset, data)
+    }
+}
+
 /// Returns pairs of key, value
 fn random_data(count: usize, key_size: usize, value_size: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
     let mut pairs = vec![];
@@ -604,37 +633,8 @@ fn non_durable_commit_persistence() {
 // in the in-memory cache, visible to readers, and only written out by a later durable commit
 #[test]
 fn non_durable_commit_issues_no_backend_writes() {
-    #[derive(Debug)]
-    struct CountingBackend {
-        inner: InMemoryBackend,
-        writes: Arc<AtomicU64>,
-    }
-
-    impl StorageBackend for CountingBackend {
-        fn len(&self) -> Result<u64, std::io::Error> {
-            self.inner.len()
-        }
-
-        fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
-            self.inner.read(offset, out)
-        }
-
-        fn set_len(&self, len: u64) -> Result<(), std::io::Error> {
-            self.inner.set_len(len)
-        }
-
-        fn sync_data(&self) -> Result<(), std::io::Error> {
-            self.inner.sync_data()
-        }
-
-        fn write(&self, offset: u64, data: &[u8]) -> Result<(), std::io::Error> {
-            self.writes.fetch_add(1, Ordering::SeqCst);
-            self.inner.write(offset, data)
-        }
-    }
-
     let writes = Arc::new(AtomicU64::new(0));
-    let backend = CountingBackend {
+    let backend = WriteCountingBackend {
         inner: InMemoryBackend::new(),
         writes: writes.clone(),
     };
@@ -677,6 +677,47 @@ fn non_durable_commit_issues_no_backend_writes() {
     }
     txn.commit().unwrap();
     assert!(writes.load(Ordering::SeqCst) > writes_before);
+}
+
+// The system root a post-commit epilogue leaves behind is never written to disk on its own, so
+// the durable commit that supersedes it updates those pages rather than copying them. Copying
+// makes a small commit write the same metadata twice.
+#[test]
+fn durable_overwrite_does_not_write_post_commit_metadata() {
+    const COMMITS: u64 = 20;
+
+    let writes = Arc::new(AtomicU64::new(0));
+    let backend = WriteCountingBackend {
+        inner: InMemoryBackend::new(),
+        writes: writes.clone(),
+    };
+    let db = Database::builder().create_with_backend(backend).unwrap();
+
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(U64_TABLE).unwrap();
+        table.insert(&0, &0).unwrap();
+    }
+    txn.commit().unwrap();
+
+    let writes_before = writes.load(Ordering::SeqCst);
+    for value in 1..=COMMITS {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(U64_TABLE).unwrap();
+            table.insert(&0, &value).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    // A steady-state single-key overwrite writes the pages it dirties and the header, nothing
+    // else. The bound leaves room above that, so it survives incidental changes to the commit
+    // path while still catching a commit that writes another root's worth of metadata.
+    let commit_writes = writes.load(Ordering::SeqCst) - writes_before;
+    assert!(
+        commit_writes <= 7 * COMMITS,
+        "{COMMITS} durable overwrites issued {commit_writes} backend writes"
+    );
 }
 
 fn test_persistence(durability: Durability) {


### PR DESCRIPTION
`f9a348d` (#1201, which fixed #829) added a post-commit epilogue that leaves behind a system root no durable commit has written yet. The next durable commit treats that root's pages as committed, so it copies them and writes **both** versions out. Every small durable commit has paid about two extra backend writes since.

This adopts those pages instead, so the durable system-tree updates overwrite them in place rather than copying a root that was never on disk. 50 lines of source, one commit.

## Effect on #829

The issue is about large transactions doubling disk usage. Repeated full overwrite of 200 MiB of live data, file size at steady state:

| | file | overhead |
|---|---|---|
| `f9a348d~1` (the bug) | 1028 MiB | 5.14x |
| master (the fix) | 514 MiB | 2.57x |
| this PR | 514 MiB | 2.57x |

Unchanged. The epilogue still runs and still processes `DATA_FREED_TABLE`, so pages freed by one transaction remain available to the next. Only the epilogue's own allocations are treated differently.

## Effect on commit speed

**Small durable commits.** This is what the change is for. 2,000 single-key durable commits against a file backend, counted with `strace`:

| | `pwrite64` | per commit | `fdatasync` |
|---|---|---|---|
| `f9a348d~1` | 10,033 | 5.0 | 2,014 |
| master | 16,040 | 8.0 | 2,014 |
| this PR | 12,035 | 6.0 | 2,014 |

25% fewer writes, and 10-20% faster on `redb_benchmark`'s individual-write case. `fdatasync` is untouched, so commit *latency* is unchanged -- this is write amplification and device wear.

**Large transactions.** Neutral: 12 large commits interleaved against master, 12.39s total for master and 12.48s for this branch.

**Non-durable commits.** A cost rather than a win, and the one place this is not neutral-or-better. 100,000 `Durability::None` commits run at ~9.6 us/commit here against ~9.1 on master -- about 5%, reproducible across interleaved runs rather than a single sample. It is not work added to that path: adoption never runs there, and building this branch with the one line it does add to it removed (`UnpersistedState::claim()` maintaining `post_commit_allocations`) measures the same. Allocations per commit are identical at 2.00 on both, so it is where pages land rather than how many: updating the epilogue's pages in place changes the layout the following commits inherit. For scale, `f9a348d~1` runs that same workload at ~21.9 us/commit, so this gives back roughly 5% of a 2.4x improvement.

The remaining write per durable commit would need the epilogue to stop writing `SYSTEM_FREED_TABLE`, which means holding those pages in memory until both durable slots have moved past the root that names them, threaded through the quick-repair allocator snapshot, the `check_integrity()` rebuild, and `compact()`'s drain loop. Written and verified, but one write per commit is not worth that, so it is dropped rather than deferred.

## Why it is safe

From the adoption point a durable commit is irreversible: it either completes or leaves the allocator state invalidated by `AllocatorStateLatch`, so nothing rolls back what it claims. `commit()` sets `completed` before anything fallible, so `Drop` never reaches `abort_inner()`, and there is no path from adoption back to `rollback_all()`.

No durable root names the adopted pages -- they were allocated after the previous commit's header was written and synced -- so a crash mid-commit recovers the previous root intact. Read transactions capture only the data root and never descend the system tree, so no reader can observe the rewrite. Every other `get_system_root()` caller is a repair or verify path holding exclusive access.

Savepoints cannot reach an adopted page either: a `Savepoint` stores only `user_root`, and `restore_savepoint` works off `DATA_ALLOCATED_TABLE` and `unpersisted_allocations_after`, which reads the data-tree allocation map. Adopted pages live in `unpersisted.pages` and never enter it.

Adoption *claims* each page out of the unpersisted set rather than only testing that it is still in it. From that point the page is an ordinary uncommitted page of the commit, and a copy-on-write may free it -- `free_if_uncommitted` reaches `TransactionalMemory::free`, and `free_helper` does not maintain that set. An entry left behind would leave a page number free and reusable within the same commit while still marked unpersisted, which is what the subset invariant on `post_commit_allocations` says cannot happen.

## Testing

`durable_overwrite_does_not_write_post_commit_metadata` counts backend writes across 20 durable overwrites: 119 here against 156 on master. It fails without the change.

`cargo test --all-features` passes in debug and release -- release matters here, since the claim above is an `assert!` rather than a `debug_assert!` and would fire there. `cargo clippy --all --all-targets --all-features`, `cargo doc` and `cargo fmt --check` are clean under `--deny warnings`; `wasm32-unknown-unknown` and `thumbv7em-none-eabihf` check clean.

`cargo fuzz run fuzz_redb -max_len=10000`: 105,201 runs against this exact commit with no crashes, plus 137,795 and 465,976 against the two previous revisions and 310,556, 531,570 and 1,176,032 against earlier ones. The target mixes durabilities, `quick_repair`, two-phase commits, savepoints, `compact()`, `check_integrity()` and simulated crashes.

A separate stress harness verifies a shadow model after every transaction while mixing durabilities, quick-repair, two-phase commits, ephemeral savepoints held across transactions and restored, aborts, and three reader threads scanning concurrently (17k-27k scans per run), with periodic `check_integrity()`, `compact()` and reopen. Clean in debug and release across several seeds.

Compared against master directly: `compact()` reaches the same size in the same number of calls; crash-and-reopen at 101 and 503 commits over mixed durable / `Durability::None` / quick-repair workloads gives identical contents with `check_integrity()` clean; and forcing recovery through `repair_primary_corrupted()` by flipping the god byte recovers the same committed state.

## What the invariants are worth

Mutation testing shows the adoption *placement* is load-bearing: moving it somewhere `rollback_all()` can reach wedges the stress harness immediately (1s to complete becomes a hang past 200s).

Claiming rather than testing is load-bearing too, and has a signal. Adding `assert!(!self.mem.unpersisted(page))` to `free_if_uncommitted` -- which asserts exactly the invariant -- separates the three states cleanly:

| | result |
|---|---|
| master | 94,067 fuzz runs, clean |
| an earlier revision, testing instead of claiming | panics within seconds |
| this PR | 102,292 fuzz runs, clean |

I could not make it *observable* without that added assertion. The window runs from the copy to `mem.commit()`'s `unpersisted.clear()`; the durable path passes `None` to `store_system_freed_pages`, so nothing reads `unpersisted` inside it, and `process_freed_pages` runs before the window opens. So it was a latent invariant violation that held by an ordering accident, not a bug you could trigger. It now holds by construction.

The `post_commit_allocations` line in `UnpersistedState::claim()` is what lets adoption assert rather than branch: `pages` only ever shrinks in `clear()` and `claim()`, and both drop the page from `post_commit_allocations` at the same time, so nothing can reach adoption having already left the unpersisted set. I could not falsify that line directly -- instrumenting it shows the recycled-page path fires zero times in the suite, the fuzzer and the stress harness -- but it is no longer insurance against an unreachable state, since the assert depends on it.

## Not covered

On a database of a few pages, the file's floor is higher than master's, because `try_shrink` only trims trailing free pages and an in-place page never migrates downward the way a copied one does. It is a constant, not proportional to anything: after 4,000 single-key durable commits master sits at 90,112 bytes and this branch at 307,200, and that same figure holds whether the workload touches 1 key or 65,536. At 200 MiB of live data both sit at 514 MiB. Nothing is leaked -- `allocated_pages()` matches and `compact()` reaches the same size.

Same root cause as the non-durable commit cost above: in-place updating keeps pages where they are, and copying quietly migrated them downward. It is also the only user-visible change this PR introduces against v4.1.0 on its own -- everything else a 4.2.0 user would notice on these paths comes from `f9a348d` -- so it is the one candidate for a changelog entry if you want one.

## Dropped from this PR

An earlier revision also batched the allocator lock in `process_freed_pages()`. Measured against the case it was written for, it made no reliable difference -- 419k pages: 1052/1062 ms master vs 1078/1107 ms batched; 838k: 4175/4175/4355 vs 4192/4014/3993; 1.7M: 8140 vs 8445. The delete is dominated by walking the tree and writing pages, not by acquiring the allocator lock. It has been removed rather than landed unproven.

A second revision generalized adoption to all non-durable commits, with a separate `PageAllocator` for the system tree and a maintained unpersisted-system-page set, which deletes the `extract_if`/`post_commit_frees`/`free_if_unpersisted` reclaim dance in `non_durable_commit`. It measured 1-2 us/commit *slower* on every path it targets and changed no write count, because under `Durability::None` the system tree is already never written -- freed-page records are held in memory precisely so a non-durable commit does not mutate it. Details in [this comment](https://github.com/cberner/redb/pull/1378#issuecomment-5304436687).