### PR TITLE
Stop derived Value implementations shadowing the struct's lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   be added behind the `experimental_cursor` feature flag, like the table cursors' were.
 
 ### redb-derive (unreleased)
+* Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are
+  named `'a` or `'b`; the generated implementations no longer shadow the struct's lifetimes.
 * Fix the derived implementations calling inherent methods named `fixed_width`, `from_bytes`,
   `as_bytes`, or `type_name` on field types, instead of the `Value` trait methods. The
   generated code now uses fully qualified paths, and no longer requires the `Value` and `Key`

--- a/crates/redb-derive/src/lib.rs
+++ b/crates/redb-derive/src/lib.rs
@@ -131,27 +131,31 @@ fn generate_value_impl(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStr
 
     Ok(quote! {
         impl #impl_generics #redb::Value for #name #ty_generics #where_clause {
-            type SelfType<'a> = #self_type
+            type SelfType<'__redb_a> = #self_type
             where
-                Self: 'a;
-            type AsBytes<'a> = ::std::vec::Vec<::std::primitive::u8>
+                Self: '__redb_a;
+            type AsBytes<'__redb_a> = ::std::vec::Vec<::std::primitive::u8>
             where
-                Self: 'a;
+                Self: '__redb_a;
 
             fn fixed_width() -> ::std::option::Option<::std::primitive::usize> {
                 #fixed_width_impl
             }
 
-            fn from_bytes<'a>(data: &'a [::std::primitive::u8]) -> Self::SelfType<'a>
+            fn from_bytes<'__redb_a>(
+                data: &'__redb_a [::std::primitive::u8],
+            ) -> Self::SelfType<'__redb_a>
             where
-                Self: 'a,
+                Self: '__redb_a,
             {
                 #from_bytes_impl
             }
 
-            fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+            fn as_bytes<'__redb_a, '__redb_b: '__redb_a>(
+                value: &'__redb_a Self::SelfType<'__redb_b>,
+            ) -> Self::AsBytes<'__redb_a>
             where
-                Self: 'b,
+                Self: '__redb_b,
             {
                 #as_bytes_impl
             }
@@ -173,7 +177,7 @@ fn generate_self_type(
         let mut params = vec![];
         for param in &generics.params {
             match param {
-                GenericParam::Lifetime(_) => params.push(quote! { 'a }),
+                GenericParam::Lifetime(_) => params.push(quote! { '__redb_a }),
                 GenericParam::Type(type_param) => {
                     return Err(syn::Error::new_spanned(
                         type_param,

--- a/crates/redb-derive/tests/derive_tests.rs
+++ b/crates/redb-derive/tests/derive_tests.rs
@@ -47,6 +47,13 @@ struct ComplexStruct<'inner, 'inner2> {
 #[derive(Value, Debug, PartialEq)]
 struct UnitStruct;
 
+// The derived implementation must not shadow the struct's own lifetimes, whatever their names
+#[derive(Key, Value, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct LifetimeNames<'a, 'b> {
+    reference: &'a str,
+    reference2: &'b str,
+}
+
 fn test_key_helper<K: Key + 'static>(key: &<K as Value>::SelfType<'_>) {
     let file = create_tempfile();
     let db = Database::create(file.path()).unwrap();
@@ -681,4 +688,15 @@ fn test_complex_struct() {
     let expected_name = "ComplexStruct {tuple_field: (u8,u16,u32), array_field: [(u8,Option<u16>);2], reference: &str, reference2: &str}";
     test_key_helper::<ComplexStruct>(&original);
     test_value_helper::<ComplexStruct>(original, expected_name);
+}
+
+#[test]
+fn lifetime_names() {
+    let original = LifetimeNames {
+        reference: "hello",
+        reference2: "world",
+    };
+    let expected_name = "LifetimeNames {reference: &str, reference2: &str}";
+    test_key_helper::<LifetimeNames>(&original);
+    test_value_helper::<LifetimeNames>(original, expected_name);
 }


### PR DESCRIPTION
Fixes P2 finding 14 from the pre-5.0 bug audit: `#[derive(Value)]` (and `#[derive(Key)]`) failed to compile on any struct whose own lifetime was named `'a` — and, it turns out, `'b` as well, which `as_bytes<'a, 'b: 'a>` shadows.

The generated impl's GAT and method lifetimes were literally named `'a`/`'b`, so a struct like `struct Foo<'a> { s: &'a str }` produced `E0496: lifetime name 'a shadows a lifetime name that is already in scope`. The generated lifetimes are renamed (`'__redb_a`/`'__redb_b`) so they cannot collide with reasonable user code. Compile-time only; no generated behavior changes.

**Test**: `LifetimeNames<'a, 'b>` in `derive_tests.rs`, exercising both colliding names through the existing key/value round-trip helpers. Verified against the unfixed macro: it fails with `E0496` for both `'a` and `'b`.

Changelog entry added under the existing "redb-derive (unreleased)" section.

**Validation**: `cargo fmt --check`, clippy with `--deny warnings`, and `RUST_BACKTRACE=1 cargo test --all-features` (all 20 suites green, 19/19 derive tests), run directly because this environment lacks the rootless podman that `just test`'s sandbox wrapper needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr)_