### PR TITLE
Rework savepoints for a multi-process database (5/6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@
   `data.redb`, rather than adopting or overwriting them. Two writer modes are
   available: one where a single process may write, which costs that process nothing on the read
   path, and one where any process may write, which uses quick-repair commits so that each writer
-  can pick up the previous one's allocator state. Non-durable commits, persistent savepoints,
+  can pick up the previous one's allocator state. Non-durable commits, ephemeral savepoints,
   compaction and integrity checks are not supported in all configurations -- see the type's
   documentation. The directory layout may change incompatibly while the feature is experimental.
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -17,6 +17,7 @@ use alloc::boxed::Box;
 use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
+use alloc::vec::Vec;
 use core::fmt::{Debug, Display, Formatter};
 
 use alloc::sync::Arc;
@@ -1451,13 +1452,54 @@ fn begin_write_with_allocation_policy(
         )
         .into());
     }
-    WriteTransaction::new(
+    let transaction = WriteTransaction::new(
         guard,
         transaction_tracker.clone(),
         mem.clone(),
         allocation_policy,
-    )
-    .map_err(|e| e.into())
+    )?;
+
+    if transaction_tracker.write_lock_is_shared() {
+        // Another process may have created or deleted a persistent savepoint since this one last
+        // held the write lock. Adopted before anything in this transaction can free a page, since
+        // that is what the savepoints hold back
+        adopt_persistent_savepoints(transaction_tracker, &transaction).map_err(|e| match e {
+            SavepointError::Storage(storage) => TransactionError::Storage(storage),
+            // Neither is reachable from reading the savepoints out of the database
+            SavepointError::InvalidSavepoint | SavepointError::ImmediateDurabilityRequired => {
+                unreachable!()
+            }
+        })?;
+    }
+
+    Ok(transaction)
+}
+
+// Reads the persistent savepoints out of the database and registers them with the tracker, in
+// place of whatever this process previously knew about.
+fn adopt_persistent_savepoints(
+    transaction_tracker: &Arc<TransactionTracker>,
+    transaction: &WriteTransaction,
+) -> Result<(), SavepointError> {
+    let next_savepoint = transaction.next_persistent_savepoint_id()?;
+    let mut savepoints = Vec::new();
+    for id in transaction.list_persistent_savepoints()? {
+        let savepoint = transaction.get_persistent_savepoint(id)?;
+        savepoints.push((savepoint.get_id(), savepoint.get_transaction_id()));
+    }
+    transaction_tracker.adopt_persistent_savepoints(next_savepoint, &savepoints)?;
+
+    Ok(())
+}
+
+// Whether closing has to write an allocator state table for the next open to load. A database
+// whose every commit is a quick-repair commit already has a current one -- or, after another
+// writer's crash, is missing one that only the rebuild under the write lock recreates -- so its
+// close never writes: deciding from this handle's possibly stale system tree could ask for a
+// write transaction, and that means blocking on the cross-process write lock while dropping the
+// database.
+fn needs_allocator_state_table(transaction_tracker: &Arc<TransactionTracker>) -> bool {
+    !transaction_tracker.requires_quick_repair()
 }
 
 fn ensure_allocator_state_table_and_trim(
@@ -1488,26 +1530,26 @@ fn ensure_allocator_state_table_and_trim(
 // transaction can be started concurrently and the commit in here cannot block on the
 // write-transaction slot.
 fn close_database(transaction_tracker: &Arc<TransactionTracker>, mem: &Arc<TransactionalMemory>) {
-    // Neither write below is this process's to make when another process may take over the write
-    // lock: the allocator state table needs a write transaction, which would wait on whatever that
-    // process is doing, and the shutdown header would land in the middle of it. Nothing is lost --
-    // every commit in that mode is already a quick-repair commit, so the allocator state in the
-    // file is current, and a multi-process database is read expecting the header's recovery flag to
-    // be set, since a writer in another process is entitled to be holding it open
-    let owns_the_file = !transaction_tracker.write_lock_is_shared();
-
     // No saved allocator state when it needs repair: the next open must rebuild it instead
     // of trusting the saved one
-    if owns_the_file
-        && !crate::panicking()
+    if !crate::panicking()
         && !mem.needs_repair()
+        && needs_allocator_state_table(transaction_tracker)
         && ensure_allocator_state_table_and_trim(transaction_tracker, mem).is_err()
     {
         #[cfg(feature = "logging")]
         warn!("Failed to write allocator state table. Repair may be required at restart.");
     }
 
-    if mem.close(owns_the_file).is_err() {
+    // Asserting a clean shutdown is only this process's to do when no other process may write. The
+    // header it writes covers the commit slots, so doing it while another process holds the write
+    // lock would put this process's view of the database over what that one has just committed. A
+    // multi-process database is read expecting the flag to be set in any case, since a writer in
+    // another process is entitled to be holding the file open
+    if mem
+        .close(!transaction_tracker.write_lock_is_shared())
+        .is_err()
+    {
         #[cfg(feature = "logging")]
         warn!("Failed to flush database file. Repair may be required at restart.");
     }

--- a/src/multiprocess/mod.rs
+++ b/src/multiprocess/mod.rs
@@ -50,10 +50,10 @@ use std::sync::Arc;
 /// * [`Durability::None`](crate::Durability) is rejected in
 ///   [`WriterMode::MultiWriterProcess`], since a non-durable commit is only visible to the process
 ///   that made it.
-/// * Persistent savepoints are only supported in [`WriterMode::SingleWriterProcess`]. One lives in
-///   the database rather than in any one process, so a writer that opened before another created
-///   it has never heard of it and would reclaim the pages it holds. Ephemeral savepoints work in
-///   both modes.
+/// * Ephemeral savepoints are rejected in [`WriterMode::MultiWriterProcess`]: every savepoint id
+///   in that mode comes from a counter stored in the database, so that two processes cannot hand
+///   out the same id, and an ephemeral savepoint's id would live only in the process that made
+///   it. Persistent savepoints work in both modes.
 /// * Compaction and [`Database::check_integrity`] are not available.
 /// * Every commit is 2-phase, which costs an extra `fsync`: a reader in another process would
 ///   otherwise be able to see a header naming pages that are not in the file yet.

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -181,11 +181,12 @@ impl TransactionTracker {
         self.process.is_some()
     }
 
-    // True when the post-commit free epilogue must be skipped: it publishes its work as a
-    // non-durable commit, which is invisible to every other process and is thrown away as soon as
-    // one of them takes the write lock
+    // The post-commit free epilogue publishes its work as a non-durable commit, which is
+    // invisible to other processes, and its horizon is clamped to what the next commit frees
+    // anyway -- so for a multi-process database it buys nothing and costs a system tree update
+    // per commit.
     pub(crate) fn defers_post_commit_free(&self) -> bool {
-        self.write_lock_is_shared()
+        self.process.is_some()
     }
 
     // False when a non-durable commit would be invisible to, and silently discarded by, the next
@@ -436,9 +437,87 @@ impl TransactionTracker {
     // older pin, which costs reclamation but is never unsafe -- and this runs on drop paths that
     // have nowhere to report an error to.
     fn publish_pinned(&self, state: &State) {
-        if let Some(process) = &self.process {
-            let _ = process.publish_pinned(state.oldest_pinned());
+        let _ = self.try_publish_pinned(state);
+    }
+
+    fn try_publish_pinned(&self, state: &State) -> Result<()> {
+        match &self.process {
+            Some(process) => process.publish_pinned(state.oldest_pinned()),
+            None => Ok(()),
         }
+    }
+
+    // Replaces the persistent savepoints this process knows about with the ones the file names.
+    //
+    // A persistent savepoint lives in the database, so a process that opened before another
+    // created one has never heard of it and would reclaim the pages it needs. Adopting the file's
+    // set also picks up the savepoint id counter, so two processes cannot allocate the same id.
+    // The caller must hold the cross-process write lock, which is what makes it safe to drop the
+    // previous set's page references before adding the new one's.
+    pub(crate) fn adopt_persistent_savepoints(
+        &self,
+        next_savepoint: Option<SavepointId>,
+        savepoints: &[(SavepointId, TransactionId)],
+    ) -> Result<()> {
+        let mut state = self.state.lock()?;
+        let previous: Vec<(SavepointId, TransactionId)> = state
+            .persistent_savepoints
+            .iter()
+            .filter_map(|id| state.valid_savepoints.get(id).map(|txn| (*id, *txn)))
+            .collect();
+        for (id, transaction) in &previous {
+            state.persistent_savepoints.remove(id);
+            state.valid_savepoints.remove(id);
+            let count = state.live_read_transactions.get_mut(transaction).unwrap();
+            *count -= 1;
+            if *count == 0 {
+                state.live_read_transactions.remove(transaction);
+            }
+        }
+
+        if let Some(next_savepoint) = next_savepoint {
+            // Only ever forwards: this process may have handed out higher ids to ephemeral
+            // savepoints, which are still live and must not be handed out again
+            state.next_savepoint_id = state.next_savepoint_id.max(next_savepoint);
+        }
+        for (id, transaction) in savepoints {
+            state
+                .live_read_transactions
+                .entry(*transaction)
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+            state.valid_savepoints.insert(*id, *transaction);
+            state.persistent_savepoints.insert(*id);
+        }
+        // Unlike the drop paths, this lowers the pinned transaction, so a failure to publish it
+        // would let another process free pages these savepoints need
+        if let Err(err) = self.try_publish_pinned(&state) {
+            // The pin was not moved down to cover the adopted set, so the tracker must not claim
+            // it either: the swap is undone, leaving state and pin agreeing on the previous set,
+            // and the begin_write that needed the adoption fails. The id counter stays advanced,
+            // which is always safe -- it only ever moves forward
+            for (id, transaction) in savepoints {
+                state.persistent_savepoints.remove(id);
+                state.valid_savepoints.remove(id);
+                let count = state.live_read_transactions.get_mut(transaction).unwrap();
+                *count -= 1;
+                if *count == 0 {
+                    state.live_read_transactions.remove(transaction);
+                }
+            }
+            for (id, transaction) in &previous {
+                state
+                    .live_read_transactions
+                    .entry(*transaction)
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+                state.valid_savepoints.insert(*id, *transaction);
+                state.persistent_savepoints.insert(*id);
+            }
+            return Err(err);
+        }
+
+        Ok(())
     }
 
     pub(crate) fn any_savepoint_exists(&self) -> bool {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1170,7 +1170,9 @@ impl WriteTransaction {
             return Err(SavepointError::ImmediateDurabilityRequired);
         }
 
-        let mut savepoint = self.ephemeral_savepoint()?;
+        // Through the inner constructor: the savepoint made here becomes persistent below, so the
+        // restriction on user-held ephemeral savepoints does not apply to it
+        let mut savepoint = self.ephemeral_savepoint_inner()?;
 
         let mut system_tables = self.system_tables.lock().unwrap();
 
@@ -1295,8 +1297,22 @@ impl WriteTransaction {
     /// This savepoint will be freed as soon as the returned [`Savepoint`] is dropped.
     ///
     /// Returns [`SavepointError::InvalidSavepoint`] if the transaction is "dirty" (a data
-    /// table has been opened, renamed, or deleted, or a savepoint has been restored)
+    /// table has been opened, renamed, or deleted, or a savepoint has been restored), or if the
+    /// database is a multi-process database in
+    /// [`WriterMode::MultiWriterProcess`](crate::WriterMode) -- an ephemeral savepoint lives only
+    /// in this process, and its id would collide with the persistent ids other writers hand out
+    /// from the shared counter. Use [`Self::persistent_savepoint`] there instead.
     pub fn ephemeral_savepoint(&self) -> Result<Savepoint, SavepointError> {
+        // In the shared-write-lock mode every savepoint id comes from the counter stored in the
+        // database, which is what keeps ids collision-free across processes -- and an ephemeral
+        // savepoint's id lives only in this process's counter
+        if self.transaction_tracker.write_lock_is_shared() {
+            return Err(SavepointError::InvalidSavepoint);
+        }
+        self.ephemeral_savepoint_inner()
+    }
+
+    fn ephemeral_savepoint_inner(&self) -> Result<Savepoint, SavepointError> {
         // Serialize the dirty check and savepoint registration against
         // `TableNamespace::set_dirty()`, which runs under the same tables lock. Without this,
         // a concurrent first table-open (legal since `WriteTransaction: Sync`) can read the
@@ -2001,13 +2017,10 @@ impl WriteTransaction {
             .unwrap()
             .apply_on_abort(&self.transaction_tracker);
         self.mem.check_io_errors()?;
+        // Freeing the pages this transaction allocated also drops their buffered writes, so
+        // nothing is left that a later flush could write over pages another process has since
+        // taken
         self.page_allocator().rollback_all();
-        if self.transaction_tracker.write_lock_is_shared() {
-            // The buffered writes belong to pages this transaction allocated, which are about to
-            // become free for another process to allocate. Flushing them later would overwrite
-            // whatever that process put there
-            self.mem.discard_buffered_writes();
-        }
         #[cfg(feature = "logging")]
         debug!("Finished abort of transaction id={:?}", self.transaction_id);
         Ok(())
@@ -2137,8 +2150,8 @@ impl WriteTransaction {
             .oldest_live_read_transaction()?
             .map_or(epilogue_transaction, |x| x.next());
         // Clamp the free horizon to what a read transaction another process is about to register
-        // may still need. Without this the epilogue's own transaction id, which is one past the
-        // commit that is in the file, would let a page that snapshot reaches be reclaimed
+        // may still need. This epilogue only runs for a single-process database, which has no such
+        // reader, but the clamp costs nothing and keeps the bound in one place
         if let Some(limit) = self
             .transaction_tracker
             .cross_process_free_limit(&self.mem)?

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -10,7 +10,7 @@
 
 use redb::{
     Database, DatabaseError, Durability, MultiProcessDatabase, ReadableDatabase, ReadableTable,
-    ReadableTableMetadata, TableDefinition, WriteTransaction, WriterMode,
+    ReadableTableMetadata, SavepointError, TableDefinition, WriteTransaction, WriterMode,
 };
 use std::env;
 use std::path::{Path, PathBuf};
@@ -1038,32 +1038,55 @@ fn non_durable_commits_work_with_a_single_writer_process() {
     assert!(db.last_durable_commit().unwrap() > durable);
 }
 
+/// Every savepoint id in multi-writer mode comes from the counter stored in the database, which
+/// is what keeps ids collision-free across processes. An ephemeral savepoint's id lives only in
+/// its own process, where another writer cannot see it, so that mode refuses to create one --
+/// persistent savepoints are the supported form there.
 #[test]
-fn an_ephemeral_savepoint_holds_pages_back_across_handles() {
+fn an_ephemeral_savepoint_is_refused_when_any_process_may_write() {
     let dir = tempdir();
     let path = db_path(&dir);
-    let first = create(&path, WriterMode::MultiWriterProcess);
-    write_generation(&first, 1);
+    let db = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&db, 1);
+
+    let txn = db.begin_write().unwrap();
+    assert!(matches!(
+        txn.ephemeral_savepoint(),
+        Err(SavepointError::InvalidSavepoint)
+    ));
+    // ... while a persistent savepoint, whose id comes from the shared counter, is fine
+    let id = txn.persistent_savepoint().unwrap();
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    assert!(txn.delete_persistent_savepoint(id).unwrap());
+    txn.commit().unwrap();
+}
+
+/// The single-writer mode has no cross-process id problem -- only one process ever hands out
+/// savepoint ids -- so ephemeral savepoints work exactly as they do in a single-process database.
+#[test]
+fn an_ephemeral_savepoint_works_with_a_single_writer_process() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = create(&path, WriterMode::SingleWriterProcess);
+    write_generation(&db, 1);
 
     let savepoint = {
-        let txn = first.begin_write().unwrap();
+        let txn = db.begin_write().unwrap();
         let savepoint = txn.ephemeral_savepoint().unwrap();
         txn.commit().unwrap();
         savepoint
     };
 
-    // Another handle churns the pages the savepoint needs
-    let second = open(&path);
     for generation in 2..20 {
-        write_generation(&second, generation);
+        write_generation(&db, generation);
     }
 
-    // Restoring it must still find them
-    let mut txn = first.begin_write().unwrap();
+    let mut txn = db.begin_write().unwrap();
     txn.restore_savepoint(&savepoint).unwrap();
     txn.commit().unwrap();
-    assert_eq!(1, read_generation(&first.begin_read().unwrap()));
-    assert_eq!(1, read_generation(&second.begin_read().unwrap()));
+    assert_eq!(1, read_generation(&db.begin_read().unwrap()));
 }
 
 #[test]
@@ -1152,6 +1175,73 @@ fn concurrent_writers_from_many_threads_and_handles() {
             );
         }
     }
+}
+
+/// A persistent savepoint lives in the database, not in the process that made it, so a writer that
+/// has never heard of one must still hold its pages back -- and must be able to restore it.
+#[test]
+fn a_persistent_savepoint_is_shared_between_handles() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    // Opened first, so it has no way of knowing about the savepoint the other handle is about to
+    // create except by reading it out of the database
+    let second = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&second, 1);
+
+    let savepoint_id = {
+        let first = open(&path);
+        let txn = first.begin_write().unwrap();
+        let id = txn.persistent_savepoint().unwrap();
+        txn.commit().unwrap();
+        // The handle that created it is gone entirely
+        id
+    };
+
+    // Enough churn that the savepoint's pages would be long gone if they were not held back
+    for generation in 2..30 {
+        write_generation(&second, generation);
+    }
+    assert_eq!(29, read_generation(&second.begin_read().unwrap()));
+
+    let mut txn = second.begin_write().unwrap();
+    let savepoint = txn.get_persistent_savepoint(savepoint_id).unwrap();
+    txn.restore_savepoint(&savepoint).unwrap();
+    txn.commit().unwrap();
+    assert_eq!(1, read_generation(&second.begin_read().unwrap()));
+
+    // And it can be deleted from a third handle, which never saw it created either
+    let third = open(&path);
+    let txn = third.begin_write().unwrap();
+    assert!(txn.delete_persistent_savepoint(savepoint_id).unwrap());
+    txn.commit().unwrap();
+    let txn = second.begin_write().unwrap();
+    assert_eq!(0, txn.list_persistent_savepoints().unwrap().count());
+    txn.abort().unwrap();
+}
+
+/// Savepoint ids are handed out from a counter that lives in the database, so two handles must not
+/// be able to allocate the same one.
+#[test]
+fn persistent_savepoint_ids_do_not_collide_between_handles() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let first = create(&path, WriterMode::MultiWriterProcess);
+    write_generation(&first, 1);
+    let second = open(&path);
+
+    let mut ids = vec![];
+    for handle in [&first, &second, &first, &second] {
+        let txn = handle.begin_write().unwrap();
+        ids.push(txn.persistent_savepoint().unwrap());
+        txn.commit().unwrap();
+    }
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(4, ids.len(), "two handles allocated the same savepoint id");
+
+    let txn = first.begin_write().unwrap();
+    assert_eq!(4, txn.list_persistent_savepoints().unwrap().count());
+    txn.abort().unwrap();
 }
 
 /// Dropping a handle must not wait on another process's write transaction. Closing writes an


### PR DESCRIPTION
Fifth of six. **Based on #1387**, which is based on #1377 → #1376 → #1375. This diff is only the savepoint change.

| | what | added |
|---|---|---|
| 1/6 | #1375 — the directory: write lock, `metadata` marker, shared lock | 794 |
| 2/6 | #1376 — refusing unmarked directories holding redb's file names | 161 |
| 3/6 | #1377 — refusing directories that are not redb's | 500 |
| 4/6 | #1387 — the cross-process protocol | 4001 |
| **5/6** | this PR — savepoints across processes | 248 |
| 6/6 | #1389 — keeping an ordinary `Database` out of `data.redb` | 73 |

---

A **persistent** savepoint lives in the database rather than in any one process, so a writer that opened before another created one has never heard of it and would reclaim the pages it holds. #1387 therefore documents them as supported only in single-writer mode.

A writer can read the file's set instead. It now adopts the persistent savepoints named by the database at the start of every write transaction, in place of whatever it previously knew, before anything in that transaction can free a page. The savepoint id counter comes from the same place, so two processes cannot hand out the same id — taken forwards only, since this process may have given higher ids to savepoints that are still live. Adopting *lowers* the transaction this process pins, so unlike the drop paths it reports a failure to publish rather than swallowing it.

**Ephemeral savepoints go the other way: they are rejected in multi-writer mode**, per the design doc. Every savepoint id in that mode now comes from the counter stored in the database, which is what keeps ids collision-free and ordered across processes — an ephemeral savepoint's id lives only in the process that made it, where another writer cannot see it before handing the same id out again as a persistent savepoint's. The savepoint a persistent savepoint passes through internally is unaffected, since its id lands in the stored counter before the write lock is released. Single-writer mode keeps ephemeral savepoints: only one process ever hands out ids there.

## Two changes that fall out of this

Both came from comparing this against a second, independent implementation of the same feature.

**Skip the post-commit free epilogue in both writer modes, not just the one where the write lock changes hands.** The epilogue reclaims a commit's freed pages immediately, rather than leaving them to the next commit, by publishing its work as a non-durable commit. Neither half survives contact with other processes: a non-durable commit is invisible to them, and the horizon the epilogue would use is clamped to what a reader about to register can still reach — exactly what the next commit frees anyway. So it buys nothing here and costs a system tree update per commit.

**Don't write an allocator state table when closing a database that already has a current one.** Closing wrote one so the next open would not have to rebuild it, but every commit in multi-writer mode already writes one — and taking the cross-process write lock to write another means dropping a handle can block for as long as another process's transaction runs. There is a test for exactly that.

Also drops the write-buffer discard on the abort path: freeing the pages an aborted transaction allocated already cancels their buffered writes, page by page, in `free_helper()`.

## Testing

Four new integration tests, 47 in the suite:

* a persistent savepoint created through one handle is held back and restorable through another that never saw it created;
* two handles cannot allocate the same savepoint id;
* an ephemeral savepoint is refused in multi-writer mode while a persistent one succeeds;
* an ephemeral savepoint still works in single-writer mode.

`cargo fmt --check`, `cargo clippy --all --all-targets` and the full test suite pass with `--all-features` and with default features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJFSfcturbVcnPqY5CNzQv