### PR TITLE
Return a Cow from Key::separator()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@
   all built-in types are unaffected.
 
 ## 4.3.0 - 2026-XX-XX
-* Add `Key::separator()`, which returns a short slice that separates two keys. Internal btree
+* Add `Key::separator()`, which returns a short byte string that separates two keys, as a
+  `Cow` so it can also be synthesized rather than borrowed from the inputs. Internal btree
   nodes store the result instead of a whole key, so more children fit in each node and lookups
   touch fewer pages. The default implementation returns a whole key, leaving existing `Key`
   implementations unchanged; `&[u8]`, `&str`, and `String` keys now store minimal prefixes.

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -4,6 +4,7 @@ use crate::tree_store::page_store::{
 use crate::tree_store::{PageAllocator, PageNumber, PageTracker};
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{Result, StorageError};
+use alloc::borrow::Cow;
 use alloc::collections::VecDeque;
 use alloc::format;
 use alloc::sync::Arc;
@@ -31,20 +32,20 @@ pub(super) const DEFERRED: Checksum = 999;
 // whose least key is `right`. Branch keys only route lookups -- they are compared, never
 // deserialized -- so a `Key` implementation may shorten them, which packs more children into each
 // branch page.
-pub(super) fn branch_separator<'a, K: Key>(left: &'a [u8], right: &'a [u8]) -> &'a [u8] {
+pub(super) fn branch_separator<'a, K: Key>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
     debug_assert!(K::compare(left, right).is_lt());
     // Branch keys of a fixed width type are stored at that stride, so a shorter separator would
     // corrupt the page, and a same width one would save nothing. Never ask for one.
     if K::fixed_width().is_some() {
-        return left;
+        return Cow::Borrowed(left);
     }
     let separator = K::separator(left, right);
     debug_assert!(
-        K::compare(left, separator).is_le(),
+        K::compare(left, &separator).is_le(),
         "separator sorts below the left child's greatest key"
     );
     debug_assert!(
-        K::compare(separator, right).is_lt(),
+        K::compare(&separator, right).is_lt(),
         "separator does not sort below the right child's least key"
     );
     separator
@@ -899,7 +900,7 @@ impl<'a, 'b> LeafBuilder<'a, 'b> {
     // Returns the two halves, and the separator to store between them in their parent
     pub(super) fn build_split<'txn, K: Key>(
         self,
-    ) -> Result<(PageMut<'txn>, &'a [u8], PageMut<'txn>)> {
+    ) -> Result<(PageMut<'txn>, Cow<'a, [u8]>, PageMut<'txn>)> {
         let total_size = self.total_key_bytes + self.total_value_bytes;
         let mut division = 0;
         let mut first_split_key_bytes = 0;
@@ -1948,7 +1949,7 @@ impl<'a: 'b, 'b, T: Page + 'a> BranchAccessor<'a, 'b, T> {
 
 pub(super) struct BranchBuilder<'a, 'b> {
     children: Vec<(PageNumber, Checksum)>,
-    keys: Vec<&'a [u8]>,
+    keys: Vec<Cow<'a, [u8]>>,
     total_key_bytes: usize,
     fixed_key_size: Option<usize>,
     page_allocator: &'b PageAllocator,
@@ -1980,9 +1981,10 @@ impl<'a, 'b> BranchBuilder<'a, 'b> {
         self.children.push((child, checksum));
     }
 
-    pub(super) fn push_key(&mut self, key: &'a [u8]) {
-        self.keys.push(key);
+    pub(super) fn push_key(&mut self, key: impl Into<Cow<'a, [u8]>>) {
+        let key = key.into();
         self.total_key_bytes += key.len();
+        self.keys.push(key);
     }
 
     pub(super) fn push_all<T: Page>(&mut self, accessor: &'a BranchAccessor<'_, '_, T>) {
@@ -2009,7 +2011,7 @@ impl<'a, 'b> BranchBuilder<'a, 'b> {
     }
 
     pub(super) fn into_parts(self) -> (Vec<(PageNumber, Checksum)>, Vec<Vec<u8>>) {
-        let owned_keys = self.keys.into_iter().map(<[u8]>::to_vec).collect();
+        let owned_keys = self.keys.into_iter().map(Cow::into_owned).collect();
         (self.children, owned_keys)
     }
 
@@ -2045,12 +2047,12 @@ impl<'a, 'b> BranchBuilder<'a, 'b> {
         (size > self.page_allocator.get_page_size() || too_many_keys) && self.keys.len() >= 3
     }
 
-    pub(super) fn build_split<'txn>(self) -> Result<(PageMut<'txn>, &'a [u8], PageMut<'txn>)> {
+    pub(super) fn build_split<'txn>(self) -> Result<(PageMut<'txn>, Cow<'a, [u8]>, PageMut<'txn>)> {
         assert_eq!(self.children.len(), self.keys.len() + 1);
         assert!(self.keys.len() >= 3);
         let division = self.keys.len() / 2;
         let first_split_key_len: usize = self.keys.iter().take(division).map(|k| k.len()).sum();
-        let division_key = self.keys[division];
+        let division_key = self.keys[division].clone();
         let second_split_key_len = self.total_key_bytes - first_split_key_len - division_key.len();
 
         let size =
@@ -2389,7 +2391,7 @@ mod tests {
         assert!(builder.should_split());
 
         let (_, separator, _) = builder.build_split::<&[u8]>().unwrap();
-        assert_eq!(separator, b"abc1");
+        assert_eq!(separator.as_ref(), b"abc1");
     }
 
     // Branch keys of a fixed width type are stored at that stride, so a `Key` implementation that
@@ -2432,14 +2434,17 @@ mod tests {
                 data1.cmp(data2)
             }
 
-            fn separator<'a>(_left: &'a [u8], right: &'a [u8]) -> &'a [u8] {
-                &right[..1]
+            fn separator<'a>(_left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
+                Cow::Borrowed(&right[..1])
             }
         }
 
         let left = [1u8; 8];
         let right = [2u8; 8];
-        assert_eq!(branch_separator::<BadSeparator>(&left, &right), left);
+        assert_eq!(
+            branch_separator::<BadSeparator>(&left, &right).as_ref(),
+            left
+        );
     }
 
     // Splitting divides by total bytes, which can be arbitrarily lopsided when one pair

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -14,6 +14,7 @@ use crate::tree_store::{
 };
 use crate::types::{Key, Value};
 use crate::{AccessGuard, Result};
+use alloc::borrow::Cow;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -461,13 +462,13 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
             let last_key = entries[range.end - 1].0;
             let separator = match plan.get(index + 1).or(balance_tail.as_ref()) {
                 Some(next) => branch_separator::<K>(last_key, entries[next.start].0),
-                None => last_key,
+                None => Cow::Borrowed(last_key),
             };
-            leaves.push((page.get_page_number(), separator.to_vec()));
+            leaves.push((page.get_page_number(), separator.into_owned()));
         }
         if let Some(range) = balance_tail {
             let (page1, split_key, page2) = fill(&range).build_split::<K>()?;
-            leaves.push((page1.get_page_number(), split_key.to_vec()));
+            leaves.push((page1.get_page_number(), split_key.into_owned()));
             leaves.push((page2.get_page_number(), entries[range.end - 1].0.to_vec()));
         }
         Ok(leaves)
@@ -776,7 +777,8 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     let guard = AccessGuardMutInPlace::new(new_page, offset, value.len());
                     return if position == 0 {
                         let split_key =
-                            branch_separator::<K>(key, accessor.entry(0).unwrap().key()).to_vec();
+                            branch_separator::<K>(key, accessor.entry(0).unwrap().key())
+                                .into_owned();
                         Ok(InsertionResult {
                             new_root: new_page_number,
                             root_checksum: DEFERRED,
@@ -790,7 +792,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                         })
                     } else {
                         let split_key =
-                            branch_separator::<K>(accessor.last_entry().key(), key).to_vec();
+                            branch_separator::<K>(accessor.last_entry().key(), key).into_owned();
                         Ok(InsertionResult {
                             new_root: page.get_page_number(),
                             root_checksum: page_checksum,
@@ -898,7 +900,7 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
                     )
                 {
                     let split_key =
-                        branch_separator::<K>(accessor.last_entry().key(), key).to_vec();
+                        branch_separator::<K>(accessor.last_entry().key(), key).into_owned();
                     let mut builder = LeafBuilder::new(
                         self.page_allocator,
                         self.allocated,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
@@ -228,10 +229,13 @@ pub trait Key: Value {
     /// valid encoding of `Self`. The shorter it is, the more children fit in each internal node,
     /// which makes the tree shallower and cheaper to search.
     ///
+    /// Returning [`Cow::Owned`] allows separators synthesized from the inputs, rather than
+    /// borrowed from them.
+    ///
     /// The default implementation returns `left`, which is always valid.
-    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> &'a [u8] {
+    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
         debug_assert!(Self::compare(left, right).is_lt());
-        left
+        Cow::Borrowed(left)
     }
 }
 
@@ -427,7 +431,7 @@ impl Key for &[u8] {
         data1.cmp(data2)
     }
 
-    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> &'a [u8] {
+    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
         debug_assert!(left < right);
         // Truncating `right` just past the first byte where it exceeds `left` leaves something
         // greater than `left`, and less than `right` as long as bytes were dropped. When that is
@@ -436,9 +440,9 @@ impl Key for &[u8] {
         // `right`.
         let separator_len = left.iter().zip(right).take_while(|(x, y)| x == y).count() + 1;
         if separator_len < left.len() && separator_len < right.len() {
-            &right[..separator_len]
+            Cow::Borrowed(&right[..separator_len])
         } else {
-            left
+            Cow::Borrowed(left)
         }
     }
 }
@@ -629,15 +633,15 @@ impl Key for &str {
         str1.cmp(str2)
     }
 
-    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> &'a [u8] {
+    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
         debug_assert!(left < right);
         // `str` orders as its bytes, but `compare()` deserializes, so the cut must keep it valid
         let common_bytes = left.iter().zip(right).take_while(|(x, y)| x == y).count();
         let separator_len = round_up_to_char_boundary(right, common_bytes + 1);
         if separator_len < left.len() && separator_len < right.len() {
-            &right[..separator_len]
+            Cow::Borrowed(&right[..separator_len])
         } else {
-            left
+            Cow::Borrowed(left)
         }
     }
 }
@@ -683,7 +687,7 @@ impl Key for String {
     }
 
     // Encoded the same way as `&str`, so it separates the same way
-    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> &'a [u8] {
+    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
         <&str as Key>::separator(left, right)
     }
 }
@@ -832,8 +836,8 @@ mod tests {
         for &(left, right, expected) in cases {
             let separator = <&[u8] as Key>::separator(left, right);
             assert_eq!(separator, expected);
-            assert!(<&[u8] as Key>::compare(left, separator).is_le());
-            assert!(<&[u8] as Key>::compare(separator, right).is_lt());
+            assert!(<&[u8] as Key>::compare(left, &separator).is_le());
+            assert!(<&[u8] as Key>::compare(&separator, right).is_lt());
         }
     }
 
@@ -895,9 +899,9 @@ mod tests {
             let separator = <&str as Key>::separator(left.as_bytes(), right.as_bytes());
             assert_eq!(separator, expected.as_bytes());
             // A separator is passed back through `compare()`, which deserializes it
-            assert!(core::str::from_utf8(separator).is_ok());
-            assert!(<&str as Key>::compare(left.as_bytes(), separator).is_le());
-            assert!(<&str as Key>::compare(separator, right.as_bytes()).is_lt());
+            assert!(core::str::from_utf8(&separator).is_ok());
+            assert!(<&str as Key>::compare(left.as_bytes(), &separator).is_le());
+            assert!(<&str as Key>::compare(&separator, right.as_bytes()).is_lt());
             assert_eq!(
                 <String as Key>::separator(left.as_bytes(), right.as_bytes()),
                 separator
@@ -909,7 +913,7 @@ mod tests {
     fn default_separator_returns_full_key() {
         let left = 1u64.to_le_bytes();
         let right = 2u64.to_le_bytes();
-        assert_eq!(<u64 as Key>::separator(&left, &right), left);
+        assert_eq!(<u64 as Key>::separator(&left, &right).as_ref(), left);
     }
 
     // A user-defined type whose name deliberately collides with the built-in `u32`, and whose

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -9,6 +9,7 @@ use redb::{
     ReadableDatabase, ReadableTable, ReadableTableMetadata, StorageError, TableDefinition,
     TableError, TableHandle, TypeName, Value, WriteTransaction,
 };
+use std::borrow::Cow;
 use std::cmp::Ordering;
 #[cfg(feature = "experimental-api-5")]
 use std::ops::Bound;
@@ -3397,7 +3398,7 @@ fn branch_separators_are_not_deserialized() {
             data1.cmp(data2)
         }
 
-        fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> &'a [u8] {
+        fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
             // Every pair of keys differs within the first two bytes, so a separator is always
             // shorter than the 8 byte encoding, and so always invalid to deserialize
             let separator = <&[u8] as Key>::separator(left, right);


### PR DESCRIPTION
From the 5.0 agenda discussion: a borrowed return type limits `Key::separator()` to slices of the two input keys, so an implementation can never synthesize a separator shorter than either input contains (e.g. a midpoint byte string). Returning `Cow<'a, [u8]>` enables that; since `separator()` is unreleased (4.3.0), this amends its signature and changelog entry rather than adding a compatibility note.

**What changed**
- `Key::separator()`, the default implementation, the `&[u8]`/`&str`/`String` implementations, and `branch_separator()` return `Cow<'a, [u8]>`. All in-tree implementations return `Cow::Borrowed` — no allocation is added anywhere.
- `BranchBuilder` stores its keys as `Cow<'a, [u8]>` and `push_key()` takes `impl Into<Cow<'a, [u8]>>`, so the many existing `&'a [u8]` callers are unchanged, and both `build_split` flavors return their promoted separator as a `Cow`. The page-build loops already went through `as_ref()`.

**Benchmarks** (`cargo bench -p redb-bench --bench redb_benchmark`, five alternating this-branch/master rounds on the same host; each column pair below is one round, run back-to-back):

| metric | this branch (r1..r5) | master (r1..r5) |
|---|---|---|
| bulk load | 168K, 253K, 240K, 248K, 248K | 222K, 254K, 256K, 243K, 245K |
| individual writes | 2.99K, 3.07K, 3.29K, 3.01K, 3.08K | 3.48K, 3.22K, 3.12K, 2.92K, 3.24K |
| small batch writes | 23.8K, 24.6K, 23.3K, 24.5K, 23.9K | 25.4K, 25.0K, 25.5K, 24.5K, 23.7K |
| sorted inserts | 1.30M, 1.29M, 1.27M, 1.26M, 1.18M | 1.31M, 1.23M, 1.30M, 1.20M, 1.21M |
| random reads | 564K, 543K, 556K, 528K, 532K | 563K, 555K, 547K, 500K, 526K |
| removals | 97.9K, 103K, 110K, 123K, 122K | 108K, 114K, 129K, 120K, 117K |
| retain | 531K, 477K, 495K, 496K, 499K | 516K, 515K, 524K, 497K, 480K |
| pop | 752K, 811K, 808K, 815K, 826K | 819K, 787K, 823K, 810K, 829K |

Read on this environment's noise: round 1 ran on a visibly contended host (bulk load 168K is a cold outlier; single-configuration spreads reach 20%, e.g. master removals 108K–129K). Per-round deltas flip sign for every metric — removals reads −9%/−10%/−15%/+2.5%/+4% across the five rounds — so there is no consistent directional effect; medians agree within ±5%, inside the measured noise. I read this as performance-neutral, but this is a shared container: if you want, re-running the same alternating protocol on quiet hardware would tighten the bound.

**Validation**: `cargo fmt --check`, clippy with `--deny warnings`, and `RUST_BACKTRACE=1 cargo test --all-features` (all 20 suites green, including the separator property tests), run directly because this environment lacks the rootless podman that `just test`'s sandbox wrapper needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr)_