### PR TITLE
Stop read cursors from resuming past an unreadable page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@
   implementations unchanged; `&[u8]`, `&str`, and `String` keys now store minimal prefixes.
 * Fix a crash shortly after a commit being able to silently roll that commit back during
   recovery, if `check_integrity()` had previously repaired the database.
+* Fix iterators silently omitting data when iteration continues after an error. An iterator
+  that yielded `Err(Corrupted)` could yield the rest of the table on later calls, skipping the
+  unreadable entries with no further error. Iterators and read-only cursors now keep returning
+  an error after the first one; re-seeking a cursor resets it.
 
 ## 4.2.0 - 2026-08-17
 

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -479,6 +479,9 @@ pub(super) struct Cursor<K: Key + 'static, V: Value + 'static> {
     leaf: Option<Leaf>,
     manager: PageResolver,
     hint: PageHint,
+    // A failed step leaves the position half-advanced, and continuing from it would silently
+    // skip the unreadable subtree, so the first error latches the cursor; seek_to() clears it
+    errored: bool,
     _key_type: PhantomData<K>,
     _value_type: PhantomData<V>,
 }
@@ -491,44 +494,69 @@ impl<K: Key + 'static, V: Value + 'static> Cursor<K, V> {
             leaf: None,
             manager,
             hint,
+            errored: false,
             _key_type: PhantomData,
             _value_type: PhantomData,
         }
     }
 
-    pub(super) fn seek_to(&mut self, position: Position<'_>) -> Result {
-        self.path.clear();
-        let root_page = self.manager.get_page(self.root, self.hint)?;
-        let Self {
-            manager,
-            hint,
-            path,
-            leaf,
-            ..
-        } = self;
-        let mut get_page = |page| manager.get_page(page, *hint);
-        *leaf = Some(descend_to_position::<K, V, _>(
-            root_page,
-            position,
-            path,
-            &mut get_page,
-        )?);
+    fn latch_errors<T>(&mut self, result: Result<T>) -> Result<T> {
+        if result.is_err() {
+            self.errored = true;
+        }
+        result
+    }
+
+    fn check_not_errored(&self) -> Result {
+        if self.errored {
+            return Err(StorageError::PreviousIo);
+        }
         Ok(())
     }
 
+    pub(super) fn seek_to(&mut self, position: Position<'_>) -> Result {
+        // A seek rebuilds the position from the root, so a previous error does not taint it
+        self.errored = false;
+        self.path.clear();
+        let result = (|| {
+            let root_page = self.manager.get_page(self.root, self.hint)?;
+            let Self {
+                manager,
+                hint,
+                path,
+                leaf,
+                ..
+            } = self;
+            let mut get_page = |page| manager.get_page(page, *hint);
+            *leaf = Some(descend_to_position::<K, V, _>(
+                root_page,
+                position,
+                path,
+                &mut get_page,
+            )?);
+            Ok(())
+        })();
+        self.latch_errors(result)
+    }
+
     fn ensure_has_entry(&mut self, direction: Direction) -> Result<bool> {
-        let Self {
-            manager,
-            hint,
-            path,
-            leaf,
-            ..
-        } = self;
-        let mut get_page = |page| manager.get_page(page, *hint);
-        prepare_leaf::<K, V, _>(leaf, path, direction, &mut get_page)
+        self.check_not_errored()?;
+        let result = {
+            let Self {
+                manager,
+                hint,
+                path,
+                leaf,
+                ..
+            } = self;
+            let mut get_page = |page| manager.get_page(page, *hint);
+            prepare_leaf::<K, V, _>(leaf, path, direction, &mut get_page)
+        };
+        self.latch_errors(result)
     }
 
     pub(super) fn normalize_forward_gap(&mut self) -> Result {
+        self.check_not_errored()?;
         if self
             .leaf
             .as_ref()
@@ -537,18 +565,18 @@ impl<K: Key + 'static, V: Value + 'static> Cursor<K, V> {
             return Ok(());
         }
 
-        let Self {
-            manager,
-            hint,
-            path,
-            leaf,
-            ..
-        } = self;
-        let mut get_page = |page| manager.get_page(page, *hint);
-        if let Some(next_leaf) =
-            move_to_adjacent_leaf::<K, V, _>(path, Direction::Next, &mut get_page)?
-        {
-            *leaf = Some(next_leaf);
+        let result = {
+            let Self {
+                manager,
+                hint,
+                path,
+                ..
+            } = self;
+            let mut get_page = |page| manager.get_page(page, *hint);
+            move_to_adjacent_leaf::<K, V, _>(path, Direction::Next, &mut get_page)
+        };
+        if let Some(next_leaf) = self.latch_errors(result)? {
+            self.leaf = Some(next_leaf);
         }
         Ok(())
     }

--- a/src/tree_store/btree_cursor_range.rs
+++ b/src/tree_store/btree_cursor_range.rs
@@ -1,9 +1,9 @@
-use crate::Result;
 use crate::tree_store::btree_cursor::{Cursor, Position};
 use crate::tree_store::btree_iters::{EntryGuard, bounds_are_empty, encode_bounds};
 use crate::tree_store::page_store::PageHint;
 use crate::tree_store::{PageNumber, PageResolver};
 use crate::types::{Key, Value};
+use crate::{Result, StorageError};
 use Bound::{Excluded, Included, Unbounded};
 use alloc::vec::Vec;
 use core::borrow::Borrow;
@@ -53,6 +53,9 @@ pub(crate) struct BtreeCursorRange<K: Key + 'static, V: Value + 'static> {
     hint: PageHint,
     front: Slot<Cursor<K, V>>,
     back: Slot<Cursor<K, V>>,
+    // The ends run on independent cursors and share the termination logic, so the first error
+    // latches the whole range. See Cursor::errored.
+    errored: bool,
 }
 
 impl<K: Key + 'static, V: Value + 'static> BtreeCursorRange<K, V> {
@@ -85,6 +88,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeCursorRange<K, V> {
             hint,
             front: Slot::Uninitialized,
             back: Slot::Uninitialized,
+            errored: false,
         })
     }
 
@@ -97,6 +101,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeCursorRange<K, V> {
             hint,
             front: Slot::Exhausted,
             back: Slot::Exhausted,
+            errored: false,
         }
     }
 
@@ -201,6 +206,17 @@ impl<K: Key + 'static, V: Value + 'static> BtreeCursorRange<K, V> {
     }
 
     fn next_from(&mut self, side: Side) -> Option<Result<EntryGuard<K, V>>> {
+        if self.errored {
+            return Some(Err(StorageError::PreviousIo));
+        }
+        let result = self.next_from_inner(side);
+        if matches!(result, Some(Err(_))) {
+            self.errored = true;
+        }
+        result
+    }
+
+    fn next_from_inner(&mut self, side: Side) -> Option<Result<EntryGuard<K, V>>> {
         match self.prepare(side) {
             Ok(true) => {}
             Ok(false) => return None,

--- a/tests/corrupted_btree_descent.rs
+++ b/tests/corrupted_btree_descent.rs
@@ -61,6 +61,19 @@ fn make_self_referential(data: &mut [u8], offset: usize) {
     }
 }
 
+// Makes one child pointer unreadable by corrupting its page-order bits: descending into it
+// reports Corrupted, without latching an I/O failure
+fn corrupt_child_pointer(data: &mut [u8], offset: usize, child: usize) {
+    let page = &mut data[offset..offset + PAGE_SIZE];
+    let num_keys = u16::from_le_bytes([page[2], page[3]]) as usize;
+    assert!(child <= num_keys);
+    // Child pointers follow the per-child checksums, which follow an 8 byte header
+    let children = 8 + 16 * (num_keys + 1);
+    let pointer = children + 8 * child;
+    // The page order lives in the top bits of the 64 bit page number
+    page[pointer + 7] |= 0xF8;
+}
+
 fn opens_cleanly(path: &Path) -> bool {
     let Ok(db) = ReadOnlyDatabase::open(path) else {
         return false;
@@ -141,4 +154,153 @@ fn cyclic_branch_pointer_is_reported_rather_than_overflowing_the_stack() {
         Ok(mut iter) => assert!(matches!(iter.next(), Some(Err(StorageError::Corrupted(_))))),
         Err(err) => panic!("expected Corrupted, got {err:?}"),
     }
+}
+
+// Resuming iteration after an error must keep reporting the error, not skip the unreadable
+// subtree and yield the rest of the table as if nothing were missing
+#[test]
+fn iteration_does_not_resume_past_corruption() {
+    let tmpfile = create_tempfile();
+    {
+        let db = redb::Database::create(tmpfile.path()).unwrap();
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(T).unwrap();
+            // Enough entries that the table's tree has branch pages
+            for i in 0..5_000u64 {
+                table.insert(&i, &i).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    let pristine = std::fs::read(tmpfile.path()).unwrap();
+    let candidates = branch_page_offsets(&pristine);
+    assert!(
+        !candidates.is_empty(),
+        "no branch page was found to corrupt"
+    );
+
+    // Corrupt the second child of one branch at a time; candidates may be stale or unreachable
+    // pages, so use the first that makes the iteration fail part way through
+    for &offset in &candidates {
+        let mut data = pristine.clone();
+        corrupt_child_pointer(&mut data, offset, 1);
+        std::fs::write(tmpfile.path(), &data).unwrap();
+        if !opens_cleanly(tmpfile.path()) {
+            continue;
+        }
+
+        let db = ReadOnlyDatabase::open(tmpfile.path()).unwrap();
+        let txn = db.begin_read().unwrap();
+        let table = txn.open_table(T).unwrap();
+
+        let mut iter = table.iter().unwrap();
+        let mut yielded = 0u64;
+        let mut saw_error = false;
+        for entry in &mut iter {
+            match entry {
+                Ok(_) => yielded += 1,
+                Err(_) => {
+                    saw_error = true;
+                    break;
+                }
+            }
+        }
+        if !saw_error {
+            // This branch page was not reachable by the iteration; try another
+            assert_eq!(yielded, 5_000);
+            continue;
+        }
+
+        assert!(yielded > 0 && yielded < 5_000, "yielded {yielded}");
+        // Yielding entries again would mean the unreadable subtree was skipped, and a bare end
+        // would claim the table is complete
+        for _ in 0..10 {
+            match iter.next() {
+                Some(Err(_)) => {}
+                Some(Ok(entry)) => panic!(
+                    "iterator resumed past the corruption at key {}",
+                    entry.0.value()
+                ),
+                None => panic!("iterator ended as if complete after {yielded} of 5000 entries"),
+            }
+        }
+        return;
+    }
+    panic!("no corruptible branch page was reachable by iteration");
+}
+
+// An error on one iteration end must latch the whole range: the other end runs on an
+// independent cursor and would otherwise keep yielding entries
+#[test]
+fn iteration_from_both_ends_latches_after_error() {
+    let tmpfile = create_tempfile();
+    {
+        let db = redb::Database::create(tmpfile.path()).unwrap();
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(T).unwrap();
+            for i in 0..5_000u64 {
+                table.insert(&i, &i).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    let pristine = std::fs::read(tmpfile.path()).unwrap();
+    let candidates = branch_page_offsets(&pristine);
+    assert!(
+        !candidates.is_empty(),
+        "no branch page was found to corrupt"
+    );
+
+    // Iterate backward into the corruption, then continue forward: the front cursor is
+    // untouched by the back cursor's error, so only the range-level latch stops it.
+    for &offset in &candidates {
+        let mut data = pristine.clone();
+        corrupt_child_pointer(&mut data, offset, 1);
+        std::fs::write(tmpfile.path(), &data).unwrap();
+        if !opens_cleanly(tmpfile.path()) {
+            continue;
+        }
+
+        let db = ReadOnlyDatabase::open(tmpfile.path()).unwrap();
+        let txn = db.begin_read().unwrap();
+        let table = txn.open_table(T).unwrap();
+
+        let mut iter = table.iter().unwrap();
+        let mut yielded = 0u64;
+        let mut saw_error = false;
+        while let Some(entry) = iter.next_back() {
+            match entry {
+                Ok(_) => yielded += 1,
+                Err(_) => {
+                    saw_error = true;
+                    break;
+                }
+            }
+        }
+        if !saw_error {
+            // This branch page was not reachable by the iteration; try another
+            assert_eq!(yielded, 5_000);
+            continue;
+        }
+
+        assert!(yielded > 0 && yielded < 5_000, "yielded {yielded}");
+        // Both ends must report the error from here on
+        for _ in 0..3 {
+            match iter.next() {
+                Some(Err(_)) => {}
+                Some(Ok(entry)) => panic!(
+                    "front end continued after the back end's error, at key {}",
+                    entry.0.value()
+                ),
+                None => panic!("iterator ended as if complete after {yielded} of 5000 entries"),
+            }
+            assert!(matches!(iter.next_back(), Some(Err(_))));
+        }
+        return;
+    }
+    panic!("no corruptible branch page was reachable by iteration");
 }


### PR DESCRIPTION
Fixes P0 finding 5 from the pre-5.0 bug audit: read iterators silently skip an entire subtree when resumed after a mid-iteration `Corrupted` error.

**The bug**
The read cursor commits its step before the page read that completes it: `move_to_adjacent_leaf()` updates the branch's child index and truncates the path before fetching the child, and `descend_to_position()` pushes path frames as it goes. When the fetch fails, the half-advanced position remains, so calling `next()` again moved on from it — skipping every entry under the unreadable child and yielding the rest of the table with no further error. Reproduced: a 5000-key table with one corrupted branch child pointer yields keys 0..=254, one `Err(Corrupted)`, then keys 510..4999 and a clean `None` — 255..509 silently absent.

I/O errors can't trigger this (the storage layer latches them, so retries keep failing), but `Corrupted` latches nothing — and the page-order validation and descent depth bound were added precisely so corruption is *reported*; resuming past it defeats that.

**The fix**
Two latches, mirroring the write cursor's `poisoned` flag:
- The shared read `Cursor` latches its first error: every later call reports `PreviousIo` instead of continuing from the tainted position. Re-seeking clears the latch, since a seek rebuilds the position from the root.
- `BtreeCursorRange` latches as a whole on top of that (added after review): its two ends run on independent cursors, so an error on one end must also stop the other — and the shared termination logic must never compare against a tainted cursor.

Together these cover every read surface: `Range`/table iteration, multimap ranges and value iterators, and the read-only `Cursor`.

**Tests**
In `tests/corrupted_btree_descent.rs`, reusing its corruption helpers:
- `iteration_does_not_resume_past_corruption` corrupts one branch child pointer's order bits, iterates to the error, and asserts continuing never yields entries again nor a clean end. Without the cursor latch it fails with "iterator resumed past the corruption at key 510".
- `iteration_from_both_ends_latches_after_error` iterates backward into the corruption and asserts the front end reports the error too. Without the range-level latch it fails with "front end continued after the back end's error, at key 0".

**Validation**: the constituent commands of `just test`, run directly because this environment lacks the rootless podman its sandbox wrapper needs — `cargo deny --workspace --all-features check licenses advisories` ("advisories ok, licenses ok"), `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` with `--deny warnings`, and `RUST_BACKTRACE=1 cargo test --all-features` (all suites green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr