### PR TITLE
Shorten separators for tuple keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@
   optional, and lets container types holding that key store shorter separators.
 * Shorten separators for array keys, when the element type is variable width. Tables with such
   keys use slightly less space, and lookups are faster.
+* Shorten separators for tuple keys, when at least one element type is variable width. Tables
+  with such keys use slightly less space, and lookups are faster.
 * Fix a crash shortly after a commit being able to silently roll that commit back during
   recovery, if `check_integrity()` had previously repaired the database.
 * Fix iterators silently omitting data when iteration continues after an error. An iterator

--- a/src/tuple_types.rs
+++ b/src/tuple_types.rs
@@ -65,6 +65,164 @@ fn not_equal<T: Key>(data1: &[u8], data2: &[u8]) -> Option<Ordering> {
     }
 }
 
+// The `Key` operations of one element's type, so that `tuple_separator()`, which is generic only
+// over the number of elements, can call them
+#[derive(Clone, Copy)]
+struct ElementType {
+    fixed_width: Option<usize>,
+    min_encoded_key: fn() -> Option<Cow<'static, [u8]>>,
+    compare: fn(&[u8], &[u8]) -> Ordering,
+    separator: for<'a> fn(&'a [u8], &'a [u8]) -> Cow<'a, [u8]>,
+}
+
+impl ElementType {
+    fn of<T: Key>() -> Self {
+        Self {
+            fixed_width: T::fixed_width(),
+            min_encoded_key: T::min_encoded_key,
+            compare: T::compare,
+            separator: T::separator,
+        }
+    }
+
+    // An encoding that sorts strictly between `left` and `right`, or `None` when the type does
+    // not offer one: `separator()` only guarantees a result in `[left, right)`
+    fn between<'a>(&self, left: &'a [u8], right: &'a [u8]) -> Option<Cow<'a, [u8]>> {
+        let separator = (self.separator)(left, right);
+        if (self.compare)(left, &separator).is_lt() {
+            Some(separator)
+        } else {
+            None
+        }
+    }
+
+    // The smallest encoding of the type, or `fallback` for a type that has none
+    fn smallest_or<'a>(&self, fallback: &'a [u8]) -> Cow<'a, [u8]> {
+        match (self.min_encoded_key)() {
+            Some(smallest) => smallest,
+            None => Cow::Borrowed(fallback),
+        }
+    }
+}
+
+// The elements of a variable width tuple encoding: the `N` leading ones, whose lengths the header
+// gives, then the last, which runs to the end
+fn split_elements<const N: usize>(fixed_width: [Option<usize>; N], data: &[u8]) -> Vec<&[u8]> {
+    let (header, lens) = parse_lens::<N>(fixed_width, data);
+    let mut elements = Vec::with_capacity(N + 1);
+    let mut offset = header;
+    for len in lens {
+        elements.push(&data[offset..(offset + len)]);
+        offset += len;
+    }
+    elements.push(&data[offset..]);
+    elements
+}
+
+// Lexicographically compares two tuples, given as their encoded elements
+fn compare_elements<A: AsRef<[u8]>, B: AsRef<[u8]>>(
+    types: &[ElementType],
+    a: &[A],
+    b: &[B],
+) -> Ordering {
+    for i in 0..types.len() {
+        let ordering = (types[i].compare)(a[i].as_ref(), b[i].as_ref());
+        if !ordering.is_eq() {
+            return ordering;
+        }
+    }
+    Ordering::Equal
+}
+
+// Encodes the tuple with these elements, or returns `None` when the encoding would be at least
+// as long as `left`. The length is checked first, so an oversized encoding -- a smallest
+// encoding can be longer than the element it replaced -- is never built.
+fn encode_if_shorter(
+    types: &[ElementType],
+    elements: &[Cow<'_, [u8]>],
+    left: &[u8],
+) -> Option<Vec<u8>> {
+    // A fixed width element's length is not recorded, so a replacement must be exactly that wide
+    debug_assert!(types.iter().zip(elements).all(|(element_type, element)| {
+        element_type
+            .fixed_width
+            .is_none_or(|width| element.len() == width)
+    }));
+    // Length varints for every variable width element but the last, whose length is implicit.
+    // They are rebuilt rather than copied, since a replaced element's length may differ.
+    let mut result = Vec::with_capacity(left.len());
+    for i in 0..(elements.len() - 1) {
+        if types[i].fixed_width.is_none() {
+            encode_varint_len(elements[i].len(), &mut result);
+        }
+    }
+    let mut total = result.len();
+    for element in elements {
+        total = total.saturating_add(element.len());
+    }
+    if total >= left.len() {
+        return None;
+    }
+    for element in elements {
+        result.extend_from_slice(element);
+    }
+    Some(result)
+}
+
+// The separator between two encodings of a variable width tuple. `leading` describes every
+// element but the last, whose length is implicit and which `last` describes.
+fn tuple_separator<'a, const N: usize>(
+    leading: [ElementType; N],
+    last: ElementType,
+    left: &'a [u8],
+    right: &'a [u8],
+) -> Cow<'a, [u8]> {
+    let fixed_width: [Option<usize>; N] = core::array::from_fn(|i| leading[i].fixed_width);
+    let types: Vec<ElementType> = leading.into_iter().chain([last]).collect();
+    let left_elements = split_elements(fixed_width, left);
+    let right_elements = split_elements(fixed_width, right);
+
+    let mut differing = None;
+    for i in 0..types.len() {
+        if !(types[i].compare)(left_elements[i], right_elements[i]).is_eq() {
+            differing = Some(i);
+            break;
+        }
+    }
+    // `left` sorts below `right`, so some element differs
+    let Some(index) = differing else {
+        return Cow::Borrowed(left);
+    };
+
+    // The candidate: the elements the two keys share, then one that sorts above `left`'s --
+    // between the differing pair when the type offers that, `right`'s own otherwise -- then the
+    // smallest encoding of each remaining type, or `right`'s element where a type has none
+    let mut elements = Vec::with_capacity(types.len());
+    for &bytes in &left_elements[..index] {
+        elements.push(Cow::Borrowed(bytes));
+    }
+    match types[index].between(left_elements[index], right_elements[index]) {
+        Some(between) => elements.push(between),
+        None => elements.push(Cow::Borrowed(right_elements[index])),
+    }
+    for (element_type, &bytes) in types[(index + 1)..]
+        .iter()
+        .zip(&right_elements[(index + 1)..])
+    {
+        elements.push(element_type.smallest_or(bytes));
+    }
+
+    // The candidate sorts above `left`, since its element at `index` does, but collapsing may
+    // have left it at or above `right`
+    if compare_elements(&types, &elements, &right_elements).is_ge() {
+        return Cow::Borrowed(left);
+    }
+    match encode_if_shorter(&types, &elements, left) {
+        Some(separator) => Cow::Owned(separator),
+        None => Cow::Borrowed(left),
+    }
+}
+
 macro_rules! fixed_width_impl {
     ( $( $t:ty ),+ ) => {
         {
@@ -276,6 +434,20 @@ macro_rules! tuple_impl {
                     compare_variable_impl!(data1, data2 $(,$t,$i)+ | $t_last, $i_last)
                 }
             }
+
+            fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
+                // A fixed width tuple's encodings are compared at that width, so nothing shorter
+                // than `left` may be returned
+                if Self::fixed_width().is_some() {
+                    return Cow::Borrowed(left);
+                }
+                tuple_separator::<$i_last>(
+                    [$(ElementType::of::<$t>(),)+],
+                    ElementType::of::<$t_last>(),
+                    left,
+                    right,
+                )
+            }
         }
     };
 }
@@ -318,6 +490,11 @@ impl<T: Value> Value for (T,) {
 impl<T: Key> Key for (T,) {
     fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
         T::compare(data1, data2)
+    }
+
+    // Encoded and compared exactly as `T`, so it separates the same way
+    fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
+        T::separator(left, right)
     }
 
     // Encoded exactly as `T`, so its smallest value encodes the same way
@@ -438,7 +615,10 @@ tuple_impl! {
 
 #[cfg(test)]
 mod test {
-    use crate::types::Value;
+    use crate::types::{Key, TypeName, Value};
+    use alloc::borrow::Cow;
+    use alloc::format;
+    use core::cmp::Ordering;
 
     #[test]
     fn width() {
@@ -457,6 +637,203 @@ mod test {
         assert_eq!(
             <(&str, u8)>::as_bytes(&("hello", 1)).len(),
             "hello".len() + size_of::<u8>() + size_of::<u8>()
+        );
+    }
+
+    // `expected` is the tuple the separator between `left` and `right` must encode to
+    fn check_separator<K: Key>(
+        left: &K::SelfType<'_>,
+        right: &K::SelfType<'_>,
+        expected: &K::SelfType<'_>,
+    ) {
+        let left = K::as_bytes(left);
+        let right = K::as_bytes(right);
+        let separator = K::separator(left.as_ref(), right.as_ref());
+        assert_eq!(separator.as_ref(), K::as_bytes(expected).as_ref());
+        assert!(K::compare(left.as_ref(), &separator).is_le());
+        assert!(K::compare(&separator, right.as_ref()).is_lt());
+        // A separator has to be an encoding of the key type
+        assert_eq!(
+            K::as_bytes(&K::from_bytes(&separator)).as_ref(),
+            separator.as_ref()
+        );
+    }
+
+    #[test]
+    fn single_element_tuple_separator() {
+        // Encoded exactly as the element, so it separates the same way
+        check_separator::<(&str,)>(&("abc0suffix",), &("abc1suffix",), &("abc1",));
+    }
+
+    #[test]
+    fn last_element_separator() {
+        // The last element stores no length, so shortening it leaves the rest of the encoding
+        // untouched
+        check_separator::<(u64, &str)>(&(7, "abc0suffix"), &(7, "abc1suffix"), &(7, "abc1"));
+    }
+
+    #[test]
+    fn leading_element_separator() {
+        // A shortened leading element's length varint is rewritten, and a `u64`, which has no
+        // smallest encoding, stays `right`'s
+        check_separator::<(&str, u64)>(&("abc0suffix", 1), &("abc1suffix", 2), &("abc1", 2));
+        // ...including when the shortened element is neither the first nor the last
+        check_separator::<(u8, &str, u64)>(
+            &(9, "abc0suffix", 1),
+            &(9, "abc1suffix", 2),
+            &(9, "abc1", 2),
+        );
+        // A varint that shrinks from three bytes to one is rewritten, not just overwritten
+        let long = "x".repeat(300);
+        check_separator::<(&str, u64)>(
+            &(&format!("0{long}"), 1),
+            &(&format!("1{long}"), 2),
+            &("1", 2),
+        );
+    }
+
+    #[test]
+    fn right_element_separator() {
+        // A fixed width element cannot shrink, but `right`'s own sorts strictly above `left`'s,
+        // which is enough to let the elements after it collapse
+        check_separator::<(u64, &str)>(&(1, "suffix"), &(2, "suffix"), &(2, ""));
+        // ...as does a variable width element with no separator above `left`'s, when taking it
+        // whole still costs less than the elements after it
+        check_separator::<(&str, &str)>(&("a", "a long tail"), &("ab", "x"), &("ab", ""));
+    }
+
+    #[test]
+    fn right_element_is_not_taken_without_a_smaller_tail() {
+        // Taking `right`'s element leaves the comparison against `right` to the elements after it,
+        // so `right`'s own already being the smallest encodings would produce `right` itself
+        check_separator::<(u64, &str)>(&(1, "x"), &(2, ""), &(1, "x"));
+        // ...and an element with no smallest encoding cannot be brought below `right`'s at all
+        check_separator::<(u64, [&str; 1])>(&(1, ["x"]), &(2, ["y"]), &(1, ["x"]));
+    }
+
+    #[test]
+    fn elements_after_the_shortened_one_are_discarded() {
+        // The shortened element sorts strictly above `left`'s, so both comparisons resolve there
+        // and the elements after it collapse to their smallest encodings
+        check_separator::<(&str, &str)>(
+            &("abc0suffix", "a long tail"),
+            &("abc1suffix", "another"),
+            &("abc1", ""),
+        );
+        // Elements whose types have no smallest encoding stay `right`'s
+        check_separator::<(&str, [&str; 2])>(
+            &("abc0suffix", ["kept", "here"]),
+            &("abc1suffix", ["other", "values"]),
+            &("abc1", ["other", "values"]),
+        );
+        check_separator::<(&str, u64, &str)>(
+            &("abc0suffix", 7, "a long tail"),
+            &("abc1suffix", 9, "another"),
+            &("abc1", 9, ""),
+        );
+        // `Option` discards down to its tag byte, which is what `None` encodes to
+        check_separator::<(&str, Option<&str>)>(
+            &("abc0suffix", Some("a long tail")),
+            &("abc1suffix", Some("another")),
+            &("abc1", None),
+        );
+        // A fixed width `Option` collapses to its `None`, which is as wide as any `Some`
+        check_separator::<(&str, Option<u64>)>(
+            &("abc0suffix", Some(7)),
+            &("abc1suffix", Some(9)),
+            &("abc1", None),
+        );
+    }
+
+    #[test]
+    fn separator_returns_full_key_when_nothing_is_shorter() {
+        check_separator::<(&str, u64)>(&("abc", 1), &("abd-suffix", 2), &("abc", 1));
+        // ...and when it is the last element that has no shorter separator
+        check_separator::<(u64, &str)>(&(7, "abc"), &(7, "abd-suffix"), &(7, "abc"));
+        // ...and when it is the last element and fixed width
+        check_separator::<(&str, u64)>(&("same", 1), &("same", 2), &("same", 1));
+        // Nothing sorts between these first elements, so only `right`'s own separates, and taking
+        // it whole costs more than collapsing the tail saves
+        check_separator::<(&str, &str)>(&("abc", "tail"), &("abc-suffix", "x"), &("abc", "tail"));
+        // A wholly fixed width tuple is compared at its width, so nothing shorter may be returned
+        check_separator::<(u64, u8)>(&(1, 1), &(2, 2), &(1, 1));
+    }
+
+    // A key type whose smallest value encodes to more bytes than an ordinary one. Nothing stops
+    // an implementation from being shaped this way, so substituting the minimum into a separator
+    // has to be able to make the result longer rather than shorter.
+    #[derive(Debug)]
+    struct WideMinimum;
+
+    const WIDE_MINIMUM: [u8; 64] = [0; 64];
+
+    impl Value for WideMinimum {
+        type SelfType<'a> = &'a [u8];
+        type AsBytes<'a>
+            = &'a [u8]
+        where
+            Self: 'a;
+
+        fn fixed_width() -> Option<usize> {
+            None
+        }
+
+        fn from_bytes<'a>(data: &'a [u8]) -> &'a [u8]
+        where
+            Self: 'a,
+        {
+            data
+        }
+
+        fn as_bytes<'a, 'b: 'a>(value: &'a &'b [u8]) -> &'a [u8]
+        where
+            Self: 'b,
+        {
+            value
+        }
+
+        fn type_name() -> TypeName {
+            TypeName::new("test::WideMinimum")
+        }
+    }
+
+    impl Key for WideMinimum {
+        // Sorts as its bytes, except that the smallest value sorts below everything
+        fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+            match (data1 == WIDE_MINIMUM, data2 == WIDE_MINIMUM) {
+                (true, true) => Ordering::Equal,
+                (true, false) => Ordering::Less,
+                (false, true) => Ordering::Greater,
+                (false, false) => data1.cmp(data2),
+            }
+        }
+
+        // A prefix of `right` separates any two values that are not the smallest one, which is
+        // all this type is used with
+        fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
+            <&[u8] as Key>::separator(left, right)
+        }
+
+        fn min_encoded_key() -> Option<Cow<'static, [u8]>> {
+            Some(Cow::Borrowed(&WIDE_MINIMUM))
+        }
+    }
+
+    // Discarding an element replaces it with the smallest encoding, which can be longer than the
+    // element it replaces. The whole key is kept when that would make the separator longer.
+    #[test]
+    fn separator_is_not_grown_by_a_wide_minimum() {
+        // It really is a minimum: at or below every value, including itself
+        assert!(WideMinimum::compare(&WIDE_MINIMUM, b"a").is_lt());
+        assert!(WideMinimum::compare(b"a", &WIDE_MINIMUM).is_gt());
+        assert!(WideMinimum::compare(&WIDE_MINIMUM, &WIDE_MINIMUM).is_eq());
+
+        // Shortening the first element saves two bytes, but the two the tail would discard to
+        // cost 64 each
+        check_separator::<(WideMinimum, WideMinimum, WideMinimum)>(
+            &(b"aaa", b"x", b"y"),
+            &(b"bbb", b"x", b"y"),
+            &(b"aaa", b"x", b"y"),
         );
     }
 }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -3594,6 +3594,163 @@ fn array_separators_shrink_branch_nodes() {
     );
 }
 
+// A tuple separator shortens one element, discards those after it, and rewrites the length
+// varints that head the encoding, so it must route and iterate correctly with that new header
+#[test]
+fn tuple_keys_with_shortened_separators() {
+    const TUPLE: TableDefinition<(&str, &str), u64> = TableDefinition::new("tuple");
+    const OPTION: TableDefinition<(&str, Option<&str>), u64> = TableDefinition::new("option");
+    const NUM_KEYS: u64 = 2_000;
+    // The first element decides the order, and runs past the digits that distinguish adjacent
+    // keys so that its separator can truncate and land strictly above the left key's. The second
+    // is long enough to dominate the key.
+    let head = |i: u64| format!("{i:08}{}", "-head".repeat(8));
+    let tail = |i: u64| format!("{i:04}{}", "-suffix".repeat(16));
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut tuple_table = write_txn.open_table(TUPLE).unwrap();
+        let mut option_table = write_txn.open_table(OPTION).unwrap();
+        for i in 0..NUM_KEYS {
+            let (head, tail) = (head(i), tail(i));
+            tuple_table
+                .insert(&(head.as_str(), tail.as_str()), &i)
+                .unwrap();
+            option_table
+                .insert(&(head.as_str(), Some(tail.as_str())), &i)
+                .unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let tuple_table = read_txn.open_table(TUPLE).unwrap();
+    let option_table = read_txn.open_table(OPTION).unwrap();
+    assert!(tuple_table.stats().unwrap().tree_height() > 1);
+    assert!(option_table.stats().unwrap().tree_height() > 1);
+    // The heads are zero padded, so insertion order is also the sorted order
+    let mut iter = tuple_table.iter().unwrap();
+    for i in 0..NUM_KEYS {
+        let (head, tail) = (head(i), tail(i));
+        let (head, tail) = (head.as_str(), tail.as_str());
+        assert_eq!(tuple_table.get(&(head, tail)).unwrap().unwrap().value(), i);
+        assert_eq!(
+            option_table
+                .get(&(head, Some(tail)))
+                .unwrap()
+                .unwrap()
+                .value(),
+            i
+        );
+        let (actual_key, actual_value) = iter.next().unwrap().unwrap();
+        assert_eq!(actual_key.value(), (head, tail));
+        assert_eq!(actual_value.value(), i);
+    }
+    assert!(iter.next().is_none());
+    drop(read_txn);
+
+    // Removing most of the keys merges and rebalances branch nodes, reshuffling separators
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut tuple_table = write_txn.open_table(TUPLE).unwrap();
+        for i in 0..NUM_KEYS {
+            if i % 4 != 0 {
+                let (head, tail) = (head(i), tail(i));
+                let removed = tuple_table.remove(&(head.as_str(), tail.as_str())).unwrap();
+                assert_eq!(removed.unwrap().value(), i);
+            }
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let tuple_table = read_txn.open_table(TUPLE).unwrap();
+    for i in 0..NUM_KEYS {
+        let (head, tail) = (head(i), tail(i));
+        let value = tuple_table
+            .get(&(head.as_str(), tail.as_str()))
+            .unwrap()
+            .map(|guard| guard.value());
+        assert_eq!(value, (i % 4 == 0).then_some(i));
+    }
+}
+
+// The same keys, differing only in whether the trailing element has a smallest encoding to be
+// discarded to. `&str` does; `[&str; 1]` does not, so its bytes have to be carried into the
+// branch node instead.
+#[test]
+fn tuple_separators_shrink_branch_nodes() {
+    const DISCARDED: TableDefinition<(&str, &str), u64> = TableDefinition::new("discarded");
+    const CARRIED: TableDefinition<(&str, [&str; 1]), u64> = TableDefinition::new("carried");
+    const NUM_KEYS: u64 = 5_000;
+    let suffix = "-suffix".repeat(16);
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut discarded = write_txn.open_table(DISCARDED).unwrap();
+        let mut carried = write_txn.open_table(CARRIED).unwrap();
+        for i in 0..NUM_KEYS {
+            let head = format!("{i:08}{}", "-head".repeat(8));
+            let tail = format!("{i:04}{suffix}");
+            discarded
+                .insert(&(head.as_str(), tail.as_str()), &i)
+                .unwrap();
+            carried
+                .insert(&(head.as_str(), [tail.as_str()]), &i)
+                .unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let discarded = read_txn.open_table(DISCARDED).unwrap().stats().unwrap();
+    let carried = read_txn.open_table(CARRIED).unwrap().stats().unwrap();
+    assert!(
+        discarded.branch_pages() * 3 < carried.branch_pages(),
+        "{} branch pages, against {} when the tail cannot be discarded",
+        discarded.branch_pages(),
+        carried.branch_pages()
+    );
+}
+
+// Keys that differ in a fixed width leading element, which cannot shrink. Taking `right`'s element
+// whole still lets the tail collapse, which is where nearly the whole key is.
+#[test]
+fn fixed_width_leading_element_separators_shrink_branch_nodes() {
+    const DISCARDED: TableDefinition<(u64, &str), u64> = TableDefinition::new("discarded");
+    const CARRIED: TableDefinition<(u64, [&str; 1]), u64> = TableDefinition::new("carried");
+    const NUM_KEYS: u64 = 5_000;
+    let suffix = "-suffix".repeat(16);
+
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut discarded = write_txn.open_table(DISCARDED).unwrap();
+        let mut carried = write_txn.open_table(CARRIED).unwrap();
+        for i in 0..NUM_KEYS {
+            let tail = format!("{i:04}{suffix}");
+            discarded.insert(&(i, tail.as_str()), &i).unwrap();
+            carried.insert(&(i, [tail.as_str()]), &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let discarded = read_txn.open_table(DISCARDED).unwrap().stats().unwrap();
+    let carried = read_txn.open_table(CARRIED).unwrap().stats().unwrap();
+    assert!(
+        discarded.branch_pages() * 3 < carried.branch_pages(),
+        "{} branch pages, against {} when the tail cannot be discarded",
+        discarded.branch_pages(),
+        carried.branch_pages()
+    );
+}
+
 // A separator is stored in a branch node and compared against keys, so it has to be an encoding
 // of the key type. Deserializing and re-serializing one reproduces it, as it would any encoding.
 #[test]


### PR DESCRIPTION
A tuple is variable width when any element type is, so it is one of the built-in key types whose branch keys `separator()` can shorten. This is the composite most likely to be a real key: `(u64, &str)` and `(&str, u64)` are common table keys.

`tuple_separator()` splits both encodings into their elements, finds the first pair that differ, and builds one candidate: the shared elements, then an element that sorts above the left key's — one strictly between the differing pair when the element type offers it, the right key's own otherwise — then the smallest encoding of each remaining type, or the right key's element where a type has none. The candidate always sorts above the left key, because its element at the differing position does. Whether it sorts below the right key depends on what the tail collapsed to, so that is checked with `compare_elements()` — a lexicographic comparison using the element types' own `compare()` — rather than argued case by case. `(1, "x")` against `(2, "")` is the case that fails it: collapsing produces `(2, "")`, which is the right key itself, so the whole key is kept instead.

That check is what the earlier version of this PR was missing, and why it was closed: discarding the tail unconditionally corrupted lookups on nested composites. #1406 supplies the other half — an element collapses to its type's smallest *encoding*, not to nothing, so `compare()` can still read it. `(&str, Option<&str>)` is the case that breaks otherwise: `Option::compare()` reads a tag byte, so an empty element leaves it indexing past the end. It collapses to `None` instead.

`encode_if_shorter()` then encodes the candidate, rebuilding the length varints — a replaced element's length may differ, and a 300 byte element cut to 4 bytes takes its varint from three bytes down to one — and rejects it before building when it would not be shorter than the whole key, which a smallest encoding longer than the element it replaced can cause. A fixed width element stores no varint, so a replacement must be exactly that wide; every encoding of such a type is, its smallest included, and a `debug_assert` now checks it, since a violation by a nonconforming `Key` implementation would corrupt the encoding silently.

The last element is not a special case: with the encodings split up front it is just the final index, and a candidate whose differing element is the last has no tail to check. `(T,)` delegates to `T`, which it is encoded and compared exactly like.

## Testing

- `single_element_tuple_separator`, `last_element_separator` and `leading_element_separator` pin the exact separator each strictly-between case produces. The last covers a shortened element in the middle of a 3-tuple, and a varint shrinking from three bytes to one.
- `right_element_separator` covers the two shapes that take the right key's element: a fixed width leading element, and a variable width one with nothing strictly between.
- `right_element_is_not_taken_without_a_smaller_tail` covers both ways the collapsed tail can fail to bring the candidate below the right key — the right key's tail already being the smallest encoding, and an element type with no smallest encoding at all.
- `elements_after_the_shortened_one_are_discarded` covers what each kind of trailing element collapses to: `&str` to empty, `Option<&str>` to `None`, a fixed width `Option<u64>` to its equally wide `None`, and a `u64` or `[&str; 2]` (no smallest encoding) staying the right key's.
- `separator_returns_full_key_when_nothing_is_shorter` covers the five ways nothing shorter exists.
- `separator_is_not_grown_by_a_wide_minimum` uses a conforming `WideMinimum` key type whose smallest value encodes to 64 bytes, so collapsing two of them would more than double the key.
- Every one of those goes through `check_separator`, which also checks the `[left, right)` bounds and that the separator is an encoding of the key type.
- `tuple_keys_with_shortened_separators` builds multi-level trees of 2,000 `(&str, &str)` and `(&str, Option<&str>)` keys whose separators collapse the trailing element, checks every lookup and the iteration order, then removes three quarters of them to exercise branch merges and rebalancing, and re-checks. `branch_separator()`'s debug assertions validate the bounds of every separator the tree stores along the way.
- `tuple_separators_shrink_branch_nodes` stores the same 5,000 keys twice, as `(&str, &str)` and as `(&str, [&str; 1])` — identical bytes, differing only in whether the trailing element has a smallest encoding to collapse to. 4 branch pages against 17.
- `fixed_width_leading_element_separators_shrink_branch_nodes` does the same for keys that differ in a fixed width leading element, `(u64, &str)` against `(u64, [&str; 1])`. 3 branch pages against 13; that shape produced 12 before taking the right key's element.
- `separators_are_encodings` (already on master, from #1405) starts exercising `(&str, &str)`, `(&str, u64)`, `(u64, &str)` and `(&str, Option<&str>)` with this change.

`cargo fmt --check`, `cargo clippy --all-targets --all-features` and `cargo test --all-features` all pass, as does the `thumbv7em-none-eabihf` no_std check. `just`/podman are unavailable in this environment, so those ran directly rather than through `just test`; no dependencies changed, so `cargo deny check licenses` was not run. The fuzz harness was not run: its keys are `u64`, which is fixed width, so it never reaches `separator()` at all.

Beyond the committed tests, two scratch harnesses (not part of this PR):

- A randomized contract check over 2,033,944 checks across 17 tuple shapes — including 12-element tuples (the maximum arity), `()` and `bool` and `[u8; 3]` elements, nested composites in every position down to `((&str, (u64, &str)), &str)`, element lengths straddling both varint width boundaries (253/254 and 65535/65536), and byte-string content containing the varint tag bytes. Each separator was checked for the `[left, right)` bounds, the length bound, the encoding round trip, and — the strongest check — against an independent oracle: three random probe keys per pair, asserting `compare(probe, separator)` equals `Ord` on the decoded values, which is exactly the comparison a lookup routed through a branch node performs.
- A model based btree differential test against a `BTreeMap`: 45,000 random inserts and removes of `(&str, &str)` keys in a debug build (every btree debug assertion active), with `check_integrity()`, full-order iteration equality, and random present-and-absent lookups after each of 30 commits, reaching tree height 3, then a full drain to empty. All matched exactly.

Codecov flags two spots in the new code, both deliberate: `WideMinimum::type_name()`, which the test type has to define but nothing calls, and the no-differing-element fallback in `tuple_separator()`, which the `left < right` precondition makes unreachable.

## Notes

Last of the four. #1405 (the `separator()` contract), #1406 (`min_encoded_key()`) and #1401 (arrays) have all merged, and this is rebased on top of them. #1401 carries its own copy of the `WideMinimum` test type, since neither PR depended on the other.

`tuple_separator()` reaches the element operations through `ElementType`, a table of function pointers, because it is generic only over the number of elements — the macro-generated impls are what can name the element types. Those calls stay indirect but are off the hot path: inserting 100k `(&str, &str)` keys makes 1,334,058 element `compare()` calls against 4,525 element `separator()` calls, at ~250ns per separator — under 0.3% of insert time. Element `compare()`, which is the hot one, is statically dispatched and fully inlined.

Tuples could also now supply a `min_encoded_key()` of their own — concatenating their elements' — which the associated const this started as could not express. Left out here to keep this to one change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcCEQ8N51j9NsV1dLHDnPL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcCEQ8N51j9NsV1dLHDnPL)_