### PR TITLE
API-5 polish: io module visibility, Debug and doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
   target with atomic compare-and-swap -- Cortex-M3 and above, but not Cortex-M0. The file backend
   and everything that opens a database from a path or a `File` are unavailable in that mode, as is
   `ReadOnlyDatabase`; storage is supplied through `Builder::create_with_backend()`, and
-  `StorageBackend` reports failures as `redb::io::Error`, a module redb makes public only in that
-  mode; with std it stays private and the type is `std::io::Error`, as before. The `cache_metrics`,
+  `StorageBackend` reports failures as `redb::io::Error`; the `io` module is public whenever
+  `experimental-api-5` is enabled, and with std it re-exports `std::io::Error`. The `cache_metrics`,
   `chrono_v0_4` and `uuid` features are unavailable there: the first needs 64-bit atomics, and the
   other two link against the standard library. Leaving `experimental-api-5` off keeps the std build
   regardless of the `std` feature, as before.

--- a/src/error.rs
+++ b/src/error.rs
@@ -398,7 +398,7 @@ impl Display for CompactionError {
 
 impl core::error::Error for CompactionError {}
 
-/// Errors related to transactions
+/// Errors related to setting a transaction's durability
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum SetDurabilityError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,12 +107,11 @@ pub mod backends;
 mod complex_types;
 mod db;
 mod error;
-// Public only where it is needed: without std a backend author has to be able to name these types
-// to implement `StorageBackend`. With std they are re-exports of `std::io`, which the caller
-// already has, so the module stays private and redb adds no public surface.
-#[cfg(redb_no_std)]
+// Public under the redb 5 API preview, so a backend author can name the error type in both
+// modes; with std it is a re-export of `std::io`
+#[cfg(feature = "experimental-api-5")]
 pub mod io;
-#[cfg(not(redb_no_std))]
+#[cfg(not(feature = "experimental-api-5"))]
 mod io;
 #[cfg(feature = "experimental-api-5")]
 mod key_range;

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1133,15 +1133,16 @@ impl WriteTransaction {
     }
 
     /// Creates a snapshot of the current database state, which can be used to rollback the database.
-    /// This savepoint will exist until it is deleted with `[delete_savepoint()]`.
+    /// This savepoint will exist until it is deleted with
+    /// [`delete_persistent_savepoint()`](Self::delete_persistent_savepoint).
     ///
     /// Note that while a savepoint exists, pages that become unused after it was created are not freed.
     /// Therefore, the lifetime of a savepoint should be minimized.
     ///
-    /// Returns `[SavepointError::InvalidSavepoint`], if the transaction is "dirty" (a data
+    /// Returns [`SavepointError::InvalidSavepoint`] if the transaction is "dirty" (a data
     /// table has been opened, renamed, or deleted, or a savepoint has been restored), or
-    /// `[SavepointError::ImmediateDurabilityRequired]` if the transaction's durability is less
-    /// than `[Durability::Immediate]`
+    /// [`SavepointError::ImmediateDurabilityRequired`] if the transaction's durability is less
+    /// than [`Durability::Immediate`]
     pub fn persistent_savepoint(&self) -> Result<u64, SavepointError> {
         if self.durability != InternalDurability::Immediate {
             return Err(SavepointError::ImmediateDurabilityRequired);
@@ -1214,8 +1215,8 @@ impl WriteTransaction {
     /// Note that if the transaction is `abort()`'ed this deletion will be rolled back.
     ///
     /// Returns `true` if the savepoint existed
-    /// Returns `[SavepointError::ImmediateDurabilityRequired]` if the transaction's durability
-    /// is less than `[Durability::Immediate]`
+    /// Returns [`SavepointError::ImmediateDurabilityRequired`] if the transaction's durability
+    /// is less than [`Durability::Immediate`]
     pub fn delete_persistent_savepoint(&self, id: u64) -> Result<bool, SavepointError> {
         if self.durability != InternalDurability::Immediate {
             return Err(SavepointError::ImmediateDurabilityRequired);
@@ -1269,9 +1270,9 @@ impl WriteTransaction {
 
     /// Creates a snapshot of the current database state, which can be used to rollback the database
     ///
-    /// This savepoint will be freed as soon as the returned `[Savepoint]` is dropped.
+    /// This savepoint will be freed as soon as the returned [`Savepoint`] is dropped.
     ///
-    /// Returns `[SavepointError::InvalidSavepoint`], if the transaction is "dirty" (a data
+    /// Returns [`SavepointError::InvalidSavepoint`] if the transaction is "dirty" (a data
     /// table has been opened, renamed, or deleted, or a savepoint has been restored)
     pub fn ephemeral_savepoint(&self) -> Result<Savepoint, SavepointError> {
         // Serialize the dirty check and savepoint registration against

--- a/src/tree_store/page_store/backends.rs
+++ b/src/tree_store/page_store/backends.rs
@@ -6,6 +6,7 @@ use crate::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 #[cfg(not(redb_no_std))]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::fmt::{Debug, Formatter};
 
 #[cfg(not(redb_no_std))]
 #[derive(Debug)]
@@ -48,8 +49,20 @@ impl StorageBackend for ReadOnlyBackend {
 }
 
 /// Acts as temporal in-memory database storage.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct InMemoryBackend(RwLock<Vec<u8>>);
+
+// Hand-written: the derived impl would print every byte of the database, and opening a database
+// formats its backend into the debug log when the "logging" feature is enabled. The length stays
+// meaningful when a writer panicked, so a poisoned lock is read through rather than branched on
+impl Debug for InMemoryBackend {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let guard = self.0.read().unwrap_or_else(|error| error.into_inner());
+        f.debug_struct("InMemoryBackend")
+            .field("len", &guard.len())
+            .finish()
+    }
+}
 
 impl InMemoryBackend {
     fn out_of_range() -> io::Error {
@@ -110,5 +123,35 @@ impl StorageBackend for InMemoryBackend {
         } else {
             Err(Self::out_of_range())
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::InMemoryBackend;
+    use crate::StorageBackend;
+
+    #[test]
+    fn debug_reports_length_not_contents() {
+        let backend = InMemoryBackend::new();
+        backend.set_len(1024).unwrap();
+        assert_eq!(format!("{backend:?}"), "InMemoryBackend { len: 1024 }");
+    }
+
+    // A writer that panics poisons the lock; the length is still reported. Poisoning requires
+    // unwinding past the guard, so the test does too.
+    #[test]
+    #[cfg(panic = "unwind")]
+    fn debug_reads_through_a_poisoned_lock() {
+        let backend = std::sync::Arc::new(InMemoryBackend::new());
+        backend.set_len(512).unwrap();
+        let poisoner = backend.clone();
+        let result = std::thread::spawn(move || {
+            let _guard = poisoner.0.write();
+            panic!("poison the lock");
+        })
+        .join();
+        assert!(result.is_err());
+        assert_eq!(format!("{backend:?}"), "InMemoryBackend { len: 512 }");
     }
 }


### PR DESCRIPTION
Three small fixes from the public API review, one commit each:

* **Expose the `io` module whenever `experimental-api-5` is enabled.** It was public only in the no_std configuration, so enabling `std` anywhere in the build graph removed it out from under a no_std backend crate naming `redb::io::Error`. The visibility is now gated on the feature flag; with std the module re-exports `std::io::Error`, and the 4.x surface (flag off) is unchanged.
* **Stop `InMemoryBackend`'s `Debug` from printing the database.** The derived impl printed the entire `Vec<u8>`, and opening a database formats its backend with `{:?}` when the `logging` feature is enabled. It now reports the storage length, reading through a poisoned lock so the output stays meaningful after a writer panic.
* **Fix broken doc links in the savepoint methods.** Inverted backtick/bracket syntax like `` `[SavepointError::InvalidSavepoint`] `` now renders as real intra-doc links, the reference to a nonexistent `delete_savepoint()` points at `delete_persistent_savepoint()`, and `SetDurabilityError`'s summary line no longer claims to be about transactions in general.

Verified with `cargo fmt --check`, clippy (`--all-targets`, with and without `--all-features`, under `--deny warnings`), the full `cargo test --frozen --all-features` suite, `cargo deny check licenses advisories`, rustdoc with `--deny warnings` (default and flag builds), the no_std `cargo check`, and the WASI test suite under wasmtime. Also compile-checked externally that `redb::io::Error` is nameable (and is `std::io::Error`) with the flag on, and remains private with it off.

Note: `cargo doc --no-deps --all-features` fails on master too, from an unescaped `DateTime<FixedOffset>` in chrono_v0_4.rs's module doc; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eKG5UgXsfZKfGRCcafVSU