### PR TITLE
Shorten separators for array keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
   `Option` keys shorten their payload, when the wrapped type is variable width.
 * Add `Key::min_encoded_key()`, the encoding of a key type's smallest value. Implementing it is
   optional, and lets container types holding that key store shorter separators.
+* Shorten separators for array keys, when the element type is variable width. Tables with such
+  keys use slightly less space, and lookups are faster.
 * Fix a crash shortly after a commit being able to silently roll that commit back during
   recovery, if `check_integrity()` had previously repaired the database.
 * Fix iterators silently omitting data when iteration continues after an error. An iterator

--- a/src/types.rs
+++ b/src/types.rs
@@ -626,6 +626,78 @@ impl<const N: usize, T: Key> Key for [T; N] {
         }
         Ordering::Equal
     }
+
+    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
+        // A fixed width element type makes the array fixed width too, and its encodings are
+        // compared at that width, so nothing shorter than `left` may be returned
+        if T::fixed_width().is_some() {
+            return Cow::Borrowed(left);
+        }
+        // Only the element the two first differ in can be shortened: the elements before it are
+        // needed for the result to sort below `right`. The elements after it can be replaced by
+        // the smallest encoding, but only once the shortened element sorts strictly above
+        // `left`'s, so that both comparisons resolve there and never read what follows.
+        let header = size_of::<u32>() * N;
+
+        for i in 0..N {
+            let left_element = array_element::<N>(left, i);
+            let right_element = array_element::<N>(right, i);
+            if T::compare(left_element, right_element).is_eq() {
+                continue;
+            }
+            let separator = T::separator(left_element, right_element);
+            // There is a tail to replace only when this is not the last element, and it may only
+            // be replaced once this element sorts strictly above `left`'s. `min_encoded_key()`
+            // may allocate, so it is asked only when the answer will be used.
+            let replaces_tail = i + 1 < N && T::compare(left_element, &separator).is_lt();
+            let min = replaces_tail.then(T::min_encoded_key).flatten();
+            let tail = min.as_deref();
+            let mut elements: Vec<&[u8]> = Vec::with_capacity(N);
+            elements.extend((0..i).map(|j| array_element::<N>(left, j)));
+            elements.push(&separator);
+            elements
+                .extend(((i + 1)..N).map(|j| tail.unwrap_or_else(|| array_element::<N>(left, j))));
+
+            // A separator longer than the whole key is no use, however it was assembled. A
+            // smallest encoding longer than the element it replaces can make it longer, so this
+            // is checked before building it, which also keeps every end offset within a `u32`.
+            let total = elements
+                .iter()
+                .map(|x| x.len())
+                .fold(header, usize::saturating_add);
+            if total >= left.len() {
+                return Cow::Borrowed(left);
+            }
+            let mut result = Vec::with_capacity(total);
+            let mut end = header;
+            for element in &elements {
+                end += element.len();
+                result.extend_from_slice(&u32::try_from(end).unwrap().to_le_bytes());
+            }
+            for element in &elements {
+                result.extend_from_slice(element);
+            }
+            return Cow::Owned(result);
+        }
+        // Every element compared equal, so `left` does not sort below `right`
+        Cow::Borrowed(left)
+    }
+}
+
+// The `index`th element of an array encoding of `N` variable width elements
+fn array_element<const N: usize>(data: &[u8], index: usize) -> &[u8] {
+    let start = if index == 0 {
+        size_of::<u32>() * N
+    } else {
+        array_end_offset(data, index - 1)
+    };
+    &data[start..array_end_offset(data, index)]
+}
+
+// The end offset an array encoding stores for its `index`th element
+fn array_end_offset(data: &[u8], index: usize) -> usize {
+    let range = size_of::<u32>() * index..size_of::<u32>() * (index + 1);
+    u32::from_le_bytes(data[range].try_into().unwrap()) as usize
 }
 
 impl Value for &str {
@@ -990,6 +1062,150 @@ mod tests {
         let left = <Option<u64> as Value>::as_bytes(&Some(1));
         let right = <Option<u64> as Value>::as_bytes(&Some(2));
         assert_eq!(<Option<u64> as Key>::separator(&left, &right), left);
+    }
+
+    #[test]
+    fn array_separator() {
+        // (left, right, the shortest separator)
+        let cases: &[([&str; 2], [&str; 2], [&str; 2])] = &[
+            // The shortened element sorts strictly above `left`'s, so the tail is discarded
+            (
+                ["abc0suffix", "left"],
+                ["abc1suffix", "right"],
+                ["abc1", ""],
+            ),
+            // Shortening the last element leaves the elements before it alone
+            (
+                ["same", "abc0suffix"],
+                ["same", "abc1suffix"],
+                ["same", "abc1"],
+            ),
+            // Nothing sorts between these first elements, so the tail has to stay: a separator
+            // equal to `left`'s element does not resolve the comparison against `left`
+            (["abc", "tail"], ["abc-suffix", "x"], ["abc", "tail"]),
+        ];
+
+        for &(left, right, expected) in cases {
+            let left = <[&str; 2] as Value>::as_bytes(&left);
+            let right = <[&str; 2] as Value>::as_bytes(&right);
+            let separator = <[&str; 2] as Key>::separator(&left, &right);
+            assert_eq!(separator, <[&str; 2] as Value>::as_bytes(&expected));
+            assert!(<[&str; 2] as Key>::compare(&left, &separator).is_le());
+            assert!(<[&str; 2] as Key>::compare(&separator, &right).is_lt());
+            assert!(separator.len() <= left.len());
+        }
+    }
+
+    // A key type whose smallest value encodes to more bytes than an ordinary one. Nothing stops
+    // an implementation from being shaped this way, so substituting the minimum into a separator
+    // has to be able to make the result longer rather than shorter.
+    #[derive(Debug)]
+    struct WideMinimum;
+
+    const WIDE_MINIMUM: [u8; 64] = [0; 64];
+
+    impl Value for WideMinimum {
+        type SelfType<'a> = &'a [u8];
+        type AsBytes<'a>
+            = &'a [u8]
+        where
+            Self: 'a;
+
+        fn fixed_width() -> Option<usize> {
+            None
+        }
+
+        fn from_bytes<'a>(data: &'a [u8]) -> &'a [u8]
+        where
+            Self: 'a,
+        {
+            data
+        }
+
+        fn as_bytes<'a, 'b: 'a>(value: &'a &'b [u8]) -> &'a [u8]
+        where
+            Self: 'b,
+        {
+            value
+        }
+
+        fn type_name() -> TypeName {
+            TypeName::new("test::WideMinimum")
+        }
+    }
+
+    impl Key for WideMinimum {
+        // Sorts as its bytes, except that the smallest value sorts below everything
+        fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+            match (data1 == WIDE_MINIMUM, data2 == WIDE_MINIMUM) {
+                (true, true) => Ordering::Equal,
+                (true, false) => Ordering::Less,
+                (false, true) => Ordering::Greater,
+                (false, false) => data1.cmp(data2),
+            }
+        }
+
+        // A prefix of `right` separates any two values that are not the smallest one, which is
+        // all this type is used with
+        fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
+            <&[u8] as Key>::separator(left, right)
+        }
+
+        fn min_encoded_key() -> Option<Cow<'static, [u8]>> {
+            Some(Cow::Borrowed(&WIDE_MINIMUM))
+        }
+    }
+
+    // Discarding an element replaces it with the smallest encoding, which can be longer than the
+    // element it replaces. The whole key is kept when that would make the separator longer.
+    #[test]
+    fn separator_is_not_grown_by_a_wide_minimum() {
+        type Key3 = [WideMinimum; 3];
+
+        // It really is a minimum: at or below every value, including itself
+        assert!(WideMinimum::compare(&WIDE_MINIMUM, b"a").is_lt());
+        assert!(WideMinimum::compare(b"a", &WIDE_MINIMUM).is_gt());
+        assert!(WideMinimum::compare(&WIDE_MINIMUM, &WIDE_MINIMUM).is_eq());
+
+        let left = <Key3 as Value>::as_bytes(&[b"aaa", b"x", b"y"]);
+        let right = <Key3 as Value>::as_bytes(&[b"bbb", b"x", b"y"]);
+        // Shortening the first element saves two bytes, but the two the tail would discard to
+        // cost 64 each
+        let separator = <Key3 as Key>::separator(&left, &right);
+        assert_eq!(separator, left);
+        // ...and it is an encoding of the key type, as every separator must be
+        let value = <Key3 as Value>::from_bytes(&separator);
+        assert_eq!(<Key3 as Value>::as_bytes(&value), separator.as_ref());
+    }
+
+    // An array of a fixed width element type is itself fixed width, so it must not shorten
+    #[test]
+    fn fixed_width_array_separator_returns_full_key() {
+        let left = <[u64; 2] as Value>::as_bytes(&[1, 1]);
+        let right = <[u64; 2] as Value>::as_bytes(&[2, 2]);
+        assert_eq!(<[u64; 2] as Key>::separator(&left, &right), left);
+    }
+
+    // A discarded element is replaced by its own smallest encoding, not by nothing. A lookup key
+    // that matches the separator up to the discarded element is compared against it, and `Option`
+    // reads a tag byte, so an empty element would leave `compare()` indexing past the end.
+    #[test]
+    fn discarded_array_elements_stay_readable_by_compare() {
+        type Key2 = [Option<&'static str>; 2];
+        let left = <Key2 as Value>::as_bytes(&[Some("aaaa"), Some("zzzz")]);
+        let right = <Key2 as Value>::as_bytes(&[Some("bbbb"), Some("yyyy")]);
+        let separator = <Key2 as Key>::separator(&left, &right);
+        assert_eq!(
+            separator,
+            // The `Some("b")` the first element shortened to, then `None` in place of the second
+            <Key2 as Value>::as_bytes(&[Some("b"), None])
+        );
+        assert!(<Key2 as Key>::compare(&left, &separator).is_le());
+        assert!(<Key2 as Key>::compare(&separator, &right).is_lt());
+
+        // The comparison a lookup makes once its first element matches the separator's
+        let probe = <Key2 as Value>::as_bytes(&[Some("b"), Some("x")]);
+        assert!(<Key2 as Key>::compare(&probe, &separator).is_gt());
     }
 
     fn assert_least<K: Key>(value: &K::SelfType<'_>) {

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -3488,6 +3488,112 @@ fn option_separators_shrink_branch_nodes() {
     );
 }
 
+// An array separator shortens one element, discards those after it, and shifts every end offset
+// from there on, so it must route and iterate correctly with that rewritten header
+#[test]
+fn array_keys_with_shortened_separators() {
+    const TABLE: TableDefinition<[&str; 2], u64> = TableDefinition::new("array");
+    const NUM_KEYS: u64 = 2_000;
+    // The first element decides the order, and runs past the digits that distinguish adjacent
+    // keys so that its separator can truncate and land strictly above the left key's. The second
+    // is long enough to dominate the key.
+    let head = |i: u64| format!("{i:08}{}", "-head".repeat(8));
+    let tail = |i: u64| format!("{i:04}{}", "-suffix".repeat(16));
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(TABLE).unwrap();
+        for i in 0..NUM_KEYS {
+            let (head, tail) = (head(i), tail(i));
+            table.insert(&[head.as_str(), tail.as_str()], &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(TABLE).unwrap();
+    assert!(table.stats().unwrap().tree_height() > 1);
+    // The heads are zero padded, so insertion order is also the sorted order
+    let mut iter = table.iter().unwrap();
+    for i in 0..NUM_KEYS {
+        let (head, tail) = (head(i), tail(i));
+        let (head, tail) = (head.as_str(), tail.as_str());
+        assert_eq!(table.get(&[head, tail]).unwrap().unwrap().value(), i);
+        let (actual_key, actual_value) = iter.next().unwrap().unwrap();
+        assert_eq!(actual_key.value(), [head, tail]);
+        assert_eq!(actual_value.value(), i);
+    }
+    assert!(iter.next().is_none());
+    drop(read_txn);
+
+    // Removing most of the keys merges and rebalances branch nodes, reshuffling separators
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(TABLE).unwrap();
+        for i in 0..NUM_KEYS {
+            if i % 4 != 0 {
+                let (head, tail) = (head(i), tail(i));
+                let removed = table.remove(&[head.as_str(), tail.as_str()]).unwrap();
+                assert_eq!(removed.unwrap().value(), i);
+            }
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(TABLE).unwrap();
+    for i in 0..NUM_KEYS {
+        let (head, tail) = (head(i), tail(i));
+        let value = table
+            .get(&[head.as_str(), tail.as_str()])
+            .unwrap()
+            .map(|guard| guard.value());
+        assert_eq!(value, (i % 4 == 0).then_some(i));
+    }
+}
+
+// The same keys, differing only in whether the trailing element has a smallest encoding to be
+// discarded to. `&str` does; `[&str; 1]` does not, so its bytes have to be carried into the
+// branch node instead.
+#[test]
+fn array_separators_shrink_branch_nodes() {
+    const DISCARDED: TableDefinition<[&str; 2], u64> = TableDefinition::new("discarded");
+    const CARRIED: TableDefinition<[[&str; 1]; 2], u64> = TableDefinition::new("carried");
+    const NUM_KEYS: u64 = 5_000;
+    let suffix = "-suffix".repeat(16);
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut discarded = write_txn.open_table(DISCARDED).unwrap();
+        let mut carried = write_txn.open_table(CARRIED).unwrap();
+        for i in 0..NUM_KEYS {
+            let head = format!("{i:08}{}", "-head".repeat(8));
+            let tail = format!("{i:04}{suffix}");
+            discarded
+                .insert(&[head.as_str(), tail.as_str()], &i)
+                .unwrap();
+            carried
+                .insert(&[[head.as_str()], [tail.as_str()]], &i)
+                .unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let discarded = read_txn.open_table(DISCARDED).unwrap().stats().unwrap();
+    let carried = read_txn.open_table(CARRIED).unwrap().stats().unwrap();
+    assert!(
+        discarded.branch_pages() * 3 < carried.branch_pages(),
+        "{} branch pages, against {} when the tail cannot be discarded",
+        discarded.branch_pages(),
+        carried.branch_pages()
+    );
+}
+
 // A separator is stored in a branch node and compared against keys, so it has to be an encoding
 // of the key type. Deserializing and re-serializing one reproduces it, as it would any encoding.
 #[test]


### PR DESCRIPTION
`[T; N]` is variable width exactly when `T` is, so it is one of the built-in key types whose branch keys `separator()` can shorten.

Only the element the two keys first differ in can be shortened: the elements before it are needed for the result to sort below the right key. The elements after it are replaced by `min_encoded_key()`, but only once the shortened element sorts **strictly** above the left key's — that is what makes both comparisons resolve at that element and never read what follows. When the shortened element comes back equal to the left key's, the comparison against the left key runs on into the tail, so the tail has to stay.

That strictness gate is what the earlier version of this PR was missing, and why it was closed. Discarding the tail unconditionally corrupted lookups on nested composites. #1406 supplies the other half: an element is discarded to its own smallest *encoding*, not to nothing, so `compare()` can still read it. `[Option<&str>; 2]` is the case that breaks otherwise — `Option::compare()` reads a tag byte, so an empty element leaves it indexing past the end.

The encoding heads each array with one end offset per element, so an assembled separator rewrites every offset. That synthesized result is what returning a `Cow` allows. An array of a fixed width element type is fixed width itself, and its encodings are compared at that width, so it keeps returning the whole key.

Nothing guarantees a smallest encoding is shorter than the element it replaces, so the assembled length is computed and compared against the whole key before anything is allocated. That also bounds every end offset below `left.len()`, which is itself a `u32` in a valid encoding, so writing the header cannot overflow. Stack use is constant in `N`: offsets are read from the header as needed rather than collected.

## Testing

- `array_separator` pins the exact separator bytes for `[&str; 2]` — a shortened leading element with the tail discarded, a shortened last element, and the case where nothing sorts between the two first elements so the tail stays — and checks the `[left, right)` bounds.
- `discarded_array_elements_stay_readable_by_compare` covers `[Option<&str>; 2]`: the discarded element comes out as `None`, not empty, and a lookup key that matches the separator's first element still compares correctly against it.
- `separator_is_not_grown_by_a_wide_minimum` uses a conforming `WideMinimum` key type whose smallest value encodes to 64 bytes. Without the length check, `[WideMinimum; 3]` turned a 17 byte key into a 141 byte separator.
- `fixed_width_array_separator_returns_full_key` covers `[u64; 2]`.
- `array_keys_with_shortened_separators` builds a multi-level tree of 2,000 `[&str; 2]` keys whose separators discard the trailing element, checks every lookup and the iteration order, then removes three quarters of them to exercise branch merges and rebalancing, and re-checks. The btree's own debug assertions validate every separator it stores along the way.
- `array_separators_shrink_branch_nodes` stores the same 5,000 keys twice, as `[&str; 2]` and as `[[&str; 1]; 2]` — identical bytes, differing only in whether the trailing element has a smallest encoding to discard to. 5 branch pages against 19.
- `separators_are_encodings` (already on master, from #1405) starts exercising `[&str; 2]`, `[&str; 3]` and `[Option<&str>; 2]` with this change.

`cargo fmt --check`, `cargo clippy --all-targets --all-features` and `cargo test --all-features` all pass, as does the `thumbv7em-none-eabihf` no_std check. `just`/podman are unavailable in this environment, so those ran directly rather than through `just test`; no dependencies changed, so `cargo deny check licenses` was not run.

Beyond the committed tests, I checked the contract over several thousand random ordered pairs per type (including nested cases such as `[Option<&str>; 2]`), and ran a model based btree test doing random inserts and deletes up to ~20k `[&str; 3]` entries at height 3, matching a `BTreeMap` exactly. That harness was scratch work and is not part of this PR.

Codecov flags two spots, both deliberate: the `Cow::Borrowed(left)` after the element loop, reached only when every element compares equal, which the method's precondition rules out; and `WideMinimum::type_name()`, which the test type has to define but nothing calls.

## Notes

#1406, which adds `min_encoded_key()`, has merged, so this targets master directly. #1402 does the same for tuples, and conflicts with this one only on the `CHANGELOG.md` entry. Both carry their own copy of the `WideMinimum` test type, since neither depends on the other.

Arrays could now supply a `min_encoded_key()` of their own — concatenating their elements' — which the associated const this started as could not express. Left out here to keep this to one change; it would let an array nested inside another composite be discarded too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcCEQ8N51j9NsV1dLHDnPL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcCEQ8N51j9NsV1dLHDnPL)_