### PR TITLE
Shorten separators for Option keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
   nodes store the result instead of a whole key, so more children fit in each node and lookups
   touch fewer pages. The default implementation returns a whole key, leaving existing `Key`
   implementations unchanged; `&[u8]`, `&str`, and `String` keys now store minimal prefixes.
+  `Option` keys shorten their payload, when the wrapped type is variable width.
 * Fix a crash shortly after a commit being able to silently roll that commit back during
   recovery, if `check_integrity()` had previously repaired the database.
 * Fix iterators silently omitting data when iteration continues after an error. An iterator

--- a/src/types.rs
+++ b/src/types.rs
@@ -391,6 +391,29 @@ impl<T: Key> Key for Option<T> {
             }
         }
     }
+
+    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
+        // A fixed width `T` makes `Option<T>` fixed width too, and its encodings are compared at
+        // that width, so nothing shorter than `left` may be returned
+        if T::fixed_width().is_some() {
+            return Cow::Borrowed(left);
+        }
+        // `None` sorts below every `Some` and encodes as the tag alone, so nothing is shorter
+        if left[0] == 0 {
+            return Cow::Borrowed(left);
+        }
+        // Both are `Some`, so a separator between the payloads, behind the same tag, separates
+        // the two. Which input the payload came from is not visible here, so the result is
+        // assembled rather than borrowed.
+        let payload = T::separator(&left[1..], &right[1..]);
+        if payload.len() + 1 >= left.len() {
+            return Cow::Borrowed(left);
+        }
+        let mut separator = Vec::with_capacity(payload.len() + 1);
+        separator.push(1);
+        separator.extend_from_slice(&payload);
+        Cow::Owned(separator)
+    }
 }
 
 impl Value for &[u8] {
@@ -907,6 +930,36 @@ mod tests {
                 separator
             );
         }
+    }
+
+    #[test]
+    fn option_separator() {
+        // (left, right, the shortest separator)
+        let cases: &[(Option<&str>, Option<&str>, &[u8])] = &[
+            // The payloads separate as `&str` does, behind the `Some` tag
+            (Some("abc0suffix"), Some("abc1suffix"), b"\x01abc1"),
+            // `None` encodes as the tag alone, so nothing is shorter
+            (None, Some("abc"), b"\x00"),
+            // Nothing shorter than `left` sorts above it
+            (Some("abc"), Some("abd-suffix"), b"\x01abc"),
+        ];
+
+        for &(left, right, expected) in cases {
+            let left = <Option<&str> as Value>::as_bytes(&left);
+            let right = <Option<&str> as Value>::as_bytes(&right);
+            let separator = <Option<&str> as Key>::separator(&left, &right);
+            assert_eq!(separator, expected);
+            assert!(<Option<&str> as Key>::compare(&left, &separator).is_le());
+            assert!(<Option<&str> as Key>::compare(&separator, &right).is_lt());
+        }
+    }
+
+    // `Option<T>` of a fixed width `T` is itself fixed width, so it must not shorten
+    #[test]
+    fn fixed_width_option_separator_returns_full_key() {
+        let left = <Option<u64> as Value>::as_bytes(&Some(1));
+        let right = <Option<u64> as Value>::as_bytes(&Some(2));
+        assert_eq!(<Option<u64> as Key>::separator(&left, &right), left);
     }
 
     #[test]

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -3392,6 +3392,103 @@ fn str_keys_with_multibyte_characters() {
     assert!(iter.next().is_none());
 }
 
+// An `Option` separator is the payload's, behind the `Some` tag, so it must route and iterate
+// correctly with that cut embedded in the larger encoding
+#[test]
+fn option_keys_with_shortened_separators() {
+    const TABLE: TableDefinition<Option<&str>, u64> = TableDefinition::new("option");
+    const NUM_KEYS: u64 = 2_000;
+    // A long shared suffix, so a separator that cuts at the first difference saves most of the key
+    let key = |i: u64| format!("{i:08}{}", "-suffix".repeat(16));
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(TABLE).unwrap();
+        for i in 0..NUM_KEYS {
+            table.insert(&Some(key(i).as_str()), &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(TABLE).unwrap();
+    assert!(table.stats().unwrap().tree_height() > 1);
+    // The keys are zero padded, so insertion order is also the sorted order
+    let mut iter = table.iter().unwrap();
+    for i in 0..NUM_KEYS {
+        let key = key(i);
+        let key = key.as_str();
+        assert_eq!(table.get(&Some(key)).unwrap().unwrap().value(), i);
+        let (actual_key, actual_value) = iter.next().unwrap().unwrap();
+        assert_eq!(actual_key.value(), Some(key));
+        assert_eq!(actual_value.value(), i);
+    }
+    assert!(iter.next().is_none());
+    drop(read_txn);
+
+    // Removing most of the keys merges and rebalances branch nodes, reshuffling separators
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(TABLE).unwrap();
+        for i in 0..NUM_KEYS {
+            if i % 4 != 0 {
+                let removed = table.remove(&Some(key(i).as_str())).unwrap();
+                assert_eq!(removed.unwrap().value(), i);
+            }
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(TABLE).unwrap();
+    for i in 0..NUM_KEYS {
+        let value = table
+            .get(&Some(key(i).as_str()))
+            .unwrap()
+            .map(|guard| guard.value());
+        assert_eq!(value, (i % 4 == 0).then_some(i));
+    }
+}
+
+// Keys that differ early separate into a few bytes, while keys of the same size that differ only
+// at the very end have no shorter separator than the whole key, and so pack far fewer children
+#[test]
+fn option_separators_shrink_branch_nodes() {
+    const EARLY: TableDefinition<Option<&str>, u64> = TableDefinition::new("early");
+    const LATE: TableDefinition<Option<&str>, u64> = TableDefinition::new("late");
+    const NUM_KEYS: u64 = 5_000;
+    let suffix = "-suffix".repeat(16);
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut early = write_txn.open_table(EARLY).unwrap();
+        let mut late = write_txn.open_table(LATE).unwrap();
+        for i in 0..NUM_KEYS {
+            early
+                .insert(&Some(format!("{i:08}{suffix}").as_str()), &i)
+                .unwrap();
+            late.insert(&Some(format!("{suffix}{i:08}").as_str()), &i)
+                .unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let early = read_txn.open_table(EARLY).unwrap().stats().unwrap();
+    let late = read_txn.open_table(LATE).unwrap().stats().unwrap();
+    assert_eq!(early.leaf_pages(), late.leaf_pages());
+    assert!(
+        early.branch_pages() * 2 < late.branch_pages(),
+        "{} branch pages, against {} without shortening",
+        early.branch_pages(),
+        late.branch_pages()
+    );
+}
+
 // Branch keys are separators, which need not be valid encodings: nothing may deserialize them
 #[test]
 fn branch_separators_are_not_deserialized() {


### PR DESCRIPTION
`Option<T>` is variable width exactly when `T` is, so it is one of the built-in key types whose branch keys `separator()` can shorten.

Whenever a separator is asked for, both keys are `Some`: `None` sorts below every `Some` and encodes as the tag alone, so it is already the shortest thing that can sit there. The payloads' separator, behind the same tag, then separates the two. The tag is not contiguous with that separator in either input, so the result is assembled — that is what returning a `Cow` allows.

`Option<T>` of a fixed width `T` is fixed width itself, and its encodings are compared at that width, so it keeps returning the whole key.

## Testing

- `option_separator` pins the exact separator bytes for `Option<&str>`, including the `None` and no-shortening cases, and checks the `[left, right)` bounds.
- `fixed_width_option_separator_returns_full_key` covers `Option<u64>`.
- `option_keys_with_shortened_separators` builds a multi-level tree of 2,000 `Option<&str>` keys, checks every lookup and the iteration order, then removes three quarters of them to exercise branch merges and rebalancing, and re-checks. The btree's own debug assertions validate every separator it stores along the way.
- `option_separators_shrink_branch_nodes` stores the same 5,000 equally sized keys twice — differing early in one table, and only at the very end in the other, where no separator can be shorter than the whole key. 3 branch pages against 12.

`cargo fmt --check`, `cargo clippy --all-targets --all-features` and `cargo test --all-features` all pass, as does the `thumbv7em-none-eabihf` no_std check. `just`/podman are unavailable in this environment, so those ran directly rather than through `just test`; no dependencies changed, so `cargo deny check licenses` was not run.

Beyond the committed tests, I checked the contract over several thousand random ordered pairs per type (including nested cases such as `Option<(u64, &str)>` and `[Option<&str>; 2]`), and ran a model based btree test doing random inserts and deletes up to ~27k entries at height 3, matching a `BTreeMap` exactly. That harness was scratch work and is not part of this PR.

## Notes

This is one of three independent PRs applying the same rule to the remaining variable width built-in key types, alongside #1401 (arrays) and #1402 (tuples). They touch different impls and different tests, so only the shared `CHANGELOG.md` line needs a trivial rebase after the first one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcCEQ8N51j9NsV1dLHDnPL