### PR TITLE
Repair a torn commit slot version byte instead of failing the open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@
   ineligible for further savepoints, so a second savepoint in the same transaction failed with
   `InvalidSavepoint`. Only opening, renaming, or deleting a data table, or restoring a
   savepoint, makes a transaction savepoint-ineligible now.
+* Fix the database failing to open after a crash that tore a commit slot's version byte. The
+  open reported `Corrupted`, or a misleading `UpgradeRequired`, even though the other commit
+  slot was intact; a torn version byte is now repaired like any other torn slot write.
 
 ### Minor improvements
 * Lock the database file on platforms other than Unix, Windows, and WASI too: a second open of

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -176,6 +176,15 @@ impl UnrepairedDatabaseHeader {
         let (slot1, slot1_corrupted) = TransactionHeader::from_bytes(
             &data[TRANSACTION_1_OFFSET..(TRANSACTION_1_OFFSET + TRANSACTION_SIZE)],
         )?;
+        // With at least one verified slot the database is v3, and a slot that failed
+        // verification is a torn write for the repair logic to handle -- whatever its version
+        // byte says. Pre-v3 files have no v3-checksummed slot at all, so when neither slot
+        // verifies, the version bytes are the only signal distinguishing an older file format
+        // from a corrupted database.
+        if slot0_corrupted && slot1_corrupted {
+            TransactionHeader::check_version(slot0.version)?;
+            TransactionHeader::check_version(slot1.version)?;
+        }
         let (primary_corrupted, secondary_corrupted) = if primary_slot == 0 {
             (slot0_corrupted, slot1_corrupted)
         } else {
@@ -413,6 +422,8 @@ impl DatabaseHeader {
         system_root: Option<BtreeHeader>,
     ) {
         let slot = &mut self.transaction_slots[self.primary_slot ^ 1];
+        // The slot may have held a torn write whose version byte never verified
+        slot.version = FILE_FORMAT_VERSION3;
         slot.transaction_id = transaction_id;
         slot.user_root = user_root;
         slot.system_root = system_root;
@@ -478,27 +489,34 @@ impl TransactionHeader {
         }
     }
 
-    // Returned bool indicates whether the checksum was corrupted
-    pub(super) fn from_bytes(data: &[u8]) -> Result<(Self, bool), DatabaseError> {
-        let version = data[VERSION_OFFSET];
+    fn check_version(version: u8) -> Result<(), DatabaseError> {
         match version {
             FILE_FORMAT_VERSION1 | FILE_FORMAT_VERSION2 => {
-                return Err(DatabaseError::UpgradeRequired(version));
+                Err(DatabaseError::UpgradeRequired(version))
             }
-            FILE_FORMAT_VERSION3 => {}
-            _ => {
-                return Err(StorageError::Corrupted(format!(
-                    "Expected file format version <= {FILE_FORMAT_VERSION3}, found {version}",
-                ))
-                .into());
-            }
+            FILE_FORMAT_VERSION3 => Ok(()),
+            _ => Err(StorageError::Corrupted(format!(
+                "Expected file format version <= {FILE_FORMAT_VERSION3}, found {version}",
+            ))
+            .into()),
         }
+    }
+
+    // Returned bool indicates whether the checksum was corrupted
+    pub(super) fn from_bytes(data: &[u8]) -> Result<(Self, bool), DatabaseError> {
         let checksum = Checksum::from_le_bytes(
             data[SLOT_CHECKSUM_OFFSET..(SLOT_CHECKSUM_OFFSET + size_of::<Checksum>())]
                 .try_into()
                 .unwrap(),
         );
         let corrupted = checksum != xxh3_checksum(&data[..SLOT_CHECKSUM_OFFSET]);
+        let version = data[VERSION_OFFSET];
+        // The version byte is covered by the slot checksum, so in a slot that failed
+        // verification it can hold anything a torn write left behind. Version errors for such
+        // slots are raised by the caller, which can see whether the other slot verified.
+        if !corrupted {
+            Self::check_version(version)?;
+        }
 
         let user_root = if data[USER_ROOT_NON_NULL_OFFSET] != 0 {
             Some(BtreeHeader::from_le_bytes(
@@ -893,6 +911,79 @@ mod test {
             &header[secondary_offset..secondary_offset + super::TRANSACTION_SIZE],
             &torn_secondary,
             "recovery laundered the torn secondary slot into a valid one"
+        );
+    }
+
+    // A torn write can leave anything in a commit slot, including in its version byte. A slot
+    // that fails checksum verification must be handled as a torn slot by the repair logic, not
+    // fail the open outright -- nor report a missing upgrade, when the garbage matches an old
+    // format version.
+    #[test]
+    fn torn_slot_version_byte_is_repaired() {
+        for garbage in [super::FILE_FORMAT_VERSION1, 0xF3] {
+            let tmpfile = crate::create_tempfile();
+            create_database_with_one_table(tmpfile.path());
+
+            let mut file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(tmpfile.path())
+                .unwrap();
+            let mut header = [0u8; DB_HEADER_SIZE];
+            file.read_exact(&mut header).unwrap();
+            let secondary_offset =
+                if primary_slot_offset(header[GOD_BYTE_OFFSET]) == TRANSACTION_0_OFFSET {
+                    TRANSACTION_1_OFFSET
+                } else {
+                    TRANSACTION_0_OFFSET
+                };
+            // Tear the secondary slot's version byte and mark the file as a crashed 1-phase
+            // commit, so that a full repair runs
+            header[secondary_offset + super::VERSION_OFFSET] = garbage;
+            header[GOD_BYTE_OFFSET] |= RECOVERY_REQUIRED;
+            header[GOD_BYTE_OFFSET] &= !TWO_PHASE_COMMIT;
+            file.seek(SeekFrom::Start(0)).unwrap();
+            file.write_all(&header).unwrap();
+            file.sync_all().unwrap();
+            drop(file);
+
+            let db = Database::open(tmpfile.path()).unwrap();
+            let txn = db.begin_read().unwrap();
+            let table = txn.open_table(X).unwrap();
+            assert_eq!(table.get("k").unwrap().unwrap().value(), "v");
+        }
+    }
+
+    // Pre-v3 files have no v3-checksummed commit slot, so the version bytes are the only
+    // evidence of their format. They must be reported as UpgradeRequired, not as corruption.
+    #[test]
+    fn old_file_format_reports_upgrade_required() {
+        let tmpfile = crate::create_tempfile();
+        create_database_with_one_table(tmpfile.path());
+
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(tmpfile.path())
+            .unwrap();
+        let mut header = [0u8; DB_HEADER_SIZE];
+        file.read_exact(&mut header).unwrap();
+        // Give both slots an old version byte; their checksums no longer verify, just like a
+        // genuine pre-v3 file's slots, which are laid out differently
+        header[TRANSACTION_0_OFFSET + super::VERSION_OFFSET] = super::FILE_FORMAT_VERSION1;
+        header[TRANSACTION_1_OFFSET + super::VERSION_OFFSET] = super::FILE_FORMAT_VERSION1;
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.write_all(&header).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+
+        let err = Database::open(tmpfile.path()).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                DatabaseError::UpgradeRequired(super::FILE_FORMAT_VERSION1)
+            ),
+            "expected UpgradeRequired, got {err:?}"
         );
     }
 


### PR DESCRIPTION
Fixes the crash-hardening gap where a torn commit slot could make the database unopenable.

## Problem

The version byte is the first byte of a commit slot, inside the checksummed region, so a torn slot write — the crash case the slot checksums exist to detect — can leave any value in it. `TransactionHeader::from_bytes` validated the version byte *before* computing the checksum and propagated the error, so a slot torn in that byte failed the whole open with `Corrupted` — or with a misleading `UpgradeRequired(1)`/`UpgradeRequired(2)` when the garbage happened to match an old format version — even though the other slot was intact and repair would have recovered everything.

## Fix

- `TransactionHeader::from_bytes` now computes the checksum first and validates the version byte only when the slot verifies. A slot that fails verification is handled like any other torn slot: flagged corrupt (its raw bytes preserved via `corrupt_bytes`), with repair falling back to the other slot.
- Pre-v3 files have no v3-checksummed slot at all, so when *neither* slot verifies, `UnrepairedDatabaseHeader::from_bytes` still interprets the version bytes — genuinely old files keep reporting `UpgradeRequired`, and files written by a future format keep reporting the version in the error. A v3 database always has at least one verified slot (only one slot is ever mid-write), so this fallback doesn't weaken the new leniency.
- `write_secondary_slot` resets the slot's version byte when overwriting it, since the previous contents may have been a torn write whose version never verified.

Behavior is unchanged for every case except the torn-version-byte one: verified slots get the same version errors as before, and a doubly-corrupted v3 file still fails with the same errors as today.

## Testing

- New test `torn_slot_version_byte_is_repaired`: tears the secondary slot's version byte (both to `0xF3` garbage and to `FILE_FORMAT_VERSION1`, the misleading-`UpgradeRequired` case), marks the file as a crashed 1-phase commit, and verifies the database opens with data intact. Fails with `UpgradeRequired`/`Corrupted` without the fix.
- New test `old_file_format_reports_upgrade_required`: sets both slots' version bytes to `FILE_FORMAT_VERSION1` (matching a genuine pre-v3 file, whose slots never verify under the v3 layout) and verifies the open still fails with `UpgradeRequired`. Fails with `Corrupted("Primary is corrupted despite 2-phase commit")` if the both-slots-corrupt fallback is removed.
- Both tests were verified to fail with their respective guard reverted.
- `cargo fmt --check`, `clippy --all-targets --all-features` with denied warnings, and `cargo test --all-features` (20 suites, 0 failures) all pass.

Note: the transaction-id monotonicity assert discussed alongside this item needed no change — it already landed in `commit()` as part of #1386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9JyGa3HvJ7gmSkG4HE8Xr)_