### PR TITLE
Keep an ordinary Database out of a multi-process data file (6/6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@
   can pick up the previous one's allocator state. Non-durable commits, ephemeral savepoints,
   compaction and integrity checks are not supported in all configurations -- see the type's
   documentation. The directory layout may change incompatibly while the feature is experimental.
+* `Database::open()`, `Database::create()` and `ReadOnlyDatabase::open()` now refuse a `data.redb`
+  that belongs to a `MultiProcessDatabase` directory, which an ordinary handle could otherwise
+  silently corrupt by writing underneath the processes using it.
 
 ### Minor improvements
 * Lock the database file on platforms other than Unix, Windows, and WASI too: a second open of

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,7 @@
 use crate::io;
 use crate::multiprocess::ProcessCoordinator;
+#[cfg(not(redb_no_std))]
+use crate::multiprocess::reject_multiprocess_data_file;
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
 #[cfg(not(redb_no_std))]
 use crate::tree_store::ReadOnlyBackend;
@@ -1697,6 +1699,7 @@ impl Builder {
     /// * otherwise this function will return an error
     #[cfg(not(redb_no_std))]
     pub fn create(&self, path: impl AsRef<Path>) -> Result<Database, DatabaseError> {
+        reject_multiprocess_data_file(path.as_ref())?;
         let file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -1717,6 +1720,7 @@ impl Builder {
     /// Opens an existing redb database.
     #[cfg(not(redb_no_std))]
     pub fn open(&self, path: impl AsRef<Path>) -> Result<Database, DatabaseError> {
+        reject_multiprocess_data_file(path.as_ref())?;
         let file = OpenOptions::new().read(true).write(true).open(path)?;
 
         Database::new(
@@ -1739,6 +1743,7 @@ impl Builder {
         &self,
         path: impl AsRef<Path>,
     ) -> Result<ReadOnlyDatabase, DatabaseError> {
+        reject_multiprocess_data_file(path.as_ref())?;
         let file = OpenOptions::new().read(true).open(path)?;
 
         ReadOnlyDatabase::new(

--- a/src/multiprocess/locks.rs
+++ b/src/multiprocess/locks.rs
@@ -8,6 +8,7 @@ use crate::tree_store::file_backend::{FileBackend, FileLockKind};
 use crate::tree_store::{DB_HEADER_SIZE, MAGICNUMBER, xxh3_checksum};
 use crate::{DatabaseError, Result, StorageBackend, StorageError};
 use alloc::vec::Vec;
+use std::ffi::OsStr;
 use std::fs::{File, OpenOptions, TryLockError};
 use std::io;
 use std::io::{ErrorKind, Read, Seek, SeekFrom, Write};
@@ -163,6 +164,35 @@ fn require_regular_file(path: &Path) -> Result<()> {
         Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
         Err(err) => Err(StorageError::Io(err)),
     }
+}
+
+/// Refuses a path naming the database file inside a multi-process database directory.
+///
+/// A multi-process database keeps its data in an ordinary redb file with *no* lock on it, so
+/// nothing about the file itself stops [`crate::Database`] from opening it and writing underneath
+/// the processes using it properly; the marker beside it is what says to keep away.
+pub(crate) fn reject_multiprocess_data_file(path: &Path) -> Result<(), DatabaseError> {
+    if path.file_name() != Some(OsStr::new(DATA_FILE_NAME)) || !marker_present(&parent_of(path)) {
+        return Ok(());
+    }
+    Err(StorageError::Io(io::Error::new(
+        ErrorKind::InvalidInput,
+        "this file belongs to a multi-process database; open the directory holding it rather than \
+         the file itself",
+    ))
+    .into())
+}
+
+/// Whether a directory carries a complete multi-process marker. Anything that is not one --
+/// absent, unreadable, the wrong size, a symlink, someone else's file under that name -- answers
+/// no: only a marker this database wrote vouches for the directory.
+fn marker_present(root: &Path) -> bool {
+    let path = root.join(METADATA_FILE_NAME);
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.is_file() && metadata.len() == METADATA_LEN as u64 => {}
+        _ => return false,
+    }
+    std::fs::read(&path).is_ok_and(|contents| contents.starts_with(&MAGIC))
 }
 
 /// Which name [`DatabaseDir::open_data`] put the database file under. Carried from the open to

--- a/src/multiprocess/mod.rs
+++ b/src/multiprocess/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use coordinator::ProcessCoordinator;
 pub use locks::WriterMode;
 #[cfg(not(feature = "experimental-multiprocess"))]
 pub(crate) use locks::WriterMode;
+pub(crate) use locks::reject_multiprocess_data_file;
 
 use crate::db::{OpenParams, RepairSession};
 use crate::sealed::Sealed;

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -9,8 +9,9 @@
 #![cfg(all(feature = "experimental-multiprocess", not(target_os = "wasi")))]
 
 use redb::{
-    Database, DatabaseError, Durability, MultiProcessDatabase, ReadableDatabase, ReadableTable,
-    ReadableTableMetadata, SavepointError, TableDefinition, WriteTransaction, WriterMode,
+    Database, DatabaseError, Durability, MultiProcessDatabase, ReadOnlyDatabase, ReadableDatabase,
+    ReadableTable, ReadableTableMetadata, SavepointError, TableDefinition, WriteTransaction,
+    WriterMode,
 };
 use std::env;
 use std::path::{Path, PathBuf};
@@ -230,6 +231,35 @@ fn an_interrupted_create_can_be_redone() {
 // --------------------------------------------------------------------------------------------
 // Tests that need a real process
 // --------------------------------------------------------------------------------------------
+
+/// The database file carries no lock at all -- every process using the directory has it open at
+/// once -- so nothing about the file itself stops an ordinary `Database` from opening it and
+/// writing underneath them. The marker beside it is what turns that away, whether or not any
+/// process currently has the directory open.
+#[test]
+fn an_ordinary_database_cannot_open_the_data_file() {
+    let dir = tempdir();
+    let path = db_path(&dir);
+    let db = MultiProcessDatabase::create(&path).unwrap();
+    write(&db, 0, 1);
+
+    let data = path.join("data.redb");
+    for opened in [
+        Database::open(&data).err(),
+        Database::create(&data).err(),
+        ReadOnlyDatabase::open(&data).err(),
+    ] {
+        let message = opened
+            .expect("the data file was opened as an ordinary database")
+            .to_string();
+        assert!(message.contains("multi-process"), "{message}");
+    }
+
+    // ... and still refused once nobody holds the directory, since opening it then is just as
+    // unsafe: the next process to open it properly would find a file some other writer had changed
+    drop(db);
+    assert!(Database::open(&data).is_err());
+}
 
 /// Entry point for the child processes the tests below spawn. Ignored so that it only runs when
 /// named explicitly, and does nothing unless the parent asked for a role.


### PR DESCRIPTION
Last of six. **Based on #1388**, which is based on #1387 → #1377 → #1376 → #1375. 73 lines, and the only one in the stack that changes behaviour outside the feature flag — which is why it is separate and last. **Drop it if you disagree; nothing above depends on it.**

| | what | added |
|---|---|---|
| 1/6 | #1375 — the directory: write lock, `metadata` marker, shared lock | 794 |
| 2/6 | #1376 — refusing unmarked directories holding redb's file names | 161 |
| 3/6 | #1377 — refusing directories that are not redb's | 500 |
| 4/6 | #1387 — the cross-process protocol | 4001 |
| 5/6 | #1388 — savepoints across processes | 248 |
| **6/6** | this PR — keeping an ordinary `Database` out | 73 |

---

## The regression this closes

#1375 put the ordinary exclusive lock on `data.redb`, on top of `write.lock`, precisely so that a process reaching past the directory could not open the database file directly. #1387 had to remove it: every process using a multi-process database has that file open at once, so an exclusive lock is impossible, and a shared lock would stop the writer writing on the platforms where locks are mandatory.

So after #1387 nothing stops this:

```rust
let db = Database::open("mydb/data.redb")?;   // succeeds
```

while other processes are reading and reallocating pages in that file. It takes the file's own exclusive lock, finds nobody holding it, and starts writing. Silent corruption, no error anywhere.

## The check

`Database::open()`, `Database::create()` and `ReadOnlyDatabase::open()` now refuse a path whose file name is `data.redb` when a valid multi-process `metadata` marker sits beside it, with a message pointing at the directory:

> this file belongs to a multi-process database; open the directory holding it rather than the file itself

The cost is one `stat` of a name that is almost never there, and only for a file called `data.redb` — a path that is not inside one of these directories cannot match. Anything that is not a complete marker (absent, wrong length, a symlink, someone else's file under that name) answers "not one of ours" and the open proceeds as before.

The refusal stands whether or not any process currently has the directory open. A `Database` that writes to the file while nothing else holds it leaves a database the next multi-process opener never made — commits nothing announced through the directory's protocol, an extended header binding no longer matching the commit slots — so "nobody is holding it right now" is not a safe moment to allow it.

## What I am unsure about

This is a behaviour change to three stable, non-feature-gated methods, so it is the one to push back on. The alternatives I considered:

* **Do nothing**, and document the hazard. Cheapest, but the protection existed in 1/6 and 3/6 and silently disappears in 4/6, which seems like the wrong direction for a feature whose whole subject is processes not stepping on each other.
* **Gate the check behind `experimental-multiprocess`.** Backwards, I think: the process at risk is the one that *doesn't* have the feature on and doesn't know these directories exist.
* **Check something other than the file name.** Matching on `data.redb` keeps the check from touching anything else, at the cost of not catching a directory a user renamed the file within — which is not a state redb can produce.

## Testing

One integration test (48 in the suite): all three entry points refused on a live directory, and `Database::open` still refused once the handle is dropped.

`cargo fmt --check`, `cargo clippy --all --all-targets` and the full test suite pass with `--all-features` and with default features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJFSfcturbVcnPqY5CNzQv