### PR TITLE
Add Key::min_encoded_key()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
   touch fewer pages. The default implementation returns a whole key, leaving existing `Key`
   implementations unchanged; `&[u8]`, `&str`, and `String` keys now store minimal prefixes.
   `Option` keys shorten their payload, when the wrapped type is variable width.
+* Add `Key::min_encoded_key()`, the encoding of a key type's smallest value. Implementing it is
+  optional, and lets container types holding that key store shorter separators.
 * Fix a crash shortly after a commit being able to silently roll that commit back during
   recovery, if `check_integrity()` had previously repaired the database.
 * Fix iterators silently omitting data when iteration continues after an error. An iterator

--- a/src/tuple_types.rs
+++ b/src/tuple_types.rs
@@ -1,5 +1,6 @@
 use crate::complex_types::{decode_varint_len, encode_varint_len};
 use crate::types::{Key, TypeName, Value};
+use alloc::borrow::Cow;
 use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -317,6 +318,11 @@ impl<T: Value> Value for (T,) {
 impl<T: Key> Key for (T,) {
     fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
         T::compare(data1, data2)
+    }
+
+    // Encoded exactly as `T`, so its smallest value encodes the same way
+    fn min_encoded_key() -> Option<Cow<'static, [u8]>> {
+        T::min_encoded_key()
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -236,6 +236,14 @@ pub trait Key: Value {
         debug_assert!(Self::compare(left, right).is_lt());
         Cow::Borrowed(left)
     }
+
+    /// The encoding of the smallest value of `Self`, or `None` when it has no smallest value.
+    ///
+    /// Providing this is optional. It lets container types holding `Self` shorten their
+    /// separators.
+    fn min_encoded_key() -> Option<Cow<'static, [u8]>> {
+        None
+    }
 }
 
 impl Value for () {
@@ -413,6 +421,15 @@ impl<T: Key> Key for Option<T> {
         separator.extend_from_slice(&payload);
         Cow::Owned(separator)
     }
+
+    // `None` sorts below every `Some`
+    fn min_encoded_key() -> Option<Cow<'static, [u8]>> {
+        Some(match T::fixed_width() {
+            // A fixed width `T` pads the tag out to the width of a `Some`
+            Some(width) => Cow::Owned(vec![0; width + 1]),
+            None => Cow::Borrowed(&[0]),
+        })
+    }
 }
 
 impl Value for &[u8] {
@@ -466,6 +483,11 @@ impl Key for &[u8] {
         } else {
             Cow::Borrowed(left)
         }
+    }
+
+    // Encodings order as their bytes, so the empty one sorts below them all
+    fn min_encoded_key() -> Option<Cow<'static, [u8]>> {
+        Some(Cow::Borrowed(&[]))
     }
 }
 
@@ -666,6 +688,11 @@ impl Key for &str {
             Cow::Borrowed(left)
         }
     }
+
+    // The empty string is valid UTF-8, and sorts below every other one
+    fn min_encoded_key() -> Option<Cow<'static, [u8]>> {
+        Some(Cow::Borrowed(&[]))
+    }
 }
 
 impl Value for String {
@@ -711,6 +738,10 @@ impl Key for String {
     // Encoded the same way as `&str`, so it separates the same way
     fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
         <&str as Key>::separator(left, right)
+    }
+
+    fn min_encoded_key() -> Option<Cow<'static, [u8]>> {
+        <&str as Key>::min_encoded_key()
     }
 }
 
@@ -959,6 +990,63 @@ mod tests {
         let left = <Option<u64> as Value>::as_bytes(&Some(1));
         let right = <Option<u64> as Value>::as_bytes(&Some(2));
         assert_eq!(<Option<u64> as Key>::separator(&left, &right), left);
+    }
+
+    fn assert_least<K: Key>(value: &K::SelfType<'_>) {
+        let encoded = K::as_bytes(value);
+        let min = K::min_encoded_key().unwrap();
+        assert!(K::compare(&min, encoded.as_ref()).is_le());
+        assert!(K::compare(&min, &min).is_eq());
+        // It is an encoding like any other, so a fixed width type's is that wide
+        if let Some(width) = K::fixed_width() {
+            assert_eq!(min.len(), width);
+        }
+    }
+
+    #[test]
+    fn min_encoded_keys() {
+        // Types whose encodings order as their bytes bottom out at the empty one
+        assert_eq!(
+            <&[u8] as Key>::min_encoded_key().as_deref(),
+            Some(b"".as_slice())
+        );
+        assert_eq!(
+            <&str as Key>::min_encoded_key().as_deref(),
+            Some(b"".as_slice())
+        );
+        assert_eq!(
+            <String as Key>::min_encoded_key().as_deref(),
+            Some(b"".as_slice())
+        );
+        // `Option` needs its tag, which is also what `None` encodes to
+        assert_eq!(
+            <Option<&str> as Key>::min_encoded_key().as_deref(),
+            Some([0].as_slice())
+        );
+        // A fixed width `T` pads that tag out to the width of a `Some`
+        assert_eq!(
+            <Option<u64> as Key>::min_encoded_key().as_deref(),
+            Some([0; 9].as_slice())
+        );
+        // A one element tuple is encoded exactly as its element
+        assert_eq!(
+            <(&str,) as Key>::min_encoded_key().as_deref(),
+            Some(b"".as_slice())
+        );
+        // Types that do not implement it keep the default
+        assert_eq!(<u64 as Key>::min_encoded_key(), None);
+        assert_eq!(<[&str; 2] as Key>::min_encoded_key(), None);
+        assert_eq!(<(&str, &str) as Key>::min_encoded_key(), None);
+
+        // Every one of them must be something `compare()` accepts, and sort at or below the
+        // encoding of any value
+        assert_least::<&[u8]>(&b"anything".as_slice());
+        assert_least::<&str>(&"anything");
+        assert_least::<String>(&String::from("anything"));
+        assert_least::<Option<&str>>(&Some("anything"));
+        assert_least::<Option<&str>>(&None);
+        assert_least::<Option<u64>>(&Some(1));
+        assert_least::<Option<u64>>(&None);
     }
 
     #[test]


### PR DESCRIPTION
A composite key's separator only has to distinguish two keys up to the element they first differ in. Everything after that can be replaced by something smaller — but only if the element type can say what that is. The empty byte string works for a type whose encodings order as their bytes, and not for one that reads a fixed prefix: `Option` reads a tag byte, so `compare()` would read past the end of an empty element.

`min_encoded_key()` names the encoding of a type's smallest value, so each element type answers for itself:

```rust
fn min_encoded_key() -> Option<Cow<'static, [u8]>> {
    None
}
```

A method rather than an associated const, because the answer can depend on the type's parameters. `Option<T>` is the case in point: for a variable width `T` its smallest value encodes as the tag alone, `[0]`, but a fixed width `T` makes `Option<T>` fixed width too and pads that tag out to `1 + width`. A const cannot branch on `T::fixed_width()`, so it would have to either give the wrong answer for one of the two or be documented as only meaningful for the other. A method just returns the right encoding in both cases. `Cow` for the same reason: a composed one has to be built rather than borrowed from a static.

`Option<_>` rather than a bare byte string for two reasons. As a required member it would break every external `impl Key`; and as a defaulted `&[]` it would silently claim the empty byte string is readable for every type that does not override it, which is exactly the case that is unsafe. The default has to mean "no smallest value".

Supplied by `&[u8]`, `&str` and `String` (the empty byte string), `Option` (its `None` encoding), and a one element tuple (its element's, since it is encoded exactly as its element). Longer tuples and arrays leave it `None` for now; composing one means concatenating their elements', which the tuple and array separator work that follows can do.

Nothing consults it yet. Those separators follow separately, so this can be reviewed as the API decision on its own.

## Testing

`min_encoded_keys` pins the value for each type that supplies one — including both widths of `Option` — checks that the types which do not are `None`, and asserts the general property for every value it has one for: that it is an encoding `compare()` accepts, sorts at or below the encoding of any value of the type, and is `fixed_width()` bytes long when the type has one.

`cargo fmt --check`, `cargo clippy --all-targets --all-features` and `cargo test --all-features` all pass, as does the `thumbv7em-none-eabihf` no_std check. `just`/podman are unavailable in this environment, so those ran directly rather than through `just test`; no dependencies changed, so `cargo deny check licenses` was not run.

## Notes

This is the second of three, after #1405, which tightens `separator()` to require an encoding of the key type — the property that makes a supplied minimum safe to substitute. The tuple and array separators follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcCEQ8N51j9NsV1dLHDnPL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcCEQ8N51j9NsV1dLHDnPL)_