### PR TITLE
Implement Value and Key for NonZero integer types

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -916,6 +916,67 @@ le_impl!(i128);
 le_value!(f32);
 le_value!(f64);
 
+// `NonZero*` is encoded exactly like the primitive it wraps, so it sorts
+// identically and costs the same width. `usize`/`isize` are excluded here for the
+// same reason they are excluded above: their width is platform dependent, which
+// would make a database non-portable.
+macro_rules! nonzero_impl {
+    ($t:ty, $prim:ty, $name:literal) => {
+        impl Value for $t {
+            type SelfType<'a> = $t;
+            type AsBytes<'a>
+                = [u8; core::mem::size_of::<$prim>()]
+            where
+                Self: 'a;
+
+            fn fixed_width() -> Option<usize> {
+                Some(core::mem::size_of::<$prim>())
+            }
+
+            fn from_bytes<'a>(data: &'a [u8]) -> $t
+            where
+                Self: 'a,
+            {
+                // `as_bytes()` cannot produce a zero encoding, and implementations may
+                // assume `data` came from it, so a zero here is unreachable in the same
+                // way an out-of-range scalar is for `char`.
+                <$t>::new(<$prim>::from_le_bytes(data.try_into().unwrap())).unwrap()
+            }
+
+            fn as_bytes<'a, 'b: 'a>(
+                value: &'a Self::SelfType<'b>,
+            ) -> [u8; core::mem::size_of::<$prim>()]
+            where
+                Self: 'a,
+                Self: 'b,
+            {
+                value.get().to_le_bytes()
+            }
+
+            fn type_name() -> TypeName {
+                TypeName::internal($name)
+            }
+        }
+
+        impl Key for $t {
+            fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+                Self::from_bytes(data1).cmp(&Self::from_bytes(data2))
+            }
+        }
+    };
+}
+
+nonzero_impl!(core::num::NonZeroU8, u8, "NonZeroU8");
+nonzero_impl!(core::num::NonZeroU16, u16, "NonZeroU16");
+nonzero_impl!(core::num::NonZeroU32, u32, "NonZeroU32");
+nonzero_impl!(core::num::NonZeroU64, u64, "NonZeroU64");
+nonzero_impl!(core::num::NonZeroU128, u128, "NonZeroU128");
+nonzero_impl!(core::num::NonZeroI8, i8, "NonZeroI8");
+nonzero_impl!(core::num::NonZeroI16, i16, "NonZeroI16");
+nonzero_impl!(core::num::NonZeroI32, i32, "NonZeroI32");
+nonzero_impl!(core::num::NonZeroI64, i64, "NonZeroI64");
+nonzero_impl!(core::num::NonZeroI128, i128, "NonZeroI128");
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -10,6 +10,7 @@ use redb::{
     TableError, TableHandle, TypeName, Value, WriteTransaction,
 };
 use std::cmp::Ordering;
+use std::num::{NonZeroI32, NonZeroU32, NonZeroU64};
 #[cfg(feature = "experimental-api-5")]
 use std::ops::Bound;
 #[cfg(not(target_os = "wasi"))]
@@ -4084,6 +4085,115 @@ fn char_type() {
     assert_eq!(iter.next().unwrap().unwrap().0.value(), 'a');
     assert_eq!(iter.next().unwrap().unwrap().0.value(), 'b');
     assert!(iter.next().is_none());
+}
+
+#[test]
+fn nonzero_type() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<NonZeroU32, NonZeroU64> = TableDefinition::new("x");
+
+    let (one, two) = (NonZeroU32::new(1).unwrap(), NonZeroU32::new(2).unwrap());
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        table.insert(two, NonZeroU64::new(20).unwrap()).unwrap();
+        table.insert(one, NonZeroU64::new(10).unwrap()).unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(definition).unwrap();
+    assert_eq!(table.get(one).unwrap().unwrap().value().get(), 10);
+    assert_eq!(table.get(two).unwrap().unwrap().value().get(), 20);
+
+    // Keys sort by numeric value, matching the primitive they wrap
+    let mut iter = table.iter().unwrap();
+    assert_eq!(iter.next().unwrap().unwrap().0.value(), one);
+    assert_eq!(iter.next().unwrap().unwrap().0.value(), two);
+    assert!(iter.next().is_none());
+}
+
+#[test]
+fn nonzero_signed_ordering() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<NonZeroI32, ()> = TableDefinition::new("x");
+
+    // Deliberately inserted out of order, and spanning zero
+    let values = [-1i32, i32::MIN, 7, -300, i32::MAX];
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for v in values {
+            table.insert(NonZeroI32::new(v).unwrap(), ()).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let mut sorted = values;
+    sorted.sort_unstable();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(definition).unwrap();
+    let stored: Vec<i32> = table
+        .iter()
+        .unwrap()
+        .map(|x| x.unwrap().0.value().get())
+        .collect();
+    assert_eq!(stored, sorted);
+}
+
+#[test]
+fn option_nonzero_type() {
+    // The motivating case: `Option<NonZero*>` goes through the blanket `Option<T>`
+    // impl once `NonZero*` itself implements `Key`.
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u32, Option<NonZeroU32>> = TableDefinition::new("x");
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        table.insert(0, Some(NonZeroU32::new(5).unwrap())).unwrap();
+        table.insert(1, None).unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(definition).unwrap();
+    assert_eq!(
+        table.get(0).unwrap().unwrap().value(),
+        Some(NonZeroU32::new(5).unwrap())
+    );
+    assert_eq!(table.get(1).unwrap().unwrap().value(), None);
+}
+
+#[test]
+fn nonzero_is_not_interchangeable_with_primitive() {
+    // `NonZero*` has a distinct type name, so a table written as `u32` cannot be
+    // reopened as `NonZeroU32` and hand back a zero that `NonZeroU32` cannot hold.
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u32, u32> = TableDefinition::new("x");
+    let wrong_definition: TableDefinition<NonZeroU32, NonZeroU32> = TableDefinition::new("x");
+
+    let txn = db.begin_write().unwrap();
+    txn.open_table(definition).unwrap();
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    assert!(matches!(
+        txn.open_table(wrong_definition),
+        Err(TableError::TableTypeMismatch { .. })
+    ));
+    txn.abort().unwrap();
 }
 
 // Opening a multimap table via open_table() returns TableIsMultimap for both


### PR DESCRIPTION
Fixes #873, for the part of it that isn't blocked.

## Scope

The specialization blocker noted on the issue applies to the `Option<NonZero…>` **niche optimization** — encoding `Option<NonZeroU32>` as `unwrap_or(0)` at the same width as a bare `u32`. That still needs [rust-lang/rust#31844](https://github.com/rust-lang/rust/issues/31844) and isn't attempted here.

Implementing `Value` + `Key` for the bare `NonZero…` types isn't blocked by anything, and it's the part that removes the wrapper-type hoops the reporter described. `Option<NonZeroU32>` then works through the existing blanket `Option<T>` impl — just at one tag byte plus payload rather than niche-optimized.

## Encoding

`NonZero*` encodes exactly like the primitive it wraps: same `fixed_width`, same little-endian bytes, same ordering. `compare()` decodes and compares numerically, matching `le_impl!`.

`usize`/`isize` are excluded, for the same reason the existing primitive impls exclude them — a platform-dependent width would make a database non-portable.

## The zero case

The issue asked what should happen if a `0` somehow reaches a `NonZero` column. Neither option offered there is reachable: `from_bytes()` isn't fallible, so it can't return `None` or an error.

I followed the convention already in the codebase — `bool::from_bytes` uses `unreachable!()` and `char::from_bytes` uses `.unwrap()` for byte patterns `as_bytes` cannot produce, and the `Value` docs state that implementations may assume `data` is the return value of `as_bytes`. So `NonZero…` unwraps.

What makes that safe in practice is that each `NonZero…` gets its own `TypeName`. A table written as `u32` cannot be reopened as `NonZeroU32`, so a legitimately-stored zero can't be re-read as a `NonZeroU32` — it fails with `TableTypeMismatch` instead. There's a test covering exactly that.

## Tests

Four added to `basic_tests.rs`:

- `nonzero_type` — round-trip as both key and value, and iteration order
- `nonzero_signed_ordering` — `NonZeroI32` inserted out of order and spanning zero, including `i32::MIN`/`MAX`, read back sorted
- `option_nonzero_type` — the motivating `Option<NonZero*>` case
- `nonzero_is_not_interchangeable_with_primitive` — `u32` table cannot be reopened as `NonZeroU32`

## Verification

`cargo fmt --check` and `cargo clippy --all --all-targets` are clean, `cargo build --no-default-features` builds, and `cargo test --test basic_tests` passes 125/125.

Happy to drop the signed types, or narrow this to just `NonZeroU64`, if you'd rather keep the surface smaller.
