### PR TITLE
Publish the grown layout when a transaction is aborted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
   with such keys use slightly less space, and lookups are faster.
 * Fix a crash shortly after a commit being able to silently roll that commit back during
   recovery, if `check_integrity()` had previously repaired the database.
+* Fix `check_integrity()` reporting a healthy database as corrupt, and repairing it, after a
+  write transaction that grew the database file was aborted or dropped. The abort left the
+  header on disk describing fewer regions than the file held, which the check read as damage.
 * Fix iterators silently omitting data when iteration continues after an error. An iterator
   that yielded `Err(Corrupted)` could yield the rest of the table on later calls, skipping the
   unreadable entries with no further error. Iterators and read-only cursors now keep returning

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1963,6 +1963,10 @@ impl WriteTransaction {
             .apply_on_abort(&self.transaction_tracker);
         self.mem.check_io_errors()?;
         self.page_allocator().rollback_all();
+        // Rolling the allocations back does not shrink the file, so a transaction that grew it
+        // leaves the layout ahead of the header on disk. Only a commit republishes it, so an
+        // abort must, or the durable header keeps describing fewer regions than the file holds.
+        self.mem.flush_grown_layout()?;
         #[cfg(feature = "logging")]
         debug!("Finished abort of transaction id={:?}", self.transaction_id);
         Ok(())

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -515,6 +515,10 @@ pub(crate) struct TransactionalMemory {
     // While set, no allocator state is persisted and shutdowns are not recorded as clean,
     // forcing the next open to rebuild the state from the committed trees
     needs_repair: AtomicBool,
+    // Set while `grow()` has extended the file past the layout the header on disk records. Only
+    // a header write publishes the larger layout, so until one happens the file is longer than
+    // the durable header describes
+    layout_ahead_of_header: AtomicBool,
     page_size: u32,
     // We store these separately from the layout because they're static, and accessed on the get_page()
     // code path where there is no locking
@@ -660,6 +664,7 @@ impl TransactionalMemory {
             #[cfg(debug_assertions)]
             allocated_pages: Arc::new(Mutex::new(PageNumberHashSet::default())),
             needs_repair: AtomicBool::new(false),
+            layout_ahead_of_header: AtomicBool::new(false),
             page_size: page_size.try_into().unwrap(),
             region_size,
             region_header_with_padding_size: region_header_size,
@@ -886,8 +891,32 @@ impl TransactionalMemory {
             .write(0, DB_HEADER_SIZE, true)?
             .mem_mut()
             .copy_from_slice(&header.to_bytes(true));
+        // The header now records the current layout, so the file is no longer ahead of it
+        self.layout_ahead_of_header.store(false, Ordering::Release);
 
         Ok(())
+    }
+
+    // Publishes a layout that `grow()` left ahead of the header on disk.
+    //
+    // A commit always writes the header, so it republishes the layout itself. An aborted
+    // transaction does not, and rolling its allocations back does not shrink the file, so
+    // without this the durable header would keep describing fewer regions than the file holds.
+    // The next open -- including `check_integrity()` -- rebuilds the layout from the file length,
+    // finds it disagrees with the stored one, and reports the database as needing repair.
+    //
+    // A pending `Durability::None` commit is left alone: its slot names pages that have not been
+    // flushed, so the header must not reach the disk ahead of them, and the live state it
+    // describes is already what a reload verifies against.
+    pub(crate) fn flush_grown_layout(&self) -> Result {
+        if !self.layout_ahead_of_header.load(Ordering::Acquire) || self.pending_non_durable_commit()
+        {
+            return Ok(());
+        }
+        let state = self.state.lock()?;
+        self.write_header(&state.header)?;
+        drop(state);
+        self.storage.flush()
     }
 
     // Durably clears the recovery flag, marking the repair as complete.
@@ -1617,6 +1646,7 @@ impl TransactionalMemory {
 
         state.allocators_mut().resize_to(new_layout);
         state.header.set_layout(new_layout);
+        self.layout_ahead_of_header.store(true, Ordering::Release);
         Ok(())
     }
 

--- a/tests/check_integrity_abort.rs
+++ b/tests/check_integrity_abort.rs
@@ -1,0 +1,87 @@
+//! Tests that an aborted transaction leaves nothing behind for `check_integrity()` to repair.
+//!
+//! Growing the file updates the layout in memory, but only a header write publishes it. A commit
+//! writes the header itself; an abort does not, and rolling the allocations back does not shrink
+//! the file. The abort must therefore publish the layout, or the header on disk keeps describing
+//! fewer regions than the file holds and the database reads as needing repair.
+
+#[cfg(feature = "experimental-api-5")]
+use redb::ReadableTable;
+use redb::{Database, ReadableDatabase, TableDefinition};
+
+const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("t");
+
+// Inserts enough data to make the file grow, then abandons it.
+fn grow_then_abort(db: &Database) {
+    let txn = db.begin_write().unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        for k in 0..3000u64 {
+            table.insert(&k, vec![0xAAu8; 2000].as_slice()).unwrap();
+        }
+    }
+    txn.abort().unwrap();
+}
+
+#[test]
+fn check_integrity_passes_after_an_abort_that_grew_the_file() {
+    let tmpfile = tempfile::NamedTempFile::new().unwrap();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+    {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            table.insert(&0u64, b"committed".as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+    assert!(db.check_integrity().unwrap());
+
+    let len_before = tmpfile.path().metadata().unwrap().len();
+    grow_then_abort(&db);
+    assert!(
+        tmpfile.path().metadata().unwrap().len() > len_before,
+        "the aborted transaction was expected to grow the file"
+    );
+
+    assert!(
+        db.check_integrity().unwrap(),
+        "an aborted transaction left the database reading as unclean"
+    );
+
+    // The abort rolled back, and the committed value is untouched
+    let read = db.begin_read().unwrap();
+    let table = read.open_table(TABLE).unwrap();
+    assert_eq!(table.get(&0u64).unwrap().unwrap().value(), b"committed");
+    assert!(table.get(&1u64).unwrap().is_none());
+}
+
+#[test]
+fn check_integrity_passes_after_a_dropped_transaction_that_grew_the_file() {
+    let tmpfile = tempfile::NamedTempFile::new().unwrap();
+    let mut db = Database::create(tmpfile.path()).unwrap();
+    {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            table.insert(&0u64, b"committed".as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    // Dropping a write transaction aborts it, and must leave the same state
+    {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            for k in 0..3000u64 {
+                table.insert(&k, vec![0xAAu8; 2000].as_slice()).unwrap();
+            }
+        }
+    }
+
+    assert!(
+        db.check_integrity().unwrap(),
+        "a dropped transaction left the database reading as unclean"
+    );
+}


### PR DESCRIPTION
Growing the database file extends it and updates the layout in memory, but only a header write publishes that layout. A commit writes the header itself, so the two stay in step. An abort does not, and rolling the transaction's allocations back does not shrink the file, so the header on disk is left describing fewer regions than the file holds.

Reloading the header rebuilds the layout from the file length and reports the database as unclean when the stored counts disagree, so `check_integrity()` returned `Ok(false)` — "failed but was repaired" — for a database that was never damaged, after repairing it. Any write transaction that grew the file and was then aborted or dropped triggered it, on a default `Database::create()`:

```rust
let mut db = Database::create(path).unwrap();
// ... one small committed row; check_integrity() == true
let txn = db.begin_write().unwrap();
{ let mut t = txn.open_table(TABLE).unwrap();
  for k in 0..3000u64 { t.insert(&k, vec![0xAA; 2000].as_slice()).unwrap(); } }
txn.abort().unwrap();
assert!(db.check_integrity().unwrap()); // fails before this change
```

Abort now writes the header, as a commit would. A pending `Durability::None` commit is left alone: its slot names pages that have not been flushed, so the header must not reach the disk ahead of them, and a reload verifies the live state it describes rather than the stored layout.

`tests/check_integrity_abort.rs` covers both the explicit `abort()` and the drop-abort path; both fail on master. Found with a model-based differential fuzzer using variable-width keys, which the in-tree harness does not exercise.
