### PR TITLE
Poison the transaction when a savepoint restore or catalog change fails partway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@
   that yielded `Err(Corrupted)` could yield the rest of the table on later calls, skipping the
   unreadable entries with no further error. Iterators and read-only cursors now keep returning
   an error after the first one; re-seeking a cursor resets it.
+* Fix `restore_savepoint()`, `rename_table()`, and `delete_table()` leaving the transaction
+  committable after a storage error. Committing it could corrupt the database or silently lose
+  a table. Such failures now poison the transaction: `commit()` returns an error instead of
+  committing the half-applied state.
 
 ## 4.2.0 - 2026-08-17
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -484,7 +484,8 @@ impl core::error::Error for TransactionError {}
 pub enum CommitError {
     /// Error from underlying storage
     Storage(StorageError),
-    /// The transaction was poisoned by a panic and can no longer be committed
+    /// The transaction was poisoned and can no longer be committed: an operation panicked, or
+    /// failed part way through modifying the transaction
     TransactionPoisoned,
 }
 
@@ -517,7 +518,10 @@ impl Display for CommitError {
         match self {
             CommitError::Storage(storage) => storage.fmt(f),
             CommitError::TransactionPoisoned => {
-                write!(f, "Transaction was poisoned by a panic")
+                write!(
+                    f,
+                    "Transaction was poisoned by a panic or a failed operation"
+                )
             }
         }
     }
@@ -548,7 +552,8 @@ pub enum Error {
     EphemeralSavepointExists,
     /// A transaction is still in-progress
     TransactionInProgress,
-    /// The transaction was poisoned by a panic and can no longer be committed
+    /// The transaction was poisoned and can no longer be committed: an operation panicked, or
+    /// failed part way through modifying the transaction
     TransactionPoisoned,
     /// The Database is corrupted
     Corrupted(String),
@@ -710,7 +715,10 @@ impl Display for Error {
                 )
             }
             Error::TransactionPoisoned => {
-                write!(f, "Transaction was poisoned by a panic")
+                write!(
+                    f,
+                    "Transaction was poisoned by a panic or a failed operation"
+                )
             }
             Error::InvalidSavepoint => {
                 write!(f, "Savepoint is invalid or cannot be created.")

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -735,7 +735,12 @@ impl TableNamespace {
         #[cfg(feature = "logging")]
         debug!("Renaming table: {name} to {new_name}");
         self.set_dirty(transaction);
-        self.inner_rename(name, new_name, TableType::Normal)
+        let result = self.inner_rename(name, new_name, TableType::Normal);
+        // A half-renamed catalog must not be committed, so any storage error poisons
+        if matches!(result, Err(TableError::Storage(_))) {
+            transaction.poison();
+        }
+        result
     }
 
     #[track_caller]
@@ -748,7 +753,12 @@ impl TableNamespace {
         #[cfg(feature = "logging")]
         debug!("Renaming multimap table: {name} to {new_name}");
         self.set_dirty(transaction);
-        self.inner_rename(name, new_name, TableType::Multimap)
+        let result = self.inner_rename(name, new_name, TableType::Multimap);
+        // See rename_table(): a half-renamed catalog must not be committed
+        if matches!(result, Err(TableError::Storage(_))) {
+            transaction.poison();
+        }
+        result
     }
 
     #[track_caller]
@@ -769,7 +779,12 @@ impl TableNamespace {
         #[cfg(feature = "logging")]
         debug!("Deleting table: {name}");
         self.set_dirty(transaction);
-        self.inner_delete(name, TableType::Normal)
+        let result = self.inner_delete(name, TableType::Normal);
+        // The catalog removal is not error-atomic part way through, so any storage error poisons
+        if matches!(result, Err(TableError::Storage(_))) {
+            transaction.poison();
+        }
+        result
     }
 
     #[track_caller]
@@ -781,7 +796,12 @@ impl TableNamespace {
         #[cfg(feature = "logging")]
         debug!("Deleting multimap table: {name}");
         self.set_dirty(transaction);
-        self.inner_delete(name, TableType::Multimap)
+        let result = self.inner_delete(name, TableType::Multimap);
+        // See delete_table(): a partial catalog removal must not be committed
+        if matches!(result, Err(TableError::Storage(_))) {
+            transaction.poison();
+        }
+        result
     }
 
     pub(crate) fn close_table<K: Key + 'static, V: Value + 'static>(
@@ -1281,6 +1301,11 @@ impl WriteTransaction {
     /// Restore the state of the database to the given [`Savepoint`]
     ///
     /// Calling this method invalidates all [`Savepoint`]s created after savepoint
+    ///
+    /// A failure partway through restoring poisons the transaction, so a half-restored state
+    /// can never be committed: [`Self::commit`] rolls the transaction back and returns
+    /// [`CommitError::TransactionPoisoned`]. After an I/O error the storage layer is latched
+    /// and [`Self::commit`] reports that failure instead; reopening the database repairs it.
     pub fn restore_savepoint(&mut self, savepoint: &Savepoint) -> Result<(), SavepointError> {
         // Reject a Savepoint that is from a different Database
         if core::ptr::from_ref(self.transaction_tracker.as_ref()) != savepoint.db_address() {
@@ -1317,6 +1342,17 @@ impl WriteTransaction {
         assert_eq!(self.mem.get_version(), savepoint.get_version());
         self.dirty.store(true, Ordering::Release);
 
+        // From the root swap onward the transaction holds half-restored state which must not be
+        // committed, so any failure poisons the transaction
+        let result = self.restore_savepoint_inner(savepoint);
+        if result.is_err() {
+            self.poison();
+        }
+        result
+    }
+
+    // The mutating phase of restore_savepoint(): the caller poisons the transaction on error
+    fn restore_savepoint_inner(&mut self, savepoint: &Savepoint) -> Result<(), SavepointError> {
         // Restoring a savepoint needs to accomplish the following:
         // 1) restore the table tree. This is trivial, since we have the old root
         // 1a) we also filter the freed tree to remove any pages referenced by the old root
@@ -1342,25 +1378,13 @@ impl WriteTransaction {
             };
             let mut system_tables = self.system_tables.lock().unwrap();
             let mut data_freed = system_tables.open_system_table(self, DATA_FREED_TABLE)?;
-            let drain = || -> Result<(), StorageError> {
-                let mut iter = data_freed.extract_from_if(lower.., |_, _| true)?;
-                for entry in &mut iter {
-                    entry?;
-                }
-                // Defensive: exhaustion has already closed the iterator and
-                // surfaced any finalization error through the loop; this only
-                // keeps errors from being swallowed if the loop ever gains an
-                // early exit.
-                iter.close()
-            };
-            let result = drain();
-            if result.is_err() {
-                // The table tree root was already restored above, so a partial
-                // purge must not be committed. System-table extract iterators
-                // carry no poison target, so poison the transaction directly.
-                self.poison();
+            let mut iter = data_freed.extract_from_if(lower.., |_, _| true)?;
+            for entry in &mut iter {
+                entry?;
             }
-            result?;
+            // Defensive: exhaustion already closed the iterator; this only keeps errors from
+            // being swallowed if the loop ever gains an early exit
+            iter.close()?;
             // No need to process the system freed table, because it only rolls forward
         }
 
@@ -1546,6 +1570,9 @@ impl WriteTransaction {
     }
 
     /// Rename the given table
+    ///
+    /// A storage error partway through poisons the transaction, so a half-renamed state can
+    /// never be committed; see [`Self::restore_savepoint`].
     pub fn rename_table(
         &self,
         definition: impl TableHandle,
@@ -1561,6 +1588,9 @@ impl WriteTransaction {
     }
 
     /// Rename the given multimap table
+    ///
+    /// A storage error partway through poisons the transaction, so a half-renamed state can
+    /// never be committed; see [`Self::restore_savepoint`].
     pub fn rename_multimap_table(
         &self,
         definition: impl MultimapTableHandle,
@@ -1578,6 +1608,9 @@ impl WriteTransaction {
     /// Delete the given table
     ///
     /// Returns a bool indicating whether the table existed
+    ///
+    /// A storage error partway through poisons the transaction, so a half-deleted state can
+    /// never be committed; see [`Self::restore_savepoint`].
     pub fn delete_table(&self, definition: impl TableHandle) -> Result<bool, TableError> {
         let name = definition.name().to_string();
         // Drop the definition so that callers can pass in a `Table` or `MultimapTable` to delete, without getting a TableAlreadyOpen error
@@ -1588,6 +1621,9 @@ impl WriteTransaction {
     /// Delete the given table
     ///
     /// Returns a bool indicating whether the table existed
+    ///
+    /// A storage error partway through poisons the transaction, so a half-deleted state can
+    /// never be committed; see [`Self::restore_savepoint`].
     pub fn delete_multimap_table(
         &self,
         definition: impl MultimapTableHandle,
@@ -1628,9 +1664,10 @@ impl WriteTransaction {
     /// All writes performed in this transaction will be visible to future transactions, and are
     /// durable as consistent with the [`Durability`] level set by [`Self::set_durability`]
     ///
-    /// Returns [`CommitError::TransactionPoisoned`] if a previous operation panicked and left the
-    /// transaction unable to commit. In that case the transaction is rolled back and the database
-    /// remains usable.
+    /// Returns [`CommitError::TransactionPoisoned`] if a previous operation panicked, or failed
+    /// part way through modifying the transaction, and left it unable to commit. The transaction
+    /// is then rolled back and new transactions may begin, though a corruption error that caused
+    /// the poisoning is in the database itself, and is not repaired by the rollback.
     ///
     /// On any other error the commit did not complete cleanly: the transaction's changes are
     /// applied atomically -- fully or not at all -- but may already have become durable, so they

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -575,12 +575,15 @@ impl TableTreeMut {
             if self.get_table_untyped(new_name, table_type)?.is_some() {
                 return Err(TableError::TableExists(new_name.to_string()));
             }
+            assert!(self.tree.remove(&name)?.is_some());
+            // A failure here leaves the table under neither name; the caller poisons the
+            // transaction so the half-renamed catalog can never be committed.
+            assert!(self.tree.insert(&new_name, &definition)?.is_none());
+            // Re-keyed only after both catalog updates succeed
             if let Some(update) = self.pending_table_updates.remove(name) {
                 self.pending_table_updates
                     .insert(new_name.to_string(), update);
             }
-            assert!(self.tree.remove(&name)?.is_some());
-            assert!(self.tree.insert(&new_name, &definition)?.is_none());
         } else {
             return Err(TableError::TableDoesNotExist(name.to_string()));
         }
@@ -601,6 +604,12 @@ impl TableTreeMut {
                 pages.push(path.page_number());
                 Ok(())
             })?;
+
+            // Free only after the fallible catalog removal: a still-reachable table's pages
+            // must never sit in the freed queue of a committable transaction
+            let found = self.tree.remove(&name)?.is_some();
+            self.pending_table_updates.remove(name);
+
             let mut freed_pages = self.freed_pages.lock().unwrap();
             for page in pages {
                 if !self
@@ -612,9 +621,6 @@ impl TableTreeMut {
             }
             drop(freed_pages);
 
-            self.pending_table_updates.remove(name);
-
-            let found = self.tree.remove(&name)?.is_some();
             return Ok(found);
         }
 


### PR DESCRIPTION
Fixes the poison-on-error class from the pre-5.0 bug audit (P0 findings 1-3): a non-latching storage failure (e.g. `Corrupted` from page validation, which does not latch `io_failed` the way real I/O errors do) part way through `restore_savepoint()`, `rename_table()`, or `delete_table()` left the transaction committable with half-applied state.

**What could go wrong before this change**
- `restore_savepoint()`: the data root is swapped first; an error in any later step (the freed-record purge's table open, queueing the pages that became unreachable, deleting invalidated persistent savepoints) returned `?` without poisoning, and `restored_transaction` was only set as the final statement. Committing afterwards durably recorded freed-page records for pages the restored root still references; a later commit reclaims and reuses them — silent corruption. Only the freed-record purge itself poisoned before.
- `rename_table()`: the catalog update is a remove/insert pair. An insert failure after a successful remove left the table under neither name; committing lost the table silently (or, with a staged root update, panicked during commit).
- `delete_table()`: every page of the table was queued for freeing (or freed immediately, when uncommitted) before the fallible catalog removal. On failure, a still-reachable table's pages sat in the freed queue of a committable transaction.

**The fix**
- `restore_savepoint()` splits into validation plus a mutating phase; any failure in the mutating phase poisons the transaction. The pre-existing validation errors (`InvalidSavepoint`, `ImmediateDurabilityRequired`) still leave the transaction usable, as the existing regression test requires.
- `rename_table()` / `rename_multimap_table()` poison on any storage error, and the staged-update re-key now happens only after both catalog updates succeed.
- `delete_table()` / `delete_multimap_table()` are reordered (catalog removal first, freeing last) *and* poison on storage errors — the removal itself is not error-atomic part way through a multi-page catalog update (the btree delete path can queue a page for freeing before a later sibling read fails), so the reorder alone is not sufficient. (Updated after review.)
- `TransactionPoisoned` docs, `Display` messages, and the `commit()`/`restore_savepoint()` contracts updated: poisoning now covers failed operations as well as panics, with the I/O-error case qualified (the latched storage error is reported instead, and reopening repairs). (Updated after review.)

**Tests**
No test code ships in the production code base (per review): the PR contains no failure-injection hooks or tests that depend on them. Each poison path was verified during development by temporarily injecting a failure at the guarded step and confirming `commit()` refuses with `TransactionPoisoned`; that injection code was then removed.

**Validation**: the constituent commands of `just test`, run directly because this environment lacks the rootless podman its sandbox wrapper needs — `cargo deny --workspace --all-features check licenses advisories` ("advisories ok, licenses ok"), `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` with `--deny warnings`, and `RUST_BACKTRACE=1 cargo test --all-features` (all suites green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr