### PR TITLE
Record the collection horizon in the commit slots

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -733,6 +733,7 @@ impl Database {
                 next_transaction_id,
                 true,
                 ShrinkPolicy::Never,
+                None,
             )?;
             // Reserve the id, or the next write transaction would commit with the same one,
             // which crash recovery could then resolve to the wrong slot
@@ -1198,6 +1199,7 @@ impl Database {
                 next_transaction_id,
                 true,
                 ShrinkPolicy::Never,
+                None,
             )?;
         }
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2040,12 +2040,16 @@ impl WriteTransaction {
         };
 
         let page_allocator = self.page_allocator();
+        // process_freed_pages ran through free_until_transaction, so reuse reaches the id below it
         self.mem.commit(
             user_root,
             system_root,
             self.transaction_id,
             self.two_phase_commit,
             self.shrink_policy,
+            Some(TransactionId::new(
+                free_until_transaction.raw_id().saturating_sub(1),
+            )),
         )?;
         // All of this transaction's allocations are durable; discard the per-txn tracker.
         let _ = page_allocator.take_allocated_since_commit();

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -73,6 +73,7 @@ const USER_ROOT_OFFSET: usize = _UNUSED_OFFSET + size_of::<u8>() + PADDING;
 const SYSTEM_ROOT_OFFSET: usize = USER_ROOT_OFFSET + BtreeHeader::serialized_size();
 const _UNUSED2_OFFSET: usize = SYSTEM_ROOT_OFFSET + BtreeHeader::serialized_size();
 const TRANSACTION_ID_OFFSET: usize = _UNUSED2_OFFSET + BtreeHeader::serialized_size();
+const COLLECTION_HORIZON_OFFSET: usize = TRANSACTION_ID_OFFSET - size_of::<u64>();
 const TRANSACTION_LAST_FIELD: usize = TRANSACTION_ID_OFFSET + size_of::<u64>();
 
 const SLOT_CHECKSUM_OFFSET: usize = TRANSACTION_SIZE - size_of::<Checksum>();
@@ -405,17 +406,20 @@ impl DatabaseHeader {
         &self.transaction_slots[self.primary_slot ^ 1]
     }
 
-    // Overwrite the secondary slot with a newly committed transaction.
+    // Reuse an earlier commit made visible cannot be taken back, so the horizon only advances
     pub(super) fn write_secondary_slot(
         &mut self,
         transaction_id: TransactionId,
         user_root: Option<BtreeHeader>,
         system_root: Option<BtreeHeader>,
+        collection_horizon: Option<TransactionId>,
     ) {
+        let floor = self.transaction_slots[self.primary_slot].collection_horizon;
         let slot = &mut self.transaction_slots[self.primary_slot ^ 1];
         slot.transaction_id = transaction_id;
         slot.user_root = user_root;
         slot.system_root = system_root;
+        slot.collection_horizon = floor.max(collection_horizon.unwrap_or(floor));
         slot.corrupt_bytes = None;
     }
 
@@ -461,6 +465,9 @@ pub(super) struct TransactionHeader {
     pub(super) user_root: Option<BtreeHeader>,
     pub(super) system_root: Option<BtreeHeader>,
     pub(super) transaction_id: TransactionId,
+    // The newest transaction whose freed pages a commit's reclamation has processed for reuse.
+    // Bounds that alone: the pages a commit frees from the system tree once it is done escape it
+    pub(super) collection_horizon: TransactionId,
     // When present, the original on-disk bytes of a slot whose checksum did not verify. They are
     // written back verbatim, so a slot that failed verification keeps its invalid checksum instead
     // of being re-serialized as if it were valid. `None` once the slot holds a new commit.
@@ -474,6 +481,7 @@ impl TransactionHeader {
             user_root: None,
             system_root: None,
             transaction_id,
+            collection_horizon: TransactionId::new(0),
             corrupt_bytes: None,
         }
     }
@@ -519,12 +527,14 @@ impl TransactionHeader {
             None
         };
         let transaction_id = TransactionId::new(get_u64(&data[TRANSACTION_ID_OFFSET..]));
+        let collection_horizon = TransactionId::new(get_u64(&data[COLLECTION_HORIZON_OFFSET..]));
 
         let result = Self {
             version,
             user_root,
             system_root,
             transaction_id,
+            collection_horizon,
             corrupt_bytes: if corrupted {
                 Some(data[..TRANSACTION_SIZE].try_into().unwrap())
             } else {
@@ -553,6 +563,8 @@ impl TransactionHeader {
             result[SYSTEM_ROOT_OFFSET..(SYSTEM_ROOT_OFFSET + BtreeHeader::serialized_size())]
                 .copy_from_slice(&header.to_le_bytes());
         }
+        result[COLLECTION_HORIZON_OFFSET..(COLLECTION_HORIZON_OFFSET + size_of::<u64>())]
+            .copy_from_slice(&self.collection_horizon.raw_id().to_le_bytes());
         result[TRANSACTION_ID_OFFSET..(TRANSACTION_ID_OFFSET + size_of::<u64>())]
             .copy_from_slice(&self.transaction_id.raw_id().to_le_bytes());
         let checksum = xxh3_checksum(&result[..SLOT_CHECKSUM_OFFSET]);
@@ -565,16 +577,18 @@ impl TransactionHeader {
 
 #[cfg(test)]
 mod test {
+    use super::{COLLECTION_HORIZON_OFFSET, TRANSACTION_SIZE, TransactionHeader};
     #[cfg(feature = "experimental-api-5")]
     use crate::ReadableTable;
     use crate::backends::FileBackend;
     use crate::db::TableDefinition;
+    use crate::transaction_tracker::TransactionId;
     use crate::tree_store::page_store::base::MAX_REGIONS;
     use crate::tree_store::page_store::header::{
         DB_HEADER_SIZE, GOD_BYTE_OFFSET, MAGICNUMBER, NUM_FULL_REGIONS_OFFSET, PAGE_SIZE_OFFSET,
         PRIMARY_BIT, RECOVERY_REQUIRED, REGION_HEADER_PAGES_OFFSET, REGION_MAX_DATA_PAGES_OFFSET,
         TRAILING_REGION_DATA_PAGES_OFFSET, TRANSACTION_0_OFFSET, TRANSACTION_1_OFFSET,
-        TWO_PHASE_COMMIT, get_u32,
+        TWO_PHASE_COMMIT, get_u32, get_u64,
     };
     use crate::{Database, DatabaseError, StorageBackend};
     use crate::{ReadableDatabase, StorageError};
@@ -585,6 +599,75 @@ mod test {
     use std::io::{Error, ErrorKind, Read, Seek, SeekFrom, Write};
 
     const X: TableDefinition<&str, &str> = TableDefinition::new("x");
+
+    fn primary_slot_horizon(path: &std::path::Path) -> u64 {
+        let mut header = [0; DB_HEADER_SIZE];
+        std::fs::File::open(path)
+            .unwrap()
+            .read_exact(&mut header)
+            .unwrap();
+        let slot = primary_slot_offset(header[GOD_BYTE_OFFSET]);
+        get_u64(&header[slot + COLLECTION_HORIZON_OFFSET..])
+    }
+
+    // Read after the close, since on Windows the database's own locks are mandatory
+    fn horizon_after(commits: usize, hold_a_reader: bool) -> u64 {
+        let tmpfile = crate::create_tempfile();
+        let db = Database::create(tmpfile.path()).unwrap();
+        let reader = hold_a_reader.then(|| db.begin_read().unwrap());
+        for i in 0..commits {
+            let write_txn = db.begin_write().unwrap();
+            {
+                let mut table = write_txn.open_table(X).unwrap();
+                table.insert("hello", i.to_string().as_str()).unwrap();
+            }
+            write_txn.commit().unwrap();
+        }
+        drop(reader);
+        drop(db);
+        primary_slot_horizon(tmpfile.path())
+    }
+
+    #[test]
+    fn every_commit_publishes_the_collection_horizon() {
+        let after_five = horizon_after(5, false);
+        let after_nine = horizon_after(9, false);
+        assert!(after_five > 0);
+        assert!(after_nine > after_five);
+
+        // Held back at the reader rather than following the commits
+        assert!(horizon_after(9, true) < after_nine);
+    }
+
+    /// The horizon goes in bytes releases without it leave zero, inside the checksummed region
+    #[test]
+    fn the_collection_horizon_round_trips_and_is_checksummed() {
+        let mut slot = TransactionHeader::new(TransactionId::new(7));
+        slot.collection_horizon = TransactionId::new(5);
+        let bytes = slot.to_bytes();
+
+        let (parsed, corrupted) = TransactionHeader::from_bytes(&bytes).unwrap();
+        assert!(!corrupted);
+        assert_eq!(parsed.collection_horizon, TransactionId::new(5));
+        assert_eq!(parsed.transaction_id, TransactionId::new(7));
+
+        // A torn write must invalidate the slot rather than parse as a different horizon
+        let mut torn = bytes;
+        torn[COLLECTION_HORIZON_OFFSET] ^= 0xFF;
+        let (_, corrupted) = TransactionHeader::from_bytes(&torn).unwrap();
+        assert!(corrupted);
+
+        // What an older release writes: zeroed but for the fields it knows
+        let mut older = [0; TRANSACTION_SIZE];
+        older[..COLLECTION_HORIZON_OFFSET].copy_from_slice(&bytes[..COLLECTION_HORIZON_OFFSET]);
+        older[COLLECTION_HORIZON_OFFSET + size_of::<u64>()..]
+            .copy_from_slice(&bytes[COLLECTION_HORIZON_OFFSET + size_of::<u64>()..]);
+        let checksum = super::xxh3_checksum(&older[..super::SLOT_CHECKSUM_OFFSET]);
+        older[super::SLOT_CHECKSUM_OFFSET..].copy_from_slice(&checksum.to_le_bytes());
+        let (parsed, corrupted) = TransactionHeader::from_bytes(&older).unwrap();
+        assert!(!corrupted);
+        assert_eq!(parsed.collection_horizon, TransactionId::new(0));
+    }
 
     fn primary_slot_offset(god_byte: u8) -> usize {
         if god_byte & PRIMARY_BIT == 0 {

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1056,6 +1056,7 @@ impl TransactionalMemory {
         transaction_id: TransactionId,
         two_phase: bool,
         shrink_policy: ShrinkPolicy,
+        collection_horizon: Option<TransactionId>,
     ) -> Result {
         // All mutable pages must be dropped, this ensures that when a transaction completes
         // no more writes can happen to the pages it allocated. Thus it is safe to make them visible
@@ -1082,7 +1083,7 @@ impl TransactionalMemory {
         );
 
         let old_transaction_id = header.secondary_slot().transaction_id;
-        header.write_secondary_slot(transaction_id, data_root, system_root);
+        header.write_secondary_slot(transaction_id, data_root, system_root, collection_horizon);
 
         self.write_header(&header)?;
 
@@ -1141,7 +1142,7 @@ impl TransactionalMemory {
         let mut state = self.state.lock().unwrap();
         state
             .header
-            .write_secondary_slot(transaction_id, data_root, system_root);
+            .write_secondary_slot(transaction_id, data_root, system_root, None);
         state.read_from_secondary = true;
 
         Ok(())


### PR DESCRIPTION
Superseded by b28523a, which takes the simpler approach: no persistent horizon at all, and a process invalidates its cache when a transaction begins and observes a new committed transaction id.

Closing rather than reworking -- there is nothing left of this PR once the field goes.

The Codex finding that led here is on the thread below: the horizon claimed to bound page reuse, but the pages a commit frees from the system tree are freed outright once it is done, so they escape it and a peer could serve a stale copy. Keeping the field would have meant routing those through the freed table, and the invariant would have stayed open-ended -- correct only as long as every future path that frees a page respects it, which had already been broken twice.

If the coarser invalidation ever proves too expensive, this field is a format-compatible addition: it sits in slot padding inside the checksummed region, so it can be added back without a version bump.