### PR TITLE
Niche-encode Option<NonZero*> without specialization

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -182,6 +182,23 @@ pub trait Value: Debug {
 
     /// Globally unique identifier for this type
     fn type_name() -> TypeName;
+
+    /// An encoding of `Self`'s width that `as_bytes()` can never produce, if one exists.
+    ///
+    /// Container types may use it to represent an absent value in place of a discriminant.
+    /// `Option<Self>` uses it to encode `None`, which makes `Option<Self>` the same width as
+    /// `Self` rather than one byte wider.
+    ///
+    /// Implementations that return `Some` must ensure the returned bytes are `fixed_width()`
+    /// long, that `fixed_width()` is not `None`, and that no value of `Self` encodes to them.
+    /// Returning a pattern that `as_bytes()` can produce will make values indistinguishable
+    /// from absence.
+    ///
+    /// The default implementation returns `None`, which leaves the discriminant encoding in
+    /// place.
+    fn niche() -> Option<Cow<'static, [u8]>> {
+        None
+    }
 }
 
 /// Implementing this trait indicates that the type can be mutated in-place as a &mut [u8].
@@ -346,13 +363,24 @@ impl<T: Value> Value for Option<T> {
         Self: 'a;
 
     fn fixed_width() -> Option<usize> {
-        T::fixed_width().map(|x| x + 1)
+        match T::niche() {
+            // The niche encodes `None`, so no discriminant is needed
+            Some(_) => T::fixed_width(),
+            None => T::fixed_width().map(|x| x + 1),
+        }
     }
 
     fn from_bytes<'a>(data: &'a [u8]) -> Option<T::SelfType<'a>>
     where
         Self: 'a,
     {
+        if let Some(niche) = T::niche() {
+            return if data == niche.as_ref() {
+                None
+            } else {
+                Some(T::from_bytes(data))
+            };
+        }
         match data[0] {
             0 => None,
             1 => Some(T::from_bytes(&data[1..])),
@@ -364,6 +392,12 @@ impl<T: Value> Value for Option<T> {
     where
         Self: 'b,
     {
+        if let Some(niche) = T::niche() {
+            return match value {
+                Some(x) => T::as_bytes(x).as_ref().to_vec(),
+                None => niche.into_owned(),
+            };
+        }
         let mut result = vec![0];
         if let Some(x) = value {
             result[0] = 1;
@@ -384,6 +418,16 @@ impl<T: Value> Value for Option<T> {
 impl<T: Key> Key for Option<T> {
     #[allow(clippy::collapsible_else_if)]
     fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+        if let Some(niche) = T::niche() {
+            let niche = niche.as_ref();
+            // `None` sorts below every `Some`, as it does with a discriminant
+            return match (data1 == niche, data2 == niche) {
+                (true, true) => Ordering::Equal,
+                (true, false) => Ordering::Less,
+                (false, true) => Ordering::Greater,
+                (false, false) => T::compare(data1, data2),
+            };
+        }
         if data1[0] == 0 {
             if data2[0] == 0 {
                 Ordering::Equal
@@ -400,6 +444,10 @@ impl<T: Key> Key for Option<T> {
     }
 
     fn separator<'a>(left: &'a [u8], right: &'a [u8]) -> Cow<'a, [u8]> {
+        // A niche implies a fixed width `T`, so the same reasoning as below applies
+        if T::niche().is_some() {
+            return Cow::Borrowed(left);
+        }
         // A fixed width `T` makes `Option<T>` fixed width too, and its encodings are compared at
         // that width, so nothing shorter than `left` may be returned
         if T::fixed_width().is_some() {
@@ -424,6 +472,9 @@ impl<T: Key> Key for Option<T> {
 
     // `None` sorts below every `Some`
     fn min_encoded_key() -> Option<Cow<'static, [u8]>> {
+        if let Some(niche) = T::niche() {
+            return Some(niche);
+        }
         Some(match T::fixed_width() {
             // A fixed width `T` pads the tag out to the width of a `Some`
             Some(width) => Cow::Owned(vec![0; width + 1]),
@@ -955,6 +1006,13 @@ macro_rules! nonzero_impl {
 
             fn type_name() -> TypeName {
                 TypeName::internal($name)
+            }
+
+            // Zero is the one encoding of the underlying primitive that this type
+            // cannot hold, which is exactly what makes it a niche.
+            fn niche() -> Option<Cow<'static, [u8]>> {
+                const { assert!(core::mem::size_of::<$prim>() <= 16) };
+                Some(Cow::Borrowed(&[0u8; 16][..core::mem::size_of::<$prim>()]))
             }
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -916,6 +916,67 @@ le_impl!(i128);
 le_value!(f32);
 le_value!(f64);
 
+// `NonZero*` is encoded exactly like the primitive it wraps, so it sorts
+// identically and costs the same width. `usize`/`isize` are excluded here for the
+// same reason they are excluded above: their width is platform dependent, which
+// would make a database non-portable.
+macro_rules! nonzero_impl {
+    ($t:ty, $prim:ty, $name:literal) => {
+        impl Value for $t {
+            type SelfType<'a> = $t;
+            type AsBytes<'a>
+                = [u8; core::mem::size_of::<$prim>()]
+            where
+                Self: 'a;
+
+            fn fixed_width() -> Option<usize> {
+                Some(core::mem::size_of::<$prim>())
+            }
+
+            fn from_bytes<'a>(data: &'a [u8]) -> $t
+            where
+                Self: 'a,
+            {
+                // `as_bytes()` cannot produce a zero encoding, and implementations may
+                // assume `data` came from it, so a zero here is unreachable in the same
+                // way an out-of-range scalar is for `char`.
+                <$t>::new(<$prim>::from_le_bytes(data.try_into().unwrap())).unwrap()
+            }
+
+            fn as_bytes<'a, 'b: 'a>(
+                value: &'a Self::SelfType<'b>,
+            ) -> [u8; core::mem::size_of::<$prim>()]
+            where
+                Self: 'a,
+                Self: 'b,
+            {
+                value.get().to_le_bytes()
+            }
+
+            fn type_name() -> TypeName {
+                TypeName::internal($name)
+            }
+        }
+
+        impl Key for $t {
+            fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+                Self::from_bytes(data1).cmp(&Self::from_bytes(data2))
+            }
+        }
+    };
+}
+
+nonzero_impl!(core::num::NonZeroU8, u8, "NonZeroU8");
+nonzero_impl!(core::num::NonZeroU16, u16, "NonZeroU16");
+nonzero_impl!(core::num::NonZeroU32, u32, "NonZeroU32");
+nonzero_impl!(core::num::NonZeroU64, u64, "NonZeroU64");
+nonzero_impl!(core::num::NonZeroU128, u128, "NonZeroU128");
+nonzero_impl!(core::num::NonZeroI8, i8, "NonZeroI8");
+nonzero_impl!(core::num::NonZeroI16, i16, "NonZeroI16");
+nonzero_impl!(core::num::NonZeroI32, i32, "NonZeroI32");
+nonzero_impl!(core::num::NonZeroI64, i64, "NonZeroI64");
+nonzero_impl!(core::num::NonZeroI128, i128, "NonZeroI128");
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -10,6 +10,7 @@ use redb::{
     TableError, TableHandle, TypeName, Value, WriteTransaction,
 };
 use std::cmp::Ordering;
+use std::num::{NonZeroI32, NonZeroU32, NonZeroU64};
 #[cfg(feature = "experimental-api-5")]
 use std::ops::Bound;
 #[cfg(not(target_os = "wasi"))]
@@ -4084,6 +4085,115 @@ fn char_type() {
     assert_eq!(iter.next().unwrap().unwrap().0.value(), 'a');
     assert_eq!(iter.next().unwrap().unwrap().0.value(), 'b');
     assert!(iter.next().is_none());
+}
+
+#[test]
+fn nonzero_type() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<NonZeroU32, NonZeroU64> = TableDefinition::new("x");
+
+    let (one, two) = (NonZeroU32::new(1).unwrap(), NonZeroU32::new(2).unwrap());
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        table.insert(two, NonZeroU64::new(20).unwrap()).unwrap();
+        table.insert(one, NonZeroU64::new(10).unwrap()).unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(definition).unwrap();
+    assert_eq!(table.get(one).unwrap().unwrap().value().get(), 10);
+    assert_eq!(table.get(two).unwrap().unwrap().value().get(), 20);
+
+    // Keys sort by numeric value, matching the primitive they wrap
+    let mut iter = table.iter().unwrap();
+    assert_eq!(iter.next().unwrap().unwrap().0.value(), one);
+    assert_eq!(iter.next().unwrap().unwrap().0.value(), two);
+    assert!(iter.next().is_none());
+}
+
+#[test]
+fn nonzero_signed_ordering() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<NonZeroI32, ()> = TableDefinition::new("x");
+
+    // Deliberately inserted out of order, and spanning zero
+    let values = [-1i32, i32::MIN, 7, -300, i32::MAX];
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for v in values {
+            table.insert(NonZeroI32::new(v).unwrap(), ()).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let mut sorted = values;
+    sorted.sort_unstable();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(definition).unwrap();
+    let stored: Vec<i32> = table
+        .iter()
+        .unwrap()
+        .map(|x| x.unwrap().0.value().get())
+        .collect();
+    assert_eq!(stored, sorted);
+}
+
+#[test]
+fn option_nonzero_type() {
+    // The motivating case: `Option<NonZero*>` goes through the blanket `Option<T>`
+    // impl once `NonZero*` itself implements `Key`.
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u32, Option<NonZeroU32>> = TableDefinition::new("x");
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        table.insert(0, Some(NonZeroU32::new(5).unwrap())).unwrap();
+        table.insert(1, None).unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(definition).unwrap();
+    assert_eq!(
+        table.get(0).unwrap().unwrap().value(),
+        Some(NonZeroU32::new(5).unwrap())
+    );
+    assert_eq!(table.get(1).unwrap().unwrap().value(), None);
+}
+
+#[test]
+fn nonzero_is_not_interchangeable_with_primitive() {
+    // `NonZero*` has a distinct type name, so a table written as `u32` cannot be
+    // reopened as `NonZeroU32` and hand back a zero that `NonZeroU32` cannot hold.
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let definition: TableDefinition<u32, u32> = TableDefinition::new("x");
+    let wrong_definition: TableDefinition<NonZeroU32, NonZeroU32> = TableDefinition::new("x");
+
+    let txn = db.begin_write().unwrap();
+    txn.open_table(definition).unwrap();
+    txn.commit().unwrap();
+
+    let txn = db.begin_write().unwrap();
+    assert!(matches!(
+        txn.open_table(wrong_definition),
+        Err(TableError::TableTypeMismatch { .. })
+    ));
+    txn.abort().unwrap();
 }
 
 // Opening a multimap table via open_table() returns TableIsMultimap for both

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -4175,6 +4175,88 @@ fn option_nonzero_type() {
 }
 
 #[test]
+fn option_nonzero_is_niche_encoded() {
+    // The point of the niche: `Option<NonZeroU32>` costs the same as `NonZeroU32`,
+    // where `Option<u32>` pays an extra discriminant byte.
+    assert_eq!(<NonZeroU32 as Value>::fixed_width(), Some(4));
+    assert_eq!(<Option<NonZeroU32> as Value>::fixed_width(), Some(4));
+    assert_eq!(<Option<u32> as Value>::fixed_width(), Some(5));
+
+    // `None` is the all-zeros encoding, which `NonZeroU32` can never produce
+    assert_eq!(
+        <Option<NonZeroU32> as Value>::as_bytes(&None),
+        vec![0, 0, 0, 0]
+    );
+    assert_eq!(
+        <Option<NonZeroU32> as Value>::as_bytes(&NonZeroU32::new(1)),
+        vec![1, 0, 0, 0]
+    );
+
+    // Round-trips both ways
+    for v in [None, NonZeroU32::new(1), NonZeroU32::new(u32::MAX)] {
+        let bytes = <Option<NonZeroU32> as Value>::as_bytes(&v);
+        assert_eq!(<Option<NonZeroU32> as Value>::from_bytes(&bytes), v);
+    }
+
+    // `None` still sorts below every `Some`
+    let none = <Option<NonZeroU32> as Value>::as_bytes(&None);
+    let some = <Option<NonZeroU32> as Value>::as_bytes(&NonZeroU32::new(1));
+    assert_eq!(
+        <Option<NonZeroU32> as Key>::compare(&none, &some),
+        Ordering::Less
+    );
+    assert_eq!(
+        <Option<NonZeroU32> as Key>::compare(&none, &none),
+        Ordering::Equal
+    );
+}
+
+#[test]
+fn option_nonzero_ordering_in_table() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    // Signed, so `None` must sort below a negative `Some` too
+    let definition: TableDefinition<Option<NonZeroI32>, ()> = TableDefinition::new("x");
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(definition).unwrap();
+        for v in [
+            NonZeroI32::new(3),
+            None,
+            NonZeroI32::new(i32::MIN),
+            NonZeroI32::new(-9),
+        ] {
+            table.insert(v, ()).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(definition).unwrap();
+    let stored: Vec<Option<i32>> = table
+        .iter()
+        .unwrap()
+        .map(|x| x.unwrap().0.value().map(|n| n.get()))
+        .collect();
+    assert_eq!(stored, vec![None, Some(i32::MIN), Some(-9), Some(3)]);
+}
+
+#[test]
+fn option_non_niche_encoding_is_unchanged() {
+    // Types without a niche keep the discriminant encoding exactly as before,
+    // so existing databases are unaffected.
+    assert_eq!(<Option<u32> as Value>::as_bytes(&None), vec![0, 0, 0, 0, 0]);
+    assert_eq!(
+        <Option<u32> as Value>::as_bytes(&Some(1)),
+        vec![1, 1, 0, 0, 0]
+    );
+    assert_eq!(<Option<&str> as Value>::fixed_width(), None);
+    assert_eq!(<Option<&str> as Value>::as_bytes(&None), vec![0]);
+}
+
+#[test]
 fn nonzero_is_not_interchangeable_with_primitive() {
     // `NonZero*` has a distinct type name, so a table written as `u32` cannot be
     // reopened as `NonZeroU32` and hand back a zero that `NonZeroU32` cannot hold.


### PR DESCRIPTION
Completes #873. **Stacked on #1408** — the first commit here is that PR; review it first, and this becomes a one-commit diff once it merges.

## The claim

The niche optimization asked for in #873 doesn't need specialization at all, so it isn't blocked on [rust-lang/rust#31844](https://github.com/rust-lang/rust/issues/31844) — which has been open since 2016 and is still labelled `I-unsound` with unresolved design concerns, so waiting on it means waiting indefinitely.

Specialization is only needed if the fix is *a second, overlapping impl* for `Option<NonZero*>`. It isn't needed if the varying behaviour moves onto `Value` instead, which is your own trait.

## The change

`Value` gains one defaulted method:

```rust
fn niche() -> Option<Cow<'static, [u8]>> { None }
```

It returns an encoding of `Self`'s width that `as_bytes()` can never produce. `NonZero*` returns all-zeros. The single blanket `impl<T: Value> Value for Option<T>` consults it and, when present, uses that pattern to mean `None` instead of prefixing a discriminant byte.

One impl. No overlap. Stable Rust. And because the method is defaulted, every existing implementor — inside the crate or out — is untouched.

Result: `Option<NonZeroU32>` is 4 bytes rather than 5, matching the layout Rust already gives it in memory.

## Compatibility

`niche()` defaults to `None`, so every type that doesn't opt in keeps the discriminant encoding byte-for-byte. There's a test asserting exactly that for `Option<u32>` and `Option<&str>`.

`Option<NonZero*>` has never existed in a released redb — `NonZero*` didn't implement `Value` — so no database can hold the old five-byte form. The niche can be introduced now at zero migration cost. Later, it couldn't.

`backward_compatibility` passes unchanged.

## Ordering

`compare()` keeps `None` sorting below every `Some`, including below negative values of the signed types, and `min_encoded_key()` returns the niche. `separator()` short-circuits since a niche implies a fixed width.

## Tests

- `option_nonzero_is_niche_encoded` — width collapses 5 → 4, `None` is all-zeros, round-trips, ordering
- `option_nonzero_ordering_in_table` — `Option<NonZeroI32>` read back in order, `None` below `i32::MIN`
- `option_non_niche_encoding_is_unchanged` — `Option<u32>` and `Option<&str>` encode exactly as before

`cargo fmt --check` and `cargo clippy --all --all-targets` clean, `--no-default-features` builds, and basic_tests 128/128, integration_tests 110/110, backward_compatibility 8/8, multimap_tests 20/20 pass.

## If you'd rather not

The trait method is the part worth arguing about — it's public API surface on `Value`, and it puts a correctness obligation on implementors (return a pattern `as_bytes` can produce and values become indistinguishable from absence; the doc comment says so). If you'd prefer to keep `Value` minimal, I'm happy to make `niche()` a sealed/internal trait instead so only redb's own types can opt in, which covers `NonZero*` and costs outside implementors nothing.
