### PR TITLE
Hold range locks on database file to prepare for multi-process support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ uuid = { version= "1.17.0", optional = true }
 [target.'cfg(target_os = "wasi")'.dependencies]
 libc = "0.2.174"
 
+# Byte-range file locks for the multi-process locking protocol; std exposes only whole-file locks
+[target.'cfg(any(target_os = "linux", target_vendor = "apple"))'.dependencies]
+libc = "0.2.174"
+
 # Common test/bench dependencies
 [dev-dependencies]
 rand = "0.10.1"

--- a/src/tree_store/page_store/file_backend/mod.rs
+++ b/src/tree_store/page_store/file_backend/mod.rs
@@ -3,6 +3,10 @@ mod optimized;
 #[cfg(any(windows, unix, target_os = "wasi"))]
 pub use optimized::FileBackend;
 
+// Beside the backend that uses it: the fallback backend below has no file to lock
+#[cfg(any(windows, unix, target_os = "wasi"))]
+pub(crate) mod range_lock;
+
 #[cfg(not(any(windows, unix, target_os = "wasi")))]
 mod fallback;
 #[cfg(not(any(windows, unix, target_os = "wasi")))]

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -1,6 +1,7 @@
 use crate::{DatabaseError, Result, StorageBackend};
 use std::fs::{File, TryLockError};
 use std::io;
+use std::ops::Range;
 
 #[cfg(feature = "logging")]
 use log::warn;
@@ -11,10 +12,30 @@ use std::os::unix::fs::FileExt;
 #[cfg(windows)]
 use std::os::windows::fs::FileExt;
 
+use super::range_lock::RangeLock;
+
+// An offset that is not used in the multi-process locking protocol. Used to detect whether flock()
+// and range locks share the same namespace.
+const NAMESPACE_PROBE_BYTE: u64 = (1 << 62) - 2;
+
+/// Every offset the multi-process locking protocol uses
+const PROTOCOL_RANGES: [Range<u64>; 2] =
+    [0..NAMESPACE_PROBE_BYTE, NAMESPACE_PROBE_BYTE + 1..u64::MAX];
+
+fn report_failed_release(result: io::Result<()>) {
+    #[cfg(feature = "logging")]
+    if let Err(err) = result {
+        warn!("Failed to release a file lock after an open failed: {err}");
+    }
+    #[cfg(not(feature = "logging"))]
+    let _ = result;
+}
+
 /// Stores a database as a file on-disk.
 #[derive(Debug)]
 pub struct FileBackend {
     lock_supported: bool,
+    range_lock_supported: bool,
     file: File,
 }
 
@@ -25,6 +46,76 @@ impl FileBackend {
     }
 
     pub(crate) fn new_internal(file: File, read_only: bool) -> Result<Self, DatabaseError> {
+        let lock_supported = Self::try_whole_file_lock(&file, read_only)?;
+
+        if !lock_supported {
+            return Ok(Self {
+                lock_supported: false,
+                range_lock_supported: false,
+                file,
+            });
+        }
+
+        let conflicts = match File::CONFLICTS_WITH_STD_FILE_LOCK {
+            Some(known) => known,
+            None => file
+                .query_lock(NAMESPACE_PROBE_BYTE..NAMESPACE_PROBE_BYTE + 1)
+                .unwrap_or(false),
+        };
+
+        let range_lock_supported = if conflicts {
+            false
+        } else {
+            match Self::try_lock_protocol_ranges(&file, read_only) {
+                Ok(true) => true,
+                // A multi-process handle has the database open
+                Ok(false) => {
+                    report_failed_release(file.unlock());
+                    return Err(DatabaseError::DatabaseAlreadyOpen);
+                }
+                Err(err) if err.kind() == io::ErrorKind::Unsupported => {
+                    // no-op. If range locks are not supported, then multi-process access is not possible
+                    false
+                }
+                Err(err) => {
+                    report_failed_release(file.unlock());
+                    return Err(err.into());
+                }
+            }
+        };
+
+        Ok(Self {
+            lock_supported,
+            range_lock_supported,
+            file,
+        })
+    }
+
+    fn try_lock_protocol_ranges(file: &File, read_only: bool) -> io::Result<bool> {
+        for (taken, range) in PROTOCOL_RANGES.into_iter().enumerate() {
+            let acquired = if read_only {
+                file.try_lock_shared_range(range)
+            } else {
+                file.try_lock_range(range)
+            };
+            if !matches!(acquired, Ok(true)) {
+                Self::release_protocol_ranges(file, taken);
+                return acquired;
+            }
+        }
+        Ok(true)
+    }
+
+    /// The first `taken` ranges of an open that is failing.
+    fn release_protocol_ranges(file: &File, taken: usize) {
+        for range in PROTOCOL_RANGES.into_iter().take(taken) {
+            report_failed_release(file.unlock_range(range));
+        }
+    }
+
+    /// `Ok(false)` means the platform does not support file locks at all, which is reported
+    /// once rather than failing the open.
+    fn try_whole_file_lock(file: &File, read_only: bool) -> Result<bool, DatabaseError> {
         let result = if read_only {
             file.try_lock_shared()
         } else {
@@ -32,10 +123,7 @@ impl FileBackend {
         };
 
         match result {
-            Ok(()) => Ok(Self {
-                file,
-                lock_supported: true,
-            }),
+            Ok(()) => Ok(true),
             Err(TryLockError::WouldBlock) => Err(DatabaseError::DatabaseAlreadyOpen),
             Err(TryLockError::Error(err)) if err.kind() == io::ErrorKind::Unsupported => {
                 #[cfg(feature = "logging")]
@@ -43,10 +131,7 @@ impl FileBackend {
                     "File locks not supported on this platform. You must ensure that only a single process opens the database file, at a time"
                 );
 
-                Ok(Self {
-                    file,
-                    lock_supported: false,
-                })
+                Ok(false)
             }
             Err(TryLockError::Error(err)) => Err(err.into()),
         }
@@ -127,11 +212,19 @@ impl StorageBackend for FileBackend {
     }
 
     fn close(&self) -> Result<(), io::Error> {
+        // Every lock is released even where one fails: a lock left behind outlives this
+        // backend wherever the description is shared
+        let mut result = Ok(());
+        if self.range_lock_supported {
+            for range in PROTOCOL_RANGES {
+                result = result.and(self.file.unlock_range(range));
+            }
+        }
         if self.lock_supported {
-            self.file.unlock()?;
+            result = result.and(self.file.unlock());
         }
 
-        Ok(())
+        result
     }
 }
 
@@ -204,4 +297,172 @@ fn write_all_at(file: &File, mut buf: &[u8], mut offset: u64) -> io::Result<()> 
         }
     }
     Ok(())
+}
+
+#[cfg(all(test, any(target_os = "linux", target_vendor = "apple")))]
+mod range_lock_tests {
+    use super::{FileBackend, NAMESPACE_PROBE_BYTE, RangeLock};
+    use crate::StorageBackend;
+    use std::fs::{File, OpenOptions, TryLockError};
+    use std::path::Path;
+
+    // Offsets docs/design.md assigns: the header lock, the coordination bytes at BASE, the
+    // transaction range, and the last addressable byte
+    const BASE: u64 = 1 << 62;
+    const PROTOCOL_OFFSETS: [u64; 6] = [0, 319, BASE, BASE + 2, BASE + 1024 + 12345, (1 << 63) - 1];
+
+    fn reopen(path: &Path) -> File {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap()
+    }
+
+    fn byte_is_free(file: &File, offset: u64, exclusive: bool) -> bool {
+        let byte = offset..offset + 1;
+        let acquired = if exclusive {
+            file.try_lock_range(byte.clone()).unwrap()
+        } else {
+            file.try_lock_shared_range(byte.clone()).unwrap()
+        };
+        if acquired {
+            file.unlock_range(byte).unwrap();
+        }
+        acquired
+    }
+
+    #[test]
+    fn a_writable_backend_holds_every_protocol_byte_exclusively() {
+        let tmpfile = crate::create_tempfile();
+        let backend = FileBackend::new_internal(reopen(tmpfile.path()), false).unwrap();
+
+        let observer = reopen(tmpfile.path());
+        for offset in PROTOCOL_OFFSETS {
+            assert!(!byte_is_free(&observer, offset, false), "offset {offset}");
+            assert!(!byte_is_free(&observer, offset, true), "offset {offset}");
+        }
+
+        // ... and releases them all at close
+        backend.close().unwrap();
+        for offset in PROTOCOL_OFFSETS {
+            assert!(byte_is_free(&observer, offset, true), "offset {offset}");
+        }
+    }
+
+    #[test]
+    fn read_only_backends_share_the_protocol_bytes_with_each_other() {
+        let tmpfile = crate::create_tempfile();
+        let first = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
+
+        let observer = reopen(tmpfile.path());
+        for offset in PROTOCOL_OFFSETS {
+            assert!(byte_is_free(&observer, offset, false), "offset {offset}");
+            assert!(!byte_is_free(&observer, offset, true), "offset {offset}");
+        }
+
+        let second = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
+        first.close().unwrap();
+        second.close().unwrap();
+    }
+
+    #[test]
+    fn a_held_protocol_byte_reads_as_already_open() {
+        let tmpfile = crate::create_tempfile();
+        let holder = reopen(tmpfile.path());
+        assert!(holder.try_lock_range(BASE..BASE + 1).unwrap());
+
+        // A held byte anywhere in the range stands in for a multi-process handle having
+        // the database open
+        assert!(matches!(
+            FileBackend::new_internal(reopen(tmpfile.path()), false),
+            Err(crate::DatabaseError::DatabaseAlreadyOpen)
+        ));
+        assert!(matches!(
+            FileBackend::new_internal(reopen(tmpfile.path()), true),
+            Err(crate::DatabaseError::DatabaseAlreadyOpen)
+        ));
+
+        holder.unlock_range(BASE..BASE + 1).unwrap();
+        let backend = FileBackend::new_internal(reopen(tmpfile.path()), false).unwrap();
+        backend.close().unwrap();
+    }
+
+    /// Dropping the file does not suffice: a caller holding a `try_clone()` of the file it
+    /// handed over keeps the open file description, and so the locks, alive
+    #[test]
+    fn a_refused_open_releases_what_it_took() {
+        let tmpfile = crate::create_tempfile();
+        let holder = reopen(tmpfile.path());
+        // In the second piece only, so that the first is taken before the conflict
+        assert!(holder.try_lock_range(BASE..BASE + 1).unwrap());
+
+        let file = reopen(tmpfile.path());
+        let kept_by_the_caller = file.try_clone().unwrap();
+        assert!(matches!(
+            FileBackend::new_internal(file, false),
+            Err(crate::DatabaseError::DatabaseAlreadyOpen)
+        ));
+
+        holder.unlock_range(BASE..BASE + 1).unwrap();
+        let observer = reopen(tmpfile.path());
+        assert!(byte_is_free(&observer, 0, true));
+        observer.try_lock().unwrap();
+        drop(kept_by_the_caller);
+    }
+
+    /// The question the namespace answer is asked with. An implementation blind to the locks
+    /// another handle holds would report every filesystem as keeping the two kinds apart.
+    #[test]
+    fn a_query_reports_the_locks_another_handle_holds() {
+        let tmpfile = crate::create_tempfile();
+        let byte = NAMESPACE_PROBE_BYTE..NAMESPACE_PROBE_BYTE + 1;
+        let asking = reopen(tmpfile.path());
+        assert!(!asking.query_lock(byte.clone()).unwrap());
+
+        let holder = reopen(tmpfile.path());
+        assert!(holder.try_lock_range(byte.clone()).unwrap());
+        assert!(asking.query_lock(byte.clone()).unwrap());
+
+        holder.unlock_range(byte.clone()).unwrap();
+        assert!(!asking.query_lock(byte).unwrap());
+    }
+
+    /// An ordinary Linux filesystem keeps the whole-file lock out of the range locks' table,
+    /// so an open holds both, and leaves the byte it asked at free for the next one to ask
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_ordinary_filesystem_answers_that_the_two_kinds_are_separate() {
+        assert!(File::CONFLICTS_WITH_STD_FILE_LOCK.is_none());
+        let tmpfile = crate::create_tempfile();
+        let backend = FileBackend::new_internal(reopen(tmpfile.path()), false).unwrap();
+
+        let observer = reopen(tmpfile.path());
+        assert!(matches!(observer.try_lock(), Err(TryLockError::WouldBlock)));
+        assert!(!byte_is_free(&observer, BASE, true));
+        assert!(byte_is_free(&observer, NAMESPACE_PROBE_BYTE, true));
+
+        backend.close().unwrap();
+    }
+
+    /// The whole-file lock is all an older version of redb takes, so an open must keep
+    /// excluding it however the namespace question is answered
+    #[test]
+    fn the_whole_file_lock_is_refused_while_a_backend_is_open() {
+        let tmpfile = crate::create_tempfile();
+        let observer = reopen(tmpfile.path());
+
+        let writable = FileBackend::new_internal(reopen(tmpfile.path()), false).unwrap();
+        assert!(matches!(
+            observer.try_lock_shared(),
+            Err(TryLockError::WouldBlock)
+        ));
+        writable.close().unwrap();
+
+        let reader = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
+        assert!(matches!(observer.try_lock(), Err(TryLockError::WouldBlock)));
+        reader.close().unwrap();
+
+        observer.try_lock().unwrap();
+    }
 }

--- a/src/tree_store/page_store/file_backend/range_lock.rs
+++ b/src/tree_store/page_store/file_backend/range_lock.rs
@@ -1,0 +1,146 @@
+use std::fs::File;
+use std::io;
+use std::ops::Range;
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+use std::os::unix::io::AsRawFd;
+
+pub(crate) trait RangeLock {
+    /// Whether these locks and [`File::lock`]'s conflict.
+    /// `None` indicates that it can only be determined at runtime, e.g. because it is filesystem
+    /// dependent.
+    const CONFLICTS_WITH_STD_FILE_LOCK: Option<bool> = None;
+
+    /// `Ok(false)` means a conflicting lock is held elsewhere. An end of `u64::MAX` covers
+    /// the file however it grows, past the last offset fcntl's signed arguments can express.
+    fn try_lock_range(&self, _range: Range<u64>) -> io::Result<bool> {
+        Err(unsupported())
+    }
+
+    fn try_lock_shared_range(&self, _range: Range<u64>) -> io::Result<bool> {
+        Err(unsupported())
+    }
+
+    fn unlock_range(&self, _range: Range<u64>) -> io::Result<()> {
+        Err(unsupported())
+    }
+
+    /// Whether an exclusive lock over the range would conflict with one already held.
+    /// [`File::lock`] is included wherever it would in fact block a range lock
+    fn query_lock(&self, _range: Range<u64>) -> io::Result<bool> {
+        Err(unsupported())
+    }
+}
+
+fn unsupported() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        "byte-range locks are not supported on this platform",
+    )
+}
+
+#[cfg(not(any(target_os = "linux", target_vendor = "apple", windows)))]
+impl RangeLock for File {}
+
+// std's whole-file lock is itself a LockFileEx over every byte, so it is one of these
+#[cfg(windows)]
+impl RangeLock for File {
+    const CONFLICTS_WITH_STD_FILE_LOCK: Option<bool> = Some(true);
+}
+
+// The lock-type constants are c_int on Linux and already c_short on the Apple platforms
+#[cfg(target_os = "linux")]
+fn lock_type(kind: libc::c_int) -> libc::c_short {
+    kind.try_into().unwrap()
+}
+
+#[cfg(target_vendor = "apple")]
+fn lock_type(kind: libc::c_short) -> libc::c_short {
+    kind
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+fn flock_struct(kind: libc::c_short, range: Range<u64>) -> libc::flock {
+    debug_assert!(!range.is_empty());
+    let len = if range.end == u64::MAX {
+        0
+    } else {
+        range.end - range.start
+    };
+    // Zeroed rather than written field by field: struct flock's layout differs between Linux
+    // and the Apple platforms
+    let mut lock: libc::flock = unsafe { std::mem::zeroed() };
+    lock.l_type = kind;
+    lock.l_whence = libc::SEEK_SET.try_into().unwrap();
+    lock.l_start = libc::off_t::try_from(range.start).unwrap();
+    lock.l_len = libc::off_t::try_from(len).unwrap();
+    lock
+}
+
+/// The last lock failure, as `Unsupported` where the filesystem has no byte-range locks.
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+fn lock_error() -> io::Error {
+    let err = io::Error::last_os_error();
+    if matches!(err.raw_os_error(), Some(code) if code == libc::EINVAL
+        || code == libc::ENOTSUP
+        || code == libc::EOPNOTSUPP)
+    {
+        io::Error::new(io::ErrorKind::Unsupported, err)
+    } else {
+        err
+    }
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+fn set_lock(file: &File, exclusive: bool, range: Range<u64>) -> io::Result<bool> {
+    let kind = lock_type(if exclusive {
+        libc::F_WRLCK
+    } else {
+        libc::F_RDLCK
+    });
+    let mut lock = flock_struct(kind, range);
+    let rc = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_OFD_SETLK, &raw mut lock) };
+    if rc == 0 {
+        return Ok(true);
+    }
+    let err = lock_error();
+    match err.raw_os_error() {
+        Some(libc::EAGAIN | libc::EACCES) => Ok(false),
+        _ => Err(err),
+    }
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+impl RangeLock for File {
+    // The Apple platforms answer flock() with the same locks fcntl() takes; Linux keeps them
+    // apart, except where a network filesystem emulates one with the other
+    const CONFLICTS_WITH_STD_FILE_LOCK: Option<bool> = if cfg!(target_vendor = "apple") {
+        Some(true)
+    } else {
+        None
+    };
+
+    fn try_lock_range(&self, range: Range<u64>) -> io::Result<bool> {
+        set_lock(self, true, range)
+    }
+
+    fn try_lock_shared_range(&self, range: Range<u64>) -> io::Result<bool> {
+        set_lock(self, false, range)
+    }
+
+    fn unlock_range(&self, range: Range<u64>) -> io::Result<()> {
+        let mut lock = flock_struct(lock_type(libc::F_UNLCK), range);
+        let rc = unsafe { libc::fcntl(self.as_raw_fd(), libc::F_OFD_SETLK, &raw mut lock) };
+        if rc == 0 { Ok(()) } else { Err(lock_error()) }
+    }
+
+    fn query_lock(&self, range: Range<u64>) -> io::Result<bool> {
+        let mut lock = flock_struct(lock_type(libc::F_WRLCK), range);
+        let rc = unsafe { libc::fcntl(self.as_raw_fd(), libc::F_OFD_GETLK, &raw mut lock) };
+        if rc != 0 {
+            return Err(lock_error());
+        }
+        // The lock-type constants are c_int on Linux and c_short on the Apple platforms, so
+        // both sides are widened rather than compared directly
+        Ok(i32::from(lock.l_type) != i32::from(lock_type(libc::F_UNLCK)))
+    }
+}


### PR DESCRIPTION
The multi-process locking protocol (docs/design.md) coordinates processes through byte-range locks on the database file. On Unix those are a separate namespace from the whole-file lock std takes -- flock() and fcntl() locks cannot see each other -- so today's locking would not stop a multi-process handle and an ordinary one from opening the same file and writing over each other once the protocol exists.

The ordinary open modes hold the entire byte range as well: exclusively from a writable Database, shared from a ReadOnlyDatabase, released at close. The range reaches to the end of the file however it grows, since the signed offsets fcntl uses cannot express an end past the last addressable byte, and is taken as open file description locks, never POSIX record locks, which die with any descriptor the process closes. A filesystem with no byte-range locks is left with the whole-file lock alone, and a warning.

Whether the whole-file lock is a namespace of its own is a question about the filesystem, not only about the platform: some emulate one kind of lock with the other, collapsing both into one table. Where the two conflict the whole-file lock already excludes range-lock holders and no range is taken -- on Windows, where the locks are mandatory, they would block this handle's own reads and writes, and the whole-file lock std takes is itself a LockFileEx over every byte. The Apple platforms and Windows answer for themselves and say the two conflict; elsewhere the open asks, with an F_OFD_GETLK at the one byte the ranges leave out and nothing else ever locks, about the whole-file lock it has just taken. Locks the same open file description holds are not conflicts, but an emulated whole-file lock is reported exactly where it would in fact block a range lock taken there: an ordinary Linux filesystem keeps flock() out of the fcntl tables altogether, the NFS client records it as an flock and gives the server one lock owner for both, and the SMB client records it as a byte-range lock that its own conflict test reports -- the one of the three where both cannot be held at once.

The platform specifics live in a range_lock module, as a trait on File whose methods default to reporting the locks unsupported, which is what platforms with no implementation get; the file backend interacts only with the trait, and handles that one error kind rather than naming platforms.

Assisted-by: Claude Code