### PR TITLE
Make renaming a table to its current name a no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@
   with every such panic; the pages are now reclaimed the next time the database is opened.
 * Fix a Windows-only hang: a write to the database file that reported writing zero bytes made
   the commit retry it forever. It now fails with a `WriteZero` I/O error.
+* Fix `rename_table()` and `rename_multimap_table()` returning `TableExists` when the new name
+  is the same as the current one. Renaming a table to its own name now succeeds and leaves the
+  table unchanged.
 
 ### Minor improvements
 * Lock the database file on platforms other than Unix, Windows, and WASI too: a second open of

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -572,6 +572,9 @@ impl TableTreeMut {
             None
         };
         if let Some(definition) = stored_definition {
+            if name == new_name {
+                return Ok(());
+            }
             if self.get_table_untyped(new_name, table_type)?.is_some() {
                 return Err(TableError::TableExists(new_name.to_string()));
             }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -2107,6 +2107,42 @@ fn delete_table() {
 }
 
 #[test]
+fn rename_table_to_same_name() {
+    let table_def: TableDefinition<&str, &str> = TableDefinition::new("x");
+    let missing_def: TableDefinition<&str, &str> = TableDefinition::new("missing");
+    let multitable_def: MultimapTableDefinition<&str, &str> = MultimapTableDefinition::new("multi");
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(table_def).unwrap();
+        table.insert("hi", "hi").unwrap();
+        let mut multitable = write_txn.open_multimap_table(multitable_def).unwrap();
+        multitable.insert("a", "b").unwrap();
+    }
+    // Renaming a table to its current name is a no-op
+    write_txn.rename_table(table_def, table_def).unwrap();
+    write_txn
+        .rename_multimap_table(multitable_def, multitable_def)
+        .unwrap();
+    // A table that does not exist still errors
+    assert!(matches!(
+        write_txn
+            .rename_table(missing_def, missing_def)
+            .unwrap_err(),
+        TableError::TableDoesNotExist(_)
+    ));
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(table_def).unwrap();
+    assert_eq!(table.get("hi").unwrap().unwrap().value(), "hi");
+    let multitable = read_txn.open_multimap_table(multitable_def).unwrap();
+    assert_eq!(multitable.len().unwrap(), 1);
+}
+
+#[test]
 fn rename_table() {
     let table_def: TableDefinition<&str, &str> = TableDefinition::new("x");
     let table_def2: TableDefinition<&str, &str> = TableDefinition::new("x2");


### PR DESCRIPTION
From item 18 of the pre-5.0 bug audit: `rename_table()` and `rename_multimap_table()` returned `TableExists` when the new name equaled the current one, because the destination-in-use check matched the table itself.

Renaming a table to its own name now returns `Ok` and leaves the catalog untouched (no remove/insert, nothing staged); renaming a nonexistent table to its own name still fails with `TableDoesNotExist`, and the type check still applies before the early return.

**Test**: `rename_table_to_same_name` — same-name rename of a regular and a multimap table succeeds with data intact, nonexistent table still errors. Fails without the fix with `TableExists`.

**Validation**: `cargo fmt --check`, clippy with `--deny warnings`, and `RUST_BACKTRACE=1 cargo test --all-features` (all 20 suites green), run directly because this environment lacks the rootless podman that `just test`'s sandbox wrapper needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr)_