### PR TITLE
Take the file lock in the fallback file backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@
   a table. Such failures now poison the transaction: `commit()` returns an error instead of
   committing the half-applied state.
 
+### Minor improvements
+* Lock the database file on platforms other than Unix, Windows, and WASI too: a second open of
+  the same file now fails with `DatabaseAlreadyOpen` where the platform supports file locks,
+  and warns via the `logging` feature where it does not, instead of the lock always being
+  silently skipped.
+
 ## 4.2.0 - 2026-08-17
 
 ### New features

--- a/src/tree_store/page_store/file_backend/fallback.rs
+++ b/src/tree_store/page_store/file_backend/fallback.rs
@@ -1,5 +1,7 @@
 use crate::{DatabaseError, Result, StorageBackend};
-use std::fs::File;
+#[cfg(feature = "logging")]
+use log::warn;
+use std::fs::{File, TryLockError};
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::sync::Mutex;
@@ -7,6 +9,7 @@ use std::sync::Mutex;
 /// Stores a database as a file on-disk.
 #[derive(Debug)]
 pub struct FileBackend {
+    lock_supported: bool,
     file: Mutex<File>,
 }
 
@@ -16,10 +19,32 @@ impl FileBackend {
         Self::new_internal(file, false)
     }
 
-    pub(crate) fn new_internal(file: File, _: bool) -> Result<Self, DatabaseError> {
-        Ok(Self {
-            file: Mutex::new(file),
-        })
+    pub(crate) fn new_internal(file: File, read_only: bool) -> Result<Self, DatabaseError> {
+        let result = if read_only {
+            file.try_lock_shared()
+        } else {
+            file.try_lock()
+        };
+
+        match result {
+            Ok(()) => Ok(Self {
+                lock_supported: true,
+                file: Mutex::new(file),
+            }),
+            Err(TryLockError::WouldBlock) => Err(DatabaseError::DatabaseAlreadyOpen),
+            Err(TryLockError::Error(err)) if err.kind() == io::ErrorKind::Unsupported => {
+                #[cfg(feature = "logging")]
+                warn!(
+                    "File locks not supported on this platform. You must ensure that only a single process opens the database file, at a time"
+                );
+
+                Ok(Self {
+                    lock_supported: false,
+                    file: Mutex::new(file),
+                })
+            }
+            Err(TryLockError::Error(err)) => Err(err.into()),
+        }
     }
 }
 
@@ -47,5 +72,13 @@ impl StorageBackend for FileBackend {
         let mut file = self.file.lock().unwrap();
         file.seek(SeekFrom::Start(offset))?;
         file.write_all(data)
+    }
+
+    fn close(&self) -> Result<(), io::Error> {
+        if self.lock_supported {
+            self.file.lock().unwrap().unlock()?;
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Addresses P1 finding 9 from the pre-5.0 bug audit: the fallback `FileBackend` (platforms other than Unix, Windows, and WASI) took no file lock at all, so a second open of the same file — from another process or another `Database` in the same process — was not detected and could corrupt the database, silently.

The std file locking API is portable, so the fallback now locks the file exactly the way the optimized backend does: `try_lock`/`try_lock_shared` on open, a held lock fails with `DatabaseAlreadyOpen`, a platform that reports locking as `Unsupported` logs the same warning the optimized backend uses (via the `logging` feature) and proceeds, and the lock is released on `close()`.

The changelog entry is under a new "Minor improvements" section of 4.3.0, not among the bug fixes.

**Validation**: no CI target compiles the fallback backend, so it was validated by temporarily swapping the cfg selection in `file_backend/mod.rs` on the host and running the full `cargo test --all-features` suite with the fallback backend live — all 20 suites green, including the `DatabaseAlreadyOpen` lock tests, which exercise the new locking for real (std file locks work on Linux). No cfg change ships in the tree. `cargo fmt --check` and clippy with `--deny warnings` pass on the normal configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr