### PR TITLE
Add multi-process concurrency modes

### DIFF
--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1348,20 +1348,30 @@ impl TransactionalMemory {
         Ok((was_clean, changed))
     }
 
-    /// Captures the committed id and data root together, reading the file for a shared read-only handle.
-    /// The caller's `header` hold must also cover registering the returned id as active.
+    /// Captures the committed id and data root together, reading the file when a peer may have
+    /// committed. The caller's `header` hold must also cover registering the returned id as active.
     pub(crate) fn latest_committed_snapshot(
         &self,
         #[cfg(feature = "experimental-multiprocess")] header: &HeaderGuard<'_>,
     ) -> Result<(TransactionId, Option<BtreeHeader>)> {
         #[cfg(feature = "experimental-multiprocess")]
-        if self.read_only && self.concurrency_mode.is_multi_process_writable() {
+        if self.externally_writable() {
             return self.read_snapshot_from_file(header);
         }
         // Local commits can publish their in-memory state without holding the header lock.
         let state = self.state.lock()?;
         let slot = state.latest_slot();
         Ok((slot.transaction_id, slot.user_root))
+    }
+
+    /// Whether another process may commit to this file
+    #[cfg(feature = "experimental-multiprocess")]
+    fn externally_writable(&self) -> bool {
+        match self.concurrency_mode {
+            ConcurrencyMode::SingleProcess => false,
+            ConcurrencyMode::SingleWriterProcess => self.read_only,
+            ConcurrencyMode::MultiWriterProcess => true,
+        }
     }
 
     /// Reads a snapshot without changing the in-memory header or allocator state.

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -471,6 +471,17 @@ mod peer_commits {
         table.get(key).unwrap().unwrap().value()
     }
 
+    /// A read on a writable handle reads the file, so it sees a peer's commit without this
+    /// handle writing anything itself.
+    #[test]
+    fn a_read_transaction_on_a_writable_handle_sees_a_peers_commit() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let (db, peer) = two_handles(tmpfile.path());
+        insert(&peer, 1);
+
+        assert_eq!(value(&db, 1), 1);
+    }
+
     /// The transaction sees the peer's commit, and its own commit lands after it, so that
     /// neither one is lost.
     #[test]


### PR DESCRIPTION
The staging branch for the rest of the multi-process implementation. One commit is left on it, and after rebasing onto "Read shared read-only snapshots directly from the file" it is down to one condition and its helper.

Rebuilt rather than rebased, back when it was first brought forward: the branch had been sitting on a master from before roughly twenty merged PRs, and most of its diff was either merged upstream since or superseded. It went from 2044 insertions across 18 files to 236 across 5, the savepoint half merged as #1464, and the read-path machinery has now gone the same way.

## The change

A read transaction on a writable handle read the state that handle already had, so it missed whatever a peer had committed since, where a read-only handle read the file (#1432). It now reads the file the same way:

```rust
-        if self.read_only && self.concurrency_mode.is_multi_process_writable() {
+        if self.externally_writable() {
             return self.read_snapshot_from_file(header);
         }
```

with `externally_writable()` naming the three cases: never in `SingleProcess`, read-only participants in `SingleWriterProcess`, and always in `MultiWriterProcess`.

## What this used to carry, and why it does not any more

The previous revision came with a good deal more: a `local_write_transaction_live` gate suppressing the read's reload while a write transaction of this process held the writer byte, the tracker plumbing to compute it, and a set of allocator-state changes (`reload_header()` dropping the state, `reload_for_write()` and `clear_cache_and_reload()` treating "none held" as a reason to sync, `check_integrity()` taking its own hash lazily).

All of it existed because `reload_header()` **replaced `state.header`** — layout included — and dropped the allocator state that described it. Two commits on master have since removed that mechanism: "Capture read snapshots under the header lock" captures `(id, root)` together and passes the root into `ReadTransaction`, and "Read shared read-only snapshots directly from the file" replaces `reload_header()` with `read_snapshot_from_file()`, which reads the file and returns the id and root **without touching the in-memory header or allocator state**.

With no in-memory state changing, none of it has anything left to protect:

* **The live-write gate.** Its whole justification was that a read would install the file's stored layout over the grown one a live local write was allocating against. Nothing installs anything now. The snapshot returned is the same either way: `Durability::None` is refused in the multi-process writable modes (`SetDurabilityError::NonDurableCommitUnsupported`), so `read_from_secondary` is never set on such a handle and `latest_slot()` is always the primary — the same slot the file read returns, with the header lock serializing the two against any commit. The one side effect left is `update_transaction_id()`, which clears the read cache and never the write buffer.
* **The allocator-state changes.** A read no longer drops the allocator state, so there is no "none held" to distinguish. Removing all of them leaves the suite green.

I had argued the gate was load-bearing, with a test that failed without it. That was true of the code as it stood; it is not true of this code. I checked it rather than assuming: with the gate removed the whole suite passes, and the mechanism it guarded against is now structurally absent rather than merely untriggered.

## Testing

`a_read_transaction_on_a_writable_handle_sees_a_peers_commit` — the handle sees a peer's row without writing anything itself. It pins the change: it fails with the condition put back to `read_only && is_multi_process_writable()`.

An earlier revision carried five more tests, which cberner cut on review: an integrity check after such a read, a write transaction syncing after one, a read beginning while a `begin_write()` was blocked on a peer's writer byte, a read during this handle's own live write, and the handle freeing its memory on close. The first four were written against the read path as it was before "Read shared read-only snapshots directly from the file", when a read adopted the peer's header into this handle's state; with the read no longer touching that state they covered variations on the one case above rather than distinct hazards.

`cargo fmt --check`, `cargo clippy --all --all-targets --all-features` under `--deny warnings`, `cargo clippy --all --all-targets` with default features, `cargo doc --all --no-deps` and `cargo test --all --all-features` (25 suites) all pass, as do master's three 32-bit steps on `i686-unknown-linux-gnu`.

## Still open

One, unchanged.

* **An integrity check while a peer reads.** `check_integrity()` holds the writer lock, so no other process writes while it runs, but a peer may be reading throughout -- and where the check has to repair, `do_repair()` rebuilds the allocator from the roots it keeps, so a page that only the discarded snapshot referenced is free again with no regard for the byte a peer's read holds on it. A later write can then overwrite pages that read is still traversing. `Arc::get_mut()` rules out this handle's own transactions and nothing else, and the writer lock excludes peer writers, not peer readers. That code is on master rather than in this branch's diff; recorded here because this is where it was reported.

Closed since, with where each went:

* **The other end of the reload gate.** Split out as #1463, merged.
* **A shared read-only open racing a create.** Fixed by #1465, merged.
* **Telling a discarded allocator state from one not yet loaded.** Split out as #1470, merged.

Not a defect, kept as a note:

* **The statistics guard.** A guard reporting allocation statistics as unsupported on a handle that tracks no allocator state was deliberately never added: `stats()` exists only on `WriteTransaction`, so nothing reaches it and the guard would be dead code. It belongs with whatever lets a read-only handle report statistics.

### Tests from the old branch that master does not have

Named rather than left implicit, since the rebuild dropped the file they were in:

* `an_open_waits_behind_a_creator_instead_of_calling_the_file_empty` -- the writable half of what it covered is master's behaviour, through #1462, but untested; the read-only half is #1465's, which does test it.
* `only_a_single_writer_scans_from_where_it_stopped` -- the scan-start restriction from #1441. `scan_from` is on master, in `oldest_active_transaction()`, with nothing pinning that it is carried between scans.
* `a_closed_multi_writer_database_frees_its_memory` -- nothing an open takes may outlive the handle, which the writer lock holding the storage rather than the memory is what secures. Carried here and cut on review.

Fixes: #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9BSFJKvzsERy8jjeMxwjD