### PR TITLE
Fail zero-byte writes on Windows instead of retrying forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@
 * Fix pages being leaked permanently when a panic unwound through a live write transaction and
   was caught with `catch_unwind`. The leak survived closing and reopening the database and grew
   with every such panic; the pages are now reclaimed the next time the database is opened.
+* Fix a Windows-only hang: a write to the database file that reported writing zero bytes made
+  the commit retry it forever. It now fails with a `WriteZero` I/O error.
 
 ### Minor improvements
 * Lock the database file on platforms other than Unix, Windows, and WASI too: a second open of

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -112,6 +112,14 @@ impl StorageBackend for FileBackend {
         let mut data_offset = 0;
         while data_offset < data.len() {
             let written = self.file.seek_write(&data[data_offset..], offset)?;
+            // seek_write can report zero bytes written; treat that as an error so the write
+            // fails instead of looping forever, like the read loop above.
+            if written == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write whole buffer",
+                ));
+            }
             offset += written as u64;
             data_offset += written;
         }


### PR DESCRIPTION
Fixes P2 finding 10 from the pre-5.0 bug audit: the Windows `FileBackend::write` loop retries `seek_write` unconditionally, so a zero-byte result makes it spin forever and hangs the commit thread.

**Why a zero-byte success return is possible, per the documentation:**

- The API redb calls, [`FileExt::seek_write`](https://doc.rust-lang.org/std/os/windows/fs/trait.FileExt.html#tymethod.seek_write), documents: *"Note that similar to `File::write`, it is not an error to return a short write."* Its contract defers to [`io::Write::write`](https://doc.rust-lang.org/std/io/trait.Write.html#tymethod.write), which documents: *"A return value of `Ok(0)` typically means that the underlying object is no longer able to accept bytes and will likely not be able to in the future as well."* std's own `write_all` handles exactly this case by returning `ErrorKind::WriteZero` instead of retrying — the same treatment this PR applies.
- On the Windows API side, [`WriteFile`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile) (Remarks → Pipes) documents success with fewer bytes than requested — zero included when no buffer space is available at all: *"When writing to a non-blocking, byte-mode pipe handle with insufficient buffer space, WriteFile returns TRUE with `*lpNumberOfBytesWritten < nNumberOfBytesToWrite`."* This is reachable through redb's public API because `FileBackend::new()` accepts any `File`, which on Windows can wrap a pipe or communications handle; communications devices likewise complete with fewer bytes on a `COMMTIMEOUTS` expiry.
- Stated honestly for the common case: for a synchronous handle to a regular disk file, the same Remarks document that WriteFile *"does not return until the operation is complete"*, so ordinary database files never take the new branch — for them this is defense against the Rust contract, identical in standing to the already-merged `seek_read` `Ok(0)` fix directly above it and the WASI backend's `WriteZero` handling.

No test: the zero-byte result cannot be provoked through the public API on a regular file without injection hooks, which this repo does not ship. The change mirrors the two adjacent, already-reviewed patterns, and the Windows CI job compiles and exercises the normal path of this loop on every run.

**Validation**: `cargo fmt --check` and clippy with `--deny warnings` pass; the `#[cfg(windows)]` body itself is compiled by the `ci (windows-latest)` job, since no Windows toolchain is available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr