### PR TITLE
Avoid rewriting pages on logical no-op writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@
 * Fix pages being leaked permanently when a panic unwound through a live write transaction and
   was caught with `catch_unwind`. The leak survived closing and reopening the database and grew
   with every such panic; the pages are now reclaimed the next time the database is opened.
+* Fix needless page rewrites on two logical no-ops: `MultimapTable::insert()` of a value that
+  the key already contains rewrote both of the trees involved, and `Table::get_mut()` of a key
+  that does not exist rewrote the whole path to where the key would have been. Both now leave
+  the database untouched.
 
 ### Minor improvements
 * Lock the database file on platforms other than Unix, Windows, and WASI too: a second open of

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -666,7 +666,14 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                         self.allocated_pages.clone(),
                     );
                     drop(guard);
+                    if subtree.get(value.borrow())?.is_some() {
+                        // The value is already present, so both trees would be unchanged.
+                        // Return early to avoid needlessly copy-on-writing them on a logical
+                        // no-op, like remove() does.
+                        return Ok(true);
+                    }
                     let existed = subtree.insert(value.borrow(), &())?.is_some();
+                    debug_assert!(!existed);
                     let subtree_data =
                         DynamicCollection::<V>::make_subtree_data(subtree.get_root().unwrap());
                     self.tree

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -11,7 +11,7 @@ use crate::tree_store::btree_cursor::BtreeCursorMut;
 use crate::tree_store::btree_cursor::{CursorMut, Position};
 use crate::tree_store::btree_iters::{bounds_are_empty, encode_bounds};
 use crate::tree_store::btree_mutator::MutateHelper;
-use crate::tree_store::page_store::{Page, PageImpl, PageMut};
+use crate::tree_store::page_store::{Page, PageImpl};
 use crate::tree_store::{
     AccessGuardMutInPlace, AllPageNumbersBtreeIter, BtreeCursorRange, BtreeExtractIf,
     PageAllocator, PageHint, PageNumber, PageNumberHashMap, PageResolver, PageTracker,
@@ -593,96 +593,109 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<K, V> {
         &mut self,
         key: &K::SelfType<'_>,
     ) -> Result<Option<AccessGuardMut<'_, V>>> {
-        if let Some(ref mut root) = self.root {
-            let key_bytes = K::as_bytes(key);
-            let query = key_bytes.as_ref();
-            let page_mut = if self.page_allocator.uncommitted(root.root) {
-                self.page_allocator.get_page_mut(root.root)?
+        let Some(root) = self.root.as_ref() else {
+            return Ok(None);
+        };
+        let root_page = root.root;
+        let key_bytes = K::as_bytes(key);
+        let query = key_bytes.as_ref();
+
+        // Search pass: a single read-only descent, recording the route. A missing key must not
+        // modify the tree, so pages are copied only after the leaf proves the key exists
+        let mut route = Vec::new();
+        let mut page = self.page_allocator.get_page(root_page, PageHint::None)?;
+        let entry_index = loop {
+            match page.memory()[0] {
+                LEAF => {
+                    let accessor =
+                        LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
+                    match accessor.find_key::<K>(query) {
+                        Some(entry_index) => break entry_index,
+                        None => return Ok(None),
+                    }
+                }
+                BRANCH => {
+                    let (child_index, child_page) = {
+                        let accessor = BranchAccessor::new(&page, K::fixed_width());
+                        accessor.child_for_key::<K>(query)
+                    };
+                    route.push(child_index);
+                    page = self.page_allocator.get_page(child_page, PageHint::None)?;
+                }
+                _ => unreachable!(),
+            }
+        };
+        drop(page);
+
+        // The key exists: copy-on-write along the recorded route, with no further comparisons
+        let root = self.root.as_mut().unwrap();
+        let mut page_mut = if self.page_allocator.uncommitted(root_page) {
+            self.page_allocator.get_page_mut(root_page)?
+        } else {
+            let mut freed_pages = self.freed_pages.lock().unwrap();
+            let required: usize = root_page
+                .page_size_bytes(self.page_allocator.get_page_size().try_into().unwrap())
+                .try_into()
+                .unwrap();
+            let mut new_page = self
+                .page_allocator
+                .allocate(required, &self.allocated_pages)?;
+            let old_page = self.page_allocator.get_page(root_page, PageHint::None)?;
+            new_page.memory_mut().copy_from_slice(old_page.memory());
+            drop(old_page);
+            freed_pages.push(root_page);
+
+            root.root = new_page.get_page_number();
+            root.checksum = DEFERRED;
+            new_page
+        };
+
+        let mut parent = None;
+        for child_index in route {
+            let child_page = {
+                let accessor = BranchAccessor::new(&page_mut, K::fixed_width());
+                accessor.child_page(child_index).unwrap()
+            };
+            let child_page_mut = if self.page_allocator.uncommitted(child_page) {
+                self.page_allocator.get_page_mut(child_page)?
             } else {
                 let mut freed_pages = self.freed_pages.lock().unwrap();
-                let required: usize = root
-                    .root
+                let required: usize = child_page
                     .page_size_bytes(self.page_allocator.get_page_size().try_into().unwrap())
                     .try_into()
                     .unwrap();
                 let mut new_page = self
                     .page_allocator
                     .allocate(required, &self.allocated_pages)?;
-                let old_page = self.page_allocator.get_page(root.root, PageHint::None)?;
-                new_page.memory_mut().copy_from_slice(old_page.memory());
-                drop(old_page);
-                freed_pages.push(root.root);
+                let old_child_page = self.page_allocator.get_page(child_page, PageHint::None)?;
+                new_page
+                    .memory_mut()
+                    .copy_from_slice(old_child_page.memory());
+                drop(old_child_page);
+                freed_pages.push(child_page);
 
-                root.root = new_page.get_page_number();
-                root.checksum = DEFERRED;
+                let mut mutator = BranchMutator::new(page_mut.memory_mut());
+                mutator.write_child_page(child_index, new_page.get_page_number(), DEFERRED);
                 new_page
             };
-            self.get_mut_helper(None, page_mut, query)
-        } else {
-            Ok(None)
+            parent = Some((page_mut, child_index));
+            page_mut = child_page_mut;
         }
-    }
 
-    fn get_mut_helper<'txn>(
-        &'txn mut self,
-        parent: Option<(PageMut<'txn>, usize)>,
-        mut page: PageMut<'txn>,
-        query: &[u8],
-    ) -> Result<Option<AccessGuardMut<'txn, V>>> {
-        let node_mem = page.memory();
-        match node_mem[0] {
-            LEAF => {
-                let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), V::fixed_width());
-                if let Some(entry_index) = accessor.find_key::<K>(query) {
-                    let (start, end) = accessor.value_range(entry_index).unwrap();
-                    let guard = AccessGuardMut::new(
-                        page,
-                        start,
-                        end - start,
-                        entry_index,
-                        parent,
-                        self.page_allocator.clone(),
-                        self.allocated_pages.clone(),
-                        self.root.as_mut().unwrap(),
-                        K::fixed_width(),
-                    );
-                    Ok(Some(guard))
-                } else {
-                    Ok(None)
-                }
-            }
-            BRANCH => {
-                let (child_index, child_page) = {
-                    let accessor = BranchAccessor::new(&page, K::fixed_width());
-                    accessor.child_for_key::<K>(query)
-                };
-                let child_page_mut = if self.page_allocator.uncommitted(child_page) {
-                    self.page_allocator.get_page_mut(child_page)?
-                } else {
-                    let mut freed_pages = self.freed_pages.lock().unwrap();
-                    let required: usize = child_page
-                        .page_size_bytes(self.page_allocator.get_page_size().try_into().unwrap())
-                        .try_into()
-                        .unwrap();
-                    let mut new_page = self
-                        .page_allocator
-                        .allocate(required, &self.allocated_pages)?;
-                    let old_child_page =
-                        self.page_allocator.get_page(child_page, PageHint::None)?;
-                    new_page
-                        .memory_mut()
-                        .copy_from_slice(old_child_page.memory());
-                    drop(old_child_page);
-                    freed_pages.push(child_page);
-
-                    let mut mutator = BranchMutator::new(page.memory_mut());
-                    mutator.write_child_page(child_index, new_page.get_page_number(), DEFERRED);
-                    new_page
-                };
-                self.get_mut_helper(Some((page, child_index)), child_page_mut, query)
-            }
-            _ => unreachable!(),
-        }
+        let accessor = LeafAccessor::new(page_mut.memory(), K::fixed_width(), V::fixed_width());
+        let (start, end) = accessor.value_range(entry_index).unwrap();
+        let guard = AccessGuardMut::new(
+            page_mut,
+            start,
+            end - start,
+            entry_index,
+            parent,
+            self.page_allocator.clone(),
+            self.allocated_pages.clone(),
+            self.root.as_mut().unwrap(),
+            K::fixed_width(),
+        );
+        Ok(Some(guard))
     }
 
     pub(crate) fn first(

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1687,6 +1687,92 @@ fn insert_reserve() {
 }
 
 #[test]
+fn get_mut_missing_key_does_not_churn() {
+    // get_mut() on a missing key is a logical no-op and must not rewrite any pages
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        // Enough entries for the tree to have branch pages.
+        for i in 0..5000u64 {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    // Finalize the cleanup of the freed pages from the setup so the baseline is at steady state.
+    db.begin_write().unwrap().commit().unwrap();
+    db.begin_write().unwrap().commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    let baseline = txn.stats().unwrap().allocated_pages();
+    txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        assert!(table.get_mut(&123_456u64).unwrap().is_none());
+    }
+    write_txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    let after = txn.stats().unwrap().allocated_pages();
+    txn.commit().unwrap();
+    assert_eq!(
+        baseline, after,
+        "get_mut() on a missing key must not allocate or free pages"
+    );
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 5000);
+}
+
+#[test]
+fn get_mut_deep_tree() {
+    let tmpfile = create_tempfile();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        // Enough entries for the tree to have branch pages.
+        for i in 0..5000u64 {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        // The first access copies the committed pages on its path; the later ones traverse a
+        // mix of the already-copied pages and committed ones
+        table.get_mut(&100u64).unwrap().unwrap().insert(&1).unwrap();
+        table.get_mut(&100u64).unwrap().unwrap().insert(&2).unwrap();
+        table
+            .get_mut(&4000u64)
+            .unwrap()
+            .unwrap()
+            .insert(&3)
+            .unwrap();
+        assert!(table.get_mut(&123_456u64).unwrap().is_none());
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.get(&100u64).unwrap().unwrap().value(), 2);
+    assert_eq!(table.get(&4000u64).unwrap().unwrap().value(), 3);
+    assert_eq!(table.get(&99u64).unwrap().unwrap().value(), 99);
+    assert_eq!(table.len().unwrap(), 5000);
+    drop(table);
+    drop(read_txn);
+    assert!(db.check_integrity().unwrap());
+}
+
+#[test]
 fn get_mut() {
     let tmpfile = create_tempfile();
     let db = Database::create(tmpfile.path()).unwrap();

--- a/tests/multimap_tests.rs
+++ b/tests/multimap_tests.rs
@@ -660,6 +660,53 @@ fn multimap_remove_nonexistent_value_from_subtree_does_not_churn() {
     assert_eq!(table.get(&0u64).unwrap().len(), 1000);
 }
 
+#[test]
+fn multimap_insert_existing_value_into_subtree_does_not_churn() {
+    // Inserting a value that is already present under a subtree-backed key is a logical no-op
+    // and must not rewrite either tree, like removing an absent one
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_TABLE).unwrap();
+        // Enough values for key 0 to be promoted from inline storage to a subtree.
+        for v in 0..1000u64 {
+            table.insert(&0u64, &v).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    // Finalize the cleanup of the freed pages from the setup so the baseline is at steady state.
+    db.begin_write().unwrap().commit().unwrap();
+    db.begin_write().unwrap().commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    let baseline = txn.stats().unwrap().allocated_pages();
+    txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_TABLE).unwrap();
+        assert!(table.insert(&0u64, &500u64).unwrap());
+        assert_eq!(table.len().unwrap(), 1000);
+    }
+    write_txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    let after = txn.stats().unwrap().allocated_pages();
+    txn.commit().unwrap();
+    assert_eq!(
+        baseline, after,
+        "inserting an already-present value under a subtree-backed key must not allocate or free pages"
+    );
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_multimap_table(U64_TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 1000);
+    assert_eq!(table.get(&0u64).unwrap().len(), 1000);
+}
+
 fn overwrite_multimap_10_times(db: &Database) {
     for _ in 0..10 {
         let write_txn = db.begin_write().unwrap();


### PR DESCRIPTION
Fixes P2 findings 12 and 15 from the pre-5.0 bug audit — both are the same class of defect: a mutating operation that turns out to be a logical no-op still rewrote pages.

**`Table::get_mut()` of a missing key (15).** The mutating descent copy-on-wrote every page from the root down before the leaf revealed the key was absent. Per review, this is now a single-search two-pass descent instead of a double lookup: one read-only descent searches for the key while recording the child index at each branch; only after the leaf proves the key exists does a second pass copy-on-write along the recorded route — fetching the just-touched pages by number, with no further key comparisons. A miss is now a pure read. On a hit, the only added work over the old combined descent is re-fetching the hot pages from the cache by page number; every binary search happens exactly once.

**`MultimapTable::insert()` of an already-present value (12).** The subtree-backed arm copy-on-wrote the subtree and re-inserted the collection into the parent tree even when the value existed. It now checks the subtree for the value first and returns `true` untouched — the same shape as the merged `remove()` fix, whose early return this mirrors. The check adds one subtree-only read descent to the miss path, ahead of the full two-tree insert that path performs anyway.

**Tests** — both mirror the existing `multimap_remove_nonexistent_value_from_subtree_does_not_churn` pattern (steady-state baseline, the no-op, then `allocated_pages` must be unchanged), and both were verified to fail without their fix with the churn assertion:
- `multimap_insert_existing_value_into_subtree_does_not_churn`
- `get_mut_missing_key_does_not_churn`

**Validation**: `cargo fmt --check`, clippy with `--deny warnings`, and `RUST_BACKTRACE=1 cargo test --all-features` (all 20 suites green, including the `get_mut`, entry-API, and guard-resize tests that exercise the rewritten path), run directly because this environment lacks the rootless podman that `just test`'s sandbox wrapper needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr