### PR TITLE
Reserve the repair commit's transaction id in check_integrity()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
   nodes store the result instead of a whole key, so more children fit in each node and lookups
   touch fewer pages. The default implementation returns a whole key, leaving existing `Key`
   implementations unchanged; `&[u8]`, `&str`, and `String` keys now store minimal prefixes.
+* Fix a crash shortly after a commit being able to silently roll that commit back during
+  recovery, if `check_integrity()` had previously repaired the database.
 
 ## 4.2.0 - 2026-08-17
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -731,6 +731,10 @@ impl Database {
                 true,
                 ShrinkPolicy::Never,
             )?;
+            // Reserve the id, or the next write transaction would commit with the same one,
+            // which crash recovery could then resolve to the wrong slot
+            self.transaction_tracker
+                .reserve_repair_transaction_id(next_transaction_id);
         }
 
         self.mem.begin_writable()?;

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -244,6 +244,14 @@ impl TransactionTracker {
         state.next_transaction_id = id;
     }
 
+    // Reserves a repair commit's id so it is never issued again: crash recovery orders the
+    // commit slots by transaction id, so an id must never be committed twice
+    pub(crate) fn reserve_repair_transaction_id(&self, id: TransactionId) {
+        let mut state = self.state.lock().unwrap();
+        assert!(state.live_write_transaction.is_none());
+        state.next_transaction_id = state.next_transaction_id.max(id);
+    }
+
     pub(crate) fn restore_savepoint_counter_state(&self, next_savepoint: SavepointId) {
         let mut state = self.state.lock().unwrap();
         assert!(state.valid_savepoints.is_empty());

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2833,6 +2833,54 @@ mod test {
         assert!(write_txn.transaction_id > first_txn_id);
     }
 
+    // check_integrity()'s repair commit must reserve its transaction id: recovery orders the
+    // commit slots by id, so committing an id twice could roll back a committed transaction.
+    // Gated on unwinding because the leak setup relies on catch_unwind.
+    #[cfg(panic = "unwind")]
+    #[test]
+    fn repair_commit_reserves_transaction_id() {
+        let tmpfile = crate::create_tempfile();
+        let db = Database::create(tmpfile.path()).unwrap();
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(X).unwrap();
+            table.insert("k1", "v1").unwrap();
+        }
+        txn.commit().unwrap();
+
+        // A transaction dropped mid-panic skips its abort, leaking pages that survive the clean
+        // close, so check_integrity() below has something to repair
+        let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let txn = db.begin_write().unwrap();
+            let mut table = txn.open_table(X).unwrap();
+            table.insert("leak", "leak").unwrap();
+            panic!("simulated panic with a live write transaction");
+        }));
+        assert!(panic_result.is_err());
+        drop(db);
+
+        let db = Database::open(tmpfile.path()).unwrap();
+        // Align the tracker's counter with the last committed id. The epilogue is disabled so
+        // no pending non-durable commit routes check_integrity() away from the repair commit.
+        let mut txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(X).unwrap();
+            table.insert("k2", "v2").unwrap();
+        }
+        txn.disable_post_commit_free();
+        txn.commit().unwrap();
+
+        // Not clean: the leaked pages make check_integrity() write a repair commit
+        let mut db = db;
+        assert!(!db.check_integrity().unwrap());
+        let repair_id = db.get_memory().get_last_committed_transaction_id().unwrap();
+
+        // The next write transaction must not commit with the repair commit's id
+        let txn = db.begin_write().unwrap();
+        assert!(txn.transaction_id > repair_id);
+        txn.abort().unwrap();
+    }
+
     #[test]
     fn post_commit_epilogue_reserves_transaction_id() {
         let tmpfile = crate::create_tempfile();

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1055,6 +1055,13 @@ impl TransactionalMemory {
         let mut header = state.header.clone();
         drop(state);
 
+        // Crash recovery orders the slots by transaction id, so every commit must be newer than
+        // the primary it supersedes; the secondary is overwritten below
+        assert!(
+            transaction_id > header.primary_slot().transaction_id,
+            "commit transaction id not newer than the primary slot's"
+        );
+
         let old_transaction_id = header.secondary_slot().transaction_id;
         header.write_secondary_slot(transaction_id, data_root, system_root);
 


### PR DESCRIPTION
Fixes P0 finding 4 from the pre-5.0 bug audit: `check_integrity()`'s non-promote repair path commits with `last_committed + 1` without reserving that id in the `TransactionTracker`. The tracker's counter keeps issuing from where it left off, and after any write transaction it equals the last committed id — so the next `begin_write()` commits the very id the repair commit just used, leaving both on-disk commit slots holding equal transaction ids with different content.

1PC+C crash recovery resolves the "only the god byte reached disk" torn-commit case by `secondary.transaction_id > primary.transaction_id` (`docs/design.md` requires monotonically increasing ids). With a duplicated id that comparison keeps the wrong slot, and a user's earlier fsync-acknowledged commit silently disappears.

**The fix**
- `check_integrity_inner()` reserves the repair commit's id in the tracker after committing, via a new `TransactionTracker::reserve_repair_transaction_id()` — mirroring what `Database::new()` (which re-seeds the tracker after its repair commit) and the post-commit epilogue (`reserve_transaction_id()`) already do for their out-of-band commits.
- `TransactionalMemory::commit()` now asserts every commit is strictly newer than the primary slot it supersedes, so any remaining way to duplicate an id fails loudly instead of corrupting recovery. Only the primary is compared: the secondary is overwritten by the commit and may legitimately hold a torn slot's garbage before a repair.

**Test**
`repair_commit_reserves_transaction_id` reproduces the collision end to end: it leaks pages via a transaction dropped during a caught panic (whose clean close persists the leak), reopens, re-aligns the tracker with a normal commit (post-commit epilogue disabled, so no pending non-durable commit routes `check_integrity()` into the tracked promote path), runs `check_integrity()`, and asserts the next write transaction's id is newer than the repair commit's. Without the fix the ids are equal and the test fails. The test is gated on `cfg(panic = "unwind")` since its leak setup needs `catch_unwind`, which aborts the whole test process on the wasi target (this was the initial CI failure on this PR).

**Validation**: the constituent commands of `just test`, run directly because this environment lacks the rootless podman its sandbox wrapper needs — `cargo deny --workspace --all-features check licenses advisories` ("advisories ok, licenses ok"), `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` with `--deny warnings`, and `RUST_BACKTRACE=1 cargo test --all-features` (all suites green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr