### PR TITLE
Add a multi-process safe database interface (4/6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@
   ineligible for further savepoints, so a second savepoint in the same transaction failed with
   `InvalidSavepoint`. Only opening, renaming, or deleting a data table, or restoring a
   savepoint, makes a transaction savepoint-ineligible now.
+* Add `MultiProcessDatabase` behind the new `experimental-multiprocess` feature. It stores a
+  database in a directory -- the database file beside a `metadata` marker carrying a magic number,
+  format version, and writer mode, and the lock files that coordinate the processes using it. Only
+  `create()` and `open()` are provided, and only one process may have the database open at a time.
 
 ### Minor improvements
 * Lock the database file on platforms other than Unix, Windows, and WASI too: a second open of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,8 +85,8 @@
   database in a directory -- the database file beside a `metadata` marker carrying a magic number,
   format version, and writer mode, and the lock files that coordinate the processes using it. Only
   `create()` and `open()` are provided, and only one process may have the database open at a time.
-  `create()` refuses an unmarked directory that already holds files under redb's names, such as a
-  plain `Database` stored as `data.redb`, rather than adopting them.
+  `create()` refuses an unmarked directory that already holds other files, such as a plain
+  `Database` stored as `data.redb`, rather than adopting or overwriting them.
 
 ### Minor improvements
 * Lock the database file on platforms other than Unix, Windows, and WASI too: a second open of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,12 +81,20 @@
   ineligible for further savepoints, so a second savepoint in the same transaction failed with
   `InvalidSavepoint`. Only opening, renaming, or deleting a data table, or restoring a
   savepoint, makes a transaction savepoint-ineligible now.
-* Add `MultiProcessDatabase` behind the new `experimental-multiprocess` feature. It stores a
-  database in a directory -- the database file beside a `metadata` marker carrying a magic number,
-  format version, and writer mode, and the lock files that coordinate the processes using it. Only
-  `create()` and `open()` are provided, and only one process may have the database open at a time.
-  `create()` refuses an unmarked directory that already holds other files, such as a plain
-  `Database` stored as `data.redb`, rather than adopting or overwriting them.
+* Add `MultiProcessDatabase` behind the new `experimental-multiprocess` feature: a prototype
+  interface for using a database from several processes at once, with one write transaction at a
+  time across all of them and any number of concurrent readers. The database lives in a directory
+  -- `data.redb` beside the lock files that coordinate the processes using it -- so it must be on a
+  filesystem that supports file locking. A `metadata` marker carries a magic number, a format
+  version, and the writer mode, so a directory is recognized as one of these rather than guessed
+  at, and one written by a later redb is refused rather than misread; `create()` refuses an
+  unmarked directory that already holds other files, such as a plain `Database` stored as
+  `data.redb`, rather than adopting or overwriting them. Two writer modes are
+  available: one where a single process may write, which costs that process nothing on the read
+  path, and one where any process may write, which uses quick-repair commits so that each writer
+  can pick up the previous one's allocator state. Non-durable commits, persistent savepoints,
+  compaction and integrity checks are not supported in all configurations -- see the type's
+  documentation. The directory layout may change incompatibly while the feature is experimental.
 
 ### Minor improvements
 * Lock the database file on platforms other than Unix, Windows, and WASI too: a second open of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@
   database in a directory -- the database file beside a `metadata` marker carrying a magic number,
   format version, and writer mode, and the lock files that coordinate the processes using it. Only
   `create()` and `open()` are provided, and only one process may have the database open at a time.
+  `create()` refuses an unmarked directory that already holds files under redb's names, such as a
+  plain `Database` stored as `data.redb`, rather than adopting them.
 
 ### Minor improvements
 * Lock the database file on platforms other than Unix, Windows, and WASI too: a second open of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ experimental_cursor = ["experimental-api-5"]
 # Unstable additions and changes to the public API, planned for redb 5. May change incompatibly, or
 # be removed, in any release
 experimental-api-5 = []
+# Incomplete support for using a database from several processes. May change incompatibly, or be
+# removed, in any release
+experimental-multiprocess = []
 
 [profile.bench]
 debug = true

--- a/crates/redb-bench/Cargo.toml
+++ b/crates/redb-bench/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace = true
 # The shared harness is a library, so these have to be regular dependencies. Engines other than redb
 # live in redb-bench-compare, which keeps their native build dependencies out of this crate.
 [dependencies]
-redb = { path = "../..", features = ["experimental_cursor"] }
+redb = { path = "../..", features = ["experimental_cursor", "experimental-multiprocess"] }
 walkdir = "2.5.0"
 byte-unit = "5.1.6"
 fastrand = "2.0.0"
@@ -46,3 +46,6 @@ harness = false
 name = "redb_benchmark"
 harness = false
 
+[[bench]]
+name = "multiprocess_benchmark"
+harness = false

--- a/crates/redb-bench/benches/multiprocess_benchmark.rs
+++ b/crates/redb-bench/benches/multiprocess_benchmark.rs
@@ -1,0 +1,334 @@
+//! What the multi-process protocol costs, compared to an ordinary single-process `Database`.
+//!
+//! The "second handle" cases open the same directory twice from this process. File locks belong to
+//! the open file description rather than the process, so a second handle takes exactly the same
+//! locks, does exactly the same I/O, and keeps its own page cache -- it pays what a second process
+//! pays, without the benchmark having to manage one.
+
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+use redb::{Database, MultiProcessDatabase, ReadableDatabase, TableDefinition, WriterMode};
+use redb_bench::benchmark_dir;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+use std::{fs, thread};
+use tempfile::TempDir;
+
+const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+
+const ELEMENTS: u64 = 500_000;
+const VALUE_SIZE: usize = 100;
+const BULK_BATCH: u64 = 5_000;
+const SMALL_COMMITS: u64 = 300;
+const READS: u64 = 200_000;
+const READ_SECONDS: u64 = 3;
+const RNG_SEED: u64 = 3;
+
+fn value() -> Vec<u8> {
+    vec![0xab; VALUE_SIZE]
+}
+
+/// The three ways of opening the same database that are being compared
+enum Db {
+    Single(Database),
+    Multi(MultiProcessDatabase),
+}
+
+impl Db {
+    fn begin_write(&self) -> redb::WriteTransaction {
+        match self {
+            Db::Single(db) => db.begin_write().unwrap(),
+            Db::Multi(db) => db.begin_write().unwrap(),
+        }
+    }
+
+    fn begin_read(&self) -> redb::ReadTransaction {
+        match self {
+            Db::Single(db) => db.begin_read().unwrap(),
+            Db::Multi(db) => db.begin_read().unwrap(),
+        }
+    }
+}
+
+fn open(kind: Kind, dir: &TempDir) -> Db {
+    let path = dir.path().join("db");
+    match kind {
+        Kind::SingleProcess => Db::Single(Database::create(path).unwrap()),
+        Kind::MultiProcessOneWriter => Db::Multi(
+            MultiProcessDatabase::builder()
+                .set_writer_mode(WriterMode::SingleWriterProcess)
+                .create(path)
+                .unwrap(),
+        ),
+        Kind::MultiProcessManyWriters => Db::Multi(
+            MultiProcessDatabase::builder()
+                .set_writer_mode(WriterMode::MultiWriterProcess)
+                .create(path)
+                .unwrap(),
+        ),
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum Kind {
+    SingleProcess,
+    MultiProcessOneWriter,
+    MultiProcessManyWriters,
+}
+
+impl Kind {
+    fn name(self) -> &'static str {
+        match self {
+            Kind::SingleProcess => "Database",
+            Kind::MultiProcessOneWriter => "MultiProcess (single writer process)",
+            Kind::MultiProcessManyWriters => "MultiProcess (multi writer process)",
+        }
+    }
+}
+
+fn tempdir() -> TempDir {
+    TempDir::new_in(benchmark_dir()).unwrap()
+}
+
+/// Fills the database, in batches, and returns how long it took
+fn bulk_load(db: &Db) -> Duration {
+    let value = value();
+    let start = Instant::now();
+    let mut key = 0;
+    while key < ELEMENTS {
+        let txn = db.begin_write();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            for _ in 0..BULK_BATCH {
+                table.insert(&key, value.as_slice()).unwrap();
+                key += 1;
+            }
+        }
+        txn.commit().unwrap();
+    }
+    start.elapsed()
+}
+
+fn small_commits(db: &Db) -> Duration {
+    let value = value();
+    let start = Instant::now();
+    for i in 0..SMALL_COMMITS {
+        let txn = db.begin_write();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            table.insert(&(i % ELEMENTS), value.as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+    start.elapsed()
+}
+
+/// Random point reads, all within one read transaction
+fn reads_in_one_transaction(txn: &redb::ReadTransaction) -> Duration {
+    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let table = txn.open_table(TABLE).unwrap();
+    let start = Instant::now();
+    for _ in 0..READS {
+        let key = rng.random_range(0..ELEMENTS);
+        assert_eq!(
+            VALUE_SIZE,
+            table.get_owned(key).unwrap().unwrap().value().len()
+        );
+    }
+    start.elapsed()
+}
+
+/// Random point reads, each in its own read transaction, which is what pays the cross-process
+/// registration cost
+fn reads_in_many_transactions<F: Fn() -> redb::ReadTransaction>(begin: F) -> Duration {
+    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let start = Instant::now();
+    for _ in 0..READS {
+        let key = rng.random_range(0..ELEMENTS);
+        let txn = begin();
+        let table = txn.open_table(TABLE).unwrap();
+        assert_eq!(
+            VALUE_SIZE,
+            table.get_owned(key).unwrap().unwrap().value().len()
+        );
+    }
+    start.elapsed()
+}
+
+fn rate(count: u64, duration: Duration) -> String {
+    let per_second = count as f64 / duration.as_secs_f64();
+    format!("{per_second:>12.0}/s")
+}
+
+fn main() {
+    println!(
+        "Filling {ELEMENTS} entries of {VALUE_SIZE} bytes, in batches of {BULK_BATCH}, then \
+         {SMALL_COMMITS} single-entry commits\n"
+    );
+    println!(
+        "{:<38} {:>14} {:>16} {:>16}",
+        "", "bulk load", "commits", "reads (1 txn)"
+    );
+
+    for kind in [
+        Kind::SingleProcess,
+        Kind::MultiProcessOneWriter,
+        Kind::MultiProcessManyWriters,
+    ] {
+        let dir = tempdir();
+        let db = open(kind, &dir);
+        let load = bulk_load(&db);
+        let commits = small_commits(&db);
+        let reads = reads_in_one_transaction(&db.begin_read());
+        println!(
+            "{:<38} {:>14} {:>16} {:>16}",
+            kind.name(),
+            rate(ELEMENTS, load),
+            rate(SMALL_COMMITS, commits),
+            rate(READS, reads),
+        );
+        drop(db);
+        fs::remove_dir_all(dir.path()).ok();
+    }
+
+    println!(
+        "\nReads, one read transaction per read (worst case for the protocol's per-transaction cost):"
+    );
+    println!("{:<38} {:>16}", "", "reads");
+    {
+        let dir = tempdir();
+        let db = open(Kind::SingleProcess, &dir);
+        bulk_load(&db);
+        let single = reads_in_many_transactions(|| db.begin_read());
+        println!("{:<38} {:>16}", "Database", rate(READS, single));
+    }
+    for (mode, label) in [
+        (
+            WriterMode::SingleWriterProcess,
+            "MultiProcess, same handle (single writer)",
+        ),
+        (
+            WriterMode::MultiWriterProcess,
+            "MultiProcess, same handle (multi writer)",
+        ),
+    ] {
+        let dir = tempdir();
+        let path = dir.path().join("db");
+        let writer = Db::Multi(
+            MultiProcessDatabase::builder()
+                .set_writer_mode(mode)
+                .create(&path)
+                .unwrap(),
+        );
+        bulk_load(&writer);
+        let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+
+        println!(
+            "{label:<38} {:>16}",
+            rate(READS, reads_in_many_transactions(|| writer.begin_read()))
+        );
+        println!(
+            "{:<38} {:>16}",
+            "  ... from a second, read-only handle",
+            rate(
+                READS,
+                reads_in_many_transactions(|| reader.begin_read().unwrap())
+            )
+        );
+    }
+
+    println!("\nReads from a second handle, 100 per read transaction, while a writer commits:");
+    for (mode, label) in [
+        (WriterMode::SingleWriterProcess, "single writer process"),
+        (WriterMode::MultiWriterProcess, "multi writer process"),
+    ] {
+        let dir = tempdir();
+        let path = dir.path().join("db");
+        let writer = MultiProcessDatabase::builder()
+            .set_writer_mode(mode)
+            .create(&path)
+            .unwrap();
+        bulk_load(&Db::Multi(writer));
+        // Reopened, so that the background thread below can own it
+        let writer = MultiProcessDatabase::open(&path).unwrap();
+
+        let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+        let stop = Arc::new(AtomicBool::new(false));
+        let commits = Arc::new(AtomicU64::new(0));
+        let writer_thread = {
+            let stop = stop.clone();
+            let commits = commits.clone();
+            let value = value();
+            thread::spawn(move || {
+                let mut key = 0;
+                while !stop.load(Ordering::Acquire) {
+                    let txn = writer.begin_write().unwrap();
+                    {
+                        let mut table = txn.open_table(TABLE).unwrap();
+                        table.insert(&(key % ELEMENTS), value.as_slice()).unwrap();
+                    }
+                    txn.commit().unwrap();
+                    commits.fetch_add(1, Ordering::Relaxed);
+                    key += 1;
+                }
+            })
+        };
+
+        let mut rng = StdRng::seed_from_u64(RNG_SEED);
+        let start = Instant::now();
+        let mut reads = 0u64;
+        while start.elapsed() < Duration::from_secs(READ_SECONDS) {
+            let txn = reader.begin_read().unwrap();
+            let table = txn.open_table(TABLE).unwrap();
+            for _ in 0..100 {
+                let key = rng.random_range(0..ELEMENTS);
+                assert_eq!(
+                    VALUE_SIZE,
+                    table.get_owned(key).unwrap().unwrap().value().len()
+                );
+                reads += 1;
+            }
+        }
+        let elapsed = start.elapsed();
+        stop.store(true, Ordering::Release);
+        writer_thread.join().unwrap();
+
+        println!(
+            "{label:<38} {:>16} while the writer made {:>16}",
+            rate(reads, elapsed),
+            rate(commits.load(Ordering::Relaxed), elapsed)
+        );
+    }
+
+    println!("\nWrite transactions alternating between two handles (multi writer process):");
+    {
+        let dir = tempdir();
+        let path = dir.path().join("db");
+        bulk_load(&Db::Multi(
+            MultiProcessDatabase::builder()
+                .set_writer_mode(WriterMode::MultiWriterProcess)
+                .create(&path)
+                .unwrap(),
+        ));
+        let first = MultiProcessDatabase::open(&path).unwrap();
+        let second = MultiProcessDatabase::open(&path).unwrap();
+
+        let value = value();
+        let start = Instant::now();
+        for i in 0..SMALL_COMMITS {
+            let db = if i % 2 == 0 { &first } else { &second };
+            let txn = db.begin_write().unwrap();
+            {
+                let mut table = txn.open_table(TABLE).unwrap();
+                table.insert(&(i % ELEMENTS), value.as_slice()).unwrap();
+            }
+            txn.commit().unwrap();
+        }
+        println!(
+            "{:<38} {:>16}",
+            "alternating handles",
+            rate(SMALL_COMMITS, start.elapsed())
+        );
+    }
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -516,7 +516,14 @@ This sequence is inspired by the PNG magic number.
 `writer mode` is 1 for a single writer process and 2 for multiple writer processes.
 
 All processes hold a shared lock on this file. This is for future format upgrades, so that a process
-can take an exclusive lock to perform a format upgrade.
+can take an exclusive lock to perform a format upgrade. An upgrader must acquire `write.lock` before
+taking this lock exclusively: a process that is part way through opening holds `write.lock` from
+before it reads the marker until after its shared lock on `metadata` is in place, so that ordering
+is what keeps an upgrade from starting -- or swapping the file -- mid-open, and acquiring in the
+opposite order would deadlock against it. A read-only open never takes `write.lock`, so it takes its
+shared lock on `metadata` first, before reading the marker or the header, and validates the marker
+only after the lock is in place: an upgrade that replaced the file before the lock landed is then
+refused by its version rather than read through a stale handle.
 
 ### Writer modes
 
@@ -630,7 +637,9 @@ greater than or equal to the current latest id.
 
 Some features are not supported by directory-structured databases.
 
-* Non-durable commits are not supported since they exist only in the local process's memory.
+* Non-durable commits are not supported in multi-writer mode, since they exist only in the
+  local process's memory. The sole writer of a single-writer database may use them, as it
+  would with an ordinary database.
 * 2-phase commits are always used to ensure that committed pages are flushed before the transaction
   becomes visible to another process. Disabling 2-phase commit is not supported.
 * Read-only processes do not detect database corruption on open. Since 2-phase commit is always used,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1153,7 +1153,7 @@ impl Database {
         root.map(|header| BtreeHeader::new(header.root, header.checksum, length))
     }
 
-    fn new(
+    pub(crate) fn new(
         file: Box<dyn StorageBackend>,
         allow_initialize: bool,
         page_size: usize,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,10 +1,11 @@
 use crate::io;
+use crate::multiprocess::ProcessCoordinator;
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
 #[cfg(not(redb_no_std))]
 use crate::tree_store::ReadOnlyBackend;
 use crate::tree_store::{
-    AllocationPolicy, BtreeHeader, InternalTableDefinition, PAGE_SIZE, PageHint, PageNumber,
-    PageResolver, ShrinkPolicy, TableTree, TableType, TransactionalMemory,
+    AccessMode, AllocationPolicy, BtreeHeader, InternalTableDefinition, PAGE_SIZE, PageHint,
+    PageNumber, PageResolver, ShrinkPolicy, TableTree, TableType, TransactionalMemory,
 };
 use crate::types::{Key, Value};
 use crate::{
@@ -33,7 +34,7 @@ use crate::transactions::{
     TransactionIdWithPagination,
 };
 #[cfg(not(redb_no_std))]
-use crate::tree_store::file_backend::FileBackend;
+use crate::tree_store::file_backend::{FileBackend, FileLockKind};
 #[cfg(feature = "logging")]
 use log::{debug, warn};
 
@@ -459,6 +460,42 @@ impl ReadOnlyDatabase {
         Builder::new().open_read_only(path)
     }
 
+    pub(crate) fn from_parts(
+        mem: Arc<TransactionalMemory>,
+        transaction_tracker: Arc<TransactionTracker>,
+    ) -> Self {
+        Self {
+            mem,
+            transaction_tracker,
+        }
+    }
+
+    /// Opens the file for reading, accepting that another process may be writing to it. Returns
+    /// the memory and the coordinator that `make_coordinator` built from it, since the caller
+    /// needs both to construct the tracker.
+    ///
+    /// No allocator state is loaded: keeping it up to date would mean re-reading it every time
+    /// another process commits, and a handle which never allocates has no other use for it.
+    pub(crate) fn new_shared_read(
+        file: Box<dyn StorageBackend>,
+        page_size: usize,
+        cache_size: usize,
+        make_coordinator: impl FnOnce(
+            Arc<TransactionalMemory>,
+        ) -> Result<Arc<ProcessCoordinator>, DatabaseError>,
+    ) -> Result<(Arc<TransactionalMemory>, Arc<ProcessCoordinator>), DatabaseError> {
+        let mem = Arc::new(TransactionalMemory::new(
+            Box::new(ReadOnlyBackend::new(file)),
+            false,
+            page_size,
+            None,
+            cache_size,
+            AccessMode::SharedRead,
+        )?);
+        let coordinator = make_coordinator(mem.clone())?;
+        Ok((mem, coordinator))
+    }
+
     fn new(
         file: Box<dyn StorageBackend>,
         page_size: usize,
@@ -475,12 +512,12 @@ impl ReadOnlyDatabase {
             page_size,
             region_size,
             cache_size,
-            true,
+            AccessMode::ReadOnly,
         )?;
         let mem = Arc::new(mem);
         // If the last transaction used 2-phase commit and updated the allocator state table, then
         // we can just load the allocator state from there. Otherwise, we need a full repair
-        if let Some(tree) = Database::get_allocator_state_table(&mem)? {
+        if let Some(tree) = Database::allocator_state_table(&mem)? {
             mem.load_allocator_state(&tree)?;
         } else {
             #[cfg(feature = "logging")]
@@ -761,7 +798,7 @@ impl Database {
             Ok(true) => {
                 let live_allocator_hash = self.mem.allocator_hash();
                 let live_roots = [self.mem.get_data_root(), self.mem.get_system_root()];
-                match Self::rebuild_allocator_state(&mut self.mem, &|_| {}) {
+                match Self::rebuild_allocator_state(&self.mem, &|_| {}) {
                     // Only a durable root can be rewritten from here, so a live root whose table
                     // count was recomputed must be rolled back and repaired by the reload below
                     Ok(roots) if roots != live_roots => Ok(None),
@@ -979,10 +1016,10 @@ impl Database {
         Ok(())
     }
 
+    // Rebuilds the set of allocated pages that debug assertions check against, which is only
+    // meaningful once the allocator state it mirrors has been loaded
     #[cfg(debug_assertions)]
-    fn mark_allocated_page_for_debug(
-        mem: &mut Arc<TransactionalMemory>, // Only &mut to ensure exclusivity
-    ) -> Result {
+    pub(crate) fn mark_allocated_page_for_debug(mem: &Arc<TransactionalMemory>) -> Result {
         let data_root = mem.get_data_root();
         {
             let untracked = Arc::new(TransactionGuard::untracked());
@@ -1091,7 +1128,7 @@ impl Database {
     // counts are stored in the commit slot rather than in a page, so no page checksum covers
     // them; recounting here is what lets the rest of the codebase trust them.
     fn rebuild_allocator_state(
-        mem: &mut Arc<TransactionalMemory>, // Only &mut to ensure exclusivity
+        mem: &Arc<TransactionalMemory>,
         repair_callback: &(dyn Fn(&mut RepairSession) + 'static),
     ) -> Result<[Option<BtreeHeader>; 2], DatabaseError> {
         mem.reset_allocator_state()?;
@@ -1153,6 +1190,28 @@ impl Database {
         root.map(|header| BtreeHeader::new(header.root, header.checksum, length))
     }
 
+    /// Rebuilds the in-memory allocator state for a writer taking over a multi-process database
+    /// whose previous writer died part way through a commit and so never wrote the allocator
+    /// state table.
+    ///
+    /// Unlike an open-time repair this runs with the memory shared and read transactions live, in
+    /// this process and others, which is safe because the walk only reads committed pages and
+    /// repopulates the in-memory allocator. Every commit here is 2-phase, so the primary is a
+    /// complete commit and its table counts need no recounting; the recounted roots are dropped.
+    ///
+    /// The caller must hold the cross-process write lock, and no write transaction may be in
+    /// progress in this process.
+    #[cfg(not(redb_no_std))]
+    pub(crate) fn rebuild_allocator_state_shared(
+        mem: &Arc<TransactionalMemory>,
+    ) -> Result<(), DatabaseError> {
+        let _ = Self::rebuild_allocator_state(mem, &|_| {})?;
+        // The allocator now holds exactly the committed reachable set, which also erases any leak
+        // a failed abort in this process had latched -- so commits may trust and persist it again
+        mem.clear_needs_repair();
+        Ok(())
+    }
+
     pub(crate) fn new(
         file: Box<dyn StorageBackend>,
         allow_initialize: bool,
@@ -1161,6 +1220,59 @@ impl Database {
         cache_size: usize,
         repair_callback: &(dyn Fn(&mut RepairSession) + 'static),
     ) -> Result<Self, DatabaseError> {
+        Self::new_inner(
+            file,
+            allow_initialize,
+            &OpenParams {
+                page_size,
+                region_size,
+                cache_size,
+                repair_callback,
+                restore_persistent_savepoints: true,
+            },
+            |_| Ok(None),
+        )
+    }
+
+    /// Opens a database that other processes may also have open. `make_coordinator` builds the
+    /// cross-process half of the transaction tracker, which needs the memory this creates.
+    ///
+    /// The caller must hold the cross-process write lock: this repairs the database if the last
+    /// writer left it dirty, and writes to it either way.
+    #[cfg(not(redb_no_std))]
+    pub(crate) fn new_multiprocess(
+        file: Box<dyn StorageBackend>,
+        allow_initialize: bool,
+        params: &OpenParams<'_>,
+        make_coordinator: impl FnOnce(
+            Arc<TransactionalMemory>,
+        ) -> Result<Arc<ProcessCoordinator>, DatabaseError>,
+    ) -> Result<Self, DatabaseError> {
+        Self::new_inner(file, allow_initialize, params, |mem| {
+            make_coordinator(mem).map(Some)
+        })
+    }
+
+    #[cfg(not(redb_no_std))]
+    pub(crate) fn transaction_tracker(&self) -> &Arc<TransactionTracker> {
+        &self.transaction_tracker
+    }
+
+    fn new_inner(
+        file: Box<dyn StorageBackend>,
+        allow_initialize: bool,
+        params: &OpenParams<'_>,
+        make_coordinator: impl FnOnce(
+            Arc<TransactionalMemory>,
+        ) -> Result<Option<Arc<ProcessCoordinator>>, DatabaseError>,
+    ) -> Result<Self, DatabaseError> {
+        let &OpenParams {
+            page_size,
+            region_size,
+            cache_size,
+            repair_callback,
+            restore_persistent_savepoints,
+        } = params;
         #[cfg(feature = "logging")]
         let file_path = format!("{:?}", &file);
         #[cfg(feature = "logging")]
@@ -1171,17 +1283,17 @@ impl Database {
             page_size,
             region_size,
             cache_size,
-            false,
+            AccessMode::ReadWrite,
         )?;
         let mut mem = Arc::new(mem);
         // If the last transaction used 2-phase commit and updated the allocator state table, then
         // we can just load the allocator state from there. Otherwise, we need a full repair
-        if let Some(tree) = Self::get_allocator_state_table(&mem)? {
+        if let Some(tree) = Self::allocator_state_table(&mem)? {
             #[cfg(feature = "logging")]
             debug!("Found valid allocator state, full repair not needed");
             mem.load_allocator_state(&tree)?;
             #[cfg(debug_assertions)]
-            Self::mark_allocated_page_for_debug(&mut mem)?;
+            Self::mark_allocated_page_for_debug(&mem)?;
         } else {
             #[cfg(feature = "logging")]
             warn!("Database {:?} not shutdown cleanly. Repairing", &file_path);
@@ -1204,10 +1316,20 @@ impl Database {
         mem.begin_writable()?;
         let next_transaction_id = mem.get_last_committed_transaction_id()?.next();
 
+        let transaction_tracker = match make_coordinator(mem.clone())? {
+            Some(coordinator) => {
+                TransactionTracker::new_multiprocess(next_transaction_id, coordinator)
+            }
+            None => TransactionTracker::new(next_transaction_id),
+        };
         let db = Database {
             mem,
-            transaction_tracker: Arc::new(TransactionTracker::new(next_transaction_id)),
+            transaction_tracker: Arc::new(transaction_tracker),
         };
+
+        if !restore_persistent_savepoints {
+            return Ok(db);
+        }
 
         // Restore the tracker state for any persistent savepoints
         let txn = db.begin_write().map_err(|e| e.into_storage_error())?;
@@ -1234,7 +1356,7 @@ impl Database {
         Ok(db)
     }
 
-    fn get_allocator_state_table(
+    pub(crate) fn allocator_state_table(
         mem: &Arc<TransactionalMemory>,
     ) -> Result<Option<AllocatorStateTree>> {
         // The allocator state table is only valid if the primary was written using 2-phase commit
@@ -1308,10 +1430,16 @@ fn begin_write_with_allocation_policy(
 ) -> Result<WriteTransaction, TransactionError> {
     // Fail early if there has been an I/O error -- nothing can be committed in that case
     mem.check_io_errors()?;
-    let guard = TransactionGuard::new_write(
-        transaction_tracker.start_write_transaction(),
-        transaction_tracker.clone(),
-    );
+    let transaction_id = match transaction_tracker.process() {
+        // Takes the cross-process write lock and picks up whatever another process has committed,
+        // before this transaction is numbered from what it finds
+        Some(process) => {
+            let process = process.clone();
+            transaction_tracker.start_write_transaction_prepared(move || process.begin_write())?
+        }
+        None => transaction_tracker.start_write_transaction(),
+    };
+    let guard = TransactionGuard::new_write(transaction_id, transaction_tracker.clone());
     // Re-checked after acquiring the write slot: the writer this call blocked on can fail its
     // commit, latching an I/O error and discarding the allocator state. The I/O check comes
     // first so a backend failure is not misreported as corruption. Returning drops the guard,
@@ -1360,9 +1488,18 @@ fn ensure_allocator_state_table_and_trim(
 // transaction can be started concurrently and the commit in here cannot block on the
 // write-transaction slot.
 fn close_database(transaction_tracker: &Arc<TransactionTracker>, mem: &Arc<TransactionalMemory>) {
+    // Neither write below is this process's to make when another process may take over the write
+    // lock: the allocator state table needs a write transaction, which would wait on whatever that
+    // process is doing, and the shutdown header would land in the middle of it. Nothing is lost --
+    // every commit in that mode is already a quick-repair commit, so the allocator state in the
+    // file is current, and a multi-process database is read expecting the header's recovery flag to
+    // be set, since a writer in another process is entitled to be holding it open
+    let owns_the_file = !transaction_tracker.write_lock_is_shared();
+
     // No saved allocator state when it needs repair: the next open must rebuild it instead
     // of trusting the saved one
-    if !crate::panicking()
+    if owns_the_file
+        && !crate::panicking()
         && !mem.needs_repair()
         && ensure_allocator_state_table_and_trim(transaction_tracker, mem).is_err()
     {
@@ -1370,9 +1507,17 @@ fn close_database(transaction_tracker: &Arc<TransactionTracker>, mem: &Arc<Trans
         warn!("Failed to write allocator state table. Repair may be required at restart.");
     }
 
-    if mem.close().is_err() {
+    if mem.close(owns_the_file).is_err() {
         #[cfg(feature = "logging")]
         warn!("Failed to flush database file. Repair may be required at restart.");
+    }
+
+    // After the storage is closed, so the sole writer still holds the write lock across its
+    // shutdown header write. A lingering read transaction's guard can keep the tracker -- and
+    // with it the coordinator's locks -- alive past this point, and the locks must not outlive
+    // the storage they protect
+    if let Some(process) = transaction_tracker.process() {
+        process.release_for_close();
     }
 }
 
@@ -1393,6 +1538,18 @@ impl Drop for Database {
 
         close_database(&self.transaction_tracker, &self.mem);
     }
+}
+
+/// How a database is to be opened. Bundled so that the paths which share the open sequence do not
+/// each thread the same handful of arguments through it.
+pub(crate) struct OpenParams<'a> {
+    pub(crate) page_size: usize,
+    pub(crate) region_size: Option<u64>,
+    pub(crate) cache_size: usize,
+    pub(crate) repair_callback: &'a (dyn Fn(&mut RepairSession) + 'static),
+    /// Persistent savepoints are restored into the tracker when the database is opened, which only
+    /// makes them visible to the process that did so
+    pub(crate) restore_persistent_savepoints: bool,
 }
 
 pub struct RepairSession {
@@ -1543,7 +1700,7 @@ impl Builder {
         let file = OpenOptions::new().read(true).open(path)?;
 
         ReadOnlyDatabase::new(
-            Box::new(FileBackend::new_internal(file, true)?),
+            Box::new(FileBackend::new_internal(file, FileLockKind::Shared)?),
             self.page_size,
             None,
             self.cache_size,

--- a/src/error.rs
+++ b/src/error.rs
@@ -404,12 +404,17 @@ impl core::error::Error for CompactionError {}
 pub enum SetDurabilityError {
     /// A persistent savepoint was modified
     PersistentSavepointModified,
+    /// The database is open for writing by more than one process, where a non-durable commit
+    /// cannot be supported: it would be visible only to the process that made it, and discarded
+    /// as soon as another process took the write lock
+    NonDurableCommitUnsupported,
 }
 
 impl From<SetDurabilityError> for Error {
     fn from(err: SetDurabilityError) -> Error {
         match err {
             SetDurabilityError::PersistentSavepointModified => Error::PersistentSavepointModified,
+            SetDurabilityError::NonDurableCommitUnsupported => Error::NonDurableCommitUnsupported,
         }
     }
 }
@@ -421,6 +426,12 @@ impl Display for SetDurabilityError {
                 write!(
                     f,
                     "Persistent savepoint modified. Cannot reduce transaction durability"
+                )
+            }
+            SetDurabilityError::NonDurableCommitUnsupported => {
+                write!(
+                    f,
+                    "Non-durable commits are not supported when several processes may write to the database"
                 )
             }
         }
@@ -546,6 +557,8 @@ pub enum Error {
     RepairAborted,
     /// A persistent savepoint was modified
     PersistentSavepointModified,
+    /// Non-durable commits are not supported when several processes may write to the database
+    NonDurableCommitUnsupported,
     /// A persistent savepoint exists
     PersistentSavepointExists,
     /// An Ephemeral savepoint exists
@@ -689,6 +702,12 @@ impl Display for Error {
             }
             Error::RepairAborted => {
                 write!(f, "Database repair aborted.")
+            }
+            Error::NonDurableCommitUnsupported => {
+                write!(
+                    f,
+                    "Non-durable commits are not supported when several processes may write to the database"
+                )
             }
             Error::PersistentSavepointModified => {
                 write!(

--- a/src/io.rs
+++ b/src/io.rs
@@ -24,6 +24,17 @@ pub(crate) fn invalid_data(message: &str) -> Error {
     }
 }
 
+pub(crate) fn unsupported(message: &str) -> Error {
+    #[cfg(not(redb_no_std))]
+    {
+        Error::new(std::io::ErrorKind::Unsupported, message)
+    }
+    #[cfg(redb_no_std)]
+    {
+        Error::other(message)
+    }
+}
+
 pub(crate) fn invalid_input(message: &str) -> Error {
     #[cfg(not(redb_no_std))]
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ pub use multimap_table::{
     ReadOnlyMultimapTable, ReadOnlyUntypedMultimapTable, ReadableMultimapTable,
 };
 #[cfg(all(feature = "experimental-multiprocess", not(redb_no_std)))]
-pub use multiprocess::{MultiProcessBuilder, MultiProcessDatabase};
+pub use multiprocess::{MultiProcessBuilder, MultiProcessDatabase, WriterMode};
 #[cfg(feature = "experimental-api-5")]
 pub use table::Cursor;
 #[cfg(feature = "experimental_cursor")]
@@ -118,8 +118,16 @@ mod io;
 #[cfg(feature = "experimental-api-5")]
 mod key_range;
 mod multimap_table;
-// Needs std::fs and std::path, like the rest of the file-backed API
-#[cfg(all(feature = "experimental-multiprocess", not(redb_no_std)))]
+// Needs std::fs and std::path. Compiled whenever std is, rather than with the feature, because
+// the coordinator is woven into the transaction tracker -- only the database type it serves is
+// behind the flag
+#[cfg(not(redb_no_std))]
+#[cfg_attr(not(feature = "experimental-multiprocess"), allow(dead_code))]
+mod multiprocess;
+// A directory of lock files needs a file system, so no_std gets a stand-in with the same shape
+// rather than a `cfg` on every path that consults a coordinator
+#[cfg(redb_no_std)]
+#[path = "multiprocess_no_std.rs"]
 mod multiprocess;
 mod sealed;
 mod sync;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@ pub use multimap_table::{
     MultimapRange, MultimapTable, MultimapValue, OwnedMultimapRange, OwnedMultimapValue,
     ReadOnlyMultimapTable, ReadOnlyUntypedMultimapTable, ReadableMultimapTable,
 };
+#[cfg(all(feature = "experimental-multiprocess", not(redb_no_std)))]
+pub use multiprocess::{MultiProcessBuilder, MultiProcessDatabase};
 #[cfg(feature = "experimental-api-5")]
 pub use table::Cursor;
 #[cfg(feature = "experimental_cursor")]
@@ -116,6 +118,9 @@ mod io;
 #[cfg(feature = "experimental-api-5")]
 mod key_range;
 mod multimap_table;
+// Needs std::fs and std::path, like the rest of the file-backed API
+#[cfg(all(feature = "experimental-multiprocess", not(redb_no_std)))]
+mod multiprocess;
 mod sealed;
 mod sync;
 mod table;

--- a/src/multiprocess/coordinator.rs
+++ b/src/multiprocess/coordinator.rs
@@ -1,0 +1,465 @@
+//! The cross-process half of [`TransactionTracker`](crate::transaction_tracker::TransactionTracker):
+//! pins what this process is reading in the `txn/` directory that other processes scan, scans what
+//! they have pinned before this process reclaims anything, and keeps this process's view of the
+//! file and its page cache current by checking the transaction collection horizon in
+//! `extended-header` whenever it looks at the file.
+
+use crate::multiprocess::locks::{
+    DatabaseDir, ExtendedHeader, RegistryLock, TransactionPins, WriteLock, WriterMode,
+};
+use crate::transaction_tracker::TransactionId;
+use crate::tree_store::{CommitHook, RawCommitSlots, TransactionalMemory};
+use crate::{DatabaseError, Result, StorageError};
+use std::fs::File;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+/// Writes the transaction collection horizon into `extended-header` at the one point the protocol
+/// allows: inside a commit, after the phase-1 flush and before the flip that makes the new commit
+/// slot primary.
+struct HorizonPublisher {
+    registry: RegistryLock,
+    extended_header: ExtendedHeader,
+    /// The newest transaction this process has garbage collected, which the next flip publishes.
+    /// Never decreases: a page freed by a transaction at or below this may already be reused.
+    pending: Mutex<u64>,
+}
+
+impl HorizonPublisher {
+    /// The horizon stored for the primary commit slot, or `None` if the extended header does not
+    /// verify against it. The caller must hold the registry lock and have read `raw` under it.
+    fn read_stored(&self, raw: &RawCommitSlots) -> Result<Option<u64>> {
+        self.extended_header
+            .read_horizon(raw.primary_index, raw.primary())
+    }
+
+    /// Raises the horizon the next flip will publish.
+    fn record(&self, horizon: u64) -> Result<()> {
+        let mut pending = self.pending.lock()?;
+        *pending = (*pending).max(horizon);
+        Ok(())
+    }
+
+    /// Rewrites both slots of the extended header to `horizon`, bound to the commit slots in
+    /// `raw`. The caller must hold the registry lock exclusively.
+    fn rewrite(&self, horizon: u64, raw: &RawCommitSlots) -> Result<()> {
+        for slot in 0..2 {
+            self.extended_header
+                .write_horizon(slot, horizon, raw.slot(slot))?;
+        }
+        self.record(horizon)
+    }
+}
+
+impl CommitHook for HorizonPublisher {
+    fn before_primary_flip(&self, slot: usize, slot_bytes: &[u8]) -> Result {
+        let horizon = *self.pending.lock()?;
+        let guard = self.registry.exclusive()?;
+        let result = self
+            .extended_header
+            .write_horizon(slot, horizon, slot_bytes);
+        drop(guard);
+        result
+    }
+}
+
+struct Inner {
+    /// This process's pin in `txn/`: the oldest transaction it still needs.
+    pins: TransactionPins,
+    /// The last committed transaction the whole in-memory state reflects, allocator state and
+    /// layout included. Only a write transaction loads those, and only it may rely on this.
+    state_committed: u64,
+    /// A bound on how old the pages in the read cache are: every one was read from a snapshot at
+    /// or after this transaction. A page cached from snapshot `S` was reachable at `S`, so only a
+    /// transaction newer than `S` can have freed it -- a collection horizon above `S` may have
+    /// reused it, one at or below cannot. Raised only when the cache is emptied.
+    cache_floor: u64,
+}
+
+pub(crate) struct ProcessCoordinator {
+    mem: Arc<TransactionalMemory>,
+    mode: WriterMode,
+    read_only: bool,
+    registry: RegistryLock,
+    horizon: Arc<HorizonPublisher>,
+    inner: Mutex<Inner>,
+    /// Held for this process's whole lifetime in [`WriterMode::SingleWriterProcess`], and for the
+    /// duration of each write transaction in [`WriterMode::MultiWriterProcess`]
+    write_lock: Mutex<WriteLock>,
+    /// The shared lock on `metadata` that every process holds for as long as it has the database
+    /// open. Nothing reads it again; a future format upgrade takes it exclusively, and this is
+    /// what it waits on.
+    metadata_lock: Mutex<Option<File>>,
+}
+
+impl ProcessCoordinator {
+    pub(crate) fn new(
+        dir: &DatabaseDir,
+        mode: WriterMode,
+        read_only: bool,
+        write_lock: WriteLock,
+        mem: Arc<TransactionalMemory>,
+    ) -> Result<Self, DatabaseError> {
+        let registry = RegistryLock::open(dir);
+        let horizon = Arc::new(HorizonPublisher {
+            registry: registry.clone(),
+            extended_header: ExtendedHeader::open(dir)?,
+            pending: Mutex::new(0),
+        });
+        if !read_only {
+            // From here on every commit binds the pending horizon to the slot it flips to
+            mem.set_commit_hook(horizon.clone());
+        }
+        Ok(Self {
+            mem,
+            mode,
+            read_only,
+            registry,
+            horizon,
+            inner: Mutex::new(Inner {
+                pins: TransactionPins::new(dir),
+                // Zero assumes nothing about the file or the cache; a read-write open sets both
+                // properly via initialize_extended_header()
+                state_committed: 0,
+                cache_floor: 0,
+            }),
+            write_lock: Mutex::new(write_lock),
+            metadata_lock: Mutex::new(None),
+        })
+    }
+
+    /// True when this process's in-memory state is authoritative: it is the only process that may
+    /// write, and it holds the write lock for as long as it is open, so nothing can change the
+    /// file behind its back and its state may legitimately be ahead of the file.
+    fn authoritative(&self) -> bool {
+        matches!(self.mode, WriterMode::SingleWriterProcess) && !self.read_only
+    }
+
+    pub(crate) fn mode(&self) -> WriterMode {
+        self.mode
+    }
+
+    /// True when the write lock is taken per transaction, so that another process can take over
+    /// between this one's transactions.
+    pub(crate) fn shares_write_lock(&self) -> bool {
+        matches!(self.mode, WriterMode::MultiWriterProcess)
+    }
+
+    /// A non-durable commit lives only in the committing process's memory, so it would be silently
+    /// discarded the moment another process took the write lock.
+    pub(crate) fn allows_non_durable_commit(&self) -> bool {
+        matches!(self.mode, WriterMode::SingleWriterProcess)
+    }
+
+    /// Keeps the shared lock on the directory's `metadata` file for as long as this coordinator
+    /// lives. Taken once the marker exists.
+    pub(crate) fn hold_metadata_lock(&self, file: File) -> Result<()> {
+        *self.metadata_lock.lock()? = Some(file);
+        Ok(())
+    }
+
+    fn lock(&self) -> Result<MutexGuard<'_, Inner>> {
+        Ok(self.inner.lock()?)
+    }
+
+    /// Drops the read cache if the collection horizon says a page in it may have been reused, and
+    /// raises the floor to what the cache can hold from now on. `horizon` is what the extended
+    /// header stored, `None` if it did not verify -- in which case the worst is assumed, per the
+    /// crash rules in `docs/design.md`. `id` is the latest transaction id, read from the file
+    /// under the registry lock the caller still holds.
+    fn revalidate_cache(
+        &self,
+        inner: &mut Inner,
+        horizon: Option<u64>,
+        local_oldest: Option<TransactionId>,
+        id: TransactionId,
+    ) {
+        let stale = match horizon {
+            Some(horizon) => horizon > inner.cache_floor,
+            None => true,
+        };
+        if stale {
+            self.mem.clear_read_cache();
+            // The oldest transaction this process has active once the caller's begins. Not simply
+            // `id`: a read transaction this process already holds goes on reading from its own,
+            // older snapshot
+            let floor = local_oldest.map_or(id, |oldest| oldest.min(id));
+            inner.cache_floor = floor.raw_id();
+        }
+    }
+
+    /// Registers a read transaction and returns the transaction it may read.
+    ///
+    /// Reading the latest transaction id, checking the horizon against the cache, and pinning the
+    /// transaction in `txn/` all happen under one shared hold of the registry lock. A writer takes
+    /// that lock exclusively to flip the header or scan the pins, so either the writer sees this
+    /// pin, or this read starts strictly after the flip and reads the file it left behind.
+    pub(crate) fn begin_read(
+        &self,
+        local_write_transaction_live: bool,
+        local_oldest: Option<TransactionId>,
+    ) -> Result<TransactionId> {
+        if self.authoritative() {
+            // The single writer's own state is the database, and no other process can collect
+            // pages out from under it
+            return self.mem.get_last_committed_transaction_id();
+        }
+        let mut inner = self.lock()?;
+        let guard = self.registry.shared()?;
+        let result = self.begin_read_locked(&mut inner, local_write_transaction_live, local_oldest);
+        drop(guard);
+        result
+    }
+
+    fn begin_read_locked(
+        &self,
+        inner: &mut Inner,
+        local_write_transaction_live: bool,
+        local_oldest: Option<TransactionId>,
+    ) -> Result<TransactionId> {
+        let id = if local_write_transaction_live {
+            // This process holds the write lock, so nothing can have committed or collected since
+            // the transaction began, and rereading the file could roll back state the writer is
+            // using
+            self.mem.get_last_committed_transaction_id()?
+        } else {
+            // Always from the file, never cached
+            let (id, raw) = self.mem.reload_transaction_slots()?;
+            let horizon = self.horizon.read_stored(&raw)?;
+            self.revalidate_cache(inner, horizon, local_oldest, id);
+            id
+        };
+        let pinned = local_oldest.map_or(id, |oldest| oldest.min(id));
+        inner.pins.publish(Some(pinned.raw_id()))?;
+        Ok(id)
+    }
+
+    /// Publishes the oldest transaction this process still needs, which is only ever used to raise
+    /// it: lowering it happens in [`Self::begin_read`], under the same lock as the read of the
+    /// transaction being pinned.
+    pub(crate) fn publish_pinned(&self, local_oldest: Option<TransactionId>) -> Result<()> {
+        if self.authoritative() {
+            // Nothing scans this process's pin: it is the only writer, and it consults its own
+            // in-memory tracker directly
+            return Ok(());
+        }
+        let mut inner = self.lock()?;
+        let pinned = local_oldest.map(TransactionId::raw_id);
+        if inner.pins.published() == pinned {
+            return Ok(());
+        }
+        let guard = self.registry.shared()?;
+        let result = inner.pins.publish(pinned);
+        drop(guard);
+        result
+    }
+
+    /// The oldest transaction pinned by any process, past which no page may be reclaimed.
+    /// `local_oldest` is this process's own answer, which the caller must read under the same lock
+    /// that read transactions register under.
+    pub(crate) fn oldest_pinned_globally(
+        &self,
+        local_oldest: Option<TransactionId>,
+    ) -> Result<Option<TransactionId>> {
+        let inner = self.lock()?;
+        let guard = self.registry.exclusive()?;
+        let result = inner.pins.scan_oldest();
+        drop(guard);
+        // Includes this process's own pin, which is harmless: it is the same value
+        // `local_oldest` carries, so the minimum below is unchanged
+        let remote = result?.map(TransactionId::new);
+        Ok(match (local_oldest, remote) {
+            (Some(local), Some(remote)) => Some(local.min(remote)),
+            (local, None) => local,
+            (None, remote) => remote,
+        })
+    }
+
+    /// Records that transactions up to and including `free_until - 1` have been garbage collected.
+    /// Nothing is written yet: the reuse only becomes visible to another process at the commit
+    /// flip, and that is when the commit hook writes the horizon recorded here.
+    pub(crate) fn record_collection_horizon(&self, free_until: TransactionId) -> Result<()> {
+        // `free_until` is exclusive; the extended header stores the newest collected, inclusive
+        self.horizon.record(free_until.raw_id().saturating_sub(1))
+    }
+
+    /// The last transaction any process has committed durably, straight from the file. Read from
+    /// the file even for the sole writer: its in-memory state runs ahead of the file after a
+    /// non-durable commit, and this reports what would survive a crash.
+    pub(crate) fn last_committed(&self) -> Result<TransactionId> {
+        let guard = self.registry.shared()?;
+        let result = self.mem.peek_committed_transaction_id();
+        drop(guard);
+        result
+    }
+
+    /// Takes the write lock and makes this process's state current, so that a write transaction
+    /// can be started. Returns the last transaction any process has committed, which the caller
+    /// uses to number the new transaction.
+    ///
+    /// In [`WriterMode::SingleWriterProcess`] the lock is already held and the state is already
+    /// current, so this is free.
+    pub(crate) fn begin_write(&self) -> Result<TransactionId> {
+        if self.authoritative() {
+            debug_assert!(self.write_lock.lock()?.is_held());
+            return self.mem.get_last_committed_transaction_id();
+        }
+        assert!(
+            !self.read_only,
+            "a read-only handle cannot start a write transaction"
+        );
+        // Taken before the state is refreshed, so nothing can commit between the refresh and the
+        // start of this transaction
+        self.write_lock.lock()?.acquire()?;
+        match self.refresh_for_write() {
+            Ok(last_committed) => Ok(last_committed),
+            Err(err) => {
+                self.write_lock
+                    .lock()
+                    .map(|mut lock| lock.release())
+                    .unwrap_or(());
+                Err(err)
+            }
+        }
+    }
+
+    fn refresh_for_write(&self) -> Result<TransactionId> {
+        let mut inner = self.lock()?;
+        let guard = self.registry.shared()?;
+        let (last_committed, raw) = self.mem.reload_transaction_slots()?;
+        let horizon = self.horizon.read_stored(&raw)?;
+        // Even when nothing new was committed, another process may have collected pages this one
+        // has cached
+        let local_oldest = inner.pins.published().map(TransactionId::new);
+        self.revalidate_cache(&mut inner, horizon, local_oldest, last_committed);
+        drop(guard);
+
+        if let Some(horizon) = horizon {
+            // What the file has published is a floor under everything this process publishes
+            self.horizon.record(horizon)?;
+        } else {
+            // The extended header did not survive some previous writer's crash. Holding the write
+            // lock entitles this process to repair it in place, with the fallback the crash rules
+            // prescribe: the lowest pinned transaction, or the latest one minus one. Both
+            // overstate the true horizon, which costs caches, not correctness
+            let guard = self.registry.exclusive()?;
+            let fallback = inner
+                .pins
+                .scan_oldest()?
+                .unwrap_or_else(|| last_committed.raw_id().saturating_sub(1))
+                .min(last_committed.raw_id().saturating_sub(1));
+            let result = self.horizon.rewrite(fallback, &raw);
+            drop(guard);
+            result?;
+        }
+
+        // Ids are ordered across processes, so an unchanged id means the file is exactly the
+        // state this process already has. Otherwise all of it is reloaded: even if a read
+        // transaction has picked up newer commit slots, the rest still describes the older
+        // database
+        if last_committed.raw_id() != inner.state_committed {
+            self.mem.reload_for_write().map_err(storage_error)?;
+            self.load_allocator_state()?;
+            inner.state_committed = last_committed.raw_id();
+        }
+
+        Ok(last_committed)
+    }
+
+    /// Loads the allocator state the previous writer left behind, or rebuilds it if that writer
+    /// died mid-commit. The rebuild is safe concurrently with readers because it only reads
+    /// committed pages and repopulates in-memory state.
+    fn load_allocator_state(&self) -> Result<()> {
+        if let Some(tree) = crate::Database::allocator_state_table(&self.mem)? {
+            self.mem.load_allocator_state(&tree)?;
+            #[cfg(debug_assertions)]
+            crate::Database::mark_allocated_page_for_debug(&self.mem)?;
+            return Ok(());
+        }
+        crate::Database::rebuild_allocator_state_shared(&self.mem).map_err(storage_error)?;
+        #[cfg(debug_assertions)]
+        crate::Database::mark_allocated_page_for_debug(&self.mem)?;
+        Ok(())
+    }
+
+    /// Brings `extended-header` in step with the file, as part of opening the database read-write.
+    /// The caller holds the write lock, and the in-memory state was just loaded from the file.
+    ///
+    /// Rewriting both slots makes the file verify from here on, whatever was in it: the zeroes of
+    /// a fresh directory, a horizon torn by a crash, or one left by an earlier database whose file
+    /// was replaced -- which the clamp also guards, since a horizon can never legitimately reach
+    /// the latest transaction.
+    pub(crate) fn initialize_extended_header(&self) -> Result<()> {
+        let mut inner = self.lock()?;
+        let guard = self.registry.exclusive()?;
+        let (last_committed, raw) = self.mem.reload_transaction_slots()?;
+        let newest_possible = last_committed.raw_id().saturating_sub(1);
+        let horizon = match self.horizon.read_stored(&raw)? {
+            Some(horizon) => horizon.min(newest_possible),
+            // The crash-rule fallback; the scan also unlinks any pins a dead process left
+            None => inner
+                .pins
+                .scan_oldest()?
+                .unwrap_or(newest_possible)
+                .min(newest_possible),
+        };
+        let result = self.horizon.rewrite(horizon, &raw);
+        drop(guard);
+        result?;
+
+        // Everything cached so far was read through the state that was just loaded
+        inner.state_committed = last_committed.raw_id();
+        inner.cache_floor = last_committed.raw_id();
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(super) fn cache_floor(&self) -> u64 {
+        self.lock().unwrap().cache_floor
+    }
+
+    /// Releases the write lock, if this mode takes it per transaction. Also used to hand back the
+    /// lock that opening the database takes.
+    pub(crate) fn end_write(&self) {
+        if self.authoritative() {
+            return;
+        }
+        if let Ok(mut lock) = self.write_lock.lock() {
+            lock.release();
+        }
+    }
+
+    /// Releases everything the directory was being held with, once the database is closed. A
+    /// lingering transaction guard can keep this coordinator alive past the close, and the locks
+    /// must not outlive the storage they protect: the sole writer's lifetime hold would refuse
+    /// every reopen, and the shared `metadata` hold would block an upgrader, for as long as that
+    /// unusable guard exists.
+    pub(crate) fn release_for_close(&self) {
+        if let Ok(mut lock) = self.write_lock.lock() {
+            lock.release();
+        }
+        if let Ok(mut metadata) = self.metadata_lock.lock() {
+            *metadata = None;
+        }
+        // Unpinned as well: a transaction a lingering guard can never read again must not go on
+        // holding every page freed after its snapshot
+        if let Ok(mut inner) = self.lock() {
+            let _ = inner.pins.publish(None);
+        }
+    }
+}
+
+impl std::fmt::Debug for ProcessCoordinator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProcessCoordinator")
+            .field("mode", &self.mode)
+            .field("read_only", &self.read_only)
+            .finish_non_exhaustive()
+    }
+}
+
+fn storage_error(error: DatabaseError) -> StorageError {
+    match error {
+        DatabaseError::Storage(storage) => storage,
+        other => StorageError::Corrupted(other.to_string()),
+    }
+}

--- a/src/multiprocess/locks.rs
+++ b/src/multiprocess/locks.rs
@@ -4,6 +4,7 @@
 //! Everything in here uses only `std::fs` file operations and the advisory file locks exposed by
 //! `std::fs::File`. See `docs/design.md` for the protocol these files implement.
 
+use crate::tree_store::MAGICNUMBER;
 use crate::tree_store::file_backend::FileBackend;
 use crate::{DatabaseError, StorageBackend, StorageError};
 use std::fs::{File, OpenOptions, TryLockError};
@@ -15,6 +16,7 @@ const DATA_FILE_NAME: &str = "data.redb";
 const WRITE_LOCK_FILE_NAME: &str = "write.lock";
 const METADATA_FILE_NAME: &str = "metadata";
 const METADATA_TMP_FILE_NAME: &str = "metadata.tmp";
+const DATA_TMP_FILE_NAME: &str = "data.redb.tmp";
 
 // The ASCII letters 'redbMP' followed by the same PNG-inspired tail as the database file's own
 // magic number, for the same reasons.
@@ -132,6 +134,34 @@ fn mark_lock_abandoned(lock: &File) {
     let _ = lock.sync_all();
 }
 
+/// Refuses anything that is not an ordinary file under one of this database's own names: opens
+/// here traverse symlinks and would write through them, and a FIFO blocks rather than fails. A
+/// missing file is fine. Best-effort -- the entry can be replaced between this check and the open,
+/// and `std` does not expose `O_NOFOLLOW` portably.
+fn require_regular_file(path: &Path) -> Result<(), DatabaseError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() => Ok(()),
+        Ok(_) => Err(StorageError::Io(io::Error::new(
+            ErrorKind::InvalidData,
+            "a multi-process database directory may hold only ordinary files",
+        ))
+        .into()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(StorageError::Io(err).into()),
+    }
+}
+
+/// Which name [`DatabaseDir::open`] put the database file under. Carried from the open to
+/// [`DatabaseDir::promote_data`] rather than worked out again from disk: a temporary file is this
+/// call's own only if this call made it, and nothing about the file itself says so.
+#[derive(Clone, Copy)]
+pub(super) enum DataLocation {
+    /// `data.redb`, which is where a database that was already finished lives.
+    Final,
+    /// `data.redb.tmp`, which is where one being initialized lives until it is renamed into place.
+    Temporary,
+}
+
 /// The paths that make up a multi-process database directory.
 pub(super) struct DatabaseDir {
     root: PathBuf,
@@ -141,7 +171,7 @@ impl DatabaseDir {
     /// Every name `create()` writes after taking the write lock. `metadata` is not among them: the
     /// check that uses this runs only where there is no marker.
     const WRITTEN_UNDER_THE_LOCK: &'static [&'static str] =
-        &[DATA_FILE_NAME, METADATA_TMP_FILE_NAME];
+        &[DATA_FILE_NAME, DATA_TMP_FILE_NAME, METADATA_TMP_FILE_NAME];
 
     pub(super) fn new(root: impl AsRef<Path>) -> Self {
         Self {
@@ -165,6 +195,10 @@ impl DatabaseDir {
         self.root.join(METADATA_TMP_FILE_NAME)
     }
 
+    fn data_tmp_file(&self) -> PathBuf {
+        self.root.join(DATA_TMP_FILE_NAME)
+    }
+
     /// Takes the write lock, which excludes every other process from the database, and reports
     /// whether this call created the file. Taken before anything in the directory is read or
     /// written, so the holder has the directory to itself.
@@ -177,6 +211,9 @@ impl DatabaseDir {
     /// really made the file.
     fn acquire_write_lock(&self, create: bool) -> Result<(File, bool), DatabaseError> {
         let path = self.write_lock_file();
+        // Otherwise the create below would follow a symlink left under this name, and the
+        // lock would be taken on a file whose identity was never checked
+        require_regular_file(&path)?;
         let open_existing = || {
             OpenOptions::new()
                 .read(true)
@@ -230,22 +267,27 @@ impl DatabaseDir {
     }
 
     /// Opens the directory, creating it if `create` is set, and returns a backend for the database
-    /// file that holds the write lock for as long as the database is open.
+    /// file that holds the write lock for as long as the database is open, along with which of the
+    /// two names that file is under.
     ///
     /// A directory being created is not marked as one of these yet -- the caller does that with
     /// [`Self::write_metadata_if_missing`], once the database file has turned out to be usable.
-    pub(super) fn open(&self, create: bool) -> Result<Box<dyn StorageBackend>, DatabaseError> {
+    pub(super) fn open(
+        &self,
+        create: bool,
+    ) -> Result<(Box<dyn StorageBackend>, DataLocation), DatabaseError> {
         let mut marked_at_preflight = false;
         if create {
-            // Both checks run before the directory is touched, so a rejected create() leaves no
+            // All checks run before the directory is touched, so a rejected create() leaves no
             // trace. A marker arrives by rename and so is either absent or complete, which is what
-            // makes refusing without the lock sound; `read_metadata` below repeats the check under
-            // the lock, which is the authoritative pass
+            // makes refusing without the lock sound; the checks run again under the lock, which is
+            // the authoritative pass
             marked_at_preflight = occupied(&self.metadata_file())?;
             if marked_at_preflight {
                 self.read_metadata(create)?;
             } else {
                 self.reject_unmarked_database()?;
+                self.reject_foreign_directory()?;
             }
             // The deepest ancestor that already exists bounds what create_dir_all makes; every
             // entry from the database directory up to there needs its own flush below
@@ -285,17 +327,78 @@ impl DatabaseDir {
         }
         self.read_metadata(create)?;
 
+        // A database being made for the first time is initialized under a temporary name and
+        // renamed into place by `promote_data`, like the marker. A crash during initialization
+        // leaves a file that is neither empty nor a database; under its own name that would be
+        // indistinguishable from a mistyped path, while under the temporary name it is unfinished
+        // work of ours, to be redone
+        let (path, location) = if create {
+            // `symlink_metadata` rather than `exists()`: the question is whether the name is
+            // occupied at all, and `exists()` reports a dangling symlink as absent
+            match std::fs::symlink_metadata(self.data_file()) {
+                // The fresh-lock pass just required this name to be absent, so anything under it
+                // now arrived while the directory was being claimed, and is refused the same way
+                Ok(_) if fresh_claim => {
+                    mark_lock_abandoned(&write_lock);
+                    return Err(StorageError::Io(io::Error::new(
+                        ErrorKind::AlreadyExists,
+                        "the database file appeared while the directory was being claimed",
+                    ))
+                    .into());
+                }
+                Ok(metadata) if metadata.is_file() && metadata.len() == 0 => {
+                    // Empty means an interrupted attempt -- but only if nobody is holding it. A
+                    // process that reached past the directory could have created and locked it,
+                    // and unlinking would leave it writing to an inode nothing points at
+                    let existing = OpenOptions::new()
+                        .read(true)
+                        .write(true)
+                        .open(self.data_file())
+                        .map_err(StorageError::Io)?;
+                    match existing.try_lock() {
+                        Ok(()) => {}
+                        Err(TryLockError::WouldBlock) => {
+                            return Err(DatabaseError::DatabaseAlreadyOpen);
+                        }
+                        Err(TryLockError::Error(err)) => return Err(lock_unsupported(err)),
+                    }
+                    // Re-read through the held lock: a process that reached past the directory
+                    // could have initialized the file between the check above and the lock
+                    // landing, and unlinking would then delete the database it just made
+                    if existing.metadata().map_err(StorageError::Io)?.len() != 0 {
+                        drop(existing);
+                        (self.data_file(), DataLocation::Final)
+                    } else {
+                        // The lock is held across the unlink, which is what closes the window
+                        std::fs::remove_file(self.data_file()).map_err(StorageError::Io)?;
+                        drop(existing);
+                        self.reject_data_tmp_holding_a_database()?;
+                        self.discard_data_tmp()?;
+                        (self.data_tmp_file(), DataLocation::Temporary)
+                    }
+                }
+                Ok(_) => (self.data_file(), DataLocation::Final),
+                Err(err) if err.kind() == ErrorKind::NotFound => {
+                    self.reject_data_tmp_holding_a_database()?;
+                    self.discard_data_tmp()?;
+                    (self.data_tmp_file(), DataLocation::Temporary)
+                }
+                Err(err) => return Err(StorageError::Io(err).into()),
+            }
+        } else {
+            (self.data_file(), DataLocation::Final)
+        };
+
+        require_regular_file(&path)?;
         let mut options = OpenOptions::new();
         options.read(true).write(true).truncate(false);
-        if fresh_claim {
-            // The pass above required this name to be absent, and a file appearing since arrived
-            // the same way -- something reaching past the directory API -- so creating exclusively
-            // turns the appearance into the same refusal instead of an adoption
-            options.create_new(true);
-        } else {
-            options.create(create);
-        }
-        let data = match options.open(self.data_file()) {
+        match location {
+            // The temporary was just cleared, so a file under that name now was made by
+            // something reaching past the directory in between, and must not be adopted
+            DataLocation::Temporary => options.create_new(true),
+            DataLocation::Final => options.create(create),
+        };
+        let data = match options.open(path) {
             Ok(data) => data,
             Err(err) if fresh_claim && err.kind() == ErrorKind::AlreadyExists => {
                 mark_lock_abandoned(&write_lock);
@@ -324,30 +427,71 @@ impl DatabaseDir {
             }
         };
 
-        Ok(Box::new(DirectoryBackend { data, write_lock }))
+        Ok((Box::new(DirectoryBackend { data, write_lock }), location))
     }
 
-    /// Writes the marker that says this directory holds a multi-process database. Called only once
-    /// the database file has been initialized, so a failed `create()` never leaves a marker.
-    ///
-    /// Written under a temporary name and renamed into place, so the marker is either absent or
-    /// complete: a half-written one would be indistinguishable from a foreign file, which
-    /// [`Self::read_metadata`] refuses, and the directory would be wedged.
-    fn write_metadata(&self) -> Result<(), DatabaseError> {
-        let mut contents = [0u8; METADATA_LEN];
-        contents[0..11].copy_from_slice(&MAGIC);
-        contents[11] = FORMAT_VERSION;
-        contents[12] = WRITER_MODE_SINGLE;
-
-        let tmp = self.metadata_tmp_file();
-        let mut file = File::create(&tmp).map_err(StorageError::Io)?;
-        file.write_all(&contents).map_err(StorageError::Io)?;
-        file.sync_all().map_err(StorageError::Io)?;
-        drop(file);
-        std::fs::rename(&tmp, self.metadata_file()).map_err(StorageError::Io)?;
+    /// Moves a freshly initialized database file into place, if this call was the one that made
+    /// it. Called once [`crate::Database`] has accepted the file, so that `data.redb` exists only
+    /// when it holds a finished database. The write lock is still held, so nothing can be looking
+    /// at either name.
+    pub(super) fn promote_data(&self, location: DataLocation) -> Result<(), DatabaseError> {
+        let tmp = self.data_tmp_file();
+        if matches!(location, DataLocation::Final) {
+            // The database opened under its own name, so anything under the temporary one is the
+            // wreckage of an earlier attempt. Deleted here rather than on the way in, so a
+            // create() pointed somewhere by mistake fails without having deleted anything; and
+            // tidying only, so a failure is not the caller's problem -- what is left is inert.
+            // Except a finished database, which is never tidied away
+            if matches!(self.reject_data_tmp_holding_a_database(), Ok(())) {
+                drop(self.discard_data_tmp());
+            }
+            return Ok(());
+        }
+        // A database file appearing since the open means something reached past the directory and
+        // made it, and renaming over it would destroy a database this call never opened
+        if occupied(&self.data_file())? {
+            return Err(StorageError::Io(io::Error::new(
+                ErrorKind::AlreadyExists,
+                "the database file appeared while it was being initialized",
+            ))
+            .into());
+        }
+        std::fs::rename(&tmp, self.data_file()).map_err(StorageError::Io)?;
         sync_dir(&self.root)?;
 
         Ok(())
+    }
+
+    /// Removes the temporary this call created, once initializing it has failed. Left behind, an
+    /// initialization that failed after the magic number was written would read, to the next
+    /// `create()`, as a finished database whose promoting rename was lost, and the refusal that
+    /// protects that state would wedge the directory. Only a crash leaves the temporary now,
+    /// where nothing could have cleaned up.
+    ///
+    /// Best-effort -- the initialization error is the story, and what a failed removal leaves is
+    /// what a crash at the same point would have -- but still only under the file's own lock: the
+    /// write lock went with the backend, so another `create()` may already be initializing a
+    /// fresh temporary here, and unlinking that would pull it out from underneath it.
+    pub(super) fn discard_failed_data(&self, location: DataLocation) {
+        if !matches!(location, DataLocation::Temporary) {
+            return;
+        }
+        let Ok(Some(metadata)) = symlink_metadata_if_any(&self.data_tmp_file()) else {
+            return;
+        };
+        if !metadata.is_file() {
+            return;
+        }
+        let Ok(held) = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(self.data_tmp_file())
+        else {
+            return;
+        };
+        if matches!(held.try_lock(), Ok(())) {
+            let _ = std::fs::remove_file(self.data_tmp_file());
+        }
     }
 
     /// Writes the marker only if the directory does not already carry one. One that is there was
@@ -366,6 +510,99 @@ impl DatabaseDir {
         }
 
         self.write_metadata()
+    }
+
+    /// Throws away a temporary database file left by an earlier attempt. Unlinks rather than
+    /// truncates, so a symlink under this name is removed rather than written through -- without
+    /// opening it first, since a link or FIFO is a name rather than a file to hold.
+    ///
+    /// A regular file is unlinked only under its own lock, exactly like an empty `data.redb`: a
+    /// process that reached past the directory could be initializing a database under this name
+    /// right now, and unlinking would leave it writing to an inode nothing points at.
+    fn discard_data_tmp(&self) -> Result<(), DatabaseError> {
+        match std::fs::symlink_metadata(self.data_tmp_file()) {
+            Ok(metadata) if !metadata.is_file() => {
+                return match std::fs::remove_file(self.data_tmp_file()) {
+                    Ok(()) => Ok(()),
+                    Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+                    Err(err) => Err(StorageError::Io(err).into()),
+                };
+            }
+            Ok(_) => {}
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(StorageError::Io(err).into()),
+        }
+        let held = match OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(self.data_tmp_file())
+        {
+            Ok(file) => file,
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(StorageError::Io(err).into()),
+        };
+        match held.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => return Err(DatabaseError::DatabaseAlreadyOpen),
+            Err(TryLockError::Error(err)) => return Err(lock_unsupported(err)),
+        }
+        // Re-read through the held lock: a process that reached past the directory could have
+        // finished a database under this name between the inspection and the lock landing, and
+        // its magic number is written last, so one present now marks a database rather than
+        // wreckage
+        let mut magic = Vec::with_capacity(MAGICNUMBER.len());
+        (&held)
+            .take(MAGICNUMBER.len() as u64)
+            .read_to_end(&mut magic)
+            .map_err(StorageError::Io)?;
+        if magic == MAGICNUMBER {
+            return Err(StorageError::Io(io::Error::new(
+                ErrorKind::InvalidData,
+                "the database is under the temporary name data.redb.tmp; rename it to data.redb \
+                 to recover it",
+            ))
+            .into());
+        }
+        // The lock is held across the unlink, which is what closes the window
+        std::fs::remove_file(self.data_tmp_file()).map_err(StorageError::Io)?;
+        drop(held);
+
+        Ok(())
+    }
+
+    /// Refuses to treat the temporary as wreckage when it holds a finished database. redb writes
+    /// a new database's magic number last, so a temporary bearing it is a database whose
+    /// promoting rename was lost -- possible wherever the directory could not be flushed -- and
+    /// discarding it would lose the data. Refused for a person to sort out instead of guessed at:
+    /// promoting it automatically would mean deciding it is newer than anything else here.
+    fn reject_data_tmp_holding_a_database(&self) -> Result<(), DatabaseError> {
+        // Only a regular file can be a database; anything else is a name for the discard to
+        // unlink, and opening it here could block -- a FIFO waits for a writer
+        match std::fs::symlink_metadata(self.data_tmp_file()) {
+            Ok(metadata) if metadata.is_file() => {}
+            Ok(_) => return Ok(()),
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(StorageError::Io(err).into()),
+        }
+        let file = match File::open(self.data_tmp_file()) {
+            Ok(file) => file,
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(StorageError::Io(err).into()),
+        };
+        let mut magic = Vec::with_capacity(MAGICNUMBER.len());
+        file.take(MAGICNUMBER.len() as u64)
+            .read_to_end(&mut magic)
+            .map_err(StorageError::Io)?;
+        if magic == MAGICNUMBER {
+            return Err(StorageError::Io(io::Error::new(
+                ErrorKind::InvalidData,
+                "the database is under the temporary name data.redb.tmp; rename it to data.redb \
+                 to recover it",
+            ))
+            .into());
+        }
+
+        Ok(())
     }
 
     /// Refuses a directory holding files under these names that this type did not put there.
@@ -433,6 +670,143 @@ impl DatabaseDir {
         Ok(())
     }
 
+    /// Writes the marker that says this directory holds a multi-process database. Called only once
+    /// the database file has been initialized, so a failed `create()` never leaves a marker.
+    ///
+    /// Written under a temporary name and renamed into place, so the marker is either absent or
+    /// complete: a half-written one would be indistinguishable from a foreign file, which
+    /// [`Self::read_metadata`] refuses, and the directory would be wedged.
+    fn write_metadata(&self) -> Result<(), DatabaseError> {
+        let mut contents = [0u8; METADATA_LEN];
+        contents[0..11].copy_from_slice(&MAGIC);
+        contents[11] = FORMAT_VERSION;
+        contents[12] = WRITER_MODE_SINGLE;
+
+        let tmp = self.metadata_tmp_file();
+        // Unlinked and created afresh rather than truncated in place, so a symlink or FIFO left
+        // under this name is never opened -- and a regular file only under its own lock, exactly
+        // like the database file's temporary: a process that reached past the directory could be
+        // holding a live file under this name, and unlinking would leave it writing to an inode
+        // nothing points at
+        match symlink_metadata_if_any(&tmp)? {
+            None => {}
+            Some(metadata) if !metadata.is_file() => match std::fs::remove_file(&tmp) {
+                Ok(()) => {}
+                Err(err) if err.kind() == ErrorKind::NotFound => {}
+                Err(err) => return Err(StorageError::Io(err).into()),
+            },
+            Some(_) => {
+                let held = match OpenOptions::new().read(true).write(true).open(&tmp) {
+                    Ok(file) => file,
+                    Err(err) if err.kind() == ErrorKind::NotFound => {
+                        return self.write_metadata_tmp_and_publish(&contents);
+                    }
+                    Err(err) => return Err(StorageError::Io(err).into()),
+                };
+                match held.try_lock() {
+                    Ok(()) => {}
+                    Err(TryLockError::WouldBlock) => {
+                        return Err(DatabaseError::DatabaseAlreadyOpen);
+                    }
+                    Err(TryLockError::Error(err)) => return Err(lock_unsupported(err)),
+                }
+                // Re-read through the held lock: redb's own temporary never exceeds the marker's
+                // length, so a bigger file was finished under this name by something that reached
+                // past the directory -- most likely a whole database -- and is refused rather
+                // than deleted
+                if held.metadata().map_err(StorageError::Io)?.len() > METADATA_LEN as u64 {
+                    return Err(StorageError::Io(io::Error::new(
+                        ErrorKind::AlreadyExists,
+                        "the marker's temporary appeared while the directory was being claimed",
+                    ))
+                    .into());
+                }
+                // The lock is held across the unlink, which is what closes the window
+                match std::fs::remove_file(&tmp) {
+                    Ok(()) => {}
+                    Err(err) if err.kind() == ErrorKind::NotFound => {}
+                    Err(err) => return Err(StorageError::Io(err).into()),
+                }
+                drop(held);
+            }
+        }
+        self.write_metadata_tmp_and_publish(&contents)
+    }
+
+    /// Writes the marker's bytes under the temporary name and renames them into place, once
+    /// [`Self::write_metadata`] has cleared the name.
+    fn write_metadata_tmp_and_publish(&self, contents: &[u8]) -> Result<(), DatabaseError> {
+        let tmp = self.metadata_tmp_file();
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)
+            .map_err(StorageError::Io)?;
+        file.write_all(contents).map_err(StorageError::Io)?;
+        file.sync_all().map_err(StorageError::Io)?;
+        drop(file);
+        // Renaming would replace whatever sits under the final name, and the caller only checked
+        // it some statements ago; refused like the database file's own promotion, with the same
+        // residual -- a no-replace rename is not portably available
+        if occupied(&self.metadata_file())? {
+            return Err(StorageError::Io(io::Error::new(
+                ErrorKind::AlreadyExists,
+                "the marker appeared while the directory was being claimed",
+            ))
+            .into());
+        }
+        std::fs::rename(&tmp, self.metadata_file()).map_err(StorageError::Io)?;
+        sync_dir(&self.root)?;
+
+        Ok(())
+    }
+
+    /// Refuses a directory that holds anything this database did not put there.
+    ///
+    /// Only consulted when there is no marker: a directory with one is this database's, and a
+    /// stray file appearing next to it must not stop it opening. Without a marker, the only
+    /// directory `create()` may accept is an interrupted create of its own, which holds nothing
+    /// but the files `create()` itself makes.
+    fn reject_foreign_directory(&self) -> Result<(), DatabaseError> {
+        let entries = match std::fs::read_dir(&self.root) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+            // Listing needs read permission, which nothing else here does. This rule guards
+            // against mistyped paths rather than being a safety property, and the refusals that
+            // are -- a foreign marker, a non-regular file, a `data.redb` with no `write.lock` --
+            // need no listing
+            Err(err) if err.kind() == ErrorKind::PermissionDenied => return Ok(()),
+            Err(err) => return Err(StorageError::Io(err).into()),
+        };
+
+        for entry in entries {
+            let entry = entry.map_err(StorageError::Io)?;
+            let name = entry.file_name();
+            let named_like_ours = [
+                DATA_FILE_NAME,
+                DATA_TMP_FILE_NAME,
+                WRITE_LOCK_FILE_NAME,
+                METADATA_FILE_NAME,
+                METADATA_TMP_FILE_NAME,
+            ]
+            .iter()
+            .any(|known| name == *known);
+            // `file_type()` reports the entry rather than what it points at, so a symlink wearing
+            // one of these names is caught instead of followed
+            let ours = named_like_ours && entry.file_type().map_err(StorageError::Io)?.is_file();
+            if !ours {
+                return Err(StorageError::Io(io::Error::new(
+                    ErrorKind::AlreadyExists,
+                    "refusing to create a multi-process database in a directory that holds files \
+                     it did not write",
+                ))
+                .into());
+            }
+        }
+
+        Ok(())
+    }
+
     /// Takes the shared lock on `metadata` that every process holds for as long as it has the
     /// database open. A future version that changes the directory's format will take this lock
     /// exclusively, so that it upgrades only once nothing is using the database.
@@ -447,7 +821,9 @@ impl DatabaseDir {
     /// taken over, even by `create()`: overwriting it would be a destructive way to report a
     /// mistyped path. The caller must hold the write lock.
     fn read_metadata(&self, create: bool) -> Result<(), DatabaseError> {
-        let file = match File::open(self.metadata_file()) {
+        let path = self.metadata_file();
+        require_regular_file(&path)?;
+        let file = match File::open(&path) {
             Ok(file) => file,
             Err(err) if err.kind() == ErrorKind::NotFound => {
                 // Opening follows symlinks, so NotFound covers a dangling one as well as a truly
@@ -467,7 +843,7 @@ impl DatabaseDir {
                     ))
                     .into());
                 }
-                return Ok(());
+                return self.reject_foreign_directory();
             }
             Err(err) => return Err(StorageError::Io(err).into()),
         };
@@ -553,12 +929,13 @@ impl StorageBackend for DirectoryBackend {
 mod test {
     use super::*;
 
-    /// The whole create sequence, which is split between here and the caller: the marker is
-    /// written only once [`crate::Database`] has accepted the database file. These tests are about
-    /// the lock and the marker rather than the database, so they stand in for that middle step by
-    /// doing nothing.
+    /// The whole create sequence, which is split between here and the caller: the database file is
+    /// moved into place and the marker written only once [`crate::Database`] has accepted the file.
+    /// These tests are about the lock and the marker rather than the database, so they stand in for
+    /// that middle step by doing nothing -- the file they promote is simply empty.
     fn create(dir: &DatabaseDir) -> Box<dyn StorageBackend> {
-        let backend = dir.open(true).unwrap();
+        let (backend, location) = dir.open(true).unwrap();
+        dir.promote_data(location).unwrap();
         dir.write_metadata_if_missing().unwrap();
         backend
     }
@@ -577,7 +954,7 @@ mod test {
         // Closing the backend is what releases the lock, since that is when redb has finished
         // with the file
         first.close().unwrap();
-        let _second = dir.open(false).unwrap();
+        let _second = dir.open(false).unwrap().0;
     }
 
     #[test]
@@ -586,7 +963,7 @@ mod test {
         let path = tmpdir.path().join("db");
         std::fs::create_dir(&path).unwrap();
         // A lock file on its own is not enough -- the marker is what says the directory is one of
-        // these
+        // these, so it has to be what this turns on rather than the lock file's absence
         std::fs::write(path.join(WRITE_LOCK_FILE_NAME), []).unwrap();
         let dir = DatabaseDir::new(&path);
         assert!(dir.open(false).is_err());
@@ -616,8 +993,9 @@ mod test {
         );
     }
 
-    /// Because the marker is never left half-written, a `metadata` file that is not a marker
-    /// belongs to something else, and `create()` must refuse rather than overwrite it.
+    /// The flip side of recovering from an interrupted create: because the marker is never left
+    /// half-written, a `metadata` file that is not a marker belongs to something else, and
+    /// `create()` must refuse rather than overwrite it.
     #[test]
     fn a_directory_belonging_to_something_else_is_left_alone() {
         let tmpdir = tempfile::tempdir().unwrap();
@@ -632,6 +1010,59 @@ mod test {
         );
         // ... and refused before anything of redb's was put in it
         assert!(!path.join(WRITE_LOCK_FILE_NAME).exists());
+    }
+
+    /// A database file with nothing in it never gets initialized under its own name: doing so
+    /// would put the header bytes there, and a crash before the magic number was written would
+    /// leave a file that has to be refused forever. It is discarded and redone under the temporary
+    /// name like any other unfinished attempt.
+    #[test]
+    fn an_empty_data_file_is_redone_through_the_temporary_name() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        let dir = DatabaseDir::new(&path);
+        create(&dir).close().unwrap();
+        std::fs::write(path.join(DATA_FILE_NAME), []).unwrap();
+
+        let (backend, location) = dir.open(true).unwrap();
+        assert!(!path.join(DATA_FILE_NAME).exists());
+        assert!(path.join(DATA_TMP_FILE_NAME).is_file());
+
+        // ... and promoting puts it back under the name it belongs under
+        dir.promote_data(location).unwrap();
+        assert!(path.join(DATA_FILE_NAME).is_file());
+        assert!(!path.join(DATA_TMP_FILE_NAME).exists());
+        backend.close().unwrap();
+    }
+
+    /// An empty database file is only wreckage if nobody is holding it. One that a process
+    /// reached past the directory to create and lock is live, and unlinking it would leave that
+    /// process writing to an inode nothing points at.
+    #[test]
+    fn an_empty_data_file_someone_is_holding_is_not_discarded() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        let dir = DatabaseDir::new(&path);
+        create(&dir).close().unwrap();
+        std::fs::write(path.join(DATA_FILE_NAME), []).unwrap();
+
+        let held = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path.join(DATA_FILE_NAME))
+            .unwrap();
+        held.try_lock().unwrap();
+
+        assert!(matches!(
+            dir.open(true),
+            Err(DatabaseError::DatabaseAlreadyOpen)
+        ));
+        assert!(path.join(DATA_FILE_NAME).is_file());
+
+        // ... and once it is let go, the empty file is wreckage again
+        held.unlock().unwrap();
+        drop(held);
+        dir.open(true).unwrap().0.close().unwrap();
     }
 
     #[test]

--- a/src/multiprocess/locks.rs
+++ b/src/multiprocess/locks.rs
@@ -1,0 +1,490 @@
+//! The files that make up a multi-process database directory, and the lock that excludes other
+//! processes from it.
+//!
+//! Everything in here uses only `std::fs` file operations and the advisory file locks exposed by
+//! `std::fs::File`. See `docs/design.md` for the protocol these files implement.
+
+use crate::tree_store::file_backend::FileBackend;
+use crate::{DatabaseError, StorageBackend, StorageError};
+use std::fs::{File, OpenOptions, TryLockError};
+use std::io;
+use std::io::{ErrorKind, Read, Write};
+use std::path::{Path, PathBuf};
+
+const DATA_FILE_NAME: &str = "data.redb";
+const WRITE_LOCK_FILE_NAME: &str = "write.lock";
+const METADATA_FILE_NAME: &str = "metadata";
+const METADATA_TMP_FILE_NAME: &str = "metadata.tmp";
+
+// The ASCII letters 'redbMP' followed by the same PNG-inspired tail as the database file's own
+// magic number, for the same reasons.
+const MAGIC: [u8; 11] = [
+    b'r', b'e', b'd', b'b', b'M', b'P', 0x1A, 0x0A, 0xA9, 0x0D, 0x0A,
+];
+const FORMAT_VERSION: u8 = 1;
+/// A single process owns `write.lock` for as long as it has the database open.
+const WRITER_MODE_SINGLE: u8 = 1;
+const METADATA_LEN: usize = 13;
+
+/// A multi-process database cannot be safe without file locks, so unlike [`crate::Database`] it
+/// refuses to open on a platform that lacks them.
+fn lock_unsupported(err: io::Error) -> DatabaseError {
+    if err.kind() == ErrorKind::Unsupported {
+        return StorageError::Io(io::Error::new(
+            ErrorKind::Unsupported,
+            "file locking is not supported on this platform, so a multi-process database cannot \
+             be opened safely",
+        ))
+        .into();
+    }
+    StorageError::Io(err).into()
+}
+
+fn open_or_create(path: &Path) -> Result<File, io::Error> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+}
+
+/// Flushes a directory itself, so that an entry a rename just created is durable. Best-effort
+/// about a directory this process cannot open: flushing needs read permission, and nothing else
+/// here does.
+#[cfg(unix)]
+fn sync_dir(root: &Path) -> Result<(), DatabaseError> {
+    let dir = match File::open(root) {
+        Ok(dir) => dir,
+        Err(err) if err.kind() == ErrorKind::PermissionDenied => return Ok(()),
+        Err(err) => return Err(StorageError::Io(err).into()),
+    };
+    dir.sync_all().map_err(StorageError::Io)?;
+
+    Ok(())
+}
+
+/// `std` exposes no directory handle to sync off Unix, and no way to make a rename write-through.
+#[cfg(not(unix))]
+fn sync_dir(_root: &Path) -> Result<(), DatabaseError> {
+    Ok(())
+}
+
+/// The directory a path lives in, as something openable. `Path::parent` gives an empty path for a
+/// bare relative name, which is not a directory anything can open.
+fn parent_of(path: &Path) -> PathBuf {
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+        _ => PathBuf::from("."),
+    }
+}
+
+/// The deepest ancestor of `path` that exists, canonicalized, before anything is created.
+fn deepest_existing_ancestor(path: &Path) -> Option<PathBuf> {
+    let mut current = parent_of(path);
+    loop {
+        if let Ok(real) = std::fs::canonicalize(&current) {
+            return Some(real);
+        }
+        let next = parent_of(&current);
+        if next == current {
+            return None;
+        }
+        current = next;
+    }
+}
+
+/// Flushes the directory entries from the database directory's parent up to and including
+/// `preexisting`, so that a crash cannot drop a freshly made ancestor while keeping the synced
+/// entries below it.
+fn sync_ancestors(root: &Path, preexisting: Option<&Path>) -> Result<(), DatabaseError> {
+    // Canonicalized first: `Path::parent` is purely lexical, so for a path ending in `..` it names
+    // a child of the real directory rather than its parent, and the fsync would flush the wrong one
+    let root = std::fs::canonicalize(root).map_err(StorageError::Io)?;
+    let mut current = parent_of(&root);
+    loop {
+        sync_dir(&current)?;
+        if Some(current.as_path()) == preexisting {
+            return Ok(());
+        }
+        let next = parent_of(&current);
+        if next == current {
+            return Ok(());
+        }
+        current = next;
+    }
+}
+
+/// The paths that make up a multi-process database directory.
+pub(super) struct DatabaseDir {
+    root: PathBuf,
+}
+
+impl DatabaseDir {
+    pub(super) fn new(root: impl AsRef<Path>) -> Self {
+        Self {
+            root: root.as_ref().to_path_buf(),
+        }
+    }
+
+    fn data_file(&self) -> PathBuf {
+        self.root.join(DATA_FILE_NAME)
+    }
+
+    fn write_lock_file(&self) -> PathBuf {
+        self.root.join(WRITE_LOCK_FILE_NAME)
+    }
+
+    fn metadata_file(&self) -> PathBuf {
+        self.root.join(METADATA_FILE_NAME)
+    }
+
+    fn metadata_tmp_file(&self) -> PathBuf {
+        self.root.join(METADATA_TMP_FILE_NAME)
+    }
+
+    /// Takes the write lock, which excludes every other process from the database. Taken before
+    /// anything in the directory is read or written, so the holder has the directory to itself.
+    ///
+    /// Only `create()` makes the file, and nothing ever unlinks one: another process may be
+    /// waiting on the lock on that same file, and unlinking would let a third process lock a
+    /// fresh `write.lock` while the second holds the old inode.
+    fn acquire_write_lock(&self, create: bool) -> Result<File, DatabaseError> {
+        let path = self.write_lock_file();
+        let file = if create {
+            open_or_create(&path)
+        } else {
+            OpenOptions::new().read(true).write(true).open(&path)
+        }
+        .map_err(|err| {
+            if err.kind() == ErrorKind::NotFound {
+                StorageError::Io(io::Error::new(
+                    ErrorKind::NotFound,
+                    "not a multi-process database directory",
+                ))
+            } else {
+                StorageError::Io(err)
+            }
+        })?;
+
+        match file.try_lock() {
+            Ok(()) => Ok(file),
+            Err(TryLockError::WouldBlock) => Err(DatabaseError::DatabaseAlreadyOpen),
+            Err(TryLockError::Error(err)) => Err(lock_unsupported(err)),
+        }
+    }
+
+    /// Opens the directory, creating it if `create` is set, and returns a backend for the database
+    /// file that holds the write lock for as long as the database is open.
+    ///
+    /// A directory being created is not marked as one of these yet -- the caller does that with
+    /// [`Self::write_metadata_if_missing`], once the database file has turned out to be usable.
+    pub(super) fn open(&self, create: bool) -> Result<Box<dyn StorageBackend>, DatabaseError> {
+        if create {
+            // The deepest ancestor that already exists bounds what create_dir_all makes; every
+            // entry from the database directory up to there needs its own flush below
+            let preexisting = deepest_existing_ancestor(&self.root);
+            std::fs::create_dir_all(&self.root).map_err(StorageError::Io)?;
+            // Syncing entries inside a directory whose own entry was never flushed loses the lot.
+            // On every create(): finding the directory already there says nothing about whether
+            // anyone flushed it, and the lock lives inside it, so it cannot cover this window --
+            // and a path of freshly made ancestors needs each one flushed, bottom-up, or a crash
+            // could drop the whole subtree by losing one entry higher up
+            sync_ancestors(&self.root, preexisting.as_deref())?;
+        } else if !self.root.is_dir() {
+            return Err(StorageError::Io(io::Error::new(
+                ErrorKind::NotFound,
+                "no such multi-process database directory",
+            ))
+            .into());
+        }
+
+        let write_lock = self.acquire_write_lock(create)?;
+        self.read_metadata(create)?;
+
+        let data = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(create)
+            .truncate(false)
+            .open(self.data_file())
+            .map_err(StorageError::Io)?;
+        // The ordinary exclusive lock, the same one a Database takes: a process that reaches past
+        // the directory and opens this file directly is not looking at the write lock, so the file
+        // needs a lock of its own. Exclusive rather than shared, because nothing coordinates a
+        // reader that attaches this way with the pages this process frees
+        let data = FileBackend::new(data)?;
+
+        Ok(Box::new(DirectoryBackend { data, write_lock }))
+    }
+
+    /// Writes the marker that says this directory holds a multi-process database. Called only once
+    /// the database file has been initialized, so a failed `create()` never leaves a marker.
+    ///
+    /// Written under a temporary name and renamed into place, so the marker is either absent or
+    /// complete: a half-written one would be indistinguishable from a foreign file, which
+    /// [`Self::read_metadata`] refuses, and the directory would be wedged.
+    fn write_metadata(&self) -> Result<(), DatabaseError> {
+        let mut contents = [0u8; METADATA_LEN];
+        contents[0..11].copy_from_slice(&MAGIC);
+        contents[11] = FORMAT_VERSION;
+        contents[12] = WRITER_MODE_SINGLE;
+
+        let tmp = self.metadata_tmp_file();
+        let mut file = File::create(&tmp).map_err(StorageError::Io)?;
+        file.write_all(&contents).map_err(StorageError::Io)?;
+        file.sync_all().map_err(StorageError::Io)?;
+        drop(file);
+        std::fs::rename(&tmp, self.metadata_file()).map_err(StorageError::Io)?;
+        sync_dir(&self.root)?;
+
+        Ok(())
+    }
+
+    /// Writes the marker only if the directory does not already carry one. One that is there was
+    /// validated by [`Self::read_metadata`] on the way in, so it is byte-for-byte what would be
+    /// written.
+    pub(super) fn write_metadata_if_missing(&self) -> Result<(), DatabaseError> {
+        if self.metadata_file().exists() {
+            // Validated here rather than assumed: the write lock keeps redb out, but the claim
+            // that an existing marker is byte-for-byte what would be written has to survive
+            // whatever else was pointed at the directory
+            self.read_metadata(false)?;
+            // This call may still have recreated the lock file or the database file after a crash
+            // lost their entries, and write_metadata() is where the directory would otherwise be
+            // flushed
+            return sync_dir(&self.root);
+        }
+
+        self.write_metadata()
+    }
+
+    /// Takes the shared lock on `metadata` that every process holds for as long as it has the
+    /// database open. A future version that changes the directory's format will take this lock
+    /// exclusively, so that it upgrades only once nothing is using the database.
+    pub(super) fn lock_metadata_shared(&self) -> Result<File, DatabaseError> {
+        let file = File::open(self.metadata_file()).map_err(StorageError::Io)?;
+        file.lock_shared().map_err(lock_unsupported)?;
+        Ok(file)
+    }
+
+    /// Checks that this directory holds a multi-process database, tolerating a missing marker when
+    /// one is being created. A directory holding some other `metadata` file is refused rather than
+    /// taken over, even by `create()`: overwriting it would be a destructive way to report a
+    /// mistyped path. The caller must hold the write lock.
+    fn read_metadata(&self, create: bool) -> Result<(), DatabaseError> {
+        let file = match File::open(self.metadata_file()) {
+            Ok(file) => file,
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                // Opening follows symlinks, so NotFound covers a dangling one as well as a truly
+                // absent marker. The name being taken at all -- by anything -- means the
+                // directory is not redb's to mark
+                if std::fs::symlink_metadata(self.metadata_file()).is_ok() {
+                    return Err(StorageError::Io(io::Error::new(
+                        ErrorKind::InvalidData,
+                        "not a multi-process database directory",
+                    ))
+                    .into());
+                }
+                if !create {
+                    return Err(StorageError::Io(io::Error::new(
+                        ErrorKind::NotFound,
+                        "not a multi-process database directory",
+                    ))
+                    .into());
+                }
+                return Ok(());
+            }
+            Err(err) => return Err(StorageError::Io(err).into()),
+        };
+
+        // Bounded read: a mistyped path can point at a `metadata` of any size, and one byte past
+        // the marker's length is enough to reject it
+        let mut bytes = Vec::with_capacity(METADATA_LEN + 1);
+        file.take((METADATA_LEN + 1) as u64)
+            .read_to_end(&mut bytes)
+            .map_err(StorageError::Io)?;
+
+        if bytes.len() != METADATA_LEN || bytes[0..11] != MAGIC {
+            return Err(StorageError::Io(io::Error::new(
+                ErrorKind::InvalidData,
+                "not a multi-process database directory",
+            ))
+            .into());
+        }
+        let version = bytes[11];
+        if version != FORMAT_VERSION {
+            return Err(StorageError::Io(io::Error::new(
+                ErrorKind::InvalidData,
+                format!("unsupported multi-process database version: {version}"),
+            ))
+            .into());
+        }
+        let mode = bytes[12];
+        if mode != WRITER_MODE_SINGLE {
+            return Err(StorageError::Io(io::Error::new(
+                ErrorKind::InvalidData,
+                format!("unsupported writer mode: {mode}"),
+            ))
+            .into());
+        }
+
+        Ok(())
+    }
+}
+
+/// The database file, plus the write lock that keeps other processes out of its directory.
+///
+/// The lock is held here rather than alongside the [`crate::Database`] because a live write
+/// transaction keeps the database open past the point where the `Database` is dropped: tied to the
+/// backend, the lock lasts exactly as long as the open file, released by `close()`.
+#[derive(Debug)]
+struct DirectoryBackend {
+    data: FileBackend,
+    write_lock: File,
+}
+
+impl StorageBackend for DirectoryBackend {
+    fn len(&self) -> Result<u64, io::Error> {
+        self.data.len()
+    }
+
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), io::Error> {
+        self.data.read(offset, out)
+    }
+
+    fn set_len(&self, len: u64) -> Result<(), io::Error> {
+        self.data.set_len(len)
+    }
+
+    fn sync_data(&self) -> Result<(), io::Error> {
+        self.data.sync_data()
+    }
+
+    fn write(&self, offset: u64, data: &[u8]) -> Result<(), io::Error> {
+        self.data.write(offset, data)
+    }
+
+    fn close(&self) -> Result<(), io::Error> {
+        // Both run: a file that failed to close must not also leave the directory locked against
+        // every other process
+        let closed = self.data.close();
+        let unlocked = self.write_lock.unlock();
+
+        closed.and(unlocked)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// The whole create sequence, which is split between here and the caller: the marker is
+    /// written only once [`crate::Database`] has accepted the database file. These tests are about
+    /// the lock and the marker rather than the database, so they stand in for that middle step by
+    /// doing nothing.
+    fn create(dir: &DatabaseDir) -> Box<dyn StorageBackend> {
+        let backend = dir.open(true).unwrap();
+        dir.write_metadata_if_missing().unwrap();
+        backend
+    }
+
+    #[test]
+    fn the_write_lock_excludes_other_handles() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = DatabaseDir::new(tmpdir.path().join("db"));
+
+        let first = create(&dir);
+        assert!(matches!(
+            dir.open(false),
+            Err(DatabaseError::DatabaseAlreadyOpen)
+        ));
+
+        // Closing the backend is what releases the lock, since that is when redb has finished
+        // with the file
+        first.close().unwrap();
+        let _second = dir.open(false).unwrap();
+    }
+
+    #[test]
+    fn a_directory_without_the_marker_is_not_a_database() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        std::fs::create_dir(&path).unwrap();
+        // A lock file on its own is not enough -- the marker is what says the directory is one of
+        // these
+        std::fs::write(path.join(WRITE_LOCK_FILE_NAME), []).unwrap();
+        let dir = DatabaseDir::new(&path);
+        assert!(dir.open(false).is_err());
+
+        // An empty file where the marker should be is rejected too, rather than being read as a
+        // database with a zero version
+        std::fs::write(path.join(METADATA_FILE_NAME), []).unwrap();
+        assert!(dir.open(false).is_err());
+    }
+
+    /// A `create()` that died while writing the marker leaves the partial copy under the temporary
+    /// name and no marker at all, which the next `create()` finishes rather than tripping over.
+    #[test]
+    fn a_marker_that_never_landed_is_written_again() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        let dir = DatabaseDir::new(&path);
+        create(&dir).close().unwrap();
+
+        std::fs::remove_file(path.join(METADATA_FILE_NAME)).unwrap();
+        std::fs::write(path.join(METADATA_TMP_FILE_NAME), &MAGIC[0..4]).unwrap();
+
+        create(&dir).close().unwrap();
+        assert_eq!(
+            METADATA_LEN,
+            std::fs::read(path.join(METADATA_FILE_NAME)).unwrap().len()
+        );
+    }
+
+    /// Because the marker is never left half-written, a `metadata` file that is not a marker
+    /// belongs to something else, and `create()` must refuse rather than overwrite it.
+    #[test]
+    fn a_directory_belonging_to_something_else_is_left_alone() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        std::fs::create_dir(&path).unwrap();
+        std::fs::write(path.join(METADATA_FILE_NAME), b"someone else's").unwrap();
+
+        assert!(DatabaseDir::new(&path).open(true).is_err());
+        assert_eq!(
+            b"someone else's",
+            &std::fs::read(path.join(METADATA_FILE_NAME)).unwrap()[..]
+        );
+    }
+
+    #[test]
+    fn a_marker_from_a_later_version_is_rejected() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        let dir = DatabaseDir::new(&path);
+        create(&dir).close().unwrap();
+
+        let mut contents = [0u8; METADATA_LEN];
+        contents[0..11].copy_from_slice(&MAGIC);
+        contents[11] = FORMAT_VERSION + 1;
+        contents[12] = WRITER_MODE_SINGLE;
+        std::fs::write(path.join(METADATA_FILE_NAME), contents).unwrap();
+        assert!(dir.open(false).is_err());
+    }
+
+    #[test]
+    fn a_marker_with_an_unknown_writer_mode_is_rejected() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        let dir = DatabaseDir::new(&path);
+        create(&dir).close().unwrap();
+
+        let mut contents = [0u8; METADATA_LEN];
+        contents[0..11].copy_from_slice(&MAGIC);
+        contents[11] = FORMAT_VERSION;
+        contents[12] = WRITER_MODE_SINGLE + 1;
+        std::fs::write(path.join(METADATA_FILE_NAME), contents).unwrap();
+        assert!(dir.open(false).is_err());
+    }
+}

--- a/src/multiprocess/locks.rs
+++ b/src/multiprocess/locks.rs
@@ -4,12 +4,13 @@
 //! Everything in here uses only `std::fs` file operations and the advisory file locks exposed by
 //! `std::fs::File`. See `docs/design.md` for the protocol these files implement.
 
-use crate::tree_store::MAGICNUMBER;
-use crate::tree_store::file_backend::FileBackend;
-use crate::{DatabaseError, StorageBackend, StorageError};
+use crate::tree_store::file_backend::{FileBackend, FileLockKind};
+use crate::tree_store::{DB_HEADER_SIZE, MAGICNUMBER, xxh3_checksum};
+use crate::{DatabaseError, Result, StorageBackend, StorageError};
+use alloc::vec::Vec;
 use std::fs::{File, OpenOptions, TryLockError};
 use std::io;
-use std::io::{ErrorKind, Read, Write};
+use std::io::{ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 const DATA_FILE_NAME: &str = "data.redb";
@@ -17,6 +18,9 @@ const WRITE_LOCK_FILE_NAME: &str = "write.lock";
 const METADATA_FILE_NAME: &str = "metadata";
 const METADATA_TMP_FILE_NAME: &str = "metadata.tmp";
 const DATA_TMP_FILE_NAME: &str = "data.redb.tmp";
+const REGISTRY_FILE_NAME: &str = "registry.lock";
+const EXTENDED_HEADER_FILE_NAME: &str = "extended-header";
+const PINNED_DIR_NAME: &str = "txn";
 
 // The ASCII letters 'redbMP' followed by the same PNG-inspired tail as the database file's own
 // magic number, for the same reasons.
@@ -26,6 +30,8 @@ const MAGIC: [u8; 11] = [
 const FORMAT_VERSION: u8 = 1;
 /// A single process owns `write.lock` for as long as it has the database open.
 const WRITER_MODE_SINGLE: u8 = 1;
+/// `write.lock` is taken per write transaction, so any process may write.
+const WRITER_MODE_MULTI: u8 = 2;
 const METADATA_LEN: usize = 13;
 
 /// A multi-process database cannot be safe without file locks, so unlike [`crate::Database`] it
@@ -42,15 +48,24 @@ fn lock_unsupported(err: io::Error) -> DatabaseError {
     StorageError::Io(err).into()
 }
 
+fn open_or_create(path: &Path) -> Result<File, io::Error> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+}
+
 /// Flushes a directory itself, so that an entry a rename just created is durable. Best-effort
 /// about a directory this process cannot open: flushing needs read permission, and nothing else
 /// here does.
 #[cfg(unix)]
-fn sync_dir(root: &Path) -> Result<(), DatabaseError> {
+fn sync_dir(root: &Path) -> Result<()> {
     let dir = match File::open(root) {
         Ok(dir) => dir,
         Err(err) if err.kind() == ErrorKind::PermissionDenied => return Ok(()),
-        Err(err) => return Err(StorageError::Io(err).into()),
+        Err(err) => return Err(StorageError::Io(err)),
     };
     dir.sync_all().map_err(StorageError::Io)?;
 
@@ -59,7 +74,7 @@ fn sync_dir(root: &Path) -> Result<(), DatabaseError> {
 
 /// `std` exposes no directory handle to sync off Unix, and no way to make a rename write-through.
 #[cfg(not(unix))]
-fn sync_dir(_root: &Path) -> Result<(), DatabaseError> {
+fn sync_dir(_root: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -138,20 +153,19 @@ fn mark_lock_abandoned(lock: &File) {
 /// here traverse symlinks and would write through them, and a FIFO blocks rather than fails. A
 /// missing file is fine. Best-effort -- the entry can be replaced between this check and the open,
 /// and `std` does not expose `O_NOFOLLOW` portably.
-fn require_regular_file(path: &Path) -> Result<(), DatabaseError> {
+fn require_regular_file(path: &Path) -> Result<()> {
     match std::fs::symlink_metadata(path) {
         Ok(metadata) if metadata.is_file() => Ok(()),
         Ok(_) => Err(StorageError::Io(io::Error::new(
             ErrorKind::InvalidData,
             "a multi-process database directory may hold only ordinary files",
-        ))
-        .into()),
+        ))),
         Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(StorageError::Io(err).into()),
+        Err(err) => Err(StorageError::Io(err)),
     }
 }
 
-/// Which name [`DatabaseDir::open`] put the database file under. Carried from the open to
+/// Which name [`DatabaseDir::open_data`] put the database file under. Carried from the open to
 /// [`DatabaseDir::promote_data`] rather than worked out again from disk: a temporary file is this
 /// call's own only if this call made it, and nothing about the file itself says so.
 #[derive(Clone, Copy)]
@@ -162,16 +176,98 @@ pub(super) enum DataLocation {
     Temporary,
 }
 
+/// Which processes may write to a multi-process database.
+///
+/// Fixed when the database is created and recorded in the directory's `metadata` file, so that
+/// every process which opens it agrees on the protocol.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum WriterMode {
+    /// Only one process may open the database for writing. That process holds the write lock for
+    /// as long as it is open, so its in-memory state is always authoritative and its own
+    /// transactions run at full single-process speed. Any number of other processes may open the
+    /// database read-only.
+    ///
+    /// A second process opening it for writing fails with
+    /// [`DatabaseError::DatabaseAlreadyOpen`](crate::DatabaseError::DatabaseAlreadyOpen).
+    SingleWriterProcess,
+    /// Any number of processes may open the database for writing, but only one write transaction
+    /// may be in progress at a time: [`begin_write`](super::MultiProcessDatabase::begin_write)
+    /// blocks until the process holding the write lock finishes.
+    ///
+    /// Every commit is a quick-repair commit, so that the next process to take the write lock can
+    /// load the allocator state from the file instead of rebuilding it.
+    MultiWriterProcess,
+}
+
+impl WriterMode {
+    fn to_byte(self) -> u8 {
+        match self {
+            WriterMode::SingleWriterProcess => WRITER_MODE_SINGLE,
+            WriterMode::MultiWriterProcess => WRITER_MODE_MULTI,
+        }
+    }
+
+    fn from_byte(value: u8) -> Option<Self> {
+        match value {
+            WRITER_MODE_SINGLE => Some(WriterMode::SingleWriterProcess),
+            WRITER_MODE_MULTI => Some(WriterMode::MultiWriterProcess),
+            _ => None,
+        }
+    }
+}
+
+fn lock_error(err: TryLockError) -> StorageError {
+    match err {
+        TryLockError::WouldBlock => StorageError::Io(io::Error::new(
+            ErrorKind::WouldBlock,
+            "a lock this database needs is held by another process",
+        )),
+        TryLockError::Error(err) => unsupported_lock(err),
+    }
+}
+
+fn unsupported_lock(err: io::Error) -> StorageError {
+    match lock_unsupported(err) {
+        DatabaseError::Storage(err) => err,
+        other => StorageError::Io(io::Error::other(other.to_string())),
+    }
+}
+
+fn read_at(file: &File, offset: u64, out: &mut [u8]) -> Result<()> {
+    // Seek-and-read rather than the platform positional APIs, to stay portable; the caller holds a
+    // lock that makes the cursor single threaded
+    let mut handle = file;
+    handle
+        .seek(SeekFrom::Start(offset))
+        .map_err(StorageError::Io)?;
+    handle.read_exact(out).map_err(StorageError::Io)
+}
+
+fn write_at(file: &File, offset: u64, data: &[u8]) -> Result<()> {
+    let mut handle = file;
+    handle
+        .seek(SeekFrom::Start(offset))
+        .map_err(StorageError::Io)?;
+    handle.write_all(data).map_err(StorageError::Io)
+}
+
 /// The paths that make up a multi-process database directory.
-pub(super) struct DatabaseDir {
+#[derive(Debug, Clone)]
+pub(crate) struct DatabaseDir {
     root: PathBuf,
 }
 
 impl DatabaseDir {
     /// Every name `create()` writes after taking the write lock. `metadata` is not among them: the
     /// check that uses this runs only where there is no marker.
-    const WRITTEN_UNDER_THE_LOCK: &'static [&'static str] =
-        &[DATA_FILE_NAME, DATA_TMP_FILE_NAME, METADATA_TMP_FILE_NAME];
+    const WRITTEN_UNDER_THE_LOCK: &'static [&'static str] = &[
+        DATA_FILE_NAME,
+        DATA_TMP_FILE_NAME,
+        METADATA_TMP_FILE_NAME,
+        REGISTRY_FILE_NAME,
+        EXTENDED_HEADER_FILE_NAME,
+        PINNED_DIR_NAME,
+    ];
 
     pub(super) fn new(root: impl AsRef<Path>) -> Self {
         Self {
@@ -179,7 +275,7 @@ impl DatabaseDir {
         }
     }
 
-    fn data_file(&self) -> PathBuf {
+    pub(super) fn data_file(&self) -> PathBuf {
         self.root.join(DATA_FILE_NAME)
     }
 
@@ -199,83 +295,86 @@ impl DatabaseDir {
         self.root.join(DATA_TMP_FILE_NAME)
     }
 
-    /// Takes the write lock, which excludes every other process from the database, and reports
-    /// whether this call created the file. Taken before anything in the directory is read or
-    /// written, so the holder has the directory to itself.
-    ///
-    /// Only `create()` makes the file, and nothing ever unlinks one: another process may be
-    /// waiting on the lock on that same file, and unlinking would let a third process lock a
-    /// fresh `write.lock` while the second holds the old inode. Creation is decided by the open
-    /// itself rather than by a look beforehand, since a snapshot can go stale while another
-    /// `create()` runs to completion, and what the fresh-lock rule may refuse turns on who
-    /// really made the file.
-    fn acquire_write_lock(&self, create: bool) -> Result<(File, bool), DatabaseError> {
-        let path = self.write_lock_file();
-        // Otherwise the create below would follow a symlink left under this name, and the
-        // lock would be taken on a file whose identity was never checked
-        require_regular_file(&path)?;
-        let open_existing = || {
-            OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(&path)
-                .map_err(|err| {
-                    if err.kind() == ErrorKind::NotFound {
-                        StorageError::Io(io::Error::new(
-                            ErrorKind::NotFound,
-                            "not a multi-process database directory",
-                        ))
-                    } else {
-                        StorageError::Io(err)
-                    }
-                })
-        };
-        let (file, created) = if create {
-            match OpenOptions::new()
-                .read(true)
-                .write(true)
-                .create_new(true)
-                .open(&path)
-            {
-                Ok(file) => (file, true),
-                Err(err) if err.kind() == ErrorKind::AlreadyExists => (open_existing()?, false),
-                Err(err) => return Err(StorageError::Io(err).into()),
-            }
-        } else {
-            (open_existing()?, false)
-        };
+    fn registry_file(&self) -> PathBuf {
+        self.root.join(REGISTRY_FILE_NAME)
+    }
 
-        match file.try_lock() {
-            Ok(()) => {}
-            Err(TryLockError::WouldBlock) => return Err(DatabaseError::DatabaseAlreadyOpen),
-            Err(TryLockError::Error(err)) => return Err(lock_unsupported(err)),
-        }
-        if !created {
-            // Re-read through the held lock: the preflight's snapshot can go stale, and a lock
-            // file that gained contents -- an abandonment mark included -- or stopped being a
-            // regular file vouches for nothing
-            let metadata = file.metadata().map_err(StorageError::Io)?;
-            if !metadata.is_file() || metadata.len() > 0 {
+    fn extended_header_file(&self) -> PathBuf {
+        self.root.join(EXTENDED_HEADER_FILE_NAME)
+    }
+
+    fn pinned_dir(&self) -> PathBuf {
+        self.root.join(PINNED_DIR_NAME)
+    }
+
+    /// The file whose *name* is `id`. Nothing is ever read from or written to it: the name carries
+    /// the whole of the data, and the lock on it says whether anyone still needs that transaction.
+    fn pinned_file(&self, id: u64) -> PathBuf {
+        self.pinned_dir().join(id.to_string())
+    }
+
+    /// Creates the files the protocol coordinates through: the `txn/` directory, the empty
+    /// `registry.lock`, and `extended-header`. Idempotent, and safe without the write lock:
+    /// everything here is create-if-absent, and the extended header's initial zeroes read as
+    /// corrupt, which every reader of it handles.
+    pub(super) fn init_protocol_files(&self) -> Result<()> {
+        std::fs::create_dir_all(self.pinned_dir()).map_err(StorageError::Io)?;
+        require_regular_file(&self.registry_file())?;
+        drop(open_or_create(&self.registry_file()).map_err(StorageError::Io)?);
+        require_regular_file(&self.extended_header_file())?;
+        drop(open_or_create(&self.extended_header_file()).map_err(StorageError::Io)?);
+        sync_dir(&self.root)?;
+
+        Ok(())
+    }
+
+    /// The mode an existing database was created with, from its `metadata` file.
+    ///
+    /// Safe to read without any lock: the marker is written once, by rename, and never changed.
+    pub(super) fn mode(&self) -> Result<WriterMode, DatabaseError> {
+        self.read_metadata(false).map(|mode| {
+            mode.expect("read_metadata only reports a missing marker when create is set")
+        })
+    }
+
+    /// The accepting pass for a directory whose lock file this call has just created. A
+    /// pre-existing `write.lock` vouches for redb's other names; a fresh one vouches for nothing,
+    /// so anything already under them arrived while the directory was being claimed -- another
+    /// process reaching past the directory API -- and adopting it would hand this handle a file
+    /// something else is using.
+    pub(super) fn reject_files_beside_a_fresh_lock(&self) -> Result<(), DatabaseError> {
+        let claimed = Self::WRITTEN_UNDER_THE_LOCK.iter().copied();
+        for name in claimed.chain([METADATA_FILE_NAME]) {
+            if occupied(&self.root.join(name))? {
                 return Err(StorageError::Io(io::Error::new(
-                    ErrorKind::InvalidData,
-                    "write.lock is not a multi-process database's lock file",
+                    ErrorKind::AlreadyExists,
+                    "another process put files into the directory while it was being claimed",
                 ))
                 .into());
             }
         }
-        Ok((file, created))
+
+        Ok(())
     }
 
-    /// Opens the directory, creating it if `create` is set, and returns a backend for the database
-    /// file that holds the write lock for as long as the database is open, along with which of the
-    /// two names that file is under.
+    /// Takes the shared lock on `metadata` that every process holds for as long as it has the
+    /// database open. A future version that changes the directory's format will take this lock
+    /// exclusively, so that it upgrades only once nothing is using the database.
+    pub(super) fn lock_metadata_shared(&self) -> Result<File> {
+        require_regular_file(&self.metadata_file())?;
+        let file = File::open(self.metadata_file()).map_err(StorageError::Io)?;
+        file.lock_shared().map_err(unsupported_lock)?;
+        Ok(file)
+    }
+
+    /// Validates the directory and creates it if `create` is set, up to but not including taking
+    /// the write lock. Split from [`Self::open_data`] because the caller decides how the write
+    /// lock is taken, and this is everything that happens before it.
     ///
-    /// A directory being created is not marked as one of these yet -- the caller does that with
-    /// [`Self::write_metadata_if_missing`], once the database file has turned out to be usable.
-    pub(super) fn open(
-        &self,
-        create: bool,
-    ) -> Result<(Box<dyn StorageBackend>, DataLocation), DatabaseError> {
+    /// Returns whether the marker was present during this pass, which only a `create` asks about:
+    /// a marker that was already here before the caller made a lock file is the one thing a fresh
+    /// lock does not have to vouch for.
+    pub(super) fn prepare(&self, create: bool) -> Result<bool, DatabaseError> {
         let mut marked_at_preflight = false;
         if create {
             // All checks run before the directory is touched, so a rejected create() leaves no
@@ -284,7 +383,7 @@ impl DatabaseDir {
             // the authoritative pass
             marked_at_preflight = occupied(&self.metadata_file())?;
             if marked_at_preflight {
-                self.read_metadata(create)?;
+                let _ = self.read_metadata(create)?;
             } else {
                 self.reject_unmarked_database()?;
                 self.reject_foreign_directory()?;
@@ -307,25 +406,29 @@ impl DatabaseDir {
             .into());
         }
 
-        let (write_lock, lock_created) = self.acquire_write_lock(create)?;
-        let mut fresh_claim = false;
+        Ok(marked_at_preflight)
+    }
+
+    /// Opens the database file, once the caller holds the write lock.
+    ///
+    /// The file is returned unlocked: every process needs it open at once, and `write.lock` and
+    /// the reader slots are what keep a page from being reused underneath one of them.
+    ///
+    /// `fresh_claim` says the caller created the lock file and found no marker, so the names
+    /// touched here were just required to be absent; anything under them now arrived while the
+    /// directory was being claimed, and is refused rather than adopted.
+    pub(super) fn open_data(
+        &self,
+        create: bool,
+        fresh_claim: bool,
+    ) -> Result<(File, DataLocation), DatabaseError> {
         if create {
             // The lock file's entry must be durable before anything else is written under these
             // names: its *absence* beside them is what says a directory is not this database's,
             // and a crash could otherwise keep `data.redb` while losing `write.lock`
             sync_dir(&self.root)?;
-            // A marker seen before the lock file was made marks a create() to finish -- a crash
-            // can lose the lock's entry while the marker survives -- and the fresh-lock rule has
-            // nothing to refuse. One that first appears after cannot be another create()'s, since
-            // finishing one needs the lock this call holds, so the rejecting pass below refuses
-            // it like every other name that arrives while the directory is being claimed
-            fresh_claim = lock_created && !marked_at_preflight;
-            if fresh_claim && let Err(err) = self.reject_files_beside_a_fresh_lock() {
-                mark_lock_abandoned(&write_lock);
-                return Err(err);
-            }
         }
-        self.read_metadata(create)?;
+        let _ = self.read_metadata(create)?;
 
         // A database being made for the first time is initialized under a temporary name and
         // renamed into place by `promote_data`, like the marker. A crash during initialization
@@ -339,7 +442,6 @@ impl DatabaseDir {
                 // The fresh-lock pass just required this name to be absent, so anything under it
                 // now arrived while the directory was being claimed, and is refused the same way
                 Ok(_) if fresh_claim => {
-                    mark_lock_abandoned(&write_lock);
                     return Err(StorageError::Io(io::Error::new(
                         ErrorKind::AlreadyExists,
                         "the database file appeared while the directory was being claimed",
@@ -401,7 +503,6 @@ impl DatabaseDir {
         let data = match options.open(path) {
             Ok(data) => data,
             Err(err) if fresh_claim && err.kind() == ErrorKind::AlreadyExists => {
-                mark_lock_abandoned(&write_lock);
                 return Err(StorageError::Io(io::Error::new(
                     ErrorKind::AlreadyExists,
                     "the database file appeared while the directory was being claimed",
@@ -410,24 +511,8 @@ impl DatabaseDir {
             }
             Err(err) => return Err(StorageError::Io(err).into()),
         };
-        // The ordinary exclusive lock, the same one a Database takes: a process that reaches past
-        // the directory and opens this file directly is not looking at the write lock, so the file
-        // needs a lock of its own. Exclusive rather than shared, because nothing coordinates a
-        // reader that attaches this way with the pages this process frees
-        let data = match FileBackend::new(data) {
-            Ok(data) => data,
-            Err(err) => {
-                // On a fresh claim the file was created exclusively just above, so failing to
-                // lock it means something took it in between -- and the lock file left empty
-                // would vouch, on the next create(), for whatever that something makes of it
-                if fresh_claim {
-                    mark_lock_abandoned(&write_lock);
-                }
-                return Err(err);
-            }
-        };
 
-        Ok((Box::new(DirectoryBackend { data, write_lock }), location))
+        Ok((data, location))
     }
 
     /// Moves a freshly initialized database file into place, if this call was the one that made
@@ -437,11 +522,10 @@ impl DatabaseDir {
     pub(super) fn promote_data(&self, location: DataLocation) -> Result<(), DatabaseError> {
         let tmp = self.data_tmp_file();
         if matches!(location, DataLocation::Final) {
-            // The database opened under its own name, so anything under the temporary one is the
-            // wreckage of an earlier attempt. Deleted here rather than on the way in, so a
-            // create() pointed somewhere by mistake fails without having deleted anything; and
-            // tidying only, so a failure is not the caller's problem -- what is left is inert.
-            // Except a finished database, which is never tidied away
+            // Anything under the temporary name is the wreckage of an earlier attempt. Deleted
+            // here rather than on the way in, so a create() pointed somewhere by mistake fails
+            // without having deleted anything; tidying only, so a failure is not the caller's
+            // problem. Except a finished database, which is never tidied away
             if matches!(self.reject_data_tmp_holding_a_database(), Ok(())) {
                 drop(self.discard_data_tmp());
             }
@@ -492,24 +576,6 @@ impl DatabaseDir {
         if matches!(held.try_lock(), Ok(())) {
             let _ = std::fs::remove_file(self.data_tmp_file());
         }
-    }
-
-    /// Writes the marker only if the directory does not already carry one. One that is there was
-    /// validated by [`Self::read_metadata`] on the way in, so it is byte-for-byte what would be
-    /// written.
-    pub(super) fn write_metadata_if_missing(&self) -> Result<(), DatabaseError> {
-        if occupied(&self.metadata_file())? {
-            // Validated here rather than assumed: the write lock keeps redb out, but the claim
-            // that an existing marker is byte-for-byte what would be written has to survive
-            // whatever else was pointed at the directory
-            self.read_metadata(false)?;
-            // This call may still have recreated the lock file or the database file after a crash
-            // lost their entries, and write_metadata() is where the directory would otherwise be
-            // flushed
-            return sync_dir(&self.root);
-        }
-
-        self.write_metadata()
     }
 
     /// Throws away a temporary database file left by an earlier attempt. Unlinks rather than
@@ -650,37 +716,17 @@ impl DatabaseDir {
         Ok(())
     }
 
-    /// The accepting pass for a directory whose lock file this call has just created. A
-    /// pre-existing `write.lock` vouches for redb's other names; a fresh one vouches for nothing,
-    /// so anything already under them arrived while the directory was being claimed -- another
-    /// process reaching past the directory API -- and adopting it would hand this handle a file
-    /// something else is using.
-    fn reject_files_beside_a_fresh_lock(&self) -> Result<(), DatabaseError> {
-        let claimed = Self::WRITTEN_UNDER_THE_LOCK.iter().copied();
-        for name in claimed.chain([METADATA_FILE_NAME]) {
-            if occupied(&self.root.join(name))? {
-                return Err(StorageError::Io(io::Error::new(
-                    ErrorKind::AlreadyExists,
-                    "another process put files into the directory while it was being claimed",
-                ))
-                .into());
-            }
-        }
-
-        Ok(())
-    }
-
     /// Writes the marker that says this directory holds a multi-process database. Called only once
     /// the database file has been initialized, so a failed `create()` never leaves a marker.
     ///
     /// Written under a temporary name and renamed into place, so the marker is either absent or
-    /// complete: a half-written one would be indistinguishable from a foreign file, which
-    /// [`Self::read_metadata`] refuses, and the directory would be wedged.
-    fn write_metadata(&self) -> Result<(), DatabaseError> {
+    /// complete and never in between: a half-written one is indistinguishable from a file that is
+    /// simply not ours, which [`Self::read_metadata`] refuses, and the directory would be wedged.
+    fn write_metadata(&self, mode: WriterMode) -> Result<(), DatabaseError> {
         let mut contents = [0u8; METADATA_LEN];
         contents[0..11].copy_from_slice(&MAGIC);
         contents[11] = FORMAT_VERSION;
-        contents[12] = WRITER_MODE_SINGLE;
+        contents[12] = mode.to_byte();
 
         let tmp = self.metadata_tmp_file();
         // Unlinked and created afresh rather than truncated in place, so a symlink or FIFO left
@@ -761,6 +807,34 @@ impl DatabaseDir {
         Ok(())
     }
 
+    /// Writes the marker only if the directory does not already carry one. One that is there was
+    /// validated by [`Self::read_metadata`] under the lock, so it is byte-for-byte what would be
+    /// written.
+    pub(super) fn write_metadata_if_missing(&self, mode: WriterMode) -> Result<(), DatabaseError> {
+        if occupied(&self.metadata_file())? {
+            // Validated here rather than assumed, and required to carry the mode being created:
+            // the claim that an existing marker is byte-for-byte what would be written has to
+            // survive whatever else was pointed at the directory, and one that validates but
+            // differs can only have arrived from outside while the directory was being claimed
+            let existing = self
+                .read_metadata(false)?
+                .expect("read_metadata only reports a missing marker when create is set");
+            if existing != mode {
+                return Err(StorageError::Io(io::Error::new(
+                    ErrorKind::AlreadyExists,
+                    "the marker appeared while the directory was being claimed",
+                ))
+                .into());
+            }
+            // This call may still have created other files, and write_metadata() is where the
+            // directory would otherwise be flushed
+            sync_dir(&self.root)?;
+            return Ok(());
+        }
+
+        self.write_metadata(mode)
+    }
+
     /// Refuses a directory that holds anything this database did not put there.
     ///
     /// Only consulted when there is no marker: a directory with one is this database's, and a
@@ -782,18 +856,27 @@ impl DatabaseDir {
         for entry in entries {
             let entry = entry.map_err(StorageError::Io)?;
             let name = entry.file_name();
-            let named_like_ours = [
-                DATA_FILE_NAME,
-                DATA_TMP_FILE_NAME,
-                WRITE_LOCK_FILE_NAME,
-                METADATA_FILE_NAME,
-                METADATA_TMP_FILE_NAME,
-            ]
-            .iter()
-            .any(|known| name == *known);
-            // `file_type()` reports the entry rather than what it points at, so a symlink wearing
-            // one of these names is caught instead of followed
-            let ours = named_like_ours && entry.file_type().map_err(StorageError::Io)?.is_file();
+            // The name is not enough: `file_type()` reports the entry rather than what it points
+            // at, so a symlink wearing one of these names is caught here instead of being followed
+            // and initialized over, somewhere outside this directory entirely
+            let file_type = entry.file_type().map_err(StorageError::Io)?;
+            let ours = if name == PINNED_DIR_NAME {
+                // The only name here that is a directory rather than a file
+                file_type.is_dir()
+            } else {
+                [
+                    DATA_FILE_NAME,
+                    DATA_TMP_FILE_NAME,
+                    WRITE_LOCK_FILE_NAME,
+                    METADATA_FILE_NAME,
+                    METADATA_TMP_FILE_NAME,
+                    REGISTRY_FILE_NAME,
+                    EXTENDED_HEADER_FILE_NAME,
+                ]
+                .iter()
+                .any(|known| name == *known)
+                    && file_type.is_file()
+            };
             if !ours {
                 return Err(StorageError::Io(io::Error::new(
                     ErrorKind::AlreadyExists,
@@ -807,20 +890,12 @@ impl DatabaseDir {
         Ok(())
     }
 
-    /// Takes the shared lock on `metadata` that every process holds for as long as it has the
-    /// database open. A future version that changes the directory's format will take this lock
-    /// exclusively, so that it upgrades only once nothing is using the database.
-    pub(super) fn lock_metadata_shared(&self) -> Result<File, DatabaseError> {
-        let file = File::open(self.metadata_file()).map_err(StorageError::Io)?;
-        file.lock_shared().map_err(lock_unsupported)?;
-        Ok(file)
-    }
-
     /// Checks that this directory holds a multi-process database, tolerating a missing marker when
-    /// one is being created. A directory holding some other `metadata` file is refused rather than
-    /// taken over, even by `create()`: overwriting it would be a destructive way to report a
-    /// mistyped path. The caller must hold the write lock.
-    fn read_metadata(&self, create: bool) -> Result<(), DatabaseError> {
+    /// one is being created, and returns the writer mode the marker records. `None` only ever
+    /// means "no marker yet, and `create` may write one". A directory holding some other
+    /// `metadata` file is refused rather than taken over, even by `create()`: overwriting it would
+    /// be a destructive way to report a mistyped path.
+    pub(super) fn read_metadata(&self, create: bool) -> Result<Option<WriterMode>, DatabaseError> {
         let path = self.metadata_file();
         require_regular_file(&path)?;
         let file = match File::open(&path) {
@@ -843,7 +918,8 @@ impl DatabaseDir {
                     ))
                     .into());
                 }
-                return self.reject_foreign_directory();
+                self.reject_foreign_directory()?;
+                return Ok(None);
             }
             Err(err) => return Err(StorageError::Io(err).into()),
         };
@@ -870,91 +946,647 @@ impl DatabaseDir {
             ))
             .into());
         }
-        let mode = bytes[12];
-        if mode != WRITER_MODE_SINGLE {
+        let Some(mode) = WriterMode::from_byte(bytes[12]) else {
             return Err(StorageError::Io(io::Error::new(
                 ErrorKind::InvalidData,
-                format!("unsupported writer mode: {mode}"),
+                format!("unsupported writer mode: {}", bytes[12]),
             ))
             .into());
-        }
+        };
 
-        Ok(())
+        Ok(Some(mode))
     }
 }
 
-/// The database file, plus the write lock that keeps other processes out of its directory.
+/// The lock on `registry.lock`, which guards cross-process access to `extended-header`, the `txn/`
+/// directory, and the header of `data.redb`: shared to read them, exclusive to write them.
 ///
-/// The lock is held here rather than alongside the [`crate::Database`] because a live write
-/// transaction keeps the database open past the point where the `Database` is dropped: tied to the
-/// backend, the lock lasts exactly as long as the open file, released by `close()`.
-#[derive(Debug)]
-struct DirectoryBackend {
-    data: FileBackend,
-    write_lock: File,
+/// The file itself is empty. Every acquisition opens its own file handle, because advisory locks
+/// belong to the open file description: with a handle per acquisition, any number of threads can
+/// hold the shared lock at once, and dropping one guard never releases another's lock.
+#[derive(Debug, Clone)]
+pub(crate) struct RegistryLock {
+    path: PathBuf,
 }
 
-impl StorageBackend for DirectoryBackend {
+impl RegistryLock {
+    pub(super) fn open(dir: &DatabaseDir) -> Self {
+        Self {
+            path: dir.registry_file(),
+        }
+    }
+
+    fn acquire(&self, exclusive: bool) -> Result<RegistryGuard> {
+        let file = open_or_create(&self.path).map_err(StorageError::Io)?;
+        if exclusive {
+            file.lock().map_err(unsupported_lock)?;
+        } else {
+            file.lock_shared().map_err(unsupported_lock)?;
+        }
+        Ok(RegistryGuard { file })
+    }
+
+    /// Blocks until every writer of the guarded state has finished. Held while reading the header
+    /// of `data.redb`, reading `extended-header`, or pinning a transaction in `txn/`.
+    pub(super) fn shared(&self) -> Result<RegistryGuard> {
+        self.acquire(false)
+    }
+
+    /// Blocks until every other process's reads and pins are complete. Held while writing the
+    /// header of `data.redb` or `extended-header`, or scanning `txn/`.
+    pub(super) fn exclusive(&self) -> Result<RegistryGuard> {
+        self.acquire(true)
+    }
+}
+
+/// A held registry lock. Dropping it releases the lock.
+pub(crate) struct RegistryGuard {
+    file: File,
+}
+
+impl Drop for RegistryGuard {
+    fn drop(&mut self) {
+        // Nothing can be done about a failure, and closing the handle releases the lock anyway;
+        // the explicit unlock only makes it prompt on platforms where the close is lazy about it
+        let _ = self.file.unlock();
+    }
+}
+
+/// `extended-header`: two slots of {transaction collection horizon, hash}, logically an extension
+/// of the commit slots in the header of `data.redb`. The active slot is the one the primary slot
+/// bit in that header selects.
+///
+/// The hash binds a horizon to the commit slot bytes it was written beside. There is no fsync of
+/// this file, so after a crash a slot can pair a stale horizon with a newer commit slot -- and the
+/// hash is how a reader notices, falling back to assuming the worst. The caller must hold the
+/// registry lock: shared to read, exclusive to write.
+pub(super) struct ExtendedHeader {
+    file: File,
+}
+
+/// 8 bytes of horizon, then 16 of hash.
+const EXTENDED_HEADER_SLOT_LEN: usize = 24;
+
+fn extended_header_hash(horizon: u64, commit_slot: &[u8]) -> u128 {
+    let mut bound = Vec::with_capacity(8 + commit_slot.len());
+    bound.extend_from_slice(&horizon.to_le_bytes());
+    bound.extend_from_slice(commit_slot);
+    xxh3_checksum(&bound)
+}
+
+impl ExtendedHeader {
+    pub(super) fn open(dir: &DatabaseDir) -> Result<Self> {
+        require_regular_file(&dir.extended_header_file())?;
+        Ok(Self {
+            file: open_or_create(&dir.extended_header_file()).map_err(StorageError::Io)?,
+        })
+    }
+
+    /// The horizon in `slot`, if the slot's hash matches `commit_slot` -- the corresponding commit
+    /// slot bytes exactly as the caller read them from `data.redb` under this same lock. `None`
+    /// means the slot is torn, stale, or never written, and the caller must assume a horizon of
+    /// its own choosing per the crash rules in `docs/design.md`.
+    pub(super) fn read_horizon(&self, slot: usize, commit_slot: &[u8]) -> Result<Option<u64>> {
+        let mut bytes = [0u8; EXTENDED_HEADER_SLOT_LEN];
+        let offset = (slot * EXTENDED_HEADER_SLOT_LEN) as u64;
+        if read_at(&self.file, offset, &mut bytes).is_err() {
+            // Too short to hold the slot, which is what a freshly created file looks like. Real
+            // I/O errors surface on the next write; misreading one as corruption costs a reread
+            // of the cache, not correctness
+            return Ok(None);
+        }
+        let horizon = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
+        let hash = u128::from_le_bytes(bytes[8..24].try_into().unwrap());
+        if hash != extended_header_hash(horizon, commit_slot) {
+            return Ok(None);
+        }
+        Ok(Some(horizon))
+    }
+
+    /// Writes `slot`, binding `horizon` to `commit_slot`. Not fsynced: a commit's flip does not
+    /// wait on this file, and the hash is what catches a write that never landed.
+    pub(super) fn write_horizon(&self, slot: usize, horizon: u64, commit_slot: &[u8]) -> Result {
+        let mut bytes = [0u8; EXTENDED_HEADER_SLOT_LEN];
+        bytes[0..8].copy_from_slice(&horizon.to_le_bytes());
+        bytes[8..24].copy_from_slice(&extended_header_hash(horizon, commit_slot).to_le_bytes());
+        write_at(&self.file, (slot * EXTENDED_HEADER_SLOT_LEN) as u64, &bytes)
+    }
+}
+
+/// This process's pin in the `txn/` directory, and the scan over everyone's.
+///
+/// A pinned transaction is a file in `txn/` whose *name* is the transaction id, held with a
+/// *shared* lock: every process reading that transaction holds the same file at once, and a writer
+/// fails to take it exclusively for as long as any of them does. Nothing is read from or written
+/// to those files -- the name is the whole of the data. That matters for more than tidiness: a
+/// lock is mandatory on some platforms, so a file another process holds locked cannot be read.
+///
+/// A process pins one file: the oldest transaction it still needs, which protects every newer one
+/// as well, since the scan stops at the lowest locked id.
+pub(super) struct TransactionPins {
+    dir: DatabaseDir,
+    /// The `txn/` file this process holds. Dropping it releases the lock; the file stays, and the
+    /// next writer to scan unlinks it once nobody holds it.
+    pinned: Option<File>,
+    /// The id `pinned` is named for, so that publishing the same value twice does no I/O
+    published: Option<u64>,
+}
+
+impl TransactionPins {
+    pub(super) fn new(dir: &DatabaseDir) -> Self {
+        Self {
+            dir: dir.clone(),
+            pinned: None,
+            published: None,
+        }
+    }
+
+    /// The transaction this process currently pins.
+    pub(super) fn published(&self) -> Option<u64> {
+        self.published
+    }
+
+    /// Pins the oldest transaction this process needs kept alive, or releases the pin. The caller
+    /// must hold the registry lock -- shared is enough: this only adds a file and takes a shared
+    /// lock on it. Releasing does not delete the file: only a writer that holds it exclusively
+    /// may, or a reader could lock a file that is already unlinked and pin nothing.
+    pub(super) fn publish(&mut self, pinned: Option<u64>) -> Result<()> {
+        if pinned == self.published {
+            return Ok(());
+        }
+        let held = if let Some(id) = pinned {
+            let file = open_or_create(&self.dir.pinned_file(id)).map_err(StorageError::Io)?;
+            file.lock_shared().map_err(unsupported_lock)?;
+            Some(file)
+        } else {
+            None
+        };
+        // Assigned rather than taken in two steps, so the new lock is held before the old one is
+        // dropped: a writer scanning in between sees this process at its older, more conservative
+        // id rather than not at all
+        self.pinned = held;
+        self.published = pinned;
+        Ok(())
+    }
+
+    /// The oldest transaction any process still needs, or `None` if nothing is pinned anywhere.
+    ///
+    /// Walks `txn/` from the lowest id up, unlinking every file it can take exclusively -- those
+    /// name transactions nobody is reading any more -- and stopping at the first it cannot, which
+    /// is therefore the oldest still in use. The caller must hold the registry lock exclusively,
+    /// so that no process is part way through pinning.
+    pub(super) fn scan_oldest(&self) -> Result<Option<u64>> {
+        let mut ids = Vec::new();
+        for entry in std::fs::read_dir(self.dir.pinned_dir()).map_err(StorageError::Io)? {
+            let entry = entry.map_err(StorageError::Io)?;
+            // The name is the whole of the data, so anything that does not parse as one is not
+            // ours and is left alone
+            if let Some(id) = entry
+                .file_name()
+                .to_str()
+                .and_then(|name| name.parse::<u64>().ok())
+            {
+                ids.push(id);
+            }
+        }
+        ids.sort_unstable();
+
+        for id in ids {
+            // Our own pin. Checked by id rather than trusted to the try-lock below, because on
+            // platforms that emulate these locks per process rather than per open file, taking it
+            // again through a second handle would succeed -- and unlink a file we are still using
+            if Some(id) == self.published {
+                return Ok(Some(id));
+            }
+            let path = self.dir.pinned_file(id);
+            let file = match File::open(&path) {
+                Ok(file) => file,
+                // Cleaned up by someone else between the listing and here
+                Err(err) if err.kind() == ErrorKind::NotFound => continue,
+                Err(err) => return Err(StorageError::Io(err)),
+            };
+            match file.try_lock() {
+                // Nobody needs this transaction any more, so the file is litter. Unlinked while
+                // the lock is held, so that a reader cannot open it in between and end up holding
+                // an inode nothing points at
+                Ok(()) => {
+                    let removed = std::fs::remove_file(&path);
+                    let _ = file.unlock();
+                    match removed {
+                        Ok(()) => {}
+                        Err(err) if err.kind() == ErrorKind::NotFound => {}
+                        Err(err) => return Err(StorageError::Io(err)),
+                    }
+                }
+                // A live reader holds it, and it is the lowest, so it is the horizon
+                Err(TryLockError::WouldBlock) => return Ok(Some(id)),
+                Err(err) => return Err(lock_error(err)),
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+/// The storage backend of a multi-process database: a [`FileBackend`] that takes the registry
+/// lock exclusively around every write to the database header.
+///
+/// This is the writing half of the protocol's rule that the header is read and written only under
+/// `registry.lock`. Placing it in the backend catches every header write there is, repair
+/// included, and the lock is taken per physical write, never across an fsync.
+///
+/// Lock order: a header write can start under a write-buffer stripe lock, so code holding the
+/// registry lock must never wait on the write path. The reader-side sections only read the file,
+/// read `extended-header`, and lock `txn/` files, none of which touches the write buffer.
+pub(crate) struct HeaderGuardedBackend {
+    inner: FileBackend,
+    registry: RegistryLock,
+}
+
+impl HeaderGuardedBackend {
+    pub(super) fn new(file: File, registry: RegistryLock) -> Result<Self, DatabaseError> {
+        Ok(Self {
+            // No file lock: `write.lock` and the files in `txn/` do that job, and every process
+            // needs the database file open at once
+            inner: FileBackend::new_internal(file, FileLockKind::None)?,
+            registry,
+        })
+    }
+}
+
+impl std::fmt::Debug for HeaderGuardedBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HeaderGuardedBackend")
+            .finish_non_exhaustive()
+    }
+}
+
+impl StorageBackend for HeaderGuardedBackend {
     fn len(&self) -> Result<u64, io::Error> {
-        self.data.len()
+        self.inner.len()
     }
 
     fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), io::Error> {
-        self.data.read(offset, out)
+        self.inner.read(offset, out)
     }
 
     fn set_len(&self, len: u64) -> Result<(), io::Error> {
-        self.data.set_len(len)
+        self.inner.set_len(len)
     }
 
     fn sync_data(&self) -> Result<(), io::Error> {
-        self.data.sync_data()
+        self.inner.sync_data()
     }
 
     fn write(&self, offset: u64, data: &[u8]) -> Result<(), io::Error> {
-        self.data.write(offset, data)
+        if offset < DB_HEADER_SIZE as u64 {
+            let _guard = self.registry.exclusive().map_err(|err| match err {
+                StorageError::Io(err) => err,
+                other => io::Error::other(other.to_string()),
+            })?;
+            return self.inner.write(offset, data);
+        }
+        self.inner.write(offset, data)
     }
 
     fn close(&self) -> Result<(), io::Error> {
-        // Both run: a file that failed to close must not also leave the directory locked against
-        // every other process
-        let closed = self.data.close();
-        let unlocked = self.write_lock.unlock();
-
-        closed.and(unlocked)
+        self.inner.close()
     }
 }
 
-#[cfg(test)]
+/// `write.lock`: held exclusively by the process which owns the single logical writer.
+pub(crate) struct WriteLock {
+    file: File,
+    held: bool,
+    created: bool,
+}
+
+impl WriteLock {
+    pub(super) fn open(dir: &DatabaseDir) -> Result<Self> {
+        let path = dir.write_lock_file();
+        // Otherwise the create below would follow a symlink left under this name, and the lock
+        // would be taken on a file whose identity was never checked
+        require_regular_file(&path)?;
+        // Creation is decided by the open itself rather than by a look beforehand, since a
+        // snapshot can go stale while another create() runs to completion, and what the
+        // fresh-lock rule may refuse turns on who really made the file
+        let (file, created) = match OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(file) => (file, true),
+            Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(&path)
+                    .map_err(StorageError::Io)?;
+                // Re-read through the opened handle: the check above can go stale, and a lock
+                // file that gained contents -- an abandonment mark included -- or stopped being
+                // a regular file vouches for nothing
+                let metadata = file.metadata().map_err(StorageError::Io)?;
+                if !metadata.is_file() || metadata.len() > 0 {
+                    return Err(StorageError::Io(io::Error::new(
+                        ErrorKind::InvalidData,
+                        "write.lock is not a multi-process database's lock file",
+                    )));
+                }
+                (file, false)
+            }
+            Err(err) => return Err(StorageError::Io(err)),
+        };
+        Ok(Self {
+            file,
+            held: false,
+            created,
+        })
+    }
+
+    /// Whether this handle's own open is what made the lock file.
+    pub(super) fn created(&self) -> bool {
+        self.created
+    }
+
+    /// Takes the lock, failing rather than blocking if another process holds it.
+    pub(super) fn try_acquire(&mut self) -> Result<bool> {
+        assert!(!self.held);
+        match self.file.try_lock() {
+            Ok(()) => {
+                self.held = true;
+                Ok(true)
+            }
+            Err(TryLockError::WouldBlock) => Ok(false),
+            Err(err) => Err(lock_error(err)),
+        }
+    }
+
+    /// Takes the lock, blocking until the process holding it releases it.
+    pub(super) fn acquire(&mut self) -> Result<()> {
+        assert!(!self.held);
+        self.file.lock().map_err(unsupported_lock)?;
+        self.held = true;
+        Ok(())
+    }
+
+    pub(super) fn release(&mut self) {
+        if self.held {
+            let _ = self.file.unlock();
+            self.held = false;
+        }
+    }
+
+    /// See [`mark_lock_abandoned`].
+    pub(super) fn mark_abandoned(&self) {
+        mark_lock_abandoned(&self.file);
+    }
+
+    pub(super) fn is_held(&self) -> bool {
+        self.held
+    }
+}
+
+// Not under WASI, which has no file locking: these all take one, and the module itself is
+// compiled there because the coordinator is woven into the transaction tracker
+#[cfg(all(test, not(target_os = "wasi")))]
 mod test {
     use super::*;
 
+    /// Everything a caller does to the directory itself when opening, in order. The write lock is
+    /// not taken here: it belongs to the coordinator rather than to the directory, and the tests
+    /// that are about it take it themselves.
+    fn open(dir: &DatabaseDir, create: bool) -> Result<(File, DataLocation), DatabaseError> {
+        dir.prepare(create)?;
+        dir.open_data(create, false)
+    }
+
     /// The whole create sequence, which is split between here and the caller: the database file is
     /// moved into place and the marker written only once [`crate::Database`] has accepted the file.
-    /// These tests are about the lock and the marker rather than the database, so they stand in for
-    /// that middle step by doing nothing -- the file they promote is simply empty.
-    fn create(dir: &DatabaseDir) -> Box<dyn StorageBackend> {
-        let (backend, location) = dir.open(true).unwrap();
+    /// These tests are about the lock files and the marker rather than the database, so they stand
+    /// in for that middle step by doing nothing -- the file they promote is simply empty.
+    fn create(dir: &DatabaseDir) -> File {
+        dir.prepare(true).unwrap();
+        let mut lock = WriteLock::open(dir).unwrap();
+        assert!(lock.try_acquire().unwrap());
+        dir.init_protocol_files().unwrap();
+        let (file, location) = dir.open_data(true, false).unwrap();
         dir.promote_data(location).unwrap();
-        dir.write_metadata_if_missing().unwrap();
-        backend
+        dir.write_metadata(WriterMode::MultiWriterProcess).unwrap();
+        file
+    }
+
+    /// Pins `pinned`, standing in for another process holding that transaction: the lock belongs
+    /// to the open file rather than to the process, so a second handle here is excluded exactly as
+    /// a second process would be.
+    fn pin(dir: &DatabaseDir, pinned: u64) -> TransactionPins {
+        let registry = RegistryLock::open(dir);
+        let mut pins = TransactionPins::new(dir);
+        let guard = registry.shared().unwrap();
+        pins.publish(Some(pinned)).unwrap();
+        drop(guard);
+        pins
+    }
+
+    /// Scans as a writer would: under the exclusive registry lock.
+    fn scan(dir: &DatabaseDir, pins: &TransactionPins) -> Option<u64> {
+        let guard = RegistryLock::open(dir).exclusive().unwrap();
+        let oldest = pins.scan_oldest().unwrap();
+        drop(guard);
+        oldest
     }
 
     #[test]
     fn the_write_lock_excludes_other_handles() {
         let tmpdir = tempfile::tempdir().unwrap();
         let dir = DatabaseDir::new(tmpdir.path().join("db"));
+        drop(create(&dir));
 
+        let mut first = WriteLock::open(&dir).unwrap();
+        assert!(first.try_acquire().unwrap());
+
+        let mut second = WriteLock::open(&dir).unwrap();
+        assert!(!second.try_acquire().unwrap());
+
+        first.release();
+        assert!(second.try_acquire().unwrap());
+    }
+
+    /// The database file itself is left unlocked: every process using the database has it open at
+    /// once, and `write.lock` and the files in `txn/` are what keep a page from being reused
+    /// underneath one of them.
+    #[test]
+    fn the_database_file_is_not_locked() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = DatabaseDir::new(tmpdir.path().join("db"));
         let first = create(&dir);
-        assert!(matches!(
-            dir.open(false),
-            Err(DatabaseError::DatabaseAlreadyOpen)
-        ));
 
-        // Closing the backend is what releases the lock, since that is when redb has finished
-        // with the file
-        first.close().unwrap();
-        let _second = dir.open(false).unwrap().0;
+        let second = open(&dir, false).unwrap().0;
+        drop(second);
+        drop(first);
+    }
+
+    #[test]
+    fn a_pinned_transaction_holds_the_horizon() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = DatabaseDir::new(tmpdir.path().join("db"));
+        drop(create(&dir));
+
+        let mut reader = pin(&dir, 5);
+        let writer = TransactionPins::new(&dir);
+        assert_eq!(Some(5), scan(&dir, &writer));
+
+        // Letting go of it is what releases the horizon, and the next scan unlinks the file
+        let guard = RegistryLock::open(&dir).shared().unwrap();
+        reader.publish(None).unwrap();
+        drop(guard);
+        assert_eq!(None, scan(&dir, &writer));
+        assert!(!dir.pinned_file(5).exists());
+    }
+
+    /// A process that pins its own transaction and then scans keeps its own file: it is still
+    /// reading that transaction.
+    #[test]
+    fn a_scan_does_not_clean_up_its_own_pin() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = DatabaseDir::new(tmpdir.path().join("db"));
+        drop(create(&dir));
+
+        let pins = pin(&dir, 5);
+        assert_eq!(Some(5), scan(&dir, &pins));
+        assert!(dir.pinned_file(5).is_file());
+    }
+
+    /// The whole point of naming the files after transactions and locking them: a process that
+    /// dies leaves its file behind, and the next writer to walk the directory takes it exclusively
+    /// -- which nobody is preventing any more -- and unlinks it.
+    #[test]
+    fn a_pin_left_by_a_dead_process_is_cleaned_up() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = DatabaseDir::new(tmpdir.path().join("db"));
+        drop(create(&dir));
+
+        // What a process that exited without unlinking leaves: the file, and no lock on it
+        std::fs::write(dir.pinned_file(7), []).unwrap();
+
+        let writer = TransactionPins::new(&dir);
+        assert_eq!(None, scan(&dir, &writer));
+        assert!(!dir.pinned_file(7).exists());
+    }
+
+    /// The scan stops at the first file it cannot take, so a live pin hides the ones above it. They
+    /// cost nothing: a later scan reaches them once this one is let go.
+    #[test]
+    fn the_scan_stops_at_the_oldest_live_pin() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = DatabaseDir::new(tmpdir.path().join("db"));
+        drop(create(&dir));
+
+        std::fs::write(dir.pinned_file(3), []).unwrap();
+        let _live = pin(&dir, 9);
+        std::fs::write(dir.pinned_file(11), []).unwrap();
+
+        let writer = TransactionPins::new(&dir);
+        assert_eq!(Some(9), scan(&dir, &writer));
+        assert!(!dir.pinned_file(3).exists());
+        assert!(dir.pinned_file(11).is_file());
+    }
+
+    /// The name is the whole of the data, so a name that is not a transaction id is not one of
+    /// these files and is left alone rather than being deleted or read as an id.
+    #[test]
+    fn a_name_that_is_not_a_transaction_id_is_ignored() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = DatabaseDir::new(tmpdir.path().join("db"));
+        drop(create(&dir));
+
+        let foreign = dir.pinned_dir().join("notanid");
+        std::fs::write(&foreign, b"someone else's").unwrap();
+
+        let writer = TransactionPins::new(&dir);
+        assert_eq!(None, scan(&dir, &writer));
+        assert!(foreign.is_file());
+    }
+
+    /// Moving a pin forward takes the new lock before dropping the old one, so a writer scanning
+    /// in between sees the older id rather than nothing.
+    #[test]
+    fn moving_a_pin_forward_releases_the_old_one() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = DatabaseDir::new(tmpdir.path().join("db"));
+        drop(create(&dir));
+
+        let mut reader = pin(&dir, 4);
+        let guard = RegistryLock::open(&dir).shared().unwrap();
+        reader.publish(Some(6)).unwrap();
+        drop(guard);
+
+        let writer = TransactionPins::new(&dir);
+        assert_eq!(Some(6), scan(&dir, &writer));
+        assert!(!dir.pinned_file(4).exists());
+    }
+
+    /// The registry lock is what a writer holds while scanning, so a pin and a scan can never
+    /// interleave. Each acquisition has its own file handle, which is what makes a shared and an
+    /// exclusive acquisition conflict even inside one process.
+    #[test]
+    fn the_registry_lock_excludes_a_scan_from_a_pinning_reader() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = DatabaseDir::new(tmpdir.path().join("db"));
+        drop(create(&dir));
+        let registry = RegistryLock::open(&dir);
+
+        let shared = registry.shared().unwrap();
+        // A second shared acquisition coexists...
+        let also_shared = registry.shared().unwrap();
+        // ... and an exclusive one cannot be taken until both are released. Probed with try_lock
+        // through a raw handle, since RegistryLock::exclusive would rightly block
+        let probe = File::open(dir.registry_file()).unwrap();
+        assert!(matches!(probe.try_lock(), Err(TryLockError::WouldBlock)));
+        drop(shared);
+        drop(also_shared);
+        probe.try_lock().unwrap();
+    }
+
+    /// The extended header round-trips a horizon, keyed to the commit slot bytes it was written
+    /// beside: the same slot read against different commit slot bytes is reported as invalid, not
+    /// as a horizon.
+    #[test]
+    fn the_extended_header_binds_the_horizon_to_the_commit_slot() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = DatabaseDir::new(tmpdir.path().join("db"));
+        drop(create(&dir));
+        let eh = ExtendedHeader::open(&dir).unwrap();
+
+        // Never written: nothing verifies
+        assert_eq!(None, eh.read_horizon(0, b"slot zero").unwrap());
+
+        eh.write_horizon(0, 41, b"slot zero").unwrap();
+        eh.write_horizon(1, 42, b"slot one").unwrap();
+        assert_eq!(Some(41), eh.read_horizon(0, b"slot zero").unwrap());
+        assert_eq!(Some(42), eh.read_horizon(1, b"slot one").unwrap());
+
+        // A slot paired with commit slot bytes it was not written beside is stale, which is
+        // exactly what a crash between the extended header write and the flip leaves behind
+        assert_eq!(None, eh.read_horizon(0, b"slot one").unwrap());
+
+        // Torn bytes fail the hash too
+        std::fs::write(dir.extended_header_file(), [0xab; 30]).unwrap();
+        assert_eq!(None, eh.read_horizon(0, b"slot zero").unwrap());
+        assert_eq!(None, eh.read_horizon(1, b"slot one").unwrap());
+    }
+
+    #[test]
+    fn the_marker_records_the_writer_mode() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("db");
+        let dir = DatabaseDir::new(&path);
+        drop(create(&dir));
+        assert_eq!(WriterMode::MultiWriterProcess, dir.mode().unwrap());
+
+        std::fs::remove_file(path.join(METADATA_FILE_NAME)).unwrap();
+        dir.write_metadata(WriterMode::SingleWriterProcess).unwrap();
+        assert_eq!(WriterMode::SingleWriterProcess, dir.mode().unwrap());
     }
 
     #[test]
@@ -966,12 +1598,12 @@ mod test {
         // these, so it has to be what this turns on rather than the lock file's absence
         std::fs::write(path.join(WRITE_LOCK_FILE_NAME), []).unwrap();
         let dir = DatabaseDir::new(&path);
-        assert!(dir.open(false).is_err());
+        assert!(open(&dir, false).is_err());
 
         // An empty file where the marker should be is rejected too, rather than being read as a
         // database with a zero version
         std::fs::write(path.join(METADATA_FILE_NAME), []).unwrap();
-        assert!(dir.open(false).is_err());
+        assert!(open(&dir, false).is_err());
     }
 
     /// A `create()` that died while writing the marker leaves the partial copy under the temporary
@@ -981,12 +1613,12 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let path = tmpdir.path().join("db");
         let dir = DatabaseDir::new(&path);
-        create(&dir).close().unwrap();
+        drop(create(&dir));
 
         std::fs::remove_file(path.join(METADATA_FILE_NAME)).unwrap();
         std::fs::write(path.join(METADATA_TMP_FILE_NAME), &MAGIC[0..4]).unwrap();
 
-        create(&dir).close().unwrap();
+        drop(create(&dir));
         assert_eq!(
             METADATA_LEN,
             std::fs::read(path.join(METADATA_FILE_NAME)).unwrap().len()
@@ -1003,7 +1635,7 @@ mod test {
         std::fs::create_dir(&path).unwrap();
         std::fs::write(path.join(METADATA_FILE_NAME), b"someone else's").unwrap();
 
-        assert!(DatabaseDir::new(&path).open(true).is_err());
+        assert!(open(&DatabaseDir::new(&path), true).is_err());
         assert_eq!(
             b"someone else's",
             &std::fs::read(path.join(METADATA_FILE_NAME)).unwrap()[..]
@@ -1021,10 +1653,10 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let path = tmpdir.path().join("db");
         let dir = DatabaseDir::new(&path);
-        create(&dir).close().unwrap();
+        drop(create(&dir));
         std::fs::write(path.join(DATA_FILE_NAME), []).unwrap();
 
-        let (backend, location) = dir.open(true).unwrap();
+        let (data, location) = open(&dir, true).unwrap();
         assert!(!path.join(DATA_FILE_NAME).exists());
         assert!(path.join(DATA_TMP_FILE_NAME).is_file());
 
@@ -1032,7 +1664,7 @@ mod test {
         dir.promote_data(location).unwrap();
         assert!(path.join(DATA_FILE_NAME).is_file());
         assert!(!path.join(DATA_TMP_FILE_NAME).exists());
-        backend.close().unwrap();
+        drop(data);
     }
 
     /// An empty database file is only wreckage if nobody is holding it. One that a process
@@ -1043,7 +1675,7 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let path = tmpdir.path().join("db");
         let dir = DatabaseDir::new(&path);
-        create(&dir).close().unwrap();
+        drop(create(&dir));
         std::fs::write(path.join(DATA_FILE_NAME), []).unwrap();
 
         let held = OpenOptions::new()
@@ -1054,7 +1686,7 @@ mod test {
         held.try_lock().unwrap();
 
         assert!(matches!(
-            dir.open(true),
+            open(&dir, true),
             Err(DatabaseError::DatabaseAlreadyOpen)
         ));
         assert!(path.join(DATA_FILE_NAME).is_file());
@@ -1062,7 +1694,7 @@ mod test {
         // ... and once it is let go, the empty file is wreckage again
         held.unlock().unwrap();
         drop(held);
-        dir.open(true).unwrap().0.close().unwrap();
+        drop(open(&dir, true).unwrap().0);
     }
 
     #[test]
@@ -1070,14 +1702,15 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let path = tmpdir.path().join("db");
         let dir = DatabaseDir::new(&path);
-        create(&dir).close().unwrap();
+        drop(create(&dir));
 
         let mut contents = [0u8; METADATA_LEN];
         contents[0..11].copy_from_slice(&MAGIC);
         contents[11] = FORMAT_VERSION + 1;
         contents[12] = WRITER_MODE_SINGLE;
         std::fs::write(path.join(METADATA_FILE_NAME), contents).unwrap();
-        assert!(dir.open(false).is_err());
+        assert!(open(&dir, false).is_err());
+        assert!(open(&dir, true).is_err());
     }
 
     #[test]
@@ -1085,13 +1718,14 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let path = tmpdir.path().join("db");
         let dir = DatabaseDir::new(&path);
-        create(&dir).close().unwrap();
+        drop(create(&dir));
 
         let mut contents = [0u8; METADATA_LEN];
         contents[0..11].copy_from_slice(&MAGIC);
         contents[11] = FORMAT_VERSION;
-        contents[12] = WRITER_MODE_SINGLE + 1;
+        contents[12] = WRITER_MODE_MULTI + 1;
         std::fs::write(path.join(METADATA_FILE_NAME), contents).unwrap();
-        assert!(dir.open(false).is_err());
+        assert!(open(&dir, false).is_err());
+        assert!(open(&dir, true).is_err());
     }
 }

--- a/src/multiprocess/locks.rs
+++ b/src/multiprocess/locks.rs
@@ -40,15 +40,6 @@ fn lock_unsupported(err: io::Error) -> DatabaseError {
     StorageError::Io(err).into()
 }
 
-fn open_or_create(path: &Path) -> Result<File, io::Error> {
-    OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(path)
-}
-
 /// Flushes a directory itself, so that an entry a rename just created is durable. Best-effort
 /// about a directory this process cannot open: flushing needs read permission, and nothing else
 /// here does.
@@ -115,12 +106,43 @@ fn sync_ancestors(root: &Path, preexisting: Option<&Path>) -> Result<(), Databas
     }
 }
 
+/// What sits under a name, without following a symlink -- `None` only for a provable absence.
+/// Any error other than `NotFound` is reported rather than read as absence, which the accepting
+/// paths would then trust.
+fn symlink_metadata_if_any(path: &Path) -> Result<Option<std::fs::Metadata>, StorageError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(StorageError::Io(err)),
+    }
+}
+
+/// Whether a name is taken, by anything at all -- including a symlink that resolves to nothing,
+/// which `Path::exists` reports as absent because it follows the link.
+fn occupied(path: &Path) -> Result<bool, DatabaseError> {
+    Ok(symlink_metadata_if_any(path)?.is_some())
+}
+
+/// Marks a lock file a `create()` made and then could not stand behind. It cannot be unlinked --
+/// nothing ever unlinks one -- but left empty it would vouch, on the next `create()`, for the very
+/// files that were just refused; written to and flushed, it fails the empty-lock-file rule
+/// instead, and the directory stays refused.
+fn mark_lock_abandoned(lock: &File) {
+    let _ = (&*lock).write_all(b"abandoned by a rejected create\n");
+    let _ = lock.sync_all();
+}
+
 /// The paths that make up a multi-process database directory.
 pub(super) struct DatabaseDir {
     root: PathBuf,
 }
 
 impl DatabaseDir {
+    /// Every name `create()` writes after taking the write lock. `metadata` is not among them: the
+    /// check that uses this runs only where there is no marker.
+    const WRITTEN_UNDER_THE_LOCK: &'static [&'static str] =
+        &[DATA_FILE_NAME, METADATA_TMP_FILE_NAME];
+
     pub(super) fn new(root: impl AsRef<Path>) -> Self {
         Self {
             root: root.as_ref().to_path_buf(),
@@ -143,35 +165,68 @@ impl DatabaseDir {
         self.root.join(METADATA_TMP_FILE_NAME)
     }
 
-    /// Takes the write lock, which excludes every other process from the database. Taken before
-    /// anything in the directory is read or written, so the holder has the directory to itself.
+    /// Takes the write lock, which excludes every other process from the database, and reports
+    /// whether this call created the file. Taken before anything in the directory is read or
+    /// written, so the holder has the directory to itself.
     ///
     /// Only `create()` makes the file, and nothing ever unlinks one: another process may be
     /// waiting on the lock on that same file, and unlinking would let a third process lock a
-    /// fresh `write.lock` while the second holds the old inode.
-    fn acquire_write_lock(&self, create: bool) -> Result<File, DatabaseError> {
+    /// fresh `write.lock` while the second holds the old inode. Creation is decided by the open
+    /// itself rather than by a look beforehand, since a snapshot can go stale while another
+    /// `create()` runs to completion, and what the fresh-lock rule may refuse turns on who
+    /// really made the file.
+    fn acquire_write_lock(&self, create: bool) -> Result<(File, bool), DatabaseError> {
         let path = self.write_lock_file();
-        let file = if create {
-            open_or_create(&path)
-        } else {
-            OpenOptions::new().read(true).write(true).open(&path)
-        }
-        .map_err(|err| {
-            if err.kind() == ErrorKind::NotFound {
-                StorageError::Io(io::Error::new(
-                    ErrorKind::NotFound,
-                    "not a multi-process database directory",
-                ))
-            } else {
-                StorageError::Io(err)
+        let open_existing = || {
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .map_err(|err| {
+                    if err.kind() == ErrorKind::NotFound {
+                        StorageError::Io(io::Error::new(
+                            ErrorKind::NotFound,
+                            "not a multi-process database directory",
+                        ))
+                    } else {
+                        StorageError::Io(err)
+                    }
+                })
+        };
+        let (file, created) = if create {
+            match OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .open(&path)
+            {
+                Ok(file) => (file, true),
+                Err(err) if err.kind() == ErrorKind::AlreadyExists => (open_existing()?, false),
+                Err(err) => return Err(StorageError::Io(err).into()),
             }
-        })?;
+        } else {
+            (open_existing()?, false)
+        };
 
         match file.try_lock() {
-            Ok(()) => Ok(file),
-            Err(TryLockError::WouldBlock) => Err(DatabaseError::DatabaseAlreadyOpen),
-            Err(TryLockError::Error(err)) => Err(lock_unsupported(err)),
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => return Err(DatabaseError::DatabaseAlreadyOpen),
+            Err(TryLockError::Error(err)) => return Err(lock_unsupported(err)),
         }
+        if !created {
+            // Re-read through the held lock: the preflight's snapshot can go stale, and a lock
+            // file that gained contents -- an abandonment mark included -- or stopped being a
+            // regular file vouches for nothing
+            let metadata = file.metadata().map_err(StorageError::Io)?;
+            if !metadata.is_file() || metadata.len() > 0 {
+                return Err(StorageError::Io(io::Error::new(
+                    ErrorKind::InvalidData,
+                    "write.lock is not a multi-process database's lock file",
+                ))
+                .into());
+            }
+        }
+        Ok((file, created))
     }
 
     /// Opens the directory, creating it if `create` is set, and returns a backend for the database
@@ -180,7 +235,18 @@ impl DatabaseDir {
     /// A directory being created is not marked as one of these yet -- the caller does that with
     /// [`Self::write_metadata_if_missing`], once the database file has turned out to be usable.
     pub(super) fn open(&self, create: bool) -> Result<Box<dyn StorageBackend>, DatabaseError> {
+        let mut marked_at_preflight = false;
         if create {
+            // Both checks run before the directory is touched, so a rejected create() leaves no
+            // trace. A marker arrives by rename and so is either absent or complete, which is what
+            // makes refusing without the lock sound; `read_metadata` below repeats the check under
+            // the lock, which is the authoritative pass
+            marked_at_preflight = occupied(&self.metadata_file())?;
+            if marked_at_preflight {
+                self.read_metadata(create)?;
+            } else {
+                self.reject_unmarked_database()?;
+            }
             // The deepest ancestor that already exists bounds what create_dir_all makes; every
             // entry from the database directory up to there needs its own flush below
             let preexisting = deepest_existing_ancestor(&self.root);
@@ -199,21 +265,64 @@ impl DatabaseDir {
             .into());
         }
 
-        let write_lock = self.acquire_write_lock(create)?;
+        let (write_lock, lock_created) = self.acquire_write_lock(create)?;
+        let mut fresh_claim = false;
+        if create {
+            // The lock file's entry must be durable before anything else is written under these
+            // names: its *absence* beside them is what says a directory is not this database's,
+            // and a crash could otherwise keep `data.redb` while losing `write.lock`
+            sync_dir(&self.root)?;
+            // A marker seen before the lock file was made marks a create() to finish -- a crash
+            // can lose the lock's entry while the marker survives -- and the fresh-lock rule has
+            // nothing to refuse. One that first appears after cannot be another create()'s, since
+            // finishing one needs the lock this call holds, so the rejecting pass below refuses
+            // it like every other name that arrives while the directory is being claimed
+            fresh_claim = lock_created && !marked_at_preflight;
+            if fresh_claim && let Err(err) = self.reject_files_beside_a_fresh_lock() {
+                mark_lock_abandoned(&write_lock);
+                return Err(err);
+            }
+        }
         self.read_metadata(create)?;
 
-        let data = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(create)
-            .truncate(false)
-            .open(self.data_file())
-            .map_err(StorageError::Io)?;
+        let mut options = OpenOptions::new();
+        options.read(true).write(true).truncate(false);
+        if fresh_claim {
+            // The pass above required this name to be absent, and a file appearing since arrived
+            // the same way -- something reaching past the directory API -- so creating exclusively
+            // turns the appearance into the same refusal instead of an adoption
+            options.create_new(true);
+        } else {
+            options.create(create);
+        }
+        let data = match options.open(self.data_file()) {
+            Ok(data) => data,
+            Err(err) if fresh_claim && err.kind() == ErrorKind::AlreadyExists => {
+                mark_lock_abandoned(&write_lock);
+                return Err(StorageError::Io(io::Error::new(
+                    ErrorKind::AlreadyExists,
+                    "the database file appeared while the directory was being claimed",
+                ))
+                .into());
+            }
+            Err(err) => return Err(StorageError::Io(err).into()),
+        };
         // The ordinary exclusive lock, the same one a Database takes: a process that reaches past
         // the directory and opens this file directly is not looking at the write lock, so the file
         // needs a lock of its own. Exclusive rather than shared, because nothing coordinates a
         // reader that attaches this way with the pages this process frees
-        let data = FileBackend::new(data)?;
+        let data = match FileBackend::new(data) {
+            Ok(data) => data,
+            Err(err) => {
+                // On a fresh claim the file was created exclusively just above, so failing to
+                // lock it means something took it in between -- and the lock file left empty
+                // would vouch, on the next create(), for whatever that something makes of it
+                if fresh_claim {
+                    mark_lock_abandoned(&write_lock);
+                }
+                return Err(err);
+            }
+        };
 
         Ok(Box::new(DirectoryBackend { data, write_lock }))
     }
@@ -245,7 +354,7 @@ impl DatabaseDir {
     /// validated by [`Self::read_metadata`] on the way in, so it is byte-for-byte what would be
     /// written.
     pub(super) fn write_metadata_if_missing(&self) -> Result<(), DatabaseError> {
-        if self.metadata_file().exists() {
+        if occupied(&self.metadata_file())? {
             // Validated here rather than assumed: the write lock keeps redb out, but the claim
             // that an existing marker is byte-for-byte what would be written has to survive
             // whatever else was pointed at the directory
@@ -257,6 +366,71 @@ impl DatabaseDir {
         }
 
         self.write_metadata()
+    }
+
+    /// Refuses a directory holding files under these names that this type did not put there.
+    ///
+    /// An unmarked directory is accepted only as an interrupted create, and `write.lock` is the
+    /// first thing `create()` makes, so every other name implies a lock file beside it. One
+    /// without means something else filled the directory in -- most likely a plain
+    /// [`crate::Database`] under `data.redb`, which `create()` would otherwise adopt.
+    fn reject_unmarked_database(&self) -> Result<(), DatabaseError> {
+        if occupied(&self.write_lock_file())? {
+            // The lock file vouches for the other names only while it could be redb's own:
+            // created empty and never written to, so one with contents was put there by something
+            // else. The marker's temporary is bounded the same way -- written fresh, always a
+            // regular file, holding at most the marker's length -- so anything else under that
+            // name cannot be an interrupted create's, and finishing the create would delete it,
+            // or write the marker through whatever a planted link points at
+            let lock = symlink_metadata_if_any(&self.write_lock_file())?;
+            let tmp = symlink_metadata_if_any(&self.metadata_tmp_file())?;
+            if lock.is_some_and(|metadata| !metadata.is_file() || metadata.len() > 0)
+                || tmp.is_some_and(|metadata| {
+                    !metadata.is_file() || metadata.len() > METADATA_LEN as u64
+                })
+            {
+                return Err(StorageError::Io(io::Error::new(
+                    ErrorKind::AlreadyExists,
+                    "refusing to take over a directory that already holds files under the names a \
+                     multi-process database uses",
+                ))
+                .into());
+            }
+            return Ok(());
+        }
+
+        for name in Self::WRITTEN_UNDER_THE_LOCK {
+            if occupied(&self.root.join(name))? {
+                return Err(StorageError::Io(io::Error::new(
+                    ErrorKind::AlreadyExists,
+                    "refusing to take over a directory that already holds files under the names a \
+                     multi-process database uses",
+                ))
+                .into());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// The accepting pass for a directory whose lock file this call has just created. A
+    /// pre-existing `write.lock` vouches for redb's other names; a fresh one vouches for nothing,
+    /// so anything already under them arrived while the directory was being claimed -- another
+    /// process reaching past the directory API -- and adopting it would hand this handle a file
+    /// something else is using.
+    fn reject_files_beside_a_fresh_lock(&self) -> Result<(), DatabaseError> {
+        let claimed = Self::WRITTEN_UNDER_THE_LOCK.iter().copied();
+        for name in claimed.chain([METADATA_FILE_NAME]) {
+            if occupied(&self.root.join(name))? {
+                return Err(StorageError::Io(io::Error::new(
+                    ErrorKind::AlreadyExists,
+                    "another process put files into the directory while it was being claimed",
+                ))
+                .into());
+            }
+        }
+
+        Ok(())
     }
 
     /// Takes the shared lock on `metadata` that every process holds for as long as it has the
@@ -279,7 +453,7 @@ impl DatabaseDir {
                 // Opening follows symlinks, so NotFound covers a dangling one as well as a truly
                 // absent marker. The name being taken at all -- by anything -- means the
                 // directory is not redb's to mark
-                if std::fs::symlink_metadata(self.metadata_file()).is_ok() {
+                if occupied(&self.metadata_file())? {
                     return Err(StorageError::Io(io::Error::new(
                         ErrorKind::InvalidData,
                         "not a multi-process database directory",
@@ -456,6 +630,8 @@ mod test {
             b"someone else's",
             &std::fs::read(path.join(METADATA_FILE_NAME)).unwrap()[..]
         );
+        // ... and refused before anything of redb's was put in it
+        assert!(!path.join(WRITE_LOCK_FILE_NAME).exists());
     }
 
     #[test]

--- a/src/multiprocess/mod.rs
+++ b/src/multiprocess/mod.rs
@@ -1,36 +1,106 @@
 //! A multi-process safe interface to a redb database.
 //!
-//! [`MultiProcessDatabase`] stores its database in a directory, alongside the coordination files
-//! described in the "Directory-structured databases" section of `docs/design.md`. Only one
-//! process may have the database open at a time.
+//! [`MultiProcessDatabase`] stores its database in a directory, alongside the files that
+//! coordinate the processes using it. One write transaction may be in progress at a time across
+//! every process, and any number of processes may read concurrently with it and with each other.
+//! The protocol is described in the "Directory-structured databases" section of `docs/design.md`.
 
+mod coordinator;
 mod locks;
 
-use crate::db::RepairSession;
-use crate::tree_store::PAGE_SIZE;
-use crate::{Database, DatabaseError, Result};
-use locks::{DataLocation, DatabaseDir};
-use std::fs::File;
-use std::path::Path;
+pub(crate) use coordinator::ProcessCoordinator;
+#[cfg(feature = "experimental-multiprocess")]
+pub use locks::WriterMode;
+#[cfg(not(feature = "experimental-multiprocess"))]
+pub(crate) use locks::WriterMode;
 
-/// A redb database stored in a directory, alongside the coordination files described in
-/// `docs/design.md`.
+use crate::db::{OpenParams, RepairSession};
+use crate::sealed::Sealed;
+use crate::transaction_tracker::TransactionTracker;
+use crate::tree_store::PAGE_SIZE;
+use crate::tree_store::file_backend::{FileBackend, FileLockKind};
+use crate::{
+    CacheStats, CommitError, Database, DatabaseError, ReadOnlyDatabase, ReadTransaction,
+    ReadableDatabase, Result, TransactionError, WriteTransaction,
+};
+use locks::{DataLocation, DatabaseDir, HeaderGuardedBackend, RegistryLock, WriteLock};
+use std::fs::OpenOptions;
+use std::io::ErrorKind;
+use std::path::Path;
+use std::sync::Arc;
+
+/// A redb database that may be used from several processes at once.
 ///
-/// The directory must be on a filesystem that supports file locking, and belongs to redb -- do not
-/// put anything else in it. A second process that opens the same directory fails with
-/// [`DatabaseError::DatabaseAlreadyOpen`]: the exclusion is carried by a lock file in the
-/// directory rather than by a lock on the database file itself.
+/// Use [`Self::begin_read`] to get a [`ReadTransaction`], and [`Self::begin_write`] to get a
+/// [`WriteTransaction`]. Reads run concurrently with writes and with each other -- a reader sees
+/// the snapshot it opened and is never waited on by the writer, though beginning a transaction
+/// may wait briefly on the lock that keeps header reads atomic. Writes are serialized
+/// across all processes: exactly one write transaction may be in progress at a time, and which
+/// processes may start one depends on the [`WriterMode`] the database was created with.
+///
+/// Unlike [`Database`], `path` names a directory rather than a file. The directory is created by
+/// [`Self::create`], and holds the database file along with the lock files that coordinate the
+/// processes using it, so it must be on a filesystem that supports file locking. Nothing else may
+/// be put in it.
+///
+/// # Limitations
+///
+/// This is a prototype. Compared to [`Database`]:
+///
+/// * [`Durability::None`](crate::Durability) is rejected in
+///   [`WriterMode::MultiWriterProcess`], since a non-durable commit is only visible to the process
+///   that made it.
+/// * Persistent savepoints are only supported in [`WriterMode::SingleWriterProcess`]. One lives in
+///   the database rather than in any one process, so a writer that opened before another created
+///   it has never heard of it and would reclaim the pages it holds. Ephemeral savepoints work in
+///   both modes.
+/// * Compaction and [`Database::check_integrity`] are not available.
+/// * Every commit is 2-phase, which costs an extra `fsync`: a reader in another process would
+///   otherwise be able to see a header naming pages that are not in the file yet.
+// Only with the feature, since the example names a type that is exported only then. The module
+// itself is compiled either way, because the coordinator is woven into the transaction tracker
+#[cfg_attr(
+    feature = "experimental-multiprocess",
+    doc = r#"
+# Examples
+
+```rust
+use redb::*;
+# use tempfile::TempDir;
+const TABLE: TableDefinition<u64, u64> = TableDefinition::new("my_data");
+
+# fn main() -> Result<(), Error> {
+# let tmpdir = TempDir::new().unwrap();
+# let path = tmpdir.path().join("my_db");
+let db = MultiProcessDatabase::create(&path)?;
+let write_txn = db.begin_write()?;
+{
+    let mut table = write_txn.open_table(TABLE)?;
+    table.insert(&0, &0)?;
+}
+write_txn.commit()?;
+
+// Any number of other processes may open the same directory and read it
+let read_only = MultiProcessDatabase::open_read_only(&path)?;
+let read_txn = read_only.begin_read()?;
+assert_eq!(0, read_txn.open_table(TABLE)?.get_owned(0)?.unwrap().value());
+# Ok(())
+# }
+```
+"#
+)]
 pub struct MultiProcessDatabase {
-    /// Holds the database open; dropping it closes the file and releases the write lock.
-    _inner: Database,
-    /// The shared lock every process holds on `metadata` for as long as it has the database open.
-    /// A future format upgrade takes it exclusively, and this is what it waits on.
-    _metadata_lock: File,
+    inner: Database,
+    coordinator: Arc<ProcessCoordinator>,
 }
 
 impl MultiProcessDatabase {
     /// Opens the directory at `path` as a multi-process database, creating it if it does not
     /// exist.
+    ///
+    /// A database created this way uses [`WriterMode::MultiWriterProcess`]. Use
+    /// [`MultiProcessBuilder::set_writer_mode`] to create one that only a single process may write
+    /// to, which is faster for that process.
     pub fn create(path: impl AsRef<Path>) -> Result<MultiProcessDatabase, DatabaseError> {
         Self::builder().create(path)
     }
@@ -40,21 +110,67 @@ impl MultiProcessDatabase {
         Self::builder().open(path)
     }
 
+    /// Opens an existing multi-process database for reading only.
+    ///
+    /// Any number of processes may do this, concurrently with each other and with a writer.
+    pub fn open_read_only(path: impl AsRef<Path>) -> Result<ReadOnlyDatabase, DatabaseError> {
+        Self::builder().open_read_only(path)
+    }
+
     /// Convenience method for [`MultiProcessBuilder::new`]
     pub fn builder() -> MultiProcessBuilder {
         MultiProcessBuilder::new()
+    }
+
+    /// The mode this database was created with, which governs which processes may write to it
+    pub fn writer_mode(&self) -> WriterMode {
+        self.coordinator.mode()
+    }
+
+    /// Begins a write transaction
+    ///
+    /// Returns a [`WriteTransaction`] which may be used to read/write to the database. Only a
+    /// single write may be in progress at a time, across every process which has the database
+    /// open. If a write is in progress, this function blocks until it completes.
+    pub fn begin_write(&self) -> Result<WriteTransaction, TransactionError> {
+        self.inner.begin_write()
+    }
+
+    /// The last transaction that has been committed and made durable, by any process.
+    ///
+    /// Intended for testing and for observing another process's progress; the value is only
+    /// meaningful relative to itself.
+    pub fn last_durable_commit(&self) -> Result<u64> {
+        Ok(self.coordinator.last_committed()?.raw_id())
+    }
+}
+
+impl Sealed for MultiProcessDatabase {}
+
+impl ReadableDatabase for MultiProcessDatabase {
+    fn begin_read(&self) -> Result<ReadTransaction, TransactionError> {
+        self.inner.begin_read()
+    }
+
+    fn cache_stats(&self) -> CacheStats {
+        self.inner.cache_stats()
     }
 }
 
 impl std::fmt::Debug for MultiProcessDatabase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MultiProcessDatabase").finish()
+        f.debug_struct("MultiProcessDatabase")
+            .field("mode", &self.coordinator.mode())
+            .finish_non_exhaustive()
     }
 }
 
 /// Configuration builder of a [`MultiProcessDatabase`].
 pub struct MultiProcessBuilder {
     cache_size: usize,
+    mode: Option<WriterMode>,
+    // Only configurable in test and fuzzing builds, exactly as for `crate::Builder`
+    region_size: Option<u64>,
     repair_callback: Box<dyn Fn(&mut RepairSession)>,
 }
 
@@ -64,10 +180,13 @@ impl MultiProcessBuilder {
     /// ## Defaults
     ///
     /// - `cache_size_bytes`: 1GiB
+    /// - `writer_mode`: [`WriterMode::MultiWriterProcess`]
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
             cache_size: 1024 * 1024 * 1024,
+            mode: None,
+            region_size: None,
             repair_callback: Box::new(|_| {}),
         }
     }
@@ -75,6 +194,15 @@ impl MultiProcessBuilder {
     /// Set the amount of memory (in bytes) used for caching data
     pub fn set_cache_size(&mut self, bytes: usize) -> &mut Self {
         self.cache_size = bytes;
+        self
+    }
+
+    /// Set which processes may write to the database.
+    ///
+    /// The mode is fixed when the database is created. Setting it before opening an existing
+    /// database asserts that it was created with that mode, and fails if it was not.
+    pub fn set_writer_mode(&mut self, mode: WriterMode) -> &mut Self {
+        self.mode = Some(mode);
         self
     }
 
@@ -88,52 +216,530 @@ impl MultiProcessBuilder {
         self
     }
 
+    #[cfg(any(test, fuzzing))]
+    pub fn set_region_size(&mut self, size: u64) -> &mut Self {
+        assert!(size.is_power_of_two());
+        self.region_size = Some(size);
+        self
+    }
+
     /// Opens the directory at `path` as a multi-process database, creating it if it does not exist
     pub fn create(&self, path: impl AsRef<Path>) -> Result<MultiProcessDatabase, DatabaseError> {
-        self.open_inner(path.as_ref(), true)
+        let dir = DatabaseDir::new(path);
+        let marked_at_preflight = dir.prepare(true)?;
+        self.open_inner(&dir, true, marked_at_preflight)
     }
 
     /// Opens an existing multi-process database
     pub fn open(&self, path: impl AsRef<Path>) -> Result<MultiProcessDatabase, DatabaseError> {
-        self.open_inner(path.as_ref(), false)
+        let dir = DatabaseDir::new(path);
+        dir.prepare(false)?;
+        self.open_inner(&dir, false, false)
     }
 
-    fn open_inner(&self, path: &Path, create: bool) -> Result<MultiProcessDatabase, DatabaseError> {
+    /// Opens an existing multi-process database for reading only
+    pub fn open_read_only(
+        &self,
+        path: impl AsRef<Path>,
+    ) -> Result<ReadOnlyDatabase, DatabaseError> {
         let dir = DatabaseDir::new(path);
-        let (backend, location) = dir.open(create)?;
-        // A guard rather than a check on the error path: the repair callback runs inside the
+        dir.prepare(false)?;
+        // Taken before the marker or header is read and held for as long as the database is open.
+        // A writer's open sits inside `write.lock`, which a format upgrader acquires first; a
+        // read-only open takes no write lock, so this shared lock is its only barrier against an
+        // upgrade running mid-open. The marker is still validated through the path below, so an
+        // upgrade that replaced the file before the lock landed is refused by its version instead
+        let metadata_lock = dir.lock_metadata_shared()?;
+        // Safe to read without the write lock: the marker is written once and never changed
+        let mode = dir.mode()?;
+        self.check_mode(mode)?;
+
+        let file = OpenOptions::new().read(true).open(dir.data_file())?;
+        // No file lock: the lock files exclude concurrent writers, and this handle only reads.
+        // And no header-write guard on the backend, since this handle never writes at all
+        let backend = FileBackend::new_internal(file, FileLockKind::None)?;
+        // Construction reads the header once, which needs the registry lock like every header
+        // read; the later ones take it inside begin_read()
+        let registry = RegistryLock::open(&dir);
+        let guard = registry.shared()?;
+        let (mem, coordinator) = ReadOnlyDatabase::new_shared_read(
+            Box::new(backend),
+            PAGE_SIZE,
+            self.cache_size,
+            |mem| {
+                let write_lock = WriteLock::open(&dir)?;
+                Ok(Arc::new(ProcessCoordinator::new(
+                    &dir, mode, true, write_lock, mem,
+                )?))
+            },
+        )?;
+        drop(guard);
+        coordinator.hold_metadata_lock(metadata_lock)?;
+        // A read-only handle never writes, so its idea of what is current comes entirely from the
+        // refresh every begin_read() does
+        Ok(ReadOnlyDatabase::from_parts(
+            mem.clone(),
+            Arc::new(TransactionTracker::new_multiprocess(
+                mem.get_last_committed_transaction_id()?.next(),
+                coordinator,
+            )),
+        ))
+    }
+
+    fn check_mode(&self, actual: WriterMode) -> Result<(), DatabaseError> {
+        if let Some(requested) = self.mode
+            && requested != actual
+        {
+            return Err(crate::StorageError::Corrupted(format!(
+                "Database was created with {actual:?}, but {requested:?} was requested"
+            ))
+            .into());
+        }
+        Ok(())
+    }
+
+    fn open_inner(
+        &self,
+        dir: &DatabaseDir,
+        allow_create: bool,
+        marked_at_preflight: bool,
+    ) -> Result<MultiProcessDatabase, DatabaseError> {
+        // Take the write lock before touching the database file, so that no other process can be
+        // part way through a transaction while this one repairs or reads the file. In
+        // SingleWriterProcess mode it is never released; in MultiWriterProcess mode it is handed
+        // back at the end of this function, and retaken per transaction.
+        //
+        // The marker is written under this same lock and never changed after. open() reads it
+        // first, so a directory that is not a database is left exactly as found; only create()
+        // must take the lock before deciding, since the marker may be missing precisely because
+        // another create() is still writing it.
+        let mut write_lock;
+        let mut fresh_claim = false;
+        let mode = if !allow_create {
+            // Read before the lock file is opened, so a directory that is not one of these is
+            // left exactly as found; this pass only chooses how the lock is taken, and the read
+            // under the held lock below is the authoritative one
+            let provisional = dir
+                .read_metadata(false)?
+                .expect("read_metadata only reports a missing marker when create is set");
+            self.check_mode(provisional)?;
+            write_lock = WriteLock::open(dir)?;
+            match provisional {
+                WriterMode::SingleWriterProcess => {
+                    if !write_lock.try_acquire()? {
+                        return Err(DatabaseError::DatabaseAlreadyOpen);
+                    }
+                }
+                // A held lock just means a transaction is in progress; wait our turn
+                WriterMode::MultiWriterProcess => write_lock.acquire()?,
+            }
+            // An upgrader acquires `write.lock` before taking `metadata` exclusively, so a marker
+            // read under the held lock cannot be mid-upgrade -- and one an upgrade replaced in
+            // the window is refused by its version here rather than opened with the old protocol
+            let mode = dir
+                .read_metadata(false)?
+                .expect("read_metadata only reports a missing marker when create is set");
+            self.check_mode(mode)?;
+            mode
+        } else {
+            write_lock = WriteLock::open(dir)?;
+            if write_lock.try_acquire()? {
+                if let Some(mode) = dir.read_metadata(true)? {
+                    // A marker seen before the lock file was made is a create() to finish -- a
+                    // crash can lose the lock's entry while the marker survives. One that first
+                    // appears after cannot be another create()'s, since finishing one needs the
+                    // lock this call holds
+                    if write_lock.created() && !marked_at_preflight {
+                        write_lock.mark_abandoned();
+                        return Err(crate::StorageError::Io(std::io::Error::new(
+                            ErrorKind::AlreadyExists,
+                            "the marker appeared while the directory was being claimed",
+                        ))
+                        .into());
+                    }
+                    mode
+                } else {
+                    // No marker means this create() is the one making the database. A lock file
+                    // this call just made vouches for nothing, so nothing may already exist under
+                    // redb's other names -- and one it cannot stand behind is marked, so the next
+                    // create() refuses it too
+                    fresh_claim = write_lock.created() && !marked_at_preflight;
+                    if fresh_claim && let Err(err) = dir.reject_files_beside_a_fresh_lock() {
+                        write_lock.mark_abandoned();
+                        return Err(err);
+                    }
+                    self.mode.unwrap_or(WriterMode::MultiWriterProcess)
+                }
+            } else {
+                // Some process holds the write lock, and what that means depends on the marker
+                match dir.read_metadata(true)? {
+                    // A multi-writer database is in the middle of a transaction; wait our turn
+                    Some(WriterMode::MultiWriterProcess) => {
+                        self.check_mode(WriterMode::MultiWriterProcess)?;
+                        write_lock.acquire()?;
+                        WriterMode::MultiWriterProcess
+                    }
+                    // A single-writer database is open in another process, and a directory with
+                    // no marker is one another process is part way through creating
+                    Some(WriterMode::SingleWriterProcess) | None => {
+                        return Err(DatabaseError::DatabaseAlreadyOpen);
+                    }
+                }
+            }
+        };
+        self.check_mode(mode)?;
+
+        dir.init_protocol_files()?;
+        let (file, location) = match dir.open_data(allow_create, fresh_claim) {
+            Ok(opened) => opened,
+            Err(err) => {
+                // On a fresh claim this refusal is the fresh-lock rule firing late -- a file
+                // arrived under a name that was just required to be absent -- and the lock is
+                // marked for the same reason it is there
+                if fresh_claim
+                    && let DatabaseError::Storage(crate::StorageError::Io(io_err)) = &err
+                    && io_err.kind() == ErrorKind::AlreadyExists
+                {
+                    write_lock.mark_abandoned();
+                }
+                return Err(err);
+            }
+        };
+        // The backend takes the registry lock around every header write, which is the writing
+        // half of the protocol's atomic header reads; it takes no file lock, since `write.lock`
+        // and the files in `txn/` do that job and every process needs the file open at once
+        let backend = HeaderGuardedBackend::new(file, RegistryLock::open(dir))?;
+
+        let dir_for_coordinator = dir.clone();
+        // A guard rather than a check on the error paths: the repair callback runs inside the
         // initialization and is the caller's code, so the span can be left by a panic the caller
         // catches as well as by an error, and the temporary has to be cleaned up either way
         let mut cleanup = DiscardFailedData {
-            dir: &dir,
+            dir,
             location,
             armed: true,
         };
-        // `create` alone decides whether an empty database file may be initialized: an existing
-        // database is recognized by its contents rather than by the marker, so a create() that
-        // died before initializing the file can be redone
-        let inner = Database::new(
-            backend,
-            create,
-            PAGE_SIZE,
-            None,
-            self.cache_size,
-            &self.repair_callback,
+        let inner = Database::new_multiprocess(
+            Box::new(backend),
+            allow_create,
+            &OpenParams {
+                page_size: PAGE_SIZE,
+                region_size: self.region_size,
+                cache_size: self.cache_size,
+                repair_callback: &self.repair_callback,
+                // Restoring persistent savepoints is enough when this process is the only writer,
+                // but not when another process could reclaim their pages without knowing about them
+                restore_persistent_savepoints: matches!(mode, WriterMode::SingleWriterProcess),
+            },
+            move |mem| {
+                Ok(Arc::new(ProcessCoordinator::new(
+                    &dir_for_coordinator,
+                    mode,
+                    false,
+                    write_lock,
+                    mem,
+                )?))
+            },
         )?;
-        if create {
-            // Both last, and in this order, so that a create() pointed somewhere that turns out
-            // not to hold a database fails without having left either a database file or a marker
-            // behind
+
+        if allow_create {
+            // Both after `Database` has accepted the file, so that a create() pointed somewhere
+            // that turns out not to hold a database fails without having left either a database
+            // file or a marker behind
             dir.promote_data(location)?;
-            dir.write_metadata_if_missing()?;
+            dir.write_metadata_if_missing(mode)?;
         }
         cleanup.armed = false;
-        let metadata_lock = dir.lock_metadata_shared()?;
 
-        Ok(MultiProcessDatabase {
-            _inner: inner,
-            _metadata_lock: metadata_lock,
-        })
+        let coordinator = inner
+            .transaction_tracker()
+            .process()
+            .expect("a multi-process database always has a coordinator")
+            .clone();
+        // Taken here rather than earlier because a fresh create() has no marker to lock until
+        // just above
+        coordinator.hold_metadata_lock(dir.lock_metadata_shared()?)?;
+        // Still under the write lock, which is what entitles this process to rewrite the file
+        coordinator.initialize_extended_header()?;
+        // A database just created, or repaired after an unclean shutdown, has no allocator state
+        // table yet; one is written below so the next writer can load it instead of rebuilding it
+        let needs_allocator_state = Database::allocator_state_table(&inner.get_memory())?.is_none();
+        coordinator.end_write();
+
+        let db = MultiProcessDatabase { inner, coordinator };
+        if needs_allocator_state && matches!(mode, WriterMode::MultiWriterProcess) {
+            // An empty transaction, which commits with quick-repair like every other one in this
+            // mode. Taken through the ordinary path, so that it contends for the write lock with
+            // any other process rather than assuming this one still holds it
+            let txn = db
+                .begin_write()
+                .map_err(TransactionError::into_storage_error)?;
+            txn.commit().map_err(CommitError::into_storage_error)?;
+        }
+
+        Ok(db)
+    }
+}
+
+// Not under WASI, which has no file locking: these all take one, and the module itself is
+// compiled there because the coordinator is woven into the transaction tracker
+#[cfg(all(test, not(target_os = "wasi")))]
+mod test {
+    use super::*;
+    use crate::{ReadableTableMetadata, TableDefinition};
+
+    const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+
+    fn write(db: &MultiProcessDatabase, keys: std::ops::Range<u64>, len: usize) {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            let value = vec![0xab; len];
+            for key in keys {
+                table.insert(&key, value.as_slice()).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    // Small regions, so that a modest amount of data pushes the database into new ones. A process
+    // that has not written since then holds a layout describing fewer regions than the file has,
+    // which it must not use to read -- or write -- the pages in them.
+    fn small_region_builder() -> MultiProcessBuilder {
+        let mut builder = MultiProcessDatabase::builder();
+        builder
+            .set_writer_mode(WriterMode::MultiWriterProcess)
+            .set_region_size(1024 * 1024);
+        builder
+    }
+
+    /// The extended header is advisory in the strict sense: a corrupted one costs every process
+    /// its page cache, and nothing else. Readers fall back to assuming the worst, and the next
+    /// commit's flip writes a slot that verifies again.
+    #[test]
+    fn a_corrupted_extended_header_only_costs_the_cache() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let path = tmpdir.path().join("db");
+        let writer = small_region_builder().create(&path).unwrap();
+        let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+        write(&writer, 0..10, 64);
+        assert_eq!(
+            10,
+            reader
+                .begin_read()
+                .unwrap()
+                .open_table(TABLE)
+                .unwrap()
+                .len()
+                .unwrap()
+        );
+
+        // What a crash between the extended header write and the flip leaves behind, at its worst
+        std::fs::write(path.join("extended-header"), [0xabu8; 48]).unwrap();
+
+        // A reader must fall back -- drop its cache and carry on -- rather than fail or trust it
+        assert_eq!(
+            10,
+            reader
+                .begin_read()
+                .unwrap()
+                .open_table(TABLE)
+                .unwrap()
+                .len()
+                .unwrap()
+        );
+
+        // The next commit writes the slot it flips to, and the file verifies again from there
+        write(&writer, 10..11, 64);
+        assert_eq!(
+            11,
+            reader
+                .begin_read()
+                .unwrap()
+                .open_table(TABLE)
+                .unwrap()
+                .len()
+                .unwrap()
+        );
+    }
+
+    /// The cache floor says that nothing in the read cache predates it. A read transaction this
+    /// process already holds goes on reading from its own, older snapshot, and everything it puts
+    /// in the cache after a drop comes from there -- so dropping the cache cannot raise the floor
+    /// past it.
+    #[test]
+    fn the_cache_floor_stays_at_or_below_a_live_read_transaction() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let path = tmpdir.path().join("db");
+        let writer = small_region_builder().create(&path).unwrap();
+        let reader = MultiProcessDatabase::open(&path).unwrap();
+        let holder = MultiProcessDatabase::open(&path).unwrap();
+
+        // Pinned before anything is committed, so that every horizon announced from here on is
+        // clamped below the floor the reader opened with, and the reader keeps its cache
+        let holding = holder.begin_read().unwrap();
+        let settled = reader.coordinator.cache_floor();
+        for key in 0..8 {
+            write(&writer, key..key + 1, 64);
+        }
+
+        // Far enough past the floor for a later announcement to exceed it
+        let pinned = writer.last_durable_commit().unwrap();
+        let held = reader.begin_read().unwrap();
+        assert!(pinned > settled + 1);
+        assert_eq!(
+            settled,
+            reader.coordinator.cache_floor(),
+            "the cache was dropped before the reader had an older snapshot to fall behind on"
+        );
+
+        // Letting the horizon rise to what `held` pins is what makes the next refresh drop the
+        // cache, while `held` goes on reading the snapshot it pinned
+        drop(holding);
+        for key in 8..16 {
+            write(&writer, key..key + 1, 64);
+        }
+        drop(reader.begin_read().unwrap());
+
+        let floor = reader.coordinator.cache_floor();
+        assert!(
+            floor <= pinned,
+            "floor {floor} passed snapshot {pinned}, which a live reader is still reading from"
+        );
+        drop(held);
+    }
+
+    #[test]
+    fn a_reader_follows_the_database_into_new_regions() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let path = tmpdir.path().join("db");
+        let writer = small_region_builder().create(&path).unwrap();
+        write(&writer, 0..10, 4096);
+
+        let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+        assert_eq!(
+            10,
+            reader
+                .begin_read()
+                .unwrap()
+                .open_table(TABLE)
+                .unwrap()
+                .len()
+                .unwrap()
+        );
+
+        // Several regions worth of data, none of which the reader's layout knows about
+        write(&writer, 10..2000, 4096);
+
+        let txn = reader.begin_read().unwrap();
+        let table = txn.open_table(TABLE).unwrap();
+        assert_eq!(2000, table.len().unwrap());
+        for key in [0, 1000, 1999] {
+            assert_eq!(4096, table.get_owned(key).unwrap().unwrap().value().len());
+        }
+    }
+
+    #[test]
+    fn a_writer_picks_up_regions_another_process_added() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let path = tmpdir.path().join("db");
+        let first = small_region_builder().create(&path).unwrap();
+        let second = small_region_builder().open(&path).unwrap();
+        write(&first, 0..10, 4096);
+
+        // The second handle grows the database well past what the first has seen...
+        write(&second, 10..2000, 4096);
+        // ... and the first must reload the layout before it allocates against it
+        write(&first, 2000..2500, 4096);
+
+        let txn = second.begin_read().unwrap();
+        let table = txn.open_table(TABLE).unwrap();
+        assert_eq!(2500, table.len().unwrap());
+        for key in [0, 1500, 2499] {
+            assert_eq!(4096, table.get_owned(key).unwrap().unwrap().value().len());
+        }
+    }
+
+    #[test]
+    fn the_file_shrinks_back_with_readers_attached() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let path = tmpdir.path().join("db");
+        let writer = small_region_builder().create(&path).unwrap();
+        write(&writer, 0..2000, 4096);
+        let grown = std::fs::metadata(path.join("data.redb")).unwrap().len();
+
+        let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+        assert_eq!(
+            2000,
+            reader
+                .begin_read()
+                .unwrap()
+                .open_table(TABLE)
+                .unwrap()
+                .len()
+                .unwrap()
+        );
+
+        let txn = writer.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            for key in 0..2000 {
+                table.remove(&key).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+        // Further commits, so that the pages the delete freed are released and the file trimmed.
+        // Reclamation lags a commit behind in this mode, and each commit trims one region
+        for _ in 0..8 {
+            write(&writer, 0..1, 8);
+        }
+
+        let shrunk = std::fs::metadata(path.join("data.redb")).unwrap().len();
+        assert!(
+            shrunk < grown,
+            "the file did not shrink: {grown} -> {shrunk}"
+        );
+        assert_eq!(
+            1,
+            reader
+                .begin_read()
+                .unwrap()
+                .open_table(TABLE)
+                .unwrap()
+                .len()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn opening_a_directory_that_is_not_a_database_fails() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        assert!(MultiProcessDatabase::open(tmpdir.path().join("missing")).is_err());
+
+        let empty = tmpdir.path().join("empty");
+        std::fs::create_dir(&empty).unwrap();
+        assert!(MultiProcessDatabase::open(&empty).is_err());
+        assert!(MultiProcessDatabase::open_read_only(&empty).is_err());
+    }
+
+    #[test]
+    fn create_is_idempotent() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let path = tmpdir.path().join("db");
+        {
+            let db = MultiProcessDatabase::create(&path).unwrap();
+            write(&db, 0..10, 8);
+        }
+        let db = MultiProcessDatabase::create(&path).unwrap();
+        assert_eq!(
+            10,
+            db.begin_read()
+                .unwrap()
+                .open_table(TABLE)
+                .unwrap()
+                .len()
+                .unwrap()
+        );
     }
 }
 

--- a/src/multiprocess/mod.rs
+++ b/src/multiprocess/mod.rs
@@ -1,0 +1,127 @@
+//! A multi-process safe interface to a redb database.
+//!
+//! [`MultiProcessDatabase`] stores its database in a directory, alongside the coordination files
+//! described in the "Directory-structured databases" section of `docs/design.md`. Only one
+//! process may have the database open at a time.
+
+mod locks;
+
+use crate::db::RepairSession;
+use crate::tree_store::PAGE_SIZE;
+use crate::{Database, DatabaseError, Result};
+use locks::DatabaseDir;
+use std::fs::File;
+use std::path::Path;
+
+/// A redb database stored in a directory, alongside the coordination files described in
+/// `docs/design.md`.
+///
+/// The directory must be on a filesystem that supports file locking, and belongs to redb -- do not
+/// put anything else in it. A second process that opens the same directory fails with
+/// [`DatabaseError::DatabaseAlreadyOpen`]: the exclusion is carried by a lock file in the
+/// directory rather than by a lock on the database file itself.
+pub struct MultiProcessDatabase {
+    /// Holds the database open; dropping it closes the file and releases the write lock.
+    _inner: Database,
+    /// The shared lock every process holds on `metadata` for as long as it has the database open.
+    /// A future format upgrade takes it exclusively, and this is what it waits on.
+    _metadata_lock: File,
+}
+
+impl MultiProcessDatabase {
+    /// Opens the directory at `path` as a multi-process database, creating it if it does not
+    /// exist.
+    pub fn create(path: impl AsRef<Path>) -> Result<MultiProcessDatabase, DatabaseError> {
+        Self::builder().create(path)
+    }
+
+    /// Opens an existing multi-process database.
+    pub fn open(path: impl AsRef<Path>) -> Result<MultiProcessDatabase, DatabaseError> {
+        Self::builder().open(path)
+    }
+
+    /// Convenience method for [`MultiProcessBuilder::new`]
+    pub fn builder() -> MultiProcessBuilder {
+        MultiProcessBuilder::new()
+    }
+}
+
+impl std::fmt::Debug for MultiProcessDatabase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MultiProcessDatabase").finish()
+    }
+}
+
+/// Configuration builder of a [`MultiProcessDatabase`].
+pub struct MultiProcessBuilder {
+    cache_size: usize,
+    repair_callback: Box<dyn Fn(&mut RepairSession)>,
+}
+
+impl MultiProcessBuilder {
+    /// Construct a new [`MultiProcessBuilder`] with sensible defaults.
+    ///
+    /// ## Defaults
+    ///
+    /// - `cache_size_bytes`: 1GiB
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            cache_size: 1024 * 1024 * 1024,
+            repair_callback: Box::new(|_| {}),
+        }
+    }
+
+    /// Set the amount of memory (in bytes) used for caching data
+    pub fn set_cache_size(&mut self, bytes: usize) -> &mut Self {
+        self.cache_size = bytes;
+        self
+    }
+
+    /// Set a callback which will be invoked periodically in the event that the database file needs
+    /// to be repaired. See [`crate::Builder::set_repair_callback`].
+    pub fn set_repair_callback(
+        &mut self,
+        callback: impl Fn(&mut RepairSession) + 'static,
+    ) -> &mut Self {
+        self.repair_callback = Box::new(callback);
+        self
+    }
+
+    /// Opens the directory at `path` as a multi-process database, creating it if it does not exist
+    pub fn create(&self, path: impl AsRef<Path>) -> Result<MultiProcessDatabase, DatabaseError> {
+        self.open_inner(path.as_ref(), true)
+    }
+
+    /// Opens an existing multi-process database
+    pub fn open(&self, path: impl AsRef<Path>) -> Result<MultiProcessDatabase, DatabaseError> {
+        self.open_inner(path.as_ref(), false)
+    }
+
+    fn open_inner(&self, path: &Path, create: bool) -> Result<MultiProcessDatabase, DatabaseError> {
+        let dir = DatabaseDir::new(path);
+        let backend = dir.open(create)?;
+        // `create` alone decides whether an empty database file may be initialized: an existing
+        // database is recognized by its contents rather than by the marker, so a create() that
+        // died before initializing the file can be redone
+        let inner = Database::new(
+            backend,
+            create,
+            PAGE_SIZE,
+            None,
+            self.cache_size,
+            &self.repair_callback,
+        )?;
+        if create {
+            // Last, so that a create() pointed at a directory which turns out not to hold a
+            // database fails without having marked it as one of these
+            dir.write_metadata_if_missing()?;
+        }
+        let metadata_lock = dir.lock_metadata_shared()?;
+
+        Ok(MultiProcessDatabase {
+            _inner: inner,
+            _metadata_lock: metadata_lock,
+        })
+    }
+}

--- a/src/multiprocess/mod.rs
+++ b/src/multiprocess/mod.rs
@@ -9,7 +9,7 @@ mod locks;
 use crate::db::RepairSession;
 use crate::tree_store::PAGE_SIZE;
 use crate::{Database, DatabaseError, Result};
-use locks::DatabaseDir;
+use locks::{DataLocation, DatabaseDir};
 use std::fs::File;
 use std::path::Path;
 
@@ -100,7 +100,15 @@ impl MultiProcessBuilder {
 
     fn open_inner(&self, path: &Path, create: bool) -> Result<MultiProcessDatabase, DatabaseError> {
         let dir = DatabaseDir::new(path);
-        let backend = dir.open(create)?;
+        let (backend, location) = dir.open(create)?;
+        // A guard rather than a check on the error path: the repair callback runs inside the
+        // initialization and is the caller's code, so the span can be left by a panic the caller
+        // catches as well as by an error, and the temporary has to be cleaned up either way
+        let mut cleanup = DiscardFailedData {
+            dir: &dir,
+            location,
+            armed: true,
+        };
         // `create` alone decides whether an empty database file may be initialized: an existing
         // database is recognized by its contents rather than by the marker, so a create() that
         // died before initializing the file can be redone
@@ -113,15 +121,36 @@ impl MultiProcessBuilder {
             &self.repair_callback,
         )?;
         if create {
-            // Last, so that a create() pointed at a directory which turns out not to hold a
-            // database fails without having marked it as one of these
+            // Both last, and in this order, so that a create() pointed somewhere that turns out
+            // not to hold a database fails without having left either a database file or a marker
+            // behind
+            dir.promote_data(location)?;
             dir.write_metadata_if_missing()?;
         }
+        cleanup.armed = false;
         let metadata_lock = dir.lock_metadata_shared()?;
 
         Ok(MultiProcessDatabase {
             _inner: inner,
             _metadata_lock: metadata_lock,
         })
+    }
+}
+
+/// Discards the temporary a `create()` made, unless initialization completed and disarmed it.
+/// A drop guard rather than error-path cleanup, because the span it covers runs the repair
+/// callback -- the caller's code -- and can be left by a panic the caller catches, which no
+/// error path would see.
+struct DiscardFailedData<'a> {
+    dir: &'a DatabaseDir,
+    location: DataLocation,
+    armed: bool,
+}
+
+impl Drop for DiscardFailedData<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.dir.discard_failed_data(self.location);
+        }
     }
 }

--- a/src/multiprocess_no_std.rs
+++ b/src/multiprocess_no_std.rs
@@ -1,0 +1,57 @@
+//! Stands in for [`crate::multiprocess`] where there is no file system to coordinate through.
+//!
+//! A multi-process database is a directory of files and locks, so `no_std` has none. The tracker
+//! and the database still carry an `Option<Arc<ProcessCoordinator>>` there, always `None`, rather
+//! than putting a `cfg` on the field and on every path that consults it.
+
+use crate::Result;
+use crate::transaction_tracker::TransactionId;
+
+/// Uninhabited: a `no_std` build never constructs one, so the methods below are unreachable and
+/// exist only so that the paths which consult a coordinator type-check.
+pub(crate) enum ProcessCoordinator {}
+
+impl ProcessCoordinator {
+    pub(crate) fn shares_write_lock(&self) -> bool {
+        match *self {}
+    }
+
+    pub(crate) fn allows_non_durable_commit(&self) -> bool {
+        match *self {}
+    }
+
+    pub(crate) fn begin_read(
+        &self,
+        _local_write_transaction_live: bool,
+        _local_oldest: Option<TransactionId>,
+    ) -> Result<TransactionId> {
+        match *self {}
+    }
+
+    pub(crate) fn publish_pinned(&self, _local_oldest: Option<TransactionId>) -> Result<()> {
+        match *self {}
+    }
+
+    pub(crate) fn oldest_pinned_globally(
+        &self,
+        _local_oldest: Option<TransactionId>,
+    ) -> Result<Option<TransactionId>> {
+        match *self {}
+    }
+
+    pub(crate) fn record_collection_horizon(&self, _free_until: TransactionId) -> Result<()> {
+        match *self {}
+    }
+
+    pub(crate) fn begin_write(&self) -> Result<TransactionId> {
+        match *self {}
+    }
+
+    pub(crate) fn end_write(&self) {
+        match *self {}
+    }
+
+    pub(crate) fn release_for_close(&self) {
+        match *self {}
+    }
+}

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -1,4 +1,5 @@
-use crate::sync::{Condvar, Mutex};
+use crate::multiprocess::ProcessCoordinator;
+use crate::sync::{Condvar, Mutex, MutexGuard};
 use crate::tree_store::TransactionalMemory;
 use crate::{Key, Result, Savepoint, TypeName, Value};
 use alloc::collections::BTreeSet;
@@ -93,19 +94,50 @@ struct State {
     pending_non_durable_commits: BTreeMap<TransactionId, TransactionId>,
     // Non-durable commits which have NOT been processed in the freed table
     unprocessed_freed_non_durable_commits: BTreeSet<TransactionId>,
+    // True while a thread is starting a write transaction but has not yet been given an id. A
+    // multi-process database takes the cross-process write lock and reloads its state in that
+    // window, which must not overlap another write transaction but must not hold the state lock
+    // either
+    write_transaction_starting: bool,
     // Set when the Database was dropped while a write transaction was live. That transaction
     // keeps the database open, and end_write_transaction() hands the close back to it when
     // it ends
     deferred_close: Option<Arc<TransactionalMemory>>,
 }
 
+impl State {
+    // The oldest transaction this process needs kept alive: read transactions and savepoints both
+    // hold a reference here
+    fn oldest_pinned(&self) -> Option<TransactionId> {
+        self.live_read_transactions.keys().next().copied()
+    }
+}
+
 pub(crate) struct TransactionTracker {
     state: Mutex<State>,
     live_write_transaction_available: Condvar,
+    // Set for a multi-process database: the half of this tracker that other processes can see.
+    // Every path that pins a transaction publishes through it, and every path that reclaims pages
+    // consults it
+    process: Option<Arc<ProcessCoordinator>>,
 }
 
 impl TransactionTracker {
     pub(crate) fn new(next_transaction_id: TransactionId) -> Self {
+        Self::new_inner(next_transaction_id, None)
+    }
+
+    pub(crate) fn new_multiprocess(
+        next_transaction_id: TransactionId,
+        process: Arc<ProcessCoordinator>,
+    ) -> Self {
+        Self::new_inner(next_transaction_id, Some(process))
+    }
+
+    fn new_inner(
+        next_transaction_id: TransactionId,
+        process: Option<Arc<ProcessCoordinator>>,
+    ) -> Self {
         Self {
             state: Mutex::new(State {
                 next_savepoint_id: SavepointId(0),
@@ -116,24 +148,103 @@ impl TransactionTracker {
                 persistent_savepoints: BTreeSet::default(),
                 pending_non_durable_commits: BTreeMap::default(),
                 unprocessed_freed_non_durable_commits: BTreeSet::default(),
+                write_transaction_starting: false,
                 deferred_close: None,
             }),
             live_write_transaction_available: Condvar::new(),
+            process,
         }
     }
 
-    pub(crate) fn start_write_transaction(&self) -> TransactionId {
+    pub(crate) fn process(&self) -> Option<&Arc<ProcessCoordinator>> {
+        self.process.as_ref()
+    }
+
+    // True when another process may take over the write lock between this process's transactions,
+    // so that everything this one leaves in memory has to be assumed lost
+    pub(crate) fn write_lock_is_shared(&self) -> bool {
+        self.process
+            .as_ref()
+            .is_some_and(|process| process.shares_write_lock())
+    }
+
+    // Every commit must be a quick-repair commit when another process may take over the write
+    // lock, since it loads the allocator state this writes rather than rebuilding it
+    pub(crate) fn requires_quick_repair(&self) -> bool {
+        self.write_lock_is_shared()
+    }
+
+    // Every commit must be 2-phase when another process may be reading the file: a 1-phase commit
+    // writes the new header and the pages it references in one flush, in no particular order, and
+    // while a crash cannot observe that intermediate state, a concurrent reader can.
+    pub(crate) fn requires_two_phase_commit(&self) -> bool {
+        self.process.is_some()
+    }
+
+    // True when the post-commit free epilogue must be skipped: it publishes its work as a
+    // non-durable commit, which is invisible to every other process and is thrown away as soon as
+    // one of them takes the write lock
+    pub(crate) fn defers_post_commit_free(&self) -> bool {
+        self.write_lock_is_shared()
+    }
+
+    // False when a non-durable commit would be invisible to, and silently discarded by, the next
+    // process to write
+    pub(crate) fn allows_non_durable_commit(&self) -> bool {
+        self.process
+            .as_ref()
+            .is_none_or(|process| process.allows_non_durable_commit())
+    }
+
+    fn reserve_write_slot(&self) -> MutexGuard<'_, State> {
         let mut state = self.state.lock().unwrap();
-        while state.live_write_transaction.is_some() {
+        while state.live_write_transaction.is_some() || state.write_transaction_starting {
             state = self.live_write_transaction_available.wait(state).unwrap();
         }
-        assert!(state.live_write_transaction.is_none());
+        state
+    }
+
+    pub(crate) fn start_write_transaction(&self) -> TransactionId {
+        let mut state = self.reserve_write_slot();
         let transaction_id = state.next_transaction_id.increment();
         #[cfg(feature = "logging")]
         debug!("Beginning write transaction id={transaction_id:?}");
         state.live_write_transaction = Some(transaction_id);
 
         transaction_id
+    }
+
+    // Starts a write transaction for a multi-process database. `prepare` runs with the write slot
+    // reserved but the state lock released -- it blocks on the cross-process write lock, which
+    // read transactions in this process must not have to wait for -- and returns the last
+    // transaction any process has committed, which numbers the new transaction.
+    pub(crate) fn start_write_transaction_prepared(
+        &self,
+        prepare: impl FnOnce() -> Result<TransactionId>,
+    ) -> Result<TransactionId> {
+        self.reserve_write_slot().write_transaction_starting = true;
+
+        let prepared = prepare();
+
+        let mut state = self.state.lock()?;
+        state.write_transaction_starting = false;
+        let last_committed = match prepared {
+            Ok(last_committed) => last_committed,
+            Err(err) => {
+                self.live_write_transaction_available.notify_one();
+                return Err(err);
+            }
+        };
+        // Transaction ids come from the file rather than from this process's counter, so that they
+        // stay ordered across processes. An aborted transaction's id is reused, exactly as it
+        // would be if this process had closed the database and reopened it
+        state.next_transaction_id = last_committed;
+        let transaction_id = state.next_transaction_id.increment();
+        #[cfg(feature = "logging")]
+        debug!("Beginning write transaction id={transaction_id:?}");
+        state.live_write_transaction = Some(transaction_id);
+
+        Ok(transaction_id)
     }
 
     // Returns the deferred close, if the Database was dropped while this transaction was live.
@@ -145,6 +256,10 @@ impl TransactionTracker {
         let mut state = self.state.lock().unwrap();
         assert_eq!(state.live_write_transaction.unwrap(), id);
         state.live_write_transaction = None;
+        if let Some(process) = &self.process {
+            // Hands the write lock to the next process, if this mode takes it per transaction
+            process.end_write();
+        }
         self.live_write_transaction_available.notify_one();
         state.deferred_close.take()
     }
@@ -179,6 +294,7 @@ impl TransactionTracker {
                 state.live_read_transactions.remove(&durable_ancestor);
             }
         }
+        self.publish_pinned(&state);
     }
 
     pub(crate) fn is_unprocessed_non_durable_commit(&self, id: TransactionId) -> bool {
@@ -229,6 +345,7 @@ impl TransactionTracker {
         if has_unprocessed_freed_pages {
             state.unprocessed_freed_non_durable_commits.insert(id);
         }
+        self.publish_pinned(&state);
     }
 
     // Reserve a transaction id that was created without starting a new write transaction.
@@ -270,6 +387,9 @@ impl TransactionTracker {
             .valid_savepoints
             .insert(savepoint.get_id(), savepoint.get_transaction_id());
         state.persistent_savepoints.insert(savepoint.get_id());
+        // A persistent savepoint pins a transaction older than any live read, so other processes
+        // have to be told about it before they can reclaim anything
+        self.publish_pinned(&state);
     }
 
     // Marks an already-registered savepoint as persistent
@@ -284,7 +404,15 @@ impl TransactionTracker {
         mem: &TransactionalMemory,
     ) -> Result<TransactionId> {
         let mut state = self.state.lock()?;
-        let id = mem.get_last_committed_transaction_id()?;
+        let id = if let Some(process) = &self.process {
+            // Held across the cross-process registration, so that a writer in this process cannot
+            // read the oldest pinned transaction in between publishing the new one and recording
+            // it here
+            let oldest = state.oldest_pinned();
+            process.begin_read(state.live_write_transaction.is_some(), oldest)?
+        } else {
+            mem.get_last_committed_transaction_id()?
+        };
         state
             .live_read_transactions
             .entry(id)
@@ -300,6 +428,16 @@ impl TransactionTracker {
         *ref_count -= 1;
         if *ref_count == 0 {
             state.live_read_transactions.remove(&id);
+            self.publish_pinned(&state);
+        }
+    }
+
+    // Tells other processes what this one still needs. A failure to publish only leaves a stale,
+    // older pin, which costs reclamation but is never unsafe -- and this runs on drop paths that
+    // have nowhere to report an error to.
+    fn publish_pinned(&self, state: &State) {
+        if let Some(process) = &self.process {
+            let _ = process.publish_pinned(state.oldest_pinned());
         }
     }
 
@@ -408,14 +546,40 @@ impl TransactionTracker {
             .map(|(id, txn_id)| (*id, *txn_id))
     }
 
-    pub(crate) fn oldest_live_read_transaction(&self) -> Option<TransactionId> {
-        self.state
-            .lock()
-            .unwrap()
-            .live_read_transactions
-            .keys()
-            .next()
-            .copied()
+    // The oldest transaction that must be kept readable, across every process. The state lock is
+    // held across the cross-process scan, which makes the scan atomic with respect to read
+    // transactions registering in this process.
+    pub(crate) fn oldest_live_read_transaction(&self) -> Result<Option<TransactionId>> {
+        let state = self.state.lock()?;
+        let local = state.oldest_pinned();
+        match &self.process {
+            Some(process) => process.oldest_pinned_globally(local),
+            None => Ok(local),
+        }
+    }
+
+    // The highest free horizon that is safe when other processes may be reading, or None when
+    // none can. A reader about to register pins the last durable commit in the file, and may read
+    // it at any moment before its pin becomes visible here; the in-memory transaction id can be
+    // ahead of the file, so the horizon this process computes does not imply this bound.
+    pub(crate) fn cross_process_free_limit(
+        &self,
+        mem: &TransactionalMemory,
+    ) -> Result<Option<TransactionId>> {
+        if self.process.is_none() {
+            return Ok(None);
+        }
+        Ok(Some(mem.get_last_durable_transaction_id()?.next()))
+    }
+
+    // Records that pages freed by transactions older than `free_until` are being reclaimed. Other
+    // processes learn of it at this transaction's commit flip, which is also when the reused pages
+    // first become visible to them; until then the reuse lives only in this process's buffers.
+    pub(crate) fn record_collection_horizon(&self, free_until: TransactionId) -> Result<()> {
+        match &self.process {
+            Some(process) => process.record_collection_horizon(free_until),
+            None => Ok(()),
+        }
     }
 
     // Returns the transaction id of the oldest non-durable transaction which has not been processed

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -892,13 +892,24 @@ impl SavepointTransactionState {
 // have returned pages to the allocator that the durable roots still reference through the
 // freed tables; such an allocator state must never be used, or persisted by a clean
 // shutdown, again.
+//
+// Under a shared write lock the commit's writes are dropped as well. They belong to pages that
+// are free in every durable state, and releasing the lock lets another process fill those pages:
+// flushing the buffered copies later would overwrite that process's data, and the read cache's
+// copies would shadow it, since a free page is refilled without the collection that drops stale
+// cache entries. The sole-writer mode keeps both -- there the buffer may also hold non-durable
+// commits that its readers are still being served from.
 struct AllocatorStateLatch {
     mem: Option<Arc<TransactionalMemory>>,
+    shared_write_lock: bool,
 }
 
 impl AllocatorStateLatch {
-    fn arm(mem: Arc<TransactionalMemory>) -> Self {
-        Self { mem: Some(mem) }
+    fn arm(mem: Arc<TransactionalMemory>, shared_write_lock: bool) -> Self {
+        Self {
+            mem: Some(mem),
+            shared_write_lock,
+        }
     }
 
     fn disarm(mut self) {
@@ -909,6 +920,10 @@ impl AllocatorStateLatch {
 impl Drop for AllocatorStateLatch {
     fn drop(&mut self) {
         if let Some(mem) = self.mem.take() {
+            if self.shared_write_lock {
+                mem.discard_buffered_writes();
+                mem.clear_read_cache();
+            }
             mem.invalidate_allocator_state();
         }
     }
@@ -953,6 +968,7 @@ impl WriteTransaction {
     ) -> Result<Self> {
         let transaction_id = guard.id();
         let guard = Arc::new(guard);
+        let defer_post_commit_free = transaction_tracker.defers_post_commit_free();
 
         let root_page = mem.get_data_root();
         let system_page = mem.get_system_root();
@@ -974,7 +990,13 @@ impl WriteTransaction {
             durability: InternalDurability::Immediate,
             two_phase_commit: false,
             quick_repair: false,
-            post_commit_free: PostCommitFree::Enabled,
+            // The epilogue publishes its work as a non-durable commit, which no other process can
+            // see. Leaving it out costs nothing but deferring those frees to the next transaction
+            post_commit_free: if defer_post_commit_free {
+                PostCommitFree::Disabled
+            } else {
+                PostCommitFree::Enabled
+            },
             restored_transaction: None,
             shrink_policy: ShrinkPolicy::Default,
             savepoint_state: Mutex::new(SavepointTransactionState::default()),
@@ -1466,6 +1488,11 @@ impl WriteTransaction {
         if persistent_modified && !matches!(durability, Durability::Immediate) {
             return Err(SetDurabilityError::PersistentSavepointModified);
         }
+        if matches!(durability, Durability::None)
+            && !self.transaction_tracker.allows_non_durable_commit()
+        {
+            return Err(SetDurabilityError::NonDurableCommitUnsupported);
+        }
 
         self.durability = match durability {
             Durability::None => InternalDurability::None,
@@ -1692,7 +1719,10 @@ impl WriteTransaction {
     fn commit_inner(&mut self) -> Result<(), CommitError> {
         // Covers both the error and the panic-unwind path. Without an allocator state,
         // begin_write() refuses new write transactions and the next open repairs.
-        let latch = AllocatorStateLatch::arm(self.mem.clone());
+        let latch = AllocatorStateLatch::arm(
+            self.mem.clone(),
+            self.transaction_tracker.write_lock_is_shared(),
+        );
         let result = self.commit_inner_helper();
         if result.is_ok() {
             latch.disarm();
@@ -1701,6 +1731,15 @@ impl WriteTransaction {
     }
 
     fn commit_inner_helper(&mut self) -> Result<(), CommitError> {
+        // The next process to take the write lock loads the allocator state this writes, rather
+        // than rebuilding it, so it is not optional
+        if self.transaction_tracker.requires_quick_repair() {
+            self.quick_repair = true;
+        }
+        // Ordering that a reader in another process depends on: see requires_two_phase_commit()
+        if self.transaction_tracker.requires_two_phase_commit() {
+            self.two_phase_commit = true;
+        }
         // Quick-repair requires 2-phase commit
         if self.quick_repair {
             self.two_phase_commit = true;
@@ -1963,6 +2002,12 @@ impl WriteTransaction {
             .apply_on_abort(&self.transaction_tracker);
         self.mem.check_io_errors()?;
         self.page_allocator().rollback_all();
+        if self.transaction_tracker.write_lock_is_shared() {
+            // The buffered writes belong to pages this transaction allocated, which are about to
+            // become free for another process to allocate. Flushing them later would overwrite
+            // whatever that process put there
+            self.mem.discard_buffered_writes();
+        }
         #[cfg(feature = "logging")]
         debug!("Finished abort of transaction id={:?}", self.transaction_id);
         Ok(())
@@ -1979,10 +2024,16 @@ impl WriteTransaction {
             self.store_data_freed_pages_for(transaction_id, pages)?;
         }
 
-        let free_until_transaction = self
+        let mut free_until_transaction = self
             .transaction_tracker
-            .oldest_live_read_transaction()
+            .oldest_live_read_transaction()?
             .map_or(self.transaction_id, |x| x.next());
+        if let Some(limit) = self
+            .transaction_tracker
+            .cross_process_free_limit(&self.mem)?
+        {
+            free_until_transaction = free_until_transaction.min(limit);
+        }
         self.process_freed_pages(free_until_transaction)?;
         // Flush allocated pages (including previously unpersisted allocations that are now
         // becoming durable) AFTER process_freed_pages, so that any pages reclaimed here have
@@ -2083,8 +2134,17 @@ impl WriteTransaction {
         let epilogue_transaction = self.transaction_id.next();
         let mut free_until = self
             .transaction_tracker
-            .oldest_live_read_transaction()
+            .oldest_live_read_transaction()?
             .map_or(epilogue_transaction, |x| x.next());
+        // Clamp the free horizon to what a read transaction another process is about to register
+        // may still need. Without this the epilogue's own transaction id, which is one past the
+        // commit that is in the file, would let a page that snapshot reaches be reclaimed
+        if let Some(limit) = self
+            .transaction_tracker
+            .cross_process_free_limit(&self.mem)?
+        {
+            free_until = free_until.min(limit);
+        }
         // Clamp the free horizon to the savepoint horizon captured during the purge. A savepoint
         // is also a live read, so absent concurrency `oldest_live_read_transaction()` never
         // exceeds it and this is a no-op. But an ephemeral `Savepoint::drop` racing this commit
@@ -2095,6 +2155,11 @@ impl WriteTransaction {
         if savepoint_horizon != u64::MAX {
             free_until = free_until.min(TransactionId::new(savepoint_horizon).next());
         }
+
+        // As in process_freed_pages(): recorded for the next commit's flip, which is what makes
+        // this epilogue's reuse visible to other processes
+        self.transaction_tracker
+            .record_collection_horizon(free_until)?;
 
         let mut freed_any = false;
         let (system_root, stored_system_freed_pages, extracted_data_transactions) = {
@@ -2293,6 +2358,11 @@ impl WriteTransaction {
     fn process_freed_pages(&mut self, free_until: TransactionId) -> Result {
         // We assume below that PageNumber is length 8
         assert_eq!(PageNumber::serialized_size(), 8);
+
+        // Other processes hear about this at the commit flip, which is also the first moment any
+        // page reclaimed below can be visibly reused
+        self.transaction_tracker
+            .record_collection_horizon(free_until)?;
 
         let page_allocator = self.page_allocator();
         let mut free_page = |page| {
@@ -2627,6 +2697,16 @@ impl Drop for WriteTransaction {
             // The abort is skipped while unwinding, leaking this transaction's pages: the
             // session stays usable, but the leak must not outlive the process
             assert!(crate::panicking());
+            // The buffered writes can only be this transaction's, and once the write lock is
+            // released another process may reuse the pages they shadow
+            self.mem.discard_buffered_writes();
+            if self.transaction_tracker.write_lock_is_shared() {
+                // A page of this transaction's can sit in the read cache as well, if it
+                // overflowed the write buffer and was read back. The leaked pages are free in
+                // every committed state, so the next writer fills them without the collection
+                // that normally drops stale cache entries
+                self.mem.clear_read_cache();
+            }
             self.mem.mark_needs_repair();
         }
     }

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -1430,7 +1430,7 @@ mod tests {
     fn test_cycle_detection_in_btree() {
         use crate::tree_store::btree_base::RawBranchBuilder;
         use crate::tree_store::{
-            AllocationPolicy, InMemoryBackend, PAGE_SIZE, TransactionalMemory,
+            AccessMode, AllocationPolicy, InMemoryBackend, PAGE_SIZE, TransactionalMemory,
         };
 
         let mem = TransactionalMemory::new(
@@ -1439,7 +1439,7 @@ mod tests {
             PAGE_SIZE,
             None,
             0,
-            false,
+            AccessMode::ReadWrite,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -2281,7 +2281,9 @@ impl<'b> BranchMutator<'b> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tree_store::{AllocationPolicy, InMemoryBackend, PAGE_SIZE, TransactionalMemory};
+    use crate::tree_store::{
+        AccessMode, AllocationPolicy, InMemoryBackend, PAGE_SIZE, TransactionalMemory,
+    };
 
     const MAX_PAIRS: usize = u16::MAX as usize;
 
@@ -2296,7 +2298,7 @@ mod tests {
             page_size,
             None,
             0,
-            false,
+            AccessMode::ReadWrite,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -2455,7 +2455,9 @@ fn park_bound<K: Key + 'static, V: Value + 'static>(
 mod tests {
     use super::*;
     use crate::tree_store::btree_base::{DEFERRED, LeafBuilder};
-    use crate::tree_store::{AllocationPolicy, InMemoryBackend, PAGE_SIZE, TransactionalMemory};
+    use crate::tree_store::{
+        AccessMode, AllocationPolicy, InMemoryBackend, PAGE_SIZE, TransactionalMemory,
+    };
 
     fn test_page_allocator() -> PageAllocator {
         let mem = TransactionalMemory::new(
@@ -2464,7 +2466,7 @@ mod tests {
             PAGE_SIZE,
             None,
             0,
-            false,
+            AccessMode::ReadWrite,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -1831,7 +1831,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
 #[cfg(all(test, feature = "experimental_cursor"))]
 mod tests {
     use super::*;
-    use crate::tree_store::{AllocationPolicy, InMemoryBackend, TransactionalMemory};
+    use crate::tree_store::{AccessMode, AllocationPolicy, InMemoryBackend, TransactionalMemory};
 
     const MAX_KEYS: usize = u16::MAX as usize;
 
@@ -1846,7 +1846,7 @@ mod tests {
             page_size,
             None,
             0,
-            false,
+            AccessMode::ReadWrite,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -22,6 +22,8 @@ pub(crate) use btree_cursor_range::BtreeCursorRange;
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, encode_bounds};
 pub(crate) use extract_if::BtreeExtractIf;
 pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multimap_btree_stats};
+#[cfg(all(feature = "experimental-multiprocess", not(redb_no_std)))]
+pub(crate) use page_store::MAGICNUMBER;
 #[cfg(not(redb_no_std))]
 pub(crate) use page_store::ReadOnlyBackend;
 #[cfg(not(redb_no_std))]

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -22,17 +22,19 @@ pub(crate) use btree_cursor_range::BtreeCursorRange;
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, encode_bounds};
 pub(crate) use extract_if::BtreeExtractIf;
 pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multimap_btree_stats};
-#[cfg(all(feature = "experimental-multiprocess", not(redb_no_std)))]
+#[cfg(not(redb_no_std))]
 pub(crate) use page_store::MAGICNUMBER;
 #[cfg(not(redb_no_std))]
 pub(crate) use page_store::ReadOnlyBackend;
 #[cfg(not(redb_no_std))]
 pub use page_store::file_backend;
 pub(crate) use page_store::{
-    AllocationPolicy, FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page,
-    PageAllocator, PageHint, PageNumber, PageNumberHashMap, PageNumberHashSet, PageResolver,
-    PageTracker, SerializedSavepoint, ShrinkPolicy, TransactionalMemory,
+    AccessMode, AllocationPolicy, FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH,
+    PAGE_SIZE, Page, PageAllocator, PageHint, PageNumber, PageNumberHashMap, PageNumberHashSet,
+    PageResolver, PageTracker, SerializedSavepoint, ShrinkPolicy, TransactionalMemory,
 };
+#[cfg(not(redb_no_std))]
+pub(crate) use page_store::{CommitHook, DB_HEADER_SIZE, RawCommitSlots, xxh3_checksum};
 pub use page_store::{InMemoryBackend, Savepoint};
 pub(crate) use table_tree::{PageListMut, TableTree, TableTreeMut};
 pub(crate) use table_tree_base::{InternalTableDefinition, TableType};

--- a/src/tree_store/page_store/file_backend/fallback.rs
+++ b/src/tree_store/page_store/file_backend/fallback.rs
@@ -13,17 +13,34 @@ pub struct FileBackend {
     file: Mutex<File>,
 }
 
+/// Which whole-file advisory lock a [`FileBackend`] takes when it is created.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub(crate) enum FileLockKind {
+    /// Excludes every other opener of the file
+    Exclusive,
+    /// Excludes writers, but not other readers
+    Shared,
+    /// Takes no lock at all. Only for multi-process databases, which exclude concurrent writers
+    /// with their own lock files instead
+    None,
+}
+
 impl FileBackend {
     /// Creates a new backend which stores data to the given file.
     pub fn new(file: File) -> Result<Self, DatabaseError> {
-        Self::new_internal(file, false)
+        Self::new_internal(file, FileLockKind::Exclusive)
     }
 
-    pub(crate) fn new_internal(file: File, read_only: bool) -> Result<Self, DatabaseError> {
-        let result = if read_only {
-            file.try_lock_shared()
-        } else {
-            file.try_lock()
+    pub(crate) fn new_internal(file: File, lock: FileLockKind) -> Result<Self, DatabaseError> {
+        let result = match lock {
+            FileLockKind::Exclusive => file.try_lock(),
+            FileLockKind::Shared => file.try_lock_shared(),
+            FileLockKind::None => {
+                return Ok(Self {
+                    lock_supported: false,
+                    file: Mutex::new(file),
+                });
+            }
         };
 
         match result {

--- a/src/tree_store/page_store/file_backend/mod.rs
+++ b/src/tree_store/page_store/file_backend/mod.rs
@@ -2,8 +2,12 @@
 mod optimized;
 #[cfg(any(windows, unix, target_os = "wasi"))]
 pub use optimized::FileBackend;
+#[cfg(any(windows, unix, target_os = "wasi"))]
+pub(crate) use optimized::FileLockKind;
 
 #[cfg(not(any(windows, unix, target_os = "wasi")))]
 mod fallback;
 #[cfg(not(any(windows, unix, target_os = "wasi")))]
 pub use fallback::FileBackend;
+#[cfg(not(any(windows, unix, target_os = "wasi")))]
+pub(crate) use fallback::FileLockKind;

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -11,6 +11,18 @@ use std::os::unix::fs::FileExt;
 #[cfg(windows)]
 use std::os::windows::fs::FileExt;
 
+/// Which whole-file advisory lock a [`FileBackend`] takes when it is created.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub(crate) enum FileLockKind {
+    /// Excludes every other opener of the file
+    Exclusive,
+    /// Excludes writers, but not other readers
+    Shared,
+    /// Takes no lock at all. Only for multi-process databases, which exclude concurrent writers
+    /// with their own lock files instead
+    None,
+}
+
 /// Stores a database as a file on-disk.
 #[derive(Debug)]
 pub struct FileBackend {
@@ -21,14 +33,19 @@ pub struct FileBackend {
 impl FileBackend {
     /// Creates a new backend which stores data to the given file.
     pub fn new(file: File) -> Result<Self, DatabaseError> {
-        Self::new_internal(file, false)
+        Self::new_internal(file, FileLockKind::Exclusive)
     }
 
-    pub(crate) fn new_internal(file: File, read_only: bool) -> Result<Self, DatabaseError> {
-        let result = if read_only {
-            file.try_lock_shared()
-        } else {
-            file.try_lock()
+    pub(crate) fn new_internal(file: File, lock: FileLockKind) -> Result<Self, DatabaseError> {
+        let result = match lock {
+            FileLockKind::Exclusive => file.try_lock(),
+            FileLockKind::Shared => file.try_lock_shared(),
+            FileLockKind::None => {
+                return Ok(Self {
+                    file,
+                    lock_supported: false,
+                });
+            }
         };
 
         match result {

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -55,7 +55,7 @@ const _UNUSED3_OFFSET: usize = TRAILING_REGION_DATA_PAGES_OFFSET + size_of::<u32
 const TRANSACTION_SIZE: usize = 128;
 const TRANSACTION_0_OFFSET: usize = 64;
 const TRANSACTION_1_OFFSET: usize = TRANSACTION_0_OFFSET + TRANSACTION_SIZE;
-pub(super) const DB_HEADER_SIZE: usize = TRANSACTION_1_OFFSET + TRANSACTION_SIZE;
+pub(crate) const DB_HEADER_SIZE: usize = TRANSACTION_1_OFFSET + TRANSACTION_SIZE;
 
 // God byte flags
 const PRIMARY_BIT: u8 = 1;
@@ -78,6 +78,43 @@ const TRANSACTION_LAST_FIELD: usize = TRANSACTION_ID_OFFSET + size_of::<u64>();
 const SLOT_CHECKSUM_OFFSET: usize = TRANSACTION_SIZE - size_of::<Checksum>();
 
 pub(crate) const PAGE_SIZE: usize = 4096;
+
+/// The commit slots of a header, byte for byte as they sit in the file, and which of them the god
+/// byte selects as primary. A multi-process database's extended header stores a hash over these
+/// bytes, so they are handed out raw rather than parsed.
+#[cfg(not(redb_no_std))]
+pub(crate) struct RawCommitSlots {
+    pub(crate) primary_index: usize,
+    slots: [[u8; TRANSACTION_SIZE]; 2],
+}
+
+#[cfg(not(redb_no_std))]
+impl RawCommitSlots {
+    pub(crate) fn primary(&self) -> &[u8] {
+        &self.slots[self.primary_index]
+    }
+
+    pub(crate) fn slot(&self, index: usize) -> &[u8] {
+        &self.slots[index]
+    }
+}
+
+/// Slices the commit slots out of a serialized header. `data` must hold at least
+/// [`DB_HEADER_SIZE`] bytes.
+#[cfg(not(redb_no_std))]
+pub(super) fn raw_commit_slots(data: &[u8]) -> RawCommitSlots {
+    RawCommitSlots {
+        primary_index: usize::from(data[GOD_BYTE_OFFSET] & PRIMARY_BIT),
+        slots: [
+            data[TRANSACTION_0_OFFSET..TRANSACTION_0_OFFSET + TRANSACTION_SIZE]
+                .try_into()
+                .unwrap(),
+            data[TRANSACTION_1_OFFSET..TRANSACTION_1_OFFSET + TRANSACTION_SIZE]
+                .try_into()
+                .unwrap(),
+        ],
+    }
+}
 
 fn get_u32(data: &[u8]) -> u32 {
     u32::from_le_bytes(data[..size_of::<u32>()].try_into().unwrap())
@@ -298,6 +335,15 @@ impl UnrepairedDatabaseHeader {
         Ok(recalculated)
     }
 
+    // Select a primary slot, without reconciling the layout against the file length. Used by a
+    // process which only reads the file while another process may be writing to it: the layout is
+    // rewritten on every resize, so it can disagree with the file length at any moment, but such a
+    // process never allocates and so never consults it.
+    pub(super) fn finalize_transaction_slots(mut self) -> Result<DatabaseHeader> {
+        self.select_primary_slot()?;
+        Ok(self.inner)
+    }
+
     fn select_primary_slot(&mut self) -> Result<bool> {
         // If the primary was written using 2-phase commit, it's guaranteed to be valid. Don't look
         // at the secondary; even if it happens to have a valid checksum, Durability::Paranoid means
@@ -395,6 +441,16 @@ impl DatabaseHeader {
             self.trailing_partial_region_pages = 0;
         }
         self.full_regions = layout.num_full_regions();
+    }
+
+    // Adopt another header's commit slots, leaving the layout alone. Used to pick up commits made
+    // by another process, whose header describes a file this process must not assume anything about
+    // beyond the trees those slots root.
+    #[cfg(not(redb_no_std))]
+    pub(super) fn adopt_transaction_slots(&mut self, other: &DatabaseHeader) {
+        self.primary_slot = other.primary_slot;
+        self.two_phase_commit = other.two_phase_commit;
+        self.transaction_slots.clone_from(&other.transaction_slots);
     }
 
     pub(super) fn primary_slot(&self) -> &TransactionHeader {

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -43,7 +43,7 @@ use core::mem::size_of;
 // Same layout as slot 0
 
 // Inspired by PNG's magic number
-pub(super) const MAGICNUMBER: [u8; 9] = [b'r', b'e', b'd', b'b', 0x1A, 0x0A, 0xA9, 0x0D, 0x0A];
+pub(crate) const MAGICNUMBER: [u8; 9] = [b'r', b'e', b'd', b'b', 0x1A, 0x0A, 0xA9, 0x0D, 0x0A];
 const GOD_BYTE_OFFSET: usize = MAGICNUMBER.len();
 const PAGE_SIZE_OFFSET: usize = GOD_BYTE_OFFSET + size_of::<u8>() + 2; // +2 for padding
 const REGION_HEADER_PAGES_OFFSET: usize = PAGE_SIZE_OFFSET + size_of::<u32>();

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -20,6 +20,8 @@ pub use backends::InMemoryBackend;
 pub(crate) use backends::ReadOnlyBackend;
 pub(crate) use base::{MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTracker};
 pub(crate) use fast_hash::{PageNumberHashMap, PageNumberHashSet};
+#[cfg(all(feature = "experimental-multiprocess", not(redb_no_std)))]
+pub(crate) use header::MAGICNUMBER;
 pub(crate) use header::PAGE_SIZE;
 pub(crate) use page_manager::{
     AllocationPolicy, FILE_FORMAT_VERSION3, PageAllocator, PageResolver, ShrinkPolicy,

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -20,11 +20,15 @@ pub use backends::InMemoryBackend;
 pub(crate) use backends::ReadOnlyBackend;
 pub(crate) use base::{MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTracker};
 pub(crate) use fast_hash::{PageNumberHashMap, PageNumberHashSet};
-#[cfg(all(feature = "experimental-multiprocess", not(redb_no_std)))]
+#[cfg(not(redb_no_std))]
 pub(crate) use header::MAGICNUMBER;
 pub(crate) use header::PAGE_SIZE;
+#[cfg(not(redb_no_std))]
+pub(crate) use header::{DB_HEADER_SIZE, RawCommitSlots};
+#[cfg(not(redb_no_std))]
+pub(crate) use page_manager::CommitHook;
 pub(crate) use page_manager::{
-    AllocationPolicy, FILE_FORMAT_VERSION3, PageAllocator, PageResolver, ShrinkPolicy,
+    AccessMode, AllocationPolicy, FILE_FORMAT_VERSION3, PageAllocator, PageResolver, ShrinkPolicy,
     TransactionalMemory, xxh3_checksum,
 };
 pub use savepoint::Savepoint;

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -10,6 +10,8 @@ use crate::tree_store::page_store::fast_hash::{PageNumberHashMap, PageNumberHash
 use crate::tree_store::page_store::header::{
     DB_HEADER_SIZE, DatabaseHeader, MAGICNUMBER, TransactionHeader, UnrepairedDatabaseHeader,
 };
+#[cfg(not(redb_no_std))]
+use crate::tree_store::page_store::header::{RawCommitSlots, raw_commit_slots};
 use crate::tree_store::page_store::layout::DatabaseLayout;
 use crate::tree_store::page_store::region::{Allocators, RegionTracker};
 use crate::tree_store::page_store::{PageImpl, PageMut, hash128_with_seed};
@@ -19,6 +21,8 @@ use crate::{DatabaseError, Result, StorageError};
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::format;
+#[cfg(not(redb_no_std))]
+use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -287,6 +291,17 @@ fn ceil_log2(x: usize) -> u8 {
     }
 }
 
+#[cfg(not(redb_no_std))]
+// Flattens the errors that reading a header can produce into the storage error that all of them
+// really are: the other DatabaseError variants describe how a database was opened, not how its
+// bytes parsed
+fn storage_error(error: DatabaseError) -> StorageError {
+    match error {
+        DatabaseError::Storage(storage) => storage,
+        other => StorageError::Corrupted(other.to_string()),
+    }
+}
+
 pub(crate) fn xxh3_checksum(data: &[u8]) -> Checksum {
     hash128_with_seed(data, 0)
 }
@@ -315,6 +330,19 @@ impl InMemoryState {
         self.allocators
             .as_ref()
             .expect("allocators have not been loaded yet")
+    }
+
+    // Reports the absence of allocator state as an error rather than a panic, for the paths a
+    // process that never allocates can reach: a read-only handle on a database another process is
+    // writing has no way to keep allocator state up to date, so it does not load any
+    fn require_allocators(&self) -> Result {
+        if self.allocators.is_none() {
+            return Err(StorageError::Io(io::unsupported(
+                "page allocation statistics are unavailable: this handle does not track the \
+                 database's allocator state",
+            )));
+        }
+        Ok(())
     }
 
     fn allocators_mut(&mut self) -> &mut Allocators {
@@ -499,10 +527,50 @@ impl UnpersistedState {
     }
 }
 
+/// How a [`TransactionalMemory`] may access its file, and what it may assume about other processes
+/// accessing it at the same time.
+///
+/// Only `ReadWrite` is reachable without a file system, since the other two describe how a file was
+/// opened, so the whole enum is kept rather than splitting it by `cfg`.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(redb_no_std, allow(dead_code))]
+pub(crate) enum AccessMode {
+    /// This process may write to the file, and is the only process with it open for writing
+    ReadWrite,
+    /// This process only reads the file, and no other process has it open for writing, so an
+    /// unclean shutdown must be repaired before the file can be used
+    ReadOnly,
+    /// This process only reads the file, and another process may be writing to it concurrently. An
+    /// unclean shutdown is left for a writer to repair, and the layout recorded in the header is
+    /// not reconciled against the file length, since a writer may be resizing it
+    SharedRead,
+}
+
+impl AccessMode {
+    fn read_only(self) -> bool {
+        !matches!(self, AccessMode::ReadWrite)
+    }
+}
+
+/// Work another part of the crate does inside a commit, at a point no caller can reach from
+/// outside. A multi-process database uses this to write its extended header after the new commit
+/// slot is durable and before the flip that makes it primary.
+#[cfg(not(redb_no_std))]
+pub(crate) trait CommitHook: Send + Sync {
+    /// Called between the phase-1 flush and the header write that flips the primary slot bit.
+    /// `slot` is the index of the commit slot the flip will make primary, and `slot_bytes` is that
+    /// slot exactly as the phase-1 write put it in the file.
+    fn before_primary_flip(&self, slot: usize, slot_bytes: &[u8]) -> Result;
+}
+
 pub(crate) struct TransactionalMemory {
     unpersisted: Mutex<UnpersistedState>,
     storage: PagedCachedFile,
     state: Mutex<InMemoryState>,
+    // Runs inside commit(), between the phase-1 flush and the primary flip. Installed after
+    // construction because the installer needs the constructed memory first.
+    #[cfg(not(redb_no_std))]
+    commit_hook: Mutex<Option<Arc<dyn CommitHook>>>,
     // The number of PageMut which are outstanding
     #[cfg(debug_assertions)]
     open_dirty_pages: Arc<Mutex<PageNumberHashSet>>,
@@ -530,7 +598,7 @@ impl TransactionalMemory {
         page_size: usize,
         requested_region_size: Option<u64>,
         cache_size: usize,
-        read_only: bool,
+        access: AccessMode,
     ) -> Result<Self, DatabaseError> {
         assert!(page_size.is_power_of_two() && page_size >= DB_HEADER_SIZE);
 
@@ -628,21 +696,30 @@ impl TransactionalMemory {
         let unrepaired =
             UnrepairedDatabaseHeader::from_bytes(&header_bytes, page_size.try_into().unwrap())?;
         let file_len = storage.raw_file_len()?;
-        let needs_recovery = unrepaired.recovery_required(file_len);
-        if needs_recovery && read_only {
-            return Err(DatabaseError::RepairAborted);
-        }
-        let (header, _) = unrepaired.finalize(file_len)?;
-        if needs_recovery {
-            storage
-                .write(0, DB_HEADER_SIZE, true)?
-                .mem_mut()
-                .copy_from_slice(&header.to_bytes(true));
-            storage.flush()?;
-        }
+        let header = if matches!(access, AccessMode::SharedRead) {
+            // A writer in another process may be holding the file open, in which case it is always
+            // flagged as requiring recovery and its layout may not match the file length at this
+            // instant. Neither matters to a reader: it only follows the committed roots, and any
+            // repair is the next writer's job
+            unrepaired.finalize_transaction_slots()?
+        } else {
+            let needs_recovery = unrepaired.recovery_required(file_len);
+            if needs_recovery && access.read_only() {
+                return Err(DatabaseError::RepairAborted);
+            }
+            let (header, _) = unrepaired.finalize(file_len)?;
+            if needs_recovery {
+                storage
+                    .write(0, DB_HEADER_SIZE, true)?
+                    .mem_mut()
+                    .copy_from_slice(&header.to_bytes(true));
+                storage.flush()?;
+            }
+            assert_eq!(header.layout().len(), storage.raw_file_len()?);
+            header
+        };
 
         let layout = header.layout();
-        assert_eq!(layout.len(), storage.raw_file_len()?);
         let region_size = layout.full_region_layout().len();
         let region_header_size = layout.full_region_layout().data_section().start;
         let state = InMemoryState::new(header);
@@ -653,6 +730,8 @@ impl TransactionalMemory {
             unpersisted: Mutex::new(UnpersistedState::default()),
             storage,
             state: Mutex::new(state),
+            #[cfg(not(redb_no_std))]
+            commit_hook: Mutex::new(None),
             #[cfg(debug_assertions)]
             open_dirty_pages: Arc::new(Mutex::new(PageNumberHashSet::default())),
             #[cfg(debug_assertions)]
@@ -733,6 +812,12 @@ impl TransactionalMemory {
         self.storage.invalidate_cache_all();
     }
 
+    /// Drops writes that have been buffered but not yet written to the file. Only valid for pages
+    /// no committed root references, i.e. those an aborted transaction allocated.
+    pub(crate) fn discard_buffered_writes(&self) {
+        self.storage.discard_write_buffer();
+    }
+
     pub(crate) fn clear_cache_and_reload(&mut self) -> Result<bool, DatabaseError> {
         // The in-memory state is being discarded for the on-disk state, so buffered writes --
         // which can only belong to the discarded state -- are dropped rather than written out;
@@ -743,6 +828,68 @@ impl TransactionalMemory {
         self.storage.invalidate_cache_all();
         self.storage.sync_file()?;
 
+        self.reload_from_file()
+    }
+
+    /// Replaces the in-memory state with what another process has left in the file, in preparation
+    /// for a write transaction. Buffered writes never survive: they can only belong to an aborted
+    /// transaction, whose pages another process may since have reused. Dropping cached pages is
+    /// the caller's decision, since it is the one that can tell whether any of them could have
+    /// been reallocated.
+    ///
+    /// The caller must hold the cross-process write lock, so that no other process can be
+    /// committing, and no write transaction may be in progress in this process.
+    #[cfg(not(redb_no_std))]
+    pub(crate) fn reload_for_write(&self) -> Result<(), DatabaseError> {
+        self.storage.discard_write_buffer();
+        // No sync: another process's commits reach this process through the file, which it has
+        // already flushed
+        self.reload_from_file()?;
+        Ok(())
+    }
+
+    /// Picks up commits made by another process, taking only the commit slots from the file. The
+    /// layout is left alone: a writer in another process rewrites it on every resize, so it can
+    /// disagree with the file length at any instant, and a process that is only reading never
+    /// consults it.
+    ///
+    /// Returns the transaction id that is now visible, along with the commit slots exactly as the
+    /// file holds them, which is what the extended header's hash is computed over.
+    #[cfg(not(redb_no_std))]
+    pub(crate) fn reload_transaction_slots(&self) -> Result<(TransactionId, RawCommitSlots)> {
+        let header_bytes = self.storage.read_direct(0, DB_HEADER_SIZE)?;
+        let raw = raw_commit_slots(&header_bytes);
+        let unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes, self.page_size)
+            .map_err(storage_error)?;
+        let header = unrepaired.finalize_transaction_slots()?;
+        let mut state = self.state.lock()?;
+        // Only a process whose own state can be ahead of the file has a pending non-durable
+        // commit, and such a process is the only writer, so it never reloads
+        assert!(!state.read_from_secondary);
+        state.header.adopt_transaction_slots(&header);
+
+        Ok((state.header.primary_slot().transaction_id, raw))
+    }
+
+    /// The last committed transaction id as the file has it, without adopting anything into this
+    /// process's state. For observing another process's progress.
+    #[cfg(not(redb_no_std))]
+    pub(crate) fn peek_committed_transaction_id(&self) -> Result<TransactionId> {
+        let header_bytes = self.storage.read_direct(0, DB_HEADER_SIZE)?;
+        let unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes, self.page_size)
+            .map_err(storage_error)?;
+        let header = unrepaired.finalize_transaction_slots()?;
+        Ok(header.primary_slot().transaction_id)
+    }
+
+    /// Installs the hook that [`Self::commit`] runs between the phase-1 flush and the primary
+    /// flip. Must be installed before the first commit that needs it.
+    #[cfg(not(redb_no_std))]
+    pub(crate) fn set_commit_hook(&self, hook: Arc<dyn CommitHook>) {
+        *self.commit_hook.lock().unwrap() = Some(hook);
+    }
+
+    fn reload_from_file(&self) -> Result<bool, DatabaseError> {
         let header_bytes = self.storage.read_direct(0, DB_HEADER_SIZE)?;
         let unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes, self.page_size)?;
         let (header, was_clean) = unrepaired.finalize(self.storage.raw_file_len()?)?;
@@ -763,6 +910,9 @@ impl TransactionalMemory {
             // load_allocator_state) before any allocation/free path runs.
             state.allocators = None;
         }
+        // Mirrors the allocator state that was just dropped, so it is repopulated with it
+        #[cfg(debug_assertions)]
+        self.allocated_pages.lock().unwrap().clear();
         // Reloading from disk discards in-memory roots, so drop volatile allocation state
         // that belonged only to those roots.
         self.unpersisted.lock().unwrap().clear();
@@ -771,10 +921,17 @@ impl TransactionalMemory {
     }
 
     pub(crate) fn begin_writable(&self) -> Result {
-        let mut state = self.state.lock().unwrap();
-        assert!(!state.header.recovery_required);
-        state.header.recovery_required = true;
-        self.write_header(&state.header)?;
+        // The state lock is released before the file I/O below, like commit() does: a
+        // multi-process backend takes the cross-process registry lock inside write(), and readers
+        // take that lock and then this one, so holding the state lock across the write would
+        // invert the two
+        let header = {
+            let mut state = self.state.lock().unwrap();
+            assert!(!state.header.recovery_required);
+            state.header.recovery_required = true;
+            state.header.clone()
+        };
+        self.write_header(&header)?;
         self.storage.flush()
     }
 
@@ -892,9 +1049,14 @@ impl TransactionalMemory {
 
     // Durably clears the recovery flag, marking the repair as complete.
     pub(crate) fn clear_recovery_required(&self) -> Result<()> {
-        let mut state = self.state.lock().unwrap();
-        state.header.recovery_required = false;
-        self.write_header(&state.header)?;
+        // State lock released before the I/O, for the same lock-ordering reason as
+        // begin_writable()
+        let header = {
+            let mut state = self.state.lock().unwrap();
+            state.header.recovery_required = false;
+            state.header.clone()
+        };
+        self.write_header(&header)?;
         self.storage.flush()?;
         Ok(())
     }
@@ -1084,21 +1246,49 @@ impl TransactionalMemory {
         let old_transaction_id = header.secondary_slot().transaction_id;
         header.write_secondary_slot(transaction_id, data_root, system_root);
 
-        self.write_header(&header)?;
+        let result: Result = (|| {
+            self.write_header(&header)?;
 
-        // Use 2-phase commit, if checksums are disabled
-        if two_phase {
+            // Use 2-phase commit, if checksums are disabled
+            if two_phase {
+                self.storage.flush()?;
+            }
+
+            // A multi-process database writes its extended header here: after the new slot is
+            // durable, before the flip below makes it primary
+            #[cfg(not(redb_no_std))]
+            {
+                let hook = self.commit_hook.lock().unwrap().clone();
+                if let Some(hook) = hook {
+                    // The hook's ordering guarantee needs the phase-1 flush above, and every
+                    // commit a multi-process database makes is 2-phase for other reasons already
+                    assert!(two_phase);
+                    let bytes = header.to_bytes(true);
+                    let raw = raw_commit_slots(&bytes);
+                    let flipping_to = raw.primary_index ^ 1;
+                    hook.before_primary_flip(flipping_to, raw.slot(flipping_to))?;
+                }
+            }
+
+            // Make our new commit the primary, and record whether it was a 2-phase commit.
+            // These two bits need to be written atomically
+            header.swap_primary_slot();
+            header.two_phase_commit = two_phase;
+
+            // Write the new header to disk
+            self.write_header(&header)?;
             self.storage.flush()?;
+
+            Ok(())
+        })();
+        // A failed commit's pages are already flushed and sitting in this handle's cache, and
+        // once the write lock is released another process may reallocate them with no horizon
+        // moving -- they were never durably allocated, so nothing later invalidates them
+        #[cfg(not(redb_no_std))]
+        if result.is_err() && self.commit_hook.lock().unwrap().is_some() {
+            self.storage.invalidate_cache_all();
         }
-
-        // Make our new commit the primary, and record whether it was a 2-phase commit.
-        // These two bits need to be written atomically
-        header.swap_primary_slot();
-        header.two_phase_commit = two_phase;
-
-        // Write the new header to disk
-        self.write_header(&header)?;
-        self.storage.flush()?;
+        result?;
 
         if shrunk {
             self.storage.resize(header.layout().len())?;
@@ -1646,6 +1836,7 @@ impl TransactionalMemory {
 
     pub(crate) fn count_allocated_pages(&self) -> Result<u64> {
         let state = self.state.lock().unwrap();
+        state.require_allocators()?;
         let mut count = 0u64;
         for i in 0..state.header.layout().num_regions() {
             count += u64::from(state.get_region(i).count_allocated_pages());
@@ -1656,6 +1847,7 @@ impl TransactionalMemory {
 
     pub(crate) fn count_free_pages(&self) -> Result<u64> {
         let state = self.state.lock().unwrap();
+        state.require_allocators()?;
         let mut count = 0u64;
         for i in 0..state.header.layout().num_regions() {
             count += u64::from(state.get_region(i).count_free_pages());
@@ -1668,8 +1860,18 @@ impl TransactionalMemory {
         self.page_size.try_into().unwrap()
     }
 
-    pub(crate) fn close(&self) -> Result {
-        let shutdown_result = self.flush_shutdown_header();
+    /// Closes the file.
+    ///
+    /// `assert_clean_shutdown` writes the header to record that this process left the file
+    /// consistent. That is only this process's to say when it is the only one that may write: in a
+    /// multi-process database another process may be part way through a commit, and this write
+    /// would land in the middle of it.
+    pub(crate) fn close(&self, assert_clean_shutdown: bool) -> Result {
+        let shutdown_result = if assert_clean_shutdown {
+            self.flush_shutdown_header()
+        } else {
+            Ok(())
+        };
         // The backend's close() contract guarantees it is called exactly once, so it must be
         // called even if the shutdown writes above failed
         let close_result = self.storage.close();
@@ -1694,6 +1896,7 @@ impl TransactionalMemory {
 
 #[cfg(test)]
 mod test {
+    use crate::tree_store::AccessMode;
     use crate::tree_store::page_store::page_manager::INITIAL_REGIONS;
     use crate::{Database, TableDefinition};
 
@@ -1756,9 +1959,15 @@ mod test {
         use super::TransactionalMemory;
         use crate::tree_store::InMemoryBackend;
 
-        let mem =
-            TransactionalMemory::new(Box::new(InMemoryBackend::new()), true, 4096, None, 0, false)
-                .unwrap();
+        let mem = TransactionalMemory::new(
+            Box::new(InMemoryBackend::new()),
+            true,
+            4096,
+            None,
+            0,
+            AccessMode::ReadWrite,
+        )
+        .unwrap();
         mem.reset_allocator_state().unwrap();
 
         std::thread::scope(|s| {
@@ -1798,7 +2007,7 @@ mod test {
             page_size,
             Some(64 * page_size as u64),
             0,
-            false,
+            AccessMode::ReadWrite,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();
@@ -1846,7 +2055,7 @@ mod test {
             page_size,
             Some(64 * page_size as u64),
             0,
-            false,
+            AccessMode::ReadWrite,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();
@@ -1889,7 +2098,7 @@ mod test {
             page_size,
             Some(region_size),
             0,
-            false,
+            AccessMode::ReadWrite,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -100,6 +100,66 @@ fn an_interrupted_create_can_be_redone() {
     drop(MultiProcessDatabase::create(&path).unwrap());
 }
 
+/// A directory holding a plain [`Database`] under `data.redb` is someone else's data, not an
+/// interrupted create: without the marker, the missing `write.lock` beside the file is what tells
+/// the two apart, and create() refuses rather than adopting the file.
+#[test]
+fn create_does_not_adopt_a_plain_database() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    std::fs::create_dir(&path).unwrap();
+    drop(Database::create(path.join("data.redb")).unwrap());
+
+    assert!(MultiProcessDatabase::create(&path).is_err());
+
+    // The refusal left no trace, and the file is still an ordinary database
+    assert!(!path.join("write.lock").exists());
+    assert!(!path.join("metadata").exists());
+    drop(Database::open(path.join("data.redb")).unwrap());
+}
+
+/// The same refusal covers every name create() writes: a directory already using one of them
+/// belongs to something else, and is left exactly as it was found.
+#[test]
+fn create_does_not_clobber_files_in_a_directory_it_did_not_make() {
+    let contents: &[u8] = b"not redb's, and bigger than its marker";
+    let dir = tempdir();
+    let path = db_path(&dir);
+    std::fs::create_dir(&path).unwrap();
+    std::fs::write(path.join("metadata.tmp"), contents).unwrap();
+
+    assert!(MultiProcessDatabase::create(&path).is_err());
+
+    assert!(!path.join("write.lock").exists());
+    assert_eq!(contents, &std::fs::read(path.join("metadata.tmp")).unwrap());
+
+    // Even beside a lock file, a temporary bigger than the marker cannot be an interrupted create
+    // of redb's, and finishing one would delete it
+    std::fs::write(path.join("write.lock"), []).unwrap();
+    assert!(MultiProcessDatabase::create(&path).is_err());
+    assert_eq!(contents, &std::fs::read(path.join("metadata.tmp")).unwrap());
+}
+
+/// An empty lock file is the only kind redb ever writes, so one with contents was put there by
+/// something else, and does not make the directory an interrupted create.
+#[test]
+fn create_does_not_trust_a_nonempty_lock_file() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    std::fs::create_dir(&path).unwrap();
+    drop(Database::create(path.join("data.redb")).unwrap());
+    std::fs::write(path.join("write.lock"), b"pid 1234").unwrap();
+
+    assert!(MultiProcessDatabase::create(&path).is_err());
+
+    assert!(!path.join("metadata").exists());
+    assert_eq!(
+        b"pid 1234",
+        &std::fs::read(path.join("write.lock")).unwrap()[..]
+    );
+    drop(Database::open(path.join("data.redb")).unwrap());
+}
+
 /// The write lock is invisible to a process that reaches past the directory and opens the database
 /// file itself, so that file carries the ordinary exclusive lock as well. Readers are turned away
 /// along with writers: nothing coordinates a reader that attaches this way with the pages the

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -1,0 +1,214 @@
+//! Tests for the multi-process database interface.
+//!
+//! The lock is exercised both from a second handle in this process -- file locks belong to the
+//! open file description rather than the process, so a second handle is excluded exactly as a
+//! second process is -- and from real child processes.
+
+#![cfg(all(feature = "experimental-multiprocess", not(target_os = "wasi")))]
+
+use redb::{Database, DatabaseError, MultiProcessDatabase, ReadOnlyDatabase};
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn tempdir() -> TempDir {
+    TempDir::new().unwrap()
+}
+
+fn db_path(dir: &TempDir) -> PathBuf {
+    dir.path().join("db")
+}
+
+#[test]
+fn create_and_reopen() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    drop(MultiProcessDatabase::create(&path).unwrap());
+
+    drop(MultiProcessDatabase::open(&path).unwrap());
+
+    // create() on an existing database opens it rather than starting over
+    drop(MultiProcessDatabase::create(&path).unwrap());
+}
+
+#[test]
+fn create_makes_a_directory() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let _db = MultiProcessDatabase::create(&path).unwrap();
+
+    assert!(path.join("data.redb").is_file());
+    assert!(path.join("write.lock").is_file());
+    assert!(path.join("metadata").is_file());
+}
+
+#[test]
+fn a_second_handle_is_rejected() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = MultiProcessDatabase::create(&path).unwrap();
+
+    assert!(matches!(
+        MultiProcessDatabase::open(&path),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+    assert!(matches!(
+        MultiProcessDatabase::create(&path),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+
+    // Once the first handle is gone the directory can be opened again
+    drop(db);
+    drop(MultiProcessDatabase::open(&path).unwrap());
+}
+
+#[test]
+fn opening_something_that_is_not_a_database_fails() {
+    let dir = tempdir();
+    assert!(MultiProcessDatabase::open(dir.path().join("missing")).is_err());
+
+    let empty = dir.path().join("empty");
+    std::fs::create_dir(&empty).unwrap();
+    assert!(MultiProcessDatabase::open(&empty).is_err());
+
+    // A directory holding a plain redb database is not one of these either -- it has no marker
+    let plain = dir.path().join("plain");
+    std::fs::create_dir(&plain).unwrap();
+    drop(Database::create(plain.join("data.redb")).unwrap());
+    assert!(MultiProcessDatabase::open(&plain).is_err());
+}
+
+#[test]
+fn open_does_not_create() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    assert!(MultiProcessDatabase::open(&path).is_err());
+    assert!(!path.exists());
+}
+
+/// A create() that made the directory but died before the database file was initialized must not
+/// leave the directory permanently unopenable: a later create() finishes the job, exactly as it
+/// would for a `Database` whose file was created and then not written to.
+#[test]
+fn an_interrupted_create_can_be_redone() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    drop(MultiProcessDatabase::create(&path).unwrap());
+    std::fs::write(path.join("data.redb"), []).unwrap();
+
+    drop(MultiProcessDatabase::create(&path).unwrap());
+}
+
+/// The write lock is invisible to a process that reaches past the directory and opens the database
+/// file itself, so that file carries the ordinary exclusive lock as well. Readers are turned away
+/// along with writers: nothing coordinates a reader that attaches this way with the pages the
+/// process holding the directory frees.
+#[test]
+fn an_ordinary_database_cannot_open_the_data_file() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = MultiProcessDatabase::create(&path).unwrap();
+
+    let data = path.join("data.redb");
+    assert!(matches!(
+        Database::open(&data),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+    assert!(matches!(
+        Database::create(&data),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+    assert!(matches!(
+        ReadOnlyDatabase::open(&data),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+
+    // ... and once the directory is closed the database file is an ordinary redb database again
+    drop(db);
+    drop(ReadOnlyDatabase::open(&data).unwrap());
+}
+
+// --------------------------------------------------------------------------------------------
+// Tests that need a real process
+// --------------------------------------------------------------------------------------------
+
+/// Entry point for the child processes the tests below spawn. Ignored so that it only runs when
+/// named explicitly, and does nothing unless the parent asked for a role.
+#[test]
+#[ignore]
+fn child_process_worker() {
+    let Ok(role) = env::var("REDB_MP_ROLE") else {
+        return;
+    };
+    let path = PathBuf::from(env::var("REDB_MP_PATH").unwrap());
+    match role.as_str() {
+        // Expects to be turned away by the lock the parent holds
+        "rejected" => {
+            assert!(matches!(
+                MultiProcessDatabase::open(&path),
+                Err(DatabaseError::DatabaseAlreadyOpen)
+            ));
+        }
+        // Expects to get in
+        "opener" => {
+            drop(MultiProcessDatabase::open(&path).unwrap());
+        }
+        // Opens the database and dies without closing it, leaving the lock to the operating system
+        "crasher" => {
+            let db = MultiProcessDatabase::open(&path).unwrap();
+            let _ = &db;
+            std::process::abort();
+        }
+        other => panic!("unknown role {other}"),
+    }
+}
+
+fn run_child(role: &str, path: &Path) -> std::process::ExitStatus {
+    Command::new(env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "child_process_worker",
+            "--ignored",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env("REDB_MP_ROLE", role)
+        .env("REDB_MP_PATH", path)
+        .status()
+        .unwrap()
+}
+
+#[test]
+fn a_child_process_cannot_open_a_database_this_one_holds() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let _db = MultiProcessDatabase::create(&path).unwrap();
+
+    assert!(run_child("rejected", &path).success());
+}
+
+#[test]
+fn a_child_process_can_open_a_database_this_one_has_closed() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    drop(MultiProcessDatabase::create(&path).unwrap());
+
+    assert!(run_child("opener", &path).success());
+
+    // ... and the child released the lock on its way out
+    drop(MultiProcessDatabase::open(&path).unwrap());
+}
+
+/// The whole point of using OS locks: a process that dies holding the database releases it with no
+/// cleanup and no timeouts.
+#[test]
+fn a_process_that_dies_releases_the_lock() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    drop(MultiProcessDatabase::create(&path).unwrap());
+
+    assert!(!run_child("crasher", &path).success());
+
+    drop(MultiProcessDatabase::open(&path).unwrap());
+}

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -87,9 +87,9 @@ fn open_does_not_create() {
     assert!(!path.exists());
 }
 
-/// A create() that made the directory but died before the database file was initialized must not
-/// leave the directory permanently unopenable: a later create() finishes the job, exactly as it
-/// would for a `Database` whose file was created and then not written to.
+/// A create() that made the directory and the marker but died before the database file was
+/// initialized must not leave the directory permanently unopenable: a later create() finishes the
+/// job, exactly as it would for a `Database` whose file was created and then not written to.
 #[test]
 fn an_interrupted_create_can_be_redone() {
     let dir = tempdir();
@@ -270,5 +270,156 @@ fn a_process_that_dies_releases_the_lock() {
 
     assert!(!run_child("crasher", &path).success());
 
+    drop(MultiProcessDatabase::open(&path).unwrap());
+}
+
+/// A directory that already holds something else is a mistyped path, not a database waiting to be
+/// made. The only reason to accept an existing directory without a marker is an interrupted
+/// `create()`, and such a directory holds nothing but the files `create()` itself writes.
+#[test]
+fn create_refuses_a_directory_holding_other_files() {
+    let dir = tempdir();
+    let path = dir.path().join("not-a-db");
+    std::fs::create_dir(&path).unwrap();
+    std::fs::write(path.join("notes.txt"), b"hello").unwrap();
+
+    assert!(MultiProcessDatabase::create(&path).is_err());
+
+    // Nothing at all this time -- the check runs before the lock file would be made
+    assert_eq!(1, std::fs::read_dir(&path).unwrap().count());
+}
+
+/// ... but only when there is no marker. A directory that is already a database stays openable
+/// whatever else turns up in it, or a stray `.DS_Store` would be enough to lock its owner out.
+#[test]
+fn a_stray_file_does_not_stop_an_existing_database_opening() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    drop(MultiProcessDatabase::create(&path).unwrap());
+    std::fs::write(path.join(".DS_Store"), b"junk").unwrap();
+
+    drop(MultiProcessDatabase::open(&path).unwrap());
+    drop(MultiProcessDatabase::create(&path).unwrap());
+}
+
+/// `open()` does not create anything, and that has to hold for a directory that exists but is not
+/// one of these: it must be left exactly as it was found rather than gaining a lock file on the
+/// way to the error.
+#[test]
+fn open_does_not_touch_a_directory_it_rejects() {
+    let dir = tempdir();
+    let path = dir.path().join("not-a-db");
+    std::fs::create_dir(&path).unwrap();
+    std::fs::write(path.join("notes.txt"), b"hello").unwrap();
+
+    assert!(MultiProcessDatabase::open(&path).is_err());
+    assert_eq!(1, std::fs::read_dir(&path).unwrap().count());
+}
+
+/// The marker is what makes a directory one of these, so `create()` must not install it in a
+/// directory it then fails on -- that would convert someone else's directory as a side effect of
+/// refusing it, and every later open would read it as a database.
+#[test]
+fn create_does_not_mark_a_directory_it_rejects() {
+    let dir = tempdir();
+    let path = dir.path().join("not-a-db");
+    std::fs::create_dir(&path).unwrap();
+    std::fs::write(path.join("data.redb"), b"this is not a redb database").unwrap();
+
+    assert!(MultiProcessDatabase::create(&path).is_err());
+    assert!(!path.join("metadata").exists());
+
+    // ... and the file it refused to read is still there, byte for byte, with nothing beside it
+    let mut left: Vec<_> = std::fs::read_dir(&path)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    left.sort();
+    assert_eq!(vec!["data.redb"], left);
+    assert_eq!(
+        b"this is not a redb database",
+        &std::fs::read(path.join("data.redb")).unwrap()[..]
+    );
+
+    // ... and it stays refused, rather than a second attempt reading the leavings of the first as
+    // evidence that the directory is one of these
+    assert!(MultiProcessDatabase::create(&path).is_err());
+    assert!(MultiProcessDatabase::open(&path).is_err());
+}
+
+/// redb writes a new database's header with the magic number zeroed, flushes, and only then writes
+/// the magic, so a crash during initialization leaves a file that is neither empty nor a database.
+/// `Database::new` refuses such a file whether or not `create` is set, so under the name
+/// `data.redb` it would wedge the directory for good -- indistinguishable from a file this call
+/// was pointed at by mistake. Initializing under a temporary name is what keeps the two apart.
+#[test]
+fn an_initialization_that_crashed_partway_can_be_redone() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    drop(MultiProcessDatabase::create(&path).unwrap());
+
+    // Exactly what such a crash leaves: no marker, no data.redb, and a temporary file that is not
+    // empty and has no magic number
+    std::fs::remove_file(path.join("metadata")).unwrap();
+    std::fs::rename(path.join("data.redb"), path.join("data.redb.tmp")).unwrap();
+    let mut partial = std::fs::read(path.join("data.redb.tmp")).unwrap();
+    partial[0..9].fill(0);
+    std::fs::write(path.join("data.redb.tmp"), &partial).unwrap();
+
+    drop(MultiProcessDatabase::create(&path).unwrap());
+
+    assert!(path.join("data.redb").is_file());
+    assert!(!path.join("data.redb.tmp").exists());
+
+    // The same crash with the marker already durable -- initialization was itself a redo -- is
+    // recovered the same way rather than refused: the zeroed magic is what says the temporary is
+    // wreckage, not the marker's absence
+    std::fs::rename(path.join("data.redb"), path.join("data.redb.tmp")).unwrap();
+    let mut partial = std::fs::read(path.join("data.redb.tmp")).unwrap();
+    partial[0..9].fill(0);
+    std::fs::write(path.join("data.redb.tmp"), &partial).unwrap();
+
+    drop(MultiProcessDatabase::create(&path).unwrap());
+    assert!(path.join("data.redb").is_file());
+    assert!(!path.join("data.redb.tmp").exists());
+}
+
+/// A temporary bearing redb's magic number is a finished database -- the magic is written last --
+/// left under the wrong name by a promoting rename that did not survive a crash. It is refused
+/// for a person to recover, marker or no marker, rather than deleted as wreckage.
+#[test]
+fn a_temporary_holding_a_finished_database_is_not_discarded() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    drop(MultiProcessDatabase::create(&path).unwrap());
+    std::fs::rename(path.join("data.redb"), path.join("data.redb.tmp")).unwrap();
+    let saved = std::fs::read(path.join("data.redb.tmp")).unwrap();
+
+    assert!(MultiProcessDatabase::create(&path).is_err());
+
+    // ... even when the marker rename was lost along with the database file's
+    std::fs::remove_file(path.join("metadata")).unwrap();
+    assert!(MultiProcessDatabase::create(&path).is_err());
+    assert_eq!(saved, std::fs::read(path.join("data.redb.tmp")).unwrap());
+
+    // Renaming it back, as the error says to, recovers the database
+    std::fs::rename(path.join("data.redb.tmp"), path.join("data.redb")).unwrap();
+    drop(MultiProcessDatabase::create(&path).unwrap());
+}
+
+/// A temporary file only ever means "an attempt that did not finish", so one sitting next to a
+/// database that *did* finish must not be moved over it: promoting on the mere presence of a
+/// temporary would swap a good database for wreckage.
+#[test]
+fn a_stale_temporary_does_not_replace_the_database() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    drop(MultiProcessDatabase::create(&path).unwrap());
+    std::fs::write(path.join("data.redb.tmp"), b"stale wreckage").unwrap();
+
+    // create() opens the finished database -- the wreckage would have been refused -- and throws
+    // the temporary away
+    drop(MultiProcessDatabase::create(&path).unwrap());
+    assert!(!path.join("data.redb.tmp").exists());
     drop(MultiProcessDatabase::open(&path).unwrap());
 }

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -1,16 +1,36 @@
 //! Tests for the multi-process database interface.
 //!
-//! The lock is exercised both from a second handle in this process -- file locks belong to the
-//! open file description rather than the process, so a second handle is excluded exactly as a
-//! second process is -- and from real child processes.
+//! Most of these use two `MultiProcessDatabase` handles on one directory from a single test
+//! process: file locks belong to the open file description rather than the process, so two handles
+//! coordinate through the lock files exactly as two processes do, while being far easier to debug.
+//! Real child processes cover what only a separate process can: a writer that dies, and the
+//! coordination working across a process boundary.
 
 #![cfg(all(feature = "experimental-multiprocess", not(target_os = "wasi")))]
 
-use redb::{Database, DatabaseError, MultiProcessDatabase, ReadOnlyDatabase};
+use redb::{
+    Database, DatabaseError, Durability, MultiProcessDatabase, ReadableDatabase, ReadableTable,
+    ReadableTableMetadata, TableDefinition, WriteTransaction, WriterMode,
+};
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
 use tempfile::TempDir;
+
+const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+const BIG_TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("big");
+// Every key holds the same value in any committed state, so a reader that sees two different
+// values in one snapshot has been shown a torn or recycled page. Enough of them that the table
+// spans many pages at more than one level, so that a snapshot which is not properly held back has
+// somewhere to go wrong
+const KEYS: u64 = 5000;
+
+// A table big enough that rewriting it churns through many pages, for the child-process tests
+const CHURN_TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("churn");
+const CHURN_ELEMENTS: u64 = 20_000;
 
 fn tempdir() -> TempDir {
     TempDir::new().unwrap()
@@ -20,23 +40,47 @@ fn db_path(dir: &TempDir) -> PathBuf {
     dir.path().join("db")
 }
 
+fn write(db: &MultiProcessDatabase, key: u64, value: u64) {
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        table.insert(&key, &value).unwrap();
+    }
+    txn.commit().unwrap();
+}
+
+fn read(db: &MultiProcessDatabase, key: u64) -> Option<u64> {
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(TABLE).unwrap();
+    table.get_owned(key).unwrap().map(|value| value.value())
+}
+
 #[test]
 fn create_and_reopen() {
     let dir = tempdir();
     let path = db_path(&dir);
-    drop(MultiProcessDatabase::create(&path).unwrap());
+    {
+        let db = MultiProcessDatabase::create(&path).unwrap();
+        write(&db, 0, 1);
+        assert_eq!(Some(1), read(&db, 0));
+    }
 
-    drop(MultiProcessDatabase::open(&path).unwrap());
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(1), read(&db, 0));
+    write(&db, 0, 2);
+    drop(db);
 
     // create() on an existing database opens it rather than starting over
-    drop(MultiProcessDatabase::create(&path).unwrap());
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    assert_eq!(Some(2), read(&db, 0));
 }
 
 #[test]
 fn create_makes_a_directory() {
     let dir = tempdir();
     let path = db_path(&dir);
-    let _db = MultiProcessDatabase::create(&path).unwrap();
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 1);
 
     assert!(path.join("data.redb").is_file());
     assert!(path.join("write.lock").is_file());
@@ -47,7 +91,10 @@ fn create_makes_a_directory() {
 fn a_second_handle_is_rejected() {
     let dir = tempdir();
     let path = db_path(&dir);
-    let db = MultiProcessDatabase::create(&path).unwrap();
+    // The exclusion this checks is what SingleWriterProcess mode promises. In the other mode a
+    // second handle is admitted and serialized per transaction instead
+    let db = create(&path, WriterMode::SingleWriterProcess);
+    write(&db, 0, 1);
 
     assert!(matches!(
         MultiProcessDatabase::open(&path),
@@ -60,7 +107,85 @@ fn a_second_handle_is_rejected() {
 
     // Once the first handle is gone the directory can be opened again
     drop(db);
-    drop(MultiProcessDatabase::open(&path).unwrap());
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(1), read(&db, 0));
+}
+
+/// A live write transaction keeps the database open past the point where the handle is dropped, so
+/// the lock has to outlive the handle too -- otherwise another process could start writing while
+/// this transaction is still running.
+#[test]
+fn the_lock_outlives_a_handle_dropped_during_a_write() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    // SingleWriterProcess, so that a second open reports the lock is held rather than waiting for
+    // it: in MultiWriterProcess mode this same test would deadlock against its own transaction
+    let db = create(&path, WriterMode::SingleWriterProcess);
+    write(&db, 0, 1);
+
+    let txn: WriteTransaction = db.begin_write().unwrap();
+    drop(db);
+
+    assert!(matches!(
+        MultiProcessDatabase::open(&path),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        table.insert(&0, &2).unwrap();
+    }
+    txn.commit().unwrap();
+
+    // ... and is released once the transaction that was keeping it open finishes
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(2), read(&db, 0));
+}
+
+/// A read transaction does not keep the database open the way a write transaction does: dropping
+/// the handle closes the storage underneath it, so the guard the transaction still holds must not
+/// go on holding the directory's locks -- the next open would be refused for as long as the
+/// unusable guard existed.
+#[test]
+fn a_lingering_read_guard_does_not_hold_the_database_open() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::SingleWriterProcess);
+    write(&db, 0, 1);
+
+    let txn = db.begin_read().unwrap();
+    drop(db);
+
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(1), read(&db, 0));
+    drop(txn);
+}
+
+/// The same rule for the transaction pin: in MultiWriterProcess mode a read transaction holds a
+/// shared lock on its `txn/<id>` file, and a guard that outlives the close must not go on holding
+/// it -- the transaction can never be read again, and the lock would stop every other process
+/// reclaiming pages freed after its snapshot.
+#[test]
+fn a_lingering_read_guard_does_not_hold_its_pin() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::MultiWriterProcess);
+    write(&db, 0, 1);
+
+    let txn = db.begin_read().unwrap();
+    drop(db);
+
+    // Every file left in txn/ must be lockable: a released pin leaves its file behind for the
+    // next writer's scan, but never the lock
+    for entry in std::fs::read_dir(path.join("txn")).unwrap() {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(entry.unwrap().path())
+            .unwrap();
+        file.try_lock().unwrap();
+    }
+    drop(txn);
 }
 
 #[test]
@@ -97,7 +222,163 @@ fn an_interrupted_create_can_be_redone() {
     drop(MultiProcessDatabase::create(&path).unwrap());
     std::fs::write(path.join("data.redb"), []).unwrap();
 
-    drop(MultiProcessDatabase::create(&path).unwrap());
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 1);
+    assert_eq!(Some(1), read(&db, 0));
+}
+
+// --------------------------------------------------------------------------------------------
+// Tests that need a real process
+// --------------------------------------------------------------------------------------------
+
+/// Entry point for the child processes the tests below spawn. Ignored so that it only runs when
+/// named explicitly, and does nothing unless the parent asked for a role.
+#[test]
+#[ignore]
+fn child_process_worker() {
+    let Ok(role) = env::var("REDB_MP_ROLE") else {
+        return;
+    };
+    let path = PathBuf::from(env::var("REDB_MP_PATH").unwrap());
+    let generations = || -> u64 { env::var("REDB_MP_GENERATIONS").unwrap().parse().unwrap() };
+    match role.as_str() {
+        // -- the directory and its lock ------------------------------------------------------
+        // Expects to be turned away by the lock the parent holds
+        "rejected" => {
+            assert!(matches!(
+                MultiProcessDatabase::open(&path),
+                Err(DatabaseError::DatabaseAlreadyOpen)
+            ));
+        }
+        // Expects to get in, and leaves a value behind for the parent to find
+        "single_write" => {
+            let db = MultiProcessDatabase::open(&path).unwrap();
+            write(&db, 0, 7);
+        }
+        // Opens the database and dies without closing it, leaving the lock to the operating system
+        "abort_after_write" => {
+            let db = MultiProcessDatabase::open(&path).unwrap();
+            write(&db, 0, 9);
+            std::process::abort();
+        }
+        // -- the cross-process protocol ------------------------------------------------------
+        // Writes generations until told to stop, so that the parent can read across them
+        "writer" => {
+            let db = MultiProcessDatabase::open(&path).unwrap();
+            for generation in 2..=generations() {
+                write_generation(&db, generation);
+            }
+        }
+        // Reads snapshots until the writer has reached the last generation, checking every one
+        "reader" => {
+            let db = MultiProcessDatabase::open_read_only(&path).unwrap();
+            let mut last = 0;
+            let mut seen = 0;
+            while last < generations() {
+                let txn = db.begin_read().unwrap();
+                let generation = spot_check(&txn);
+                assert!(generation >= last, "a snapshot went backwards");
+                // Hold the snapshot across more of the writer's commits, then read all of it
+                thread::yield_now();
+                assert_eq!(generation, read_generation(&txn));
+                last = generation;
+                seen += 1;
+                assert!(seen < 10_000_000, "the writer never finished");
+            }
+        }
+        // Opens for writing and expects to be turned away
+        "rejected_writer" => {
+            assert!(matches!(
+                MultiProcessDatabase::open(&path),
+                Err(DatabaseError::DatabaseAlreadyOpen)
+            ));
+        }
+        // Pins a transaction with a read and dies holding it, leaving its file in txn/
+        "abort_with_read" => {
+            let db = MultiProcessDatabase::open(&path).unwrap();
+            let txn = db.begin_read().unwrap();
+            let _ = spot_check(&txn);
+            std::process::abort();
+        }
+        // Starts a write transaction and dies holding the write lock, without committing
+        "crasher" => {
+            let db = MultiProcessDatabase::open(&path).unwrap();
+            let txn = db.begin_write().unwrap();
+            {
+                let mut table = txn.open_table(TABLE).unwrap();
+                for key in 0..KEYS {
+                    table.insert(&key, &999).unwrap();
+                }
+            }
+            // Leaves the file with a half-written transaction and the lock files as they are
+            std::process::abort();
+        }
+        other => panic!("unknown role {other}"),
+    }
+}
+
+fn run_child(role: &str, path: &Path) -> std::process::ExitStatus {
+    Command::new(env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "child_process_worker",
+            "--ignored",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env("REDB_MP_ROLE", role)
+        .env("REDB_MP_PATH", path)
+        .status()
+        .unwrap()
+}
+
+#[test]
+fn a_child_process_cannot_open_a_database_this_one_holds() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    // SingleWriterProcess, which is the mode that promises this: the other one admits the child and
+    // serializes it against this process one transaction at a time
+    let db = create(&path, WriterMode::SingleWriterProcess);
+    write(&db, 0, 1);
+
+    assert!(run_child("rejected", &path).success());
+
+    // The child's failed open must not have disturbed anything
+    write(&db, 0, 2);
+    assert_eq!(Some(2), read(&db, 0));
+}
+
+#[test]
+fn a_child_process_can_open_a_database_this_one_has_closed() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    {
+        let db = MultiProcessDatabase::create(&path).unwrap();
+        write(&db, 0, 1);
+    }
+
+    assert!(run_child("single_write", &path).success());
+
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(7), read(&db, 0));
+}
+
+#[test]
+fn a_process_that_dies_releases_the_lock() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    {
+        let db = MultiProcessDatabase::create(&path).unwrap();
+        write(&db, 0, 1);
+    }
+
+    assert!(!run_child("abort_after_write", &path).success());
+
+    // Nothing has to clean up after it: the operating system dropped its lock when it died
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(9), read(&db, 0));
+    write(&db, 0, 10);
+    assert_eq!(Some(10), read(&db, 0));
 }
 
 /// A directory holding a plain [`Database`] under `data.redb` is someone else's data, not an
@@ -160,119 +441,6 @@ fn create_does_not_trust_a_nonempty_lock_file() {
     drop(Database::open(path.join("data.redb")).unwrap());
 }
 
-/// The write lock is invisible to a process that reaches past the directory and opens the database
-/// file itself, so that file carries the ordinary exclusive lock as well. Readers are turned away
-/// along with writers: nothing coordinates a reader that attaches this way with the pages the
-/// process holding the directory frees.
-#[test]
-fn an_ordinary_database_cannot_open_the_data_file() {
-    let dir = tempdir();
-    let path = db_path(&dir);
-    let db = MultiProcessDatabase::create(&path).unwrap();
-
-    let data = path.join("data.redb");
-    assert!(matches!(
-        Database::open(&data),
-        Err(DatabaseError::DatabaseAlreadyOpen)
-    ));
-    assert!(matches!(
-        Database::create(&data),
-        Err(DatabaseError::DatabaseAlreadyOpen)
-    ));
-    assert!(matches!(
-        ReadOnlyDatabase::open(&data),
-        Err(DatabaseError::DatabaseAlreadyOpen)
-    ));
-
-    // ... and once the directory is closed the database file is an ordinary redb database again
-    drop(db);
-    drop(ReadOnlyDatabase::open(&data).unwrap());
-}
-
-// --------------------------------------------------------------------------------------------
-// Tests that need a real process
-// --------------------------------------------------------------------------------------------
-
-/// Entry point for the child processes the tests below spawn. Ignored so that it only runs when
-/// named explicitly, and does nothing unless the parent asked for a role.
-#[test]
-#[ignore]
-fn child_process_worker() {
-    let Ok(role) = env::var("REDB_MP_ROLE") else {
-        return;
-    };
-    let path = PathBuf::from(env::var("REDB_MP_PATH").unwrap());
-    match role.as_str() {
-        // Expects to be turned away by the lock the parent holds
-        "rejected" => {
-            assert!(matches!(
-                MultiProcessDatabase::open(&path),
-                Err(DatabaseError::DatabaseAlreadyOpen)
-            ));
-        }
-        // Expects to get in
-        "opener" => {
-            drop(MultiProcessDatabase::open(&path).unwrap());
-        }
-        // Opens the database and dies without closing it, leaving the lock to the operating system
-        "crasher" => {
-            let db = MultiProcessDatabase::open(&path).unwrap();
-            let _ = &db;
-            std::process::abort();
-        }
-        other => panic!("unknown role {other}"),
-    }
-}
-
-fn run_child(role: &str, path: &Path) -> std::process::ExitStatus {
-    Command::new(env::current_exe().unwrap())
-        .args([
-            "--exact",
-            "child_process_worker",
-            "--ignored",
-            "--nocapture",
-            "--test-threads=1",
-        ])
-        .env("REDB_MP_ROLE", role)
-        .env("REDB_MP_PATH", path)
-        .status()
-        .unwrap()
-}
-
-#[test]
-fn a_child_process_cannot_open_a_database_this_one_holds() {
-    let dir = tempdir();
-    let path = db_path(&dir);
-    let _db = MultiProcessDatabase::create(&path).unwrap();
-
-    assert!(run_child("rejected", &path).success());
-}
-
-#[test]
-fn a_child_process_can_open_a_database_this_one_has_closed() {
-    let dir = tempdir();
-    let path = db_path(&dir);
-    drop(MultiProcessDatabase::create(&path).unwrap());
-
-    assert!(run_child("opener", &path).success());
-
-    // ... and the child released the lock on its way out
-    drop(MultiProcessDatabase::open(&path).unwrap());
-}
-
-/// The whole point of using OS locks: a process that dies holding the database releases it with no
-/// cleanup and no timeouts.
-#[test]
-fn a_process_that_dies_releases_the_lock() {
-    let dir = tempdir();
-    let path = db_path(&dir);
-    drop(MultiProcessDatabase::create(&path).unwrap());
-
-    assert!(!run_child("crasher", &path).success());
-
-    drop(MultiProcessDatabase::open(&path).unwrap());
-}
-
 /// A directory that already holds something else is a mistyped path, not a database waiting to be
 /// made. The only reason to accept an existing directory without a marker is an interrupted
 /// `create()`, and such a directory holds nothing but the files `create()` itself writes.
@@ -298,8 +466,12 @@ fn a_stray_file_does_not_stop_an_existing_database_opening() {
     drop(MultiProcessDatabase::create(&path).unwrap());
     std::fs::write(path.join(".DS_Store"), b"junk").unwrap();
 
-    drop(MultiProcessDatabase::open(&path).unwrap());
-    drop(MultiProcessDatabase::create(&path).unwrap());
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    write(&db, 0, 1);
+    drop(db);
+
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    assert_eq!(Some(1), read(&db, 0));
 }
 
 /// `open()` does not create anything, and that has to hold for a directory that exists but is not
@@ -350,8 +522,8 @@ fn create_does_not_mark_a_directory_it_rejects() {
 /// redb writes a new database's header with the magic number zeroed, flushes, and only then writes
 /// the magic, so a crash during initialization leaves a file that is neither empty nor a database.
 /// `Database::new` refuses such a file whether or not `create` is set, so under the name
-/// `data.redb` it would wedge the directory for good -- indistinguishable from a file this call
-/// was pointed at by mistake. Initializing under a temporary name is what keeps the two apart.
+/// `data.redb` it would wedge the directory for good -- indistinguishable from a file this call was
+/// pointed at by mistake. Initializing under a temporary name is what keeps the two apart.
 #[test]
 fn an_initialization_that_crashed_partway_can_be_redone() {
     let dir = tempdir();
@@ -366,7 +538,10 @@ fn an_initialization_that_crashed_partway_can_be_redone() {
     partial[0..9].fill(0);
     std::fs::write(path.join("data.redb.tmp"), &partial).unwrap();
 
-    drop(MultiProcessDatabase::create(&path).unwrap());
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 1);
+    assert_eq!(Some(1), read(&db, 0));
+    drop(db);
 
     assert!(path.join("data.redb").is_file());
     assert!(!path.join("data.redb.tmp").exists());
@@ -379,7 +554,9 @@ fn an_initialization_that_crashed_partway_can_be_redone() {
     partial[0..9].fill(0);
     std::fs::write(path.join("data.redb.tmp"), &partial).unwrap();
 
-    drop(MultiProcessDatabase::create(&path).unwrap());
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 2);
+    drop(db);
     assert!(path.join("data.redb").is_file());
     assert!(!path.join("data.redb.tmp").exists());
 }
@@ -391,7 +568,10 @@ fn an_initialization_that_crashed_partway_can_be_redone() {
 fn a_temporary_holding_a_finished_database_is_not_discarded() {
     let dir = tempdir();
     let path = db_path(&dir);
-    drop(MultiProcessDatabase::create(&path).unwrap());
+    {
+        let db = MultiProcessDatabase::create(&path).unwrap();
+        write(&db, 0, 7);
+    }
     std::fs::rename(path.join("data.redb"), path.join("data.redb.tmp")).unwrap();
     let saved = std::fs::read(path.join("data.redb.tmp")).unwrap();
 
@@ -402,24 +582,783 @@ fn a_temporary_holding_a_finished_database_is_not_discarded() {
     assert!(MultiProcessDatabase::create(&path).is_err());
     assert_eq!(saved, std::fs::read(path.join("data.redb.tmp")).unwrap());
 
-    // Renaming it back, as the error says to, recovers the database
+    // Renaming it back, as the error says to, recovers the database and the data in it
     std::fs::rename(path.join("data.redb.tmp"), path.join("data.redb")).unwrap();
-    drop(MultiProcessDatabase::create(&path).unwrap());
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    assert_eq!(Some(7), read(&db, 0));
 }
 
 /// A temporary file only ever means "an attempt that did not finish", so one sitting next to a
-/// database that *did* finish must not be moved over it: promoting on the mere presence of a
-/// temporary would swap a good database for wreckage.
+/// database that *did* finish must not be moved over it. Promoting on the mere presence of a
+/// temporary would swap a good database for wreckage, and leave the handle this call returns
+/// writing to an inode nothing points at any more.
 #[test]
 fn a_stale_temporary_does_not_replace_the_database() {
     let dir = tempdir();
     let path = db_path(&dir);
-    drop(MultiProcessDatabase::create(&path).unwrap());
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 42);
+    drop(db);
+
     std::fs::write(path.join("data.redb.tmp"), b"stale wreckage").unwrap();
 
-    // create() opens the finished database -- the wreckage would have been refused -- and throws
-    // the temporary away
-    drop(MultiProcessDatabase::create(&path).unwrap());
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    assert_eq!(Some(42), read(&db, 0));
+    write(&db, 1, 43);
+    drop(db);
+
+    // ... and what this call wrote is in the database the directory actually points at
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    assert_eq!(Some(42), read(&db, 0));
+    assert_eq!(Some(43), read(&db, 1));
     assert!(!path.join("data.redb.tmp").exists());
-    drop(MultiProcessDatabase::open(&path).unwrap());
+}
+
+fn create(path: &Path, mode: WriterMode) -> MultiProcessDatabase {
+    MultiProcessDatabase::builder()
+        .set_writer_mode(mode)
+        .create(path)
+        .unwrap()
+}
+
+fn open(path: &Path) -> MultiProcessDatabase {
+    MultiProcessDatabase::open(path).unwrap()
+}
+
+/// Writes `value` to every key, replacing whatever was there. Rewriting the whole table makes the
+/// writer free and reallocate pages on every commit, which is what puts a reader's cached pages at
+/// risk if the protocol is wrong.
+fn write_generation(db: &MultiProcessDatabase, value: u64) {
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        for key in 0..KEYS {
+            table.insert(&key, &value).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+}
+
+/// Reads one key, which is enough to make a snapshot real without pulling the whole table into
+/// this process's page cache. A later `read_generation` on the same snapshot then has to go to the
+/// file for most of what it reads, which is where a page that was reused underneath it shows up.
+fn spot_check(txn: &redb::ReadTransaction) -> u64 {
+    let table = txn.open_table(TABLE).unwrap();
+    table.get_owned(0).unwrap().unwrap().value()
+}
+
+/// Returns the generation a snapshot holds, asserting that it is the same for every key
+fn read_generation(txn: &redb::ReadTransaction) -> u64 {
+    let table = txn.open_table(TABLE).unwrap();
+    let mut generation = None;
+    // Descending, so that the pages a spot check may have cached are read last
+    for key in (0..KEYS).rev() {
+        let value = table.get_owned(key).unwrap().unwrap().value();
+        match generation {
+            None => generation = Some(value),
+            Some(expected) => assert_eq!(
+                expected, value,
+                "key {key} holds {value}, but the snapshot is at generation {expected}"
+            ),
+        }
+    }
+    generation.unwrap()
+}
+
+#[test]
+fn create_makes_a_directory_of_lock_files() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&db, 1);
+
+    assert!(path.join("data.redb").is_file());
+    assert!(path.join("metadata").is_file());
+    assert!(path.join("extended-header").is_file());
+    assert!(path.join("write.lock").is_file());
+    assert!(path.join("registry.lock").is_file());
+    assert!(path.join("txn").is_dir());
+    // Nothing is pinned: the handle has no read transaction open
+    assert_eq!(0, std::fs::read_dir(path.join("txn")).unwrap().count());
+
+    // ... and one that does pins it under its own transaction id
+    let read = db.begin_read().unwrap();
+    let pinned: Vec<_> = std::fs::read_dir(path.join("txn"))
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    assert_eq!(1, pinned.len(), "{pinned:?}");
+    drop(read);
+}
+
+#[test]
+fn the_mode_is_fixed_at_creation() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::SingleWriterProcess);
+    drop(db);
+
+    // Opening without asking for a mode adopts the one the database was created with
+    assert_eq!(
+        WriterMode::SingleWriterProcess,
+        MultiProcessDatabase::open(&path).unwrap().writer_mode()
+    );
+    // Asking for the wrong one is an error rather than a silently different protocol
+    assert!(
+        MultiProcessDatabase::builder()
+            .set_writer_mode(WriterMode::MultiWriterProcess)
+            .open(&path)
+            .is_err()
+    );
+}
+
+#[test]
+fn a_second_writer_is_rejected_in_single_writer_mode() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::SingleWriterProcess);
+    write_generation(&db, 1);
+
+    assert!(matches!(
+        MultiProcessDatabase::open(&path),
+        Err(redb::DatabaseError::DatabaseAlreadyOpen)
+    ));
+    // ... but read-only handles are fine
+    let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+    assert_eq!(1, read_generation(&reader.begin_read().unwrap()));
+
+    drop(db);
+    // Once the writer is gone the slot is free again
+    let db = MultiProcessDatabase::open(&path).unwrap();
+    write_generation(&db, 2);
+}
+
+#[test]
+fn writers_take_turns_in_multi_writer_mode() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let first = create(&path, WriterMode::MultiWriterProcess);
+    let second = open(&path);
+
+    for generation in 1..10 {
+        let db = if generation % 2 == 0 { &first } else { &second };
+        write_generation(db, generation);
+        // Both handles see the commit, whichever of them made it
+        assert_eq!(generation, read_generation(&first.begin_read().unwrap()));
+        assert_eq!(generation, read_generation(&second.begin_read().unwrap()));
+    }
+}
+
+#[test]
+fn a_read_only_handle_sees_new_commits() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::SingleWriterProcess);
+    write_generation(&db, 1);
+
+    let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+    assert_eq!(1, read_generation(&reader.begin_read().unwrap()));
+
+    for generation in 2..10 {
+        write_generation(&db, generation);
+        assert_eq!(generation, read_generation(&reader.begin_read().unwrap()));
+    }
+}
+
+#[test]
+fn a_read_only_handle_cannot_be_opened_for_writing() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&db, 1);
+    drop(db);
+
+    let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+    assert_eq!(1, read_generation(&reader.begin_read().unwrap()));
+}
+
+/// The core safety property: a snapshot another process is reading must stay readable, however
+/// much the writer churns the pages underneath it.
+#[test]
+fn a_snapshot_survives_a_writer_recycling_pages() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let writer = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&writer, 1);
+
+    let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+    let snapshot = reader.begin_read().unwrap();
+    assert_eq!(1, spot_check(&snapshot));
+
+    // Enough transactions that the writer must reuse the pages the snapshot above still points at,
+    // if it is allowed to
+    for generation in 2..30 {
+        write_generation(&writer, generation);
+    }
+
+    // The snapshot still reads the generation it was opened at, page for page
+    assert_eq!(1, read_generation(&snapshot));
+    drop(snapshot);
+
+    // And a new snapshot sees the latest generation, rather than anything left in the page cache
+    assert_eq!(29, read_generation(&reader.begin_read().unwrap()));
+}
+
+/// The same, with the reader in a handle that can also write: it goes through a different refresh
+/// path, since its memory is not read-only.
+#[test]
+fn a_snapshot_in_a_writer_handle_survives_another_writer() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let first = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&first, 1);
+    let second = open(&path);
+
+    let snapshot = second.begin_read().unwrap();
+    assert_eq!(1, spot_check(&snapshot));
+
+    for generation in 2..30 {
+        write_generation(&first, generation);
+    }
+
+    assert_eq!(1, read_generation(&snapshot));
+    drop(snapshot);
+    assert_eq!(29, read_generation(&second.begin_read().unwrap()));
+
+    // The second handle can still take over the writer role afterwards
+    write_generation(&second, 30);
+    assert_eq!(30, read_generation(&first.begin_read().unwrap()));
+}
+
+/// A reader that has cached pages, and then falls behind, must not serve them from its cache after
+/// the writer has handed those pages back out.
+#[test]
+fn a_stale_page_cache_is_dropped() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let writer = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&writer, 1);
+
+    let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+    // Fills the reader's page cache with generation 1's pages, then releases the snapshot so that
+    // nothing pins them
+    assert_eq!(1, read_generation(&reader.begin_read().unwrap()));
+
+    for generation in 2..20 {
+        write_generation(&writer, generation);
+        assert_eq!(
+            generation,
+            read_generation(&reader.begin_read().unwrap()),
+            "the reader served generation {generation} from a stale cache"
+        );
+    }
+}
+
+/// A write transaction that dies in a panic the caller catches leaves its pages allocated until
+/// another process takes over, but the bytes it wrote must die with it. A page that overflowed
+/// the write buffer mid-transaction was written to the file and, once read back, cached like any
+/// committed page -- yet the pages themselves are free in every committed state, so the next
+/// writer fills them without the collection that normally drops a stale cache. The reader's pin
+/// here holds the collection horizon still while the pages change hands.
+#[test]
+fn a_caught_panic_does_not_poison_the_page_cache() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = MultiProcessDatabase::builder()
+        .set_writer_mode(WriterMode::MultiWriterProcess)
+        // Small enough that the doomed transaction below overflows the write buffer, putting its
+        // pages in the file -- and, where they are read back, the page cache -- before the panic
+        .set_cache_size(1024 * 1024)
+        .create(&path)
+        .unwrap();
+    write(&db, 0, 1);
+
+    let pin = db.begin_read().unwrap();
+
+    let doomed = vec![0xAAu8; 4096];
+    let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(BIG_TABLE).unwrap();
+            for key in 0..1024u64 {
+                table.insert(&key, doomed.as_slice()).unwrap();
+            }
+            // Pull the spilled pages back in through the cache
+            for key in 0..1024u64 {
+                assert!(table.get(&key).unwrap().is_some());
+            }
+        }
+        panic!("the transaction dies with its pages in the cache");
+    }));
+    assert!(panicked.is_err());
+
+    let second = open(&path);
+    let committed = vec![0x55u8; 4096];
+    let txn = second.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(BIG_TABLE).unwrap();
+        for key in 0..1024u64 {
+            table.insert(&key, committed.as_slice()).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    // The first handle must see what was committed, not what its dead transaction wrote. Probed
+    // key by key: scanning the table end to end would stream enough fresh pages through the small
+    // cache to evict the dead transaction's entries before the scan reached their offsets.
+    let txn = db.begin_read().unwrap();
+    let table = txn.open_table(BIG_TABLE).unwrap();
+    for key in (0..1024u64).step_by(16) {
+        match table.get_owned(key).unwrap() {
+            Some(value) => assert!(
+                value.value().iter().all(|&byte| byte == 0x55),
+                "key {key} was served the dead transaction's bytes"
+            ),
+            None => panic!("key {key} was lost to a stale page from the dead transaction"),
+        }
+    }
+    drop(txn);
+    drop(pin);
+}
+
+#[test]
+fn a_reader_holds_pages_back_while_a_writer_churns() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let writer = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&writer, 1);
+
+    let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let reader_thread = {
+        let stop = stop.clone();
+        thread::spawn(move || {
+            let mut snapshots = 0;
+            while !stop.load(Ordering::Acquire) {
+                let txn = reader.begin_read().unwrap();
+                let generation = spot_check(&txn);
+                // Read the rest of the snapshot only after the writer has had a chance to commit
+                // over it, so that most of it comes from the file rather than this process's cache
+                thread::yield_now();
+                assert_eq!(generation, read_generation(&txn));
+                snapshots += 1;
+            }
+            snapshots
+        })
+    };
+
+    for generation in 2..40 {
+        write_generation(&writer, generation);
+    }
+    stop.store(true, Ordering::Release);
+    let snapshots = reader_thread.join().unwrap();
+    assert!(snapshots > 0);
+}
+
+#[test]
+fn many_readers_and_one_writer() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let writer = create(&path, WriterMode::SingleWriterProcess);
+    write_generation(&writer, 1);
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let readers: Vec<_> = (0..4)
+        .map(|_| {
+            let stop = stop.clone();
+            let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+            thread::spawn(move || {
+                let mut last = 0;
+                while !stop.load(Ordering::Acquire) {
+                    let txn = reader.begin_read().unwrap();
+                    let generation = spot_check(&txn);
+                    thread::yield_now();
+                    assert_eq!(generation, read_generation(&txn));
+                    // Snapshots never go backwards for a given reader
+                    assert!(generation >= last);
+                    last = generation;
+                }
+                last
+            })
+        })
+        .collect();
+
+    for generation in 2..30 {
+        write_generation(&writer, generation);
+    }
+    stop.store(true, Ordering::Release);
+    for reader in readers {
+        reader.join().unwrap();
+    }
+}
+
+#[test]
+fn non_durable_commits_are_rejected_with_multiple_writer_processes() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::MultiWriterProcess);
+
+    let mut txn = db.begin_write().unwrap();
+    assert!(matches!(
+        txn.set_durability(Durability::None),
+        Err(redb::SetDurabilityError::NonDurableCommitUnsupported)
+    ));
+    txn.abort().unwrap();
+}
+
+#[test]
+fn non_durable_commits_work_with_a_single_writer_process() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::SingleWriterProcess);
+    write_generation(&db, 1);
+    let durable = db.last_durable_commit().unwrap();
+
+    let mut txn = db.begin_write().unwrap();
+    txn.set_durability(Durability::None).unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        for key in 0..KEYS {
+            table.insert(&key, &2).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    // Visible in the writing process...
+    assert_eq!(2, read_generation(&db.begin_read().unwrap()));
+    // ... but not to anyone else, until a durable commit publishes it -- and not reported as
+    // durable, even by the process that made it
+    let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+    assert_eq!(1, read_generation(&reader.begin_read().unwrap()));
+    assert_eq!(durable, db.last_durable_commit().unwrap());
+
+    write_generation(&db, 3);
+    assert_eq!(3, read_generation(&reader.begin_read().unwrap()));
+    assert!(db.last_durable_commit().unwrap() > durable);
+}
+
+#[test]
+fn an_ephemeral_savepoint_holds_pages_back_across_handles() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let first = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&first, 1);
+
+    let savepoint = {
+        let txn = first.begin_write().unwrap();
+        let savepoint = txn.ephemeral_savepoint().unwrap();
+        txn.commit().unwrap();
+        savepoint
+    };
+
+    // Another handle churns the pages the savepoint needs
+    let second = open(&path);
+    for generation in 2..20 {
+        write_generation(&second, generation);
+    }
+
+    // Restoring it must still find them
+    let mut txn = first.begin_write().unwrap();
+    txn.restore_savepoint(&savepoint).unwrap();
+    txn.commit().unwrap();
+    assert_eq!(1, read_generation(&first.begin_read().unwrap()));
+    assert_eq!(1, read_generation(&second.begin_read().unwrap()));
+}
+
+#[test]
+fn the_database_grows_and_shrinks_across_handles() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let first = create(&path, WriterMode::MultiWriterProcess);
+    let second = open(&path);
+
+    write_generation(&first, 1);
+
+    // The second handle grows the file well past what the first has seen
+    let txn = second.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(BIG_TABLE).unwrap();
+        let value = vec![7u8; 4096];
+        for key in 0..2000u64 {
+            table.insert(&key, value.as_slice()).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+
+    // ... and the first picks it up, including pages in regions it has never seen
+    let read = first.begin_read().unwrap();
+    let table = read.open_table(BIG_TABLE).unwrap();
+    assert_eq!(2000, table.len().unwrap());
+    assert_eq!(4096, table.get_owned(1999).unwrap().unwrap().value().len());
+    drop(read);
+
+    // The first handle can still write, having reloaded the grown layout
+    let txn = first.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(BIG_TABLE).unwrap();
+        for key in 0..2000u64 {
+            table.remove(&key).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+    assert_eq!(
+        0,
+        second
+            .begin_read()
+            .unwrap()
+            .open_table(BIG_TABLE)
+            .unwrap()
+            .len()
+            .unwrap()
+    );
+}
+
+#[test]
+fn concurrent_writers_from_many_threads_and_handles() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let first = Arc::new(create(&path, WriterMode::MultiWriterProcess));
+    let second = Arc::new(open(&path));
+
+    let threads: Vec<_> = [first.clone(), second.clone(), first.clone(), second.clone()]
+        .into_iter()
+        .enumerate()
+        .map(|(index, db)| {
+            thread::spawn(move || {
+                for i in 0..20u64 {
+                    let txn = db.begin_write().unwrap();
+                    {
+                        let mut table = txn.open_table(TABLE).unwrap();
+                        table.insert(&(index as u64 * 100 + i), &i).unwrap();
+                    }
+                    txn.commit().unwrap();
+                }
+            })
+        })
+        .collect();
+    for thread in threads {
+        thread.join().unwrap();
+    }
+
+    let read = first.begin_read().unwrap();
+    let table = read.open_table(TABLE).unwrap();
+    assert_eq!(80, table.len().unwrap());
+    for index in 0..4u64 {
+        for i in 0..20u64 {
+            assert_eq!(
+                i,
+                table.get_owned(index * 100 + i).unwrap().unwrap().value()
+            );
+        }
+    }
+}
+
+/// Dropping a handle must not wait on another process's write transaction. Closing writes an
+/// allocator state table so that the next open does not have to rebuild one, but in multi-writer
+/// mode every commit has already written one.
+#[test]
+fn dropping_a_handle_does_not_wait_for_the_write_lock() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let first = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&first, 1);
+
+    let second = open(&path);
+    // Held for the whole of the drop below, which must not need it
+    let blocking = second.begin_write().unwrap();
+
+    let (done, closed) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        drop(first);
+        let _ = done.send(());
+    });
+    // Fails rather than hanging if the drop is waiting for the write lock
+    closed
+        .recv_timeout(std::time::Duration::from_secs(10))
+        .expect("dropping the handle blocked on the write lock");
+
+    blocking.abort().unwrap();
+    assert_eq!(1, read_generation(&second.begin_read().unwrap()));
+}
+
+/// A writer committing as fast as it can, against a reader in another handle doing the same. Small
+/// transactions and a table large enough to span many pages, so that the writer is constantly
+/// freeing and reusing pages that the reader may be part way through reading.
+fn churn(mode: WriterMode, rounds: u64) {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    {
+        let db = create(&path, mode);
+        let value = vec![0xab; 100];
+        let mut key = 0;
+        while key < CHURN_ELEMENTS {
+            let txn = db.begin_write().unwrap();
+            {
+                let mut table = txn.open_table(CHURN_TABLE).unwrap();
+                for _ in 0..2000 {
+                    table.insert(&key, value.as_slice()).unwrap();
+                    key += 1;
+                }
+            }
+            txn.commit().unwrap();
+        }
+    }
+
+    let writer = open(&path);
+    let reader = MultiProcessDatabase::open_read_only(&path).unwrap();
+    let stop = Arc::new(AtomicBool::new(false));
+    let writer_thread = {
+        let stop = stop.clone();
+        thread::spawn(move || {
+            let value = vec![0xcd; 100];
+            let mut commits = 0u64;
+            while !stop.load(Ordering::Acquire) {
+                let txn = writer.begin_write().unwrap();
+                {
+                    let mut table = txn.open_table(CHURN_TABLE).unwrap();
+                    table
+                        .insert(&(commits % CHURN_ELEMENTS), value.as_slice())
+                        .unwrap();
+                }
+                txn.commit().unwrap();
+                commits += 1;
+            }
+            commits
+        })
+    };
+
+    for round in 0..rounds {
+        let txn = reader.begin_read().unwrap();
+        let table = txn.open_table(CHURN_TABLE).unwrap();
+        for i in 0..50 {
+            let key = (round * 37 + i * 401) % CHURN_ELEMENTS;
+            assert_eq!(100, table.get_owned(key).unwrap().unwrap().value().len());
+        }
+    }
+    stop.store(true, Ordering::Release);
+    assert!(writer_thread.join().unwrap() > 0);
+}
+
+#[test]
+fn churn_with_a_single_writer_process() {
+    churn(WriterMode::SingleWriterProcess, 2000);
+}
+
+#[test]
+fn churn_with_multiple_writer_processes() {
+    churn(WriterMode::MultiWriterProcess, 2000);
+}
+
+fn spawn_child(role: &str, path: &Path, generations: u64) -> std::process::Child {
+    Command::new(env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "child_process_worker",
+            "--ignored",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env("REDB_MP_ROLE", role)
+        .env("REDB_MP_PATH", path)
+        .env("REDB_MP_GENERATIONS", generations.to_string())
+        .spawn()
+        .unwrap()
+}
+
+#[test]
+fn a_child_process_reads_while_this_one_writes() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let writer = create(&path, WriterMode::SingleWriterProcess);
+    write_generation(&writer, 1);
+
+    let generations = 40;
+    let mut reader = spawn_child("reader", &path, generations);
+    for generation in 2..=generations {
+        write_generation(&writer, generation);
+    }
+    assert!(reader.wait().unwrap().success(), "the reader child failed");
+}
+
+#[test]
+fn a_child_process_writes_while_this_one_reads() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&db, 1);
+
+    let generations = 40;
+    let mut writer = spawn_child("writer", &path, generations);
+    let mut last = 0;
+    while last < generations {
+        let txn = db.begin_read().unwrap();
+        let generation = spot_check(&txn);
+        assert!(generation >= last);
+        thread::yield_now();
+        assert_eq!(generation, read_generation(&txn));
+        last = generation;
+    }
+    assert!(writer.wait().unwrap().success(), "the writer child failed");
+    assert_eq!(generations, read_generation(&db.begin_read().unwrap()));
+}
+
+#[test]
+fn a_child_process_cannot_write_in_single_writer_mode() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::SingleWriterProcess);
+    write_generation(&db, 1);
+
+    let mut child = spawn_child("rejected_writer", &path, 0);
+    assert!(child.wait().unwrap().success());
+
+    // The child's failed open must not have disturbed anything
+    write_generation(&db, 2);
+    assert_eq!(2, read_generation(&db.begin_read().unwrap()));
+}
+
+#[test]
+fn a_writer_that_dies_mid_transaction_is_recovered() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    {
+        let db = create(&path, WriterMode::MultiWriterProcess);
+        write_generation(&db, 1);
+    }
+
+    let mut child = spawn_child("crasher", &path, 0);
+    let status = child.wait().unwrap();
+    assert!(!status.success(), "the child was supposed to abort");
+
+    // The uncommitted transaction is rolled back, and the database is usable again
+    let db = open(&path);
+    assert_eq!(1, read_generation(&db.begin_read().unwrap()));
+    write_generation(&db, 2);
+    assert_eq!(2, read_generation(&db.begin_read().unwrap()));
+}
+
+#[test]
+fn a_reader_that_dies_stops_holding_pages_back() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&db, 1);
+
+    // The child pins a transaction in txn/ with a read, then dies with the file still there
+    let mut child = spawn_child("abort_with_read", &path, 0);
+    assert!(!child.wait().unwrap().success());
+    assert!(std::fs::read_dir(path.join("txn")).unwrap().count() > 0);
+
+    // The dead process's pin must not stop this one from reclaiming pages, which it would if the
+    // file's presence were trusted without checking whether anyone still holds it locked
+    let before = std::fs::metadata(path.join("data.redb")).unwrap().len();
+    for generation in 2..40 {
+        write_generation(&db, generation);
+    }
+    let after = std::fs::metadata(path.join("data.redb")).unwrap().len();
+    assert!(
+        after <= before * 2,
+        "the file grew from {before} to {after}, so pages were not being reused"
+    );
 }


### PR DESCRIPTION
Fourth of six. **Based on #1377, which is based on #1376 and #1375** — review those first; this diff is the protocol itself. The first three PRs built the directory and made it safe to point `create()` at anything; this one is what the directory is for. It implements the protocol in the "Directory-structured databases" section of `docs/design.md`, and it is where `begin_read()` and `begin_write()` arrive: until here a `MultiProcessDatabase` could only be created and opened.

| | what | added |
|---|---|---|
| 1/6 | #1375 — the directory: write lock, `metadata` marker, shared lock | 794 |
| 2/6 | #1376 — refusing unmarked directories holding redb's file names | 161 |
| 3/6 | #1377 — refusing directories that are not redb's | 500 |
| **4/6** | this PR — the cross-process protocol | 4001 |
| 5/6 | #1388 — savepoints across processes | 248 |
| 6/6 | #1389 — keeping an ordinary `Database` out of `data.redb` | 73 |

---

redb allows one writer and many readers, but only within a single process: the tracker that keeps a page from being reused while a reader can still see it lives in memory, and the file is locked exclusively. This extends that same epoch-based reclamation across processes, using only ordinary file I/O and the advisory locks in `std::fs::File` — no shared memory, no `unsafe`.

## The directory

| file | contents |
|---|---|
| `data.redb` | the database, in the ordinary file format |
| `metadata` | magic number, format version, and the writer mode |
| `extended-header` | the transaction collection horizon, logically part of the header |
| `write.lock` | empty; held by the process that owns the single logical writer |
| `registry.lock` | empty; its lock guards the header, `extended-header`, and `txn/` |
| `txn/` | empty; one file per transaction some process is still reading |

## Pinning a transaction

A process pins the oldest transaction it needs — the minimum over its live read transactions and savepoints, which the in-memory tracker already computes — by creating `txn/` and taking a **shared** lock on it. Nothing is ever read from or written to those files: **the name carries the whole of the data.** That is what makes the scheme portable, since a lock is mandatory on some platforms and a file another process holds could not be read at all. Every process needing the same transaction holds the same file, which is why the lock is shared. Releasing a pin releases the lock but leaves the file: unlinking is only safe for a writer that holds the file exclusively.

A writer walks `txn/` from the lowest id up and tries to take each file **exclusively**:

* succeeding means nobody needs that transaction any more, so the file is litter — left by a process that moved on or exited — and is unlinked while the lock is still held, so a reader cannot open it in between and end up holding an inode nothing points at;
* failing means a live reader holds it. It is the lowest, so it is the horizon, and the scan stops there.

The free horizon is the minimum of that and the writer's own tracker. A process that exits therefore stops holding pages back with no cleanup and no timeouts: the OS drops its locks, and the name it leaves behind is unlinked by the next writer to walk past it.

## The registry lock

`registry.lock` is empty; its lock serializes everything else. A reader takes it **shared** and, in one hold, reads the latest transaction id from the header — always from the file, never cached — and pins it in `txn/`. A writer takes it **exclusively** to write the header or to scan the pins. The header writes go through the storage backend, so every one of them is covered, the ones repair makes included, and the lock is never held across an `fsync`. That gives two properties at once:

* header reads are atomic, even though no platform actually promises read/write atomicity for overlapping file I/O;
* either a scanning writer sees a starting reader's pin, or the reader reads the file strictly after the scan and gets a snapshot at least as new as the horizon that scan produced.

## Page cache invalidation

A page a process has cached can be reallocated by another one. Each process tracks a **cache floor**: a transaction id such that every cached page was read from a snapshot at or after it. Whenever it looks at the file it also reads the **transaction collection horizon** — the newest transaction garbage collected, whose freed pages may have been reused — and drops its whole read cache if the horizon is newer than its floor.

The horizon lives in `extended-header`, logically an extension of the header's two commit slots: per slot, a horizon plus an XXH3 hash binding it to the commit slot bytes it was written beside, selected by the same primary bit. A committing writer updates the slot it is about to flip to *after* the phase-1 flush and *before* the flip, so the horizon and the reuse it describes become visible together — and the file needs no fsync of its own, because a crash between the two writes leaves a binding the hash rejects. A reader that finds the hash wrong assumes the worst and drops its cache; the next writer rewrites the file with the fallback the design doc's crash rules allow (the lowest pinned id, or the latest transaction minus one), both of which overstate the true horizon and cost caches rather than correctness.

## Two writer modes

Chosen at creation and recorded in `metadata`, whose lifetime shared lock (#1375) is what a future format upgrade takes exclusively.

* **Single writer process** — one process holds `write.lock` for its lifetime. Nothing changes the file behind its back, so it never reloads anything, never handles external cache invalidation, and its own read transactions cost exactly what they do today. Other processes may open the database read-only.
* **Multiple writer processes** — `write.lock` is taken per write transaction, so any process may write, one at a time. Each writer loads the allocator state the previous one left rather than rebuilding it, which is why every commit in this mode is a quick-repair commit. A writer that finds none — the previous one died mid-commit — rebuilds it in place with the normal repair walk, which is safe concurrently with readers because it never modifies a reachable page.

## What concurrency forces, in both modes

* **Every commit is 2-phase.** A 1-phase commit writes the new header and the pages it references in one flush, in no particular order, relying on checksums to detect an interrupted result. A crash cannot observe that intermediate state; a concurrent reader can, and would follow a header naming pages that are not in the file yet. Costs one extra `fsync` per commit.
* **The free horizon is clamped to one past the last durable commit.** A reader about to register pins that transaction, and non-durable state leaves the in-memory transaction id ahead of the file, so the horizon a writer computes does not imply the bound.
* **`Durability::None` is rejected in multi-writer mode**, since such a commit lives only in the committing process's memory. In single-writer mode it works as for a `Database`, and `last_durable_commit()` keeps reporting the file rather than the in-memory state that is running ahead of it.

## The database file carries no lock

It cannot: every process using the database has it open at once, so an exclusive lock is impossible, and a shared one would stop the writer writing where locks are mandatory. This replaces the exclusive lock #1375 put on `data.redb`. **Nothing in this PR keeps a plain `Database` out of that file** — 6/6 is where that is fixed, kept separate because it changes `Database::open()`'s behaviour for everyone.

## Testing

44 integration tests and 25 unit tests. Most use two `MultiProcessDatabase` handles on one directory: file locks belong to the open file description, so two handles coordinate exactly as two processes do, while being far easier to debug. Real child processes cover what only a separate process can: a writer that dies mid-transaction, a reader that dies holding a pinned transaction, and the coordination working across a process boundary. Removing any one of the three protocol pieces — the `txn/` scan, pinning a transaction, cache invalidation — fails the suite, and so does breaking the extended header's write ordering.

`cargo fmt --check`, `cargo clippy --all --all-targets` and the full test suite pass with `--all-features` and with default features.

## Benchmarks

`crates/redb-bench/benches/multiprocess_benchmark.rs`, added here. 500k rows of 100 bytes, one machine, so treat these as ratios rather than absolute numbers:

| | bulk load | single-entry commits | reads in 1 txn |
|---|---|---|---|
| `Database` | 723k/s | 3435/s | 1.39M/s |
| MultiProcess, single writer | 790k/s | 2209/s | 1.44M/s |
| MultiProcess, multi writer | 827k/s | 1172/s | 1.03M/s |

Bulk load and reads within a transaction are unchanged. Single-entry commits run at about two thirds the rate with a single writer process and a third of it with multiple — the second `fsync`, plus the extended header write and the lock traffic around it. For one read transaction per read — the worst case for the protocol's per-transaction cost — `Database` does 805k/s, a sole-writer process's own handle does 798k/s (unchanged), and a handle that is not the sole writer does ~140k/s: each transaction pays a lock acquisition and a few small file reads. The cost is per transaction, not per read.

## For review

The parts I would most like a second opinion on:

1. **Windows.** The `txn/` scheme exists because `LockFileEx` is mandatory: a locked range denies `ReadFile`/`WriteFile` from other processes, and a *shared* range denies writes even to the holder. Naming the files after the data means nothing is ever read from a locked file. Windows CI on this PR is the check that matters.
2. **The commit hook ordering** — the extended header write sits between the phase-1 flush and the primary flip inside `TransactionalMemory::commit()`, and the hash binding is what makes skipping the fsync sound.
3. **The clamp on the free horizon** (`cross_process_free_limit`) — the subtlest invariant in the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJFSfcturbVcnPqY5CNzQv