### PR TITLE
Require a separator to be an encoding of the key type

### DIFF
--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -29,9 +29,9 @@ pub(super) type Checksum = u128;
 pub(super) const DEFERRED: Checksum = 999;
 
 // The key to store in a branch node between a child whose greatest key is `left` and the next,
-// whose least key is `right`. Branch keys only route lookups -- they are compared, never
-// deserialized -- so a `Key` implementation may shorten them, which packs more children into each
-// branch page.
+// whose least key is `right`. Branch keys only route lookups, so a `Key` implementation may
+// shorten them to any encoding that still sorts between the two, which packs more children into
+// each branch page.
 pub(super) fn branch_separator<'a, K: Key>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
     debug_assert!(K::compare(left, right).is_lt());
     // Branch keys of a fixed width type are stored at that stride, so a shorter separator would
@@ -1833,7 +1833,7 @@ impl<'a: 'b, 'b, T: Page + 'a> BranchAccessor<'a, 'b, T> {
         );
         for i in 0..(self.count_children() - 1) {
             if let Some(child) = self.child_page(i + 1) {
-                // Branch keys are separators, which need not be valid encodings of the key type
+                // Branch keys are separators, which are shortened encodings of the key type
                 let key = self.key(i).unwrap();
                 eprint!(" key_{i}={key:?}");
                 eprint!(" child_{}={child:?}", i + 1);

--- a/src/types.rs
+++ b/src/types.rs
@@ -221,13 +221,12 @@ pub trait Key: Value {
     /// Returns a separator between `left` and `right`.
     ///
     /// `left` and `right` are encoded values for which [`compare()`](Self::compare) returns
-    /// [`Ordering::Less`]. The result must be greater than or equal to `left`, and less than
-    /// `right`, under [`compare()`](Self::compare).
+    /// [`Ordering::Less`]. The result must be an encoding of `Self` that is greater than or equal
+    /// to `left`, and less than `right`, under [`compare()`](Self::compare).
     ///
-    /// The result is only used to route lookups through the btree's internal nodes: it is passed
-    /// to [`compare()`](Self::compare), and never to [`Value::from_bytes()`], so it need not be a
-    /// valid encoding of `Self`. The shorter it is, the more children fit in each internal node,
-    /// which makes the tree shallower and cheaper to search.
+    /// The result is stored in the btree's internal nodes to route lookups. The shorter it is,
+    /// the more children fit in each internal node, which makes the tree shallower and cheaper to
+    /// search. It should never be longer than `left`, which is always available to fall back to.
     ///
     /// Returning [`Cow::Owned`] allows separators synthesized from the inputs, rather than
     /// borrowed from them.

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -9,7 +9,6 @@ use redb::{
     ReadableDatabase, ReadableTable, ReadableTableMetadata, StorageError, TableDefinition,
     TableError, TableHandle, TypeName, Value, WriteTransaction,
 };
-use std::borrow::Cow;
 use std::cmp::Ordering;
 #[cfg(feature = "experimental-api-5")]
 use std::ops::Bound;
@@ -3489,76 +3488,37 @@ fn option_separators_shrink_branch_nodes() {
     );
 }
 
-// Branch keys are separators, which need not be valid encodings: nothing may deserialize them
+// A separator is stored in a branch node and compared against keys, so it has to be an encoding
+// of the key type. Deserializing and re-serializing one reproduces it, as it would any encoding.
 #[test]
-fn branch_separators_are_not_deserialized() {
-    #[derive(Debug)]
-    struct SeparatorKey;
-
-    impl Value for SeparatorKey {
-        type SelfType<'a> = u64;
-        type AsBytes<'a> = [u8; 8];
-
-        fn fixed_width() -> Option<usize> {
-            None
-        }
-
-        fn from_bytes<'a>(data: &'a [u8]) -> u64
-        where
-            Self: 'a,
-        {
-            assert_eq!(data.len(), 8, "separator passed to from_bytes()");
-            (u64::from(data[0]) << 8) | u64::from(data[1])
-        }
-
-        fn as_bytes<'a, 'b: 'a>(value: &'a u64) -> [u8; 8]
-        where
-            Self: 'b,
-        {
-            let mut result = [0; 8];
-            result[0] = u8::try_from(value >> 8).unwrap();
-            result[1] = *value as u8;
-            result
-        }
-
-        fn type_name() -> TypeName {
-            TypeName::new("test::SeparatorKey")
-        }
+fn separators_are_encodings() {
+    fn check<K: Key>(left: &K::SelfType<'_>, right: &K::SelfType<'_>) {
+        let left = K::as_bytes(left);
+        let right = K::as_bytes(right);
+        let separator = K::separator(left.as_ref(), right.as_ref());
+        let value = K::from_bytes(&separator);
+        assert_eq!(
+            K::as_bytes(&value).as_ref(),
+            separator.as_ref(),
+            "separator is not an encoding: {separator:?}"
+        );
     }
 
-    impl Key for SeparatorKey {
-        fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
-            data1.cmp(data2)
-        }
-
-        fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
-            // Every pair of keys differs within the first two bytes, so a separator is always
-            // shorter than the 8 byte encoding, and so always invalid to deserialize
-            let separator = <&[u8] as Key>::separator(left, right);
-            assert!(separator.len() < left.len());
-            separator
-        }
-    }
-
-    const NUM_KEYS: u64 = 1_024;
-    let definition: TableDefinition<SeparatorKey, u64> = TableDefinition::new("separators");
-    let tmpfile = create_tempfile();
-    let db = Database::create(tmpfile.path()).unwrap();
-    let write_txn = db.begin_write().unwrap();
-    {
-        let mut table = write_txn.open_table(definition).unwrap();
-        for i in 0..NUM_KEYS {
-            table.insert(&i, &i).unwrap();
-        }
-    }
-    write_txn.commit().unwrap();
-
-    let read_txn = db.begin_read().unwrap();
-    let table = read_txn.open_table(definition).unwrap();
-    assert!(table.stats().unwrap().tree_height() > 1);
-    for i in 0..NUM_KEYS {
-        assert_eq!(table.get(&i).unwrap().unwrap().value(), i);
-    }
+    check::<&str>(&"abc0suffix", &"abc1suffix");
+    // A cut inside a multi-byte character would leave the separator invalid UTF-8
+    check::<&str>(&"aaaaaa", &"a\u{1d11e}zz");
+    check::<&[u8]>(&b"abc0suffix".as_slice(), &b"abc1suffix".as_slice());
+    check::<String>(&String::from("abc0suffix"), &String::from("abc1suffix"));
+    check::<Option<&str>>(&Some("abc0suffix"), &Some("abc1suffix"));
+    check::<Option<&str>>(&None, &Some("abc"));
+    // Composites assemble their separators, so their headers have to come out consistent
+    check::<(&str, &str)>(&("abc0suffix", "tail"), &("abc1suffix", "other"));
+    check::<(&str, u64)>(&("abc0suffix", 1), &("abc1suffix", 2));
+    check::<(u64, &str)>(&(7, "abc0suffix"), &(7, "abc1suffix"));
+    check::<(&str, Option<&str>)>(&("abc0suffix", Some("tail")), &("abc1suffix", Some("x")));
+    check::<[&str; 2]>(&["abc0suffix", "tail"], &["abc1suffix", "other"]);
+    check::<[&str; 3]>(&["abc0suffix", "a", "b"], &["abc1suffix", "c", "d"]);
+    check::<[Option<&str>; 2]>(&[Some("aaaa"), Some("zzzz")], &[Some("bbbb"), Some("yyyy")]);
 }
 
 #[test]


### PR DESCRIPTION
`separator()` documented the result as needing only to sort between the two keys, and explicitly relaxed it from being a valid encoding:

> it is passed to `compare()`, and never to `Value::from_bytes()`, so it need not be a valid encoding of `Self`

That relaxation is only worth anything to a `Key` whose `compare()` reads byte strings its `from_bytes()` would reject, and it hides an obligation the two ordering bounds do not. A branch key is compared against every key of the type, not just the two it was built from, so bytes that order correctly against those two can still be unreadable against a third — and the two bounds still hold, so testing them does not catch it.

This replaces the relaxation with the plain requirement:

> The result must be an encoding of `Self` that is greater than or equal to `left`, and less than `right`, under `compare()`.

which subsumes the readability obligation, since an encoding is by definition what `compare()` handles.

Nothing in the crate uses the relaxation. `&str` already rounds its cut up to a character boundary to stay valid UTF-8 — its comment says "the cut must keep it valid", which is really the requirement asserting itself despite what the docs allowed. I checked the rest by round-tripping every separator through `from_bytes()`/`as_bytes()` across 13 key shapes, several thousand per shape: all of them already produce encodings.

Also added, from hitting it while writing composite separators: the result should never be longer than `left`, which is always available to fall back to.

## Testing

`branch_separators_are_not_deserialized` existed to pin the relaxation — its `SeparatorKey` deliberately emits invalid separators and asserts redb never deserializes them. That is a test of the promise being dropped, using a type that no longer satisfies the contract, so it is replaced by `separators_are_encodings`, which checks that separators deserialize and re-serialize to themselves across the leaf and composite key types, including a cut that would land inside a multi-byte character.

redb still does not deserialize branch keys; it just no longer promises not to. Two internal comments in `btree_base.rs` that described them as "never deserialized" / "need not be valid encodings" are updated to match.

`cargo fmt --check`, `cargo clippy --all-targets --all-features` and `cargo test --all-features` all pass. `just`/podman are unavailable in this environment, so those ran directly rather than through `just test`; no dependencies changed, so `cargo deny check licenses` was not run.

## Notes

No changelog entry: `separator()` is unreleased, and the 4.3.0 entry never described the relaxation.

This is the first of three. #1406 adds `Key::MIN_ENCODED_KEY`, and the tuple and array separators that use it follow. They touch adjacent lines in `src/types.rs`, so whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcCEQ8N51j9NsV1dLHDnPL