### PR TITLE
Add the concurrency modes and the mode bytes they announce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   be added behind the `experimental_cursor` feature flag, like the table cursors' were.
 * Under the `experimental-api-5` feature flag, a database file is locked with byte-range locks
   alone, rather than also with the whole-file lock earlier versions take.
+* Add the `experimental-multiprocess` feature flag, under which `Builder::set_concurrency_mode()`
+  takes a `ConcurrencyMode` configuring how processes may share the database.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ experimental_cursor = ["experimental-api-5"]
 # Unstable additions and changes to the public API, planned for redb 5. May change incompatibly, or
 # be removed, in any release
 experimental-api-5 = []
+# Unstable support for sharing a database between processes. Requires "std", and a platform with
+# byte-range file locks.
+# May change incompatibly, or be removed, in any release
+experimental-multiprocess = ["std", "experimental-api-5"]
 
 [profile.bench]
 debug = true

--- a/src/db.rs
+++ b/src/db.rs
@@ -76,12 +76,31 @@ pub trait StorageBackend: 'static + Debug + Send + Sync {
 #[cfg_attr(redb_no_std, allow(dead_code))]
 pub(crate) const FULL_RANGE: Range<u64> = 0..u64::MAX;
 
-#[cfg(any(windows, unix, target_os = "wasi"))]
+#[cfg_attr(not(any(windows, unix, target_os = "wasi")), allow(dead_code))]
 const LOCK_BASE: u64 = 1 << 62;
 /// An offset that is not used in the multi-process locking protocol. Used to detect whether
-/// `flock()` and range locks share the same namespace.
-#[cfg(any(windows, unix, target_os = "wasi"))]
+/// `flock()` and range locks share the same namespace, which only matters while a whole-file
+/// lock is taken alongside the ranges.
+#[cfg(not(feature = "experimental-api-5"))]
+#[cfg_attr(not(any(windows, unix, target_os = "wasi")), allow(dead_code))]
 pub(crate) const NAMESPACE_PROBE_BYTE: u64 = LOCK_BASE - 2;
+/// Held exclusively by the writing process in single-writer mode.
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) const WRITER_BYTE: u64 = LOCK_BASE;
+/// Whether the database is open for a single writer (held exclusively by it) or for many (held
+/// shared by each writing process while the database is open).
+#[cfg_attr(not(any(windows, unix, target_os = "wasi")), allow(dead_code))]
+pub(crate) const SHARED_WRITER_BYTE: u64 = LOCK_BASE + 1;
+/// Held shared by every read-only multi-process handle while the database is open, so that a
+/// single-process open conflicts with a live reader no matter what the reader is doing.
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) const SHARED_READER_BYTE: u64 = LOCK_BASE + 2;
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) const IMMUTABLE_READER_BYTE: u64 = LOCK_BASE + 3;
+
+pub(crate) fn byte_range(offset: u64) -> Range<u64> {
+    offset..offset + 1
+}
 
 /// A range reaching [`u64::MAX`] covers the entire storage.
 #[cfg_attr(redb_no_std, allow(dead_code))]
@@ -98,6 +117,9 @@ pub(crate) trait InternalStorageBackend: StorageBackend {
     fn try_lock_shared_range(&self, range: Range<u64>) -> core::result::Result<bool, io::Error>;
 
     fn unlock_range(&self, range: Range<u64>) -> core::result::Result<(), io::Error>;
+
+    /// Whether an exclusive lock over the range would conflict with one held elsewhere.
+    fn query_lock_range(&self, range: Range<u64>) -> core::result::Result<bool, io::Error>;
 }
 
 pub trait TableHandle: Sealed {
@@ -493,6 +515,7 @@ impl ReadOnlyDatabase {
         page_size: usize,
         region_size: Option<u64>,
         cache_size: usize,
+        concurrency_mode: ConcurrencyMode,
     ) -> Result<Self, DatabaseError> {
         #[cfg(feature = "logging")]
         let file_path = format!("{:?}", &file);
@@ -505,6 +528,7 @@ impl ReadOnlyDatabase {
             region_size,
             cache_size,
             true,
+            concurrency_mode,
         )?;
         let mem = Arc::new(mem);
         // If the last transaction used 2-phase commit and updated the allocator state table, then
@@ -1188,6 +1212,7 @@ impl Database {
         page_size: usize,
         region_size: Option<u64>,
         cache_size: usize,
+        concurrency_mode: ConcurrencyMode,
         repair_callback: &(dyn Fn(&mut RepairSession) + 'static),
     ) -> Result<Self, DatabaseError> {
         #[cfg(feature = "logging")]
@@ -1201,6 +1226,7 @@ impl Database {
             region_size,
             cache_size,
             false,
+            concurrency_mode,
         )?;
         let mut mem = Arc::new(mem);
         // If the last transaction used 2-phase commit and updated the allocator state table, then
@@ -1452,11 +1478,36 @@ impl RepairSession {
     }
 }
 
+/// The sharing mode between processes accessing the database
+///
+/// Every process opening one database concurrently must use a compatible mode: one
+/// `SingleWriterProcess` writer or any number of `MultiWriterProcess` writers, plus read-only
+/// handles in either case. The multi-process modes need byte-range file locks, so they are
+/// supported on Linux, the Apple platforms and Windows; elsewhere, opening a database in one of
+/// them fails.
+#[cfg_attr(
+    not(feature = "experimental-multiprocess"),
+    allow(dead_code, unreachable_pub, clippy::enum_variant_names)
+)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+pub enum ConcurrencyMode {
+    /// The database is not shared: one process may open it for writing, or several read-only.
+    /// Enforced by locking the whole file. The default.
+    #[default]
+    SingleProcess,
+    /// One process writes; any number of processes may, concurrently, open the database read-only.
+    SingleWriterProcess,
+    /// Any number of processes may, concurrently open the database for reading and writing.
+    /// Only one write transaction may be open at a time.
+    MultiWriterProcess,
+}
+
 /// Configuration builder of a redb [Database].
 pub struct Builder {
     page_size: usize,
     region_size: Option<u64>,
     cache_size: usize,
+    concurrency_mode: ConcurrencyMode,
     repair_callback: Box<dyn Fn(&mut RepairSession)>,
 }
 
@@ -1474,6 +1525,7 @@ impl Builder {
             // It is part of the file format, so can be enabled in the future.
             page_size: PAGE_SIZE,
             region_size: None,
+            concurrency_mode: ConcurrencyMode::SingleProcess,
             cache_size: 1024 * 1024 * 1024,
             repair_callback: Box::new(|_| {}),
         }
@@ -1514,6 +1566,13 @@ impl Builder {
         self
     }
 
+    /// Set how processes may share this database. Defaults to [`ConcurrencyMode::SingleProcess`].
+    #[cfg(feature = "experimental-multiprocess")]
+    pub fn set_concurrency_mode(&mut self, mode: ConcurrencyMode) -> &mut Self {
+        self.concurrency_mode = mode;
+        self
+    }
+
     #[cfg(any(test, fuzzing))]
     pub fn set_region_size(&mut self, size: u64) -> &mut Self {
         assert!(size.is_power_of_two());
@@ -1540,6 +1599,7 @@ impl Builder {
             self.page_size,
             self.region_size,
             self.cache_size,
+            self.concurrency_mode,
             &self.repair_callback,
         )
     }
@@ -1555,6 +1615,7 @@ impl Builder {
             self.page_size,
             None,
             self.cache_size,
+            self.concurrency_mode,
             &self.repair_callback,
         )
     }
@@ -1576,6 +1637,7 @@ impl Builder {
             self.page_size,
             None,
             self.cache_size,
+            self.concurrency_mode,
         )
     }
 
@@ -1590,6 +1652,7 @@ impl Builder {
             self.page_size,
             self.region_size,
             self.cache_size,
+            self.concurrency_mode,
             &self.repair_callback,
         )
     }
@@ -1605,6 +1668,7 @@ impl Builder {
             self.page_size,
             self.region_size,
             self.cache_size,
+            self.concurrency_mode,
             &self.repair_callback,
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,8 @@
 // std builds.
 extern crate alloc;
 
+#[cfg(feature = "experimental-multiprocess")]
+pub use db::ConcurrencyMode;
 #[cfg(not(redb_no_std))]
 pub use db::ReadOnlyDatabase;
 pub use db::{

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -1440,6 +1440,7 @@ mod tests {
             None,
             0,
             false,
+            crate::db::ConcurrencyMode::SingleProcess,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -2299,6 +2299,7 @@ mod tests {
             None,
             0,
             false,
+            crate::db::ConcurrencyMode::SingleProcess,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -2467,6 +2467,7 @@ mod tests {
             None,
             0,
             false,
+            crate::db::ConcurrencyMode::SingleProcess,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -1849,6 +1849,7 @@ mod tests {
             None,
             0,
             false,
+            crate::db::ConcurrencyMode::SingleProcess,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/src/tree_store/page_store/backends.rs
+++ b/src/tree_store/page_store/backends.rs
@@ -65,6 +65,10 @@ impl InternalStorageBackend for LocklessBackend {
     fn unlock_range(&self, _range: Range<u64>) -> Result<(), io::Error> {
         Err(unsupported())
     }
+
+    fn query_lock_range(&self, _range: Range<u64>) -> Result<bool, io::Error> {
+        Err(unsupported())
+    }
 }
 
 #[cfg_attr(redb_no_std, allow(dead_code))]
@@ -101,6 +105,10 @@ impl InternalStorageBackend for ReadOnlyBackend {
 
     fn unlock_range(&self, range: Range<u64>) -> Result<(), Error> {
         self.inner.unlock_range(range)
+    }
+
+    fn query_lock_range(&self, range: Range<u64>) -> Result<bool, Error> {
+        self.inner.query_lock_range(range)
     }
 }
 
@@ -223,6 +231,7 @@ mod test {
             backend.try_lock_range(FULL_RANGE).err(),
             backend.try_lock_shared_range(FULL_RANGE).err(),
             backend.unlock_range(FULL_RANGE).err(),
+            backend.query_lock_range(FULL_RANGE).err(),
         ] {
             let err = result.expect("the locks are unsupported");
             assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -13,6 +13,7 @@ use core::slice::SliceIndex;
 #[cfg(feature = "cache_metrics")]
 use core::sync::atomic::AtomicU64;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
 // Allocates an `Arc<[u8]>` in one step. `Arc::<[u8]>::from(vec![0; len])` would
 // allocate the Vec and then allocate a new Arc and memcpy into it.
 fn zero_filled_arc(len: usize) -> Arc<[u8]> {
@@ -156,6 +157,10 @@ impl CheckedBackend {
 
     fn try_lock_shared_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
         self.file.try_lock_shared_range(range)
+    }
+
+    fn query_lock_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
+        self.file.query_lock_range(range)
     }
 
     fn check_failure(&self) -> Result<()> {
@@ -346,6 +351,11 @@ impl PagedCachedFile {
 
     pub(crate) fn try_lock_shared_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
         self.file.try_lock_shared_range(range)
+    }
+
+    /// Whether an exclusive lock over the range would conflict with one held elsewhere.
+    pub(crate) fn query_lock_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
+        self.file.query_lock_range(range)
     }
 
     fn write_buffer_stripe(&self, offset: u64) -> &Arc<Mutex<LRUWriteCache>> {

--- a/src/tree_store/page_store/file_backend/fallback.rs
+++ b/src/tree_store/page_store/file_backend/fallback.rs
@@ -71,6 +71,10 @@ impl InternalStorageBackend for FileBackend {
 
         Ok(())
     }
+
+    fn query_lock_range(&self, _range: Range<u64>) -> Result<bool, io::Error> {
+        Err(unsupported())
+    }
 }
 
 fn unsupported() -> io::Error {

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -1,4 +1,8 @@
-use crate::db::{FULL_RANGE, InternalStorageBackend, NAMESPACE_PROBE_BYTE};
+#[cfg(not(feature = "experimental-api-5"))]
+use crate::db::NAMESPACE_PROBE_BYTE;
+#[cfg(not(feature = "experimental-api-5"))]
+use crate::db::byte_range;
+use crate::db::{FULL_RANGE, InternalStorageBackend, SHARED_WRITER_BYTE};
 use crate::{DatabaseError, Result, StorageBackend};
 use std::collections::HashSet;
 use std::fs::{File, TryLockError};
@@ -18,9 +22,26 @@ use std::os::windows::fs::FileExt;
 
 use super::range_lock::RangeLock;
 
-/// Every offset the multi-process locking protocol uses
-const PROTOCOL_RANGES: [Range<u64>; 2] =
-    [0..NAMESPACE_PROBE_BYTE, NAMESPACE_PROBE_BYTE + 1..u64::MAX];
+#[cfg(feature = "experimental-api-5")]
+fn protocol_ranges(shared: bool) -> &'static [Range<u64>] {
+    static EXCLUSIVE: [Range<u64>; 1] = [FULL_RANGE];
+    static SHARED: [Range<u64>; 2] = [0..SHARED_WRITER_BYTE, SHARED_WRITER_BYTE + 1..u64::MAX];
+
+    if shared { &SHARED } else { &EXCLUSIVE }
+}
+
+#[cfg(not(feature = "experimental-api-5"))]
+fn protocol_ranges(shared: bool) -> &'static [Range<u64>] {
+    static EXCLUSIVE: [Range<u64>; 2] =
+        [0..NAMESPACE_PROBE_BYTE, NAMESPACE_PROBE_BYTE + 1..u64::MAX];
+    static SHARED: [Range<u64>; 3] = [
+        0..NAMESPACE_PROBE_BYTE,
+        NAMESPACE_PROBE_BYTE + 1..SHARED_WRITER_BYTE,
+        SHARED_WRITER_BYTE + 1..u64::MAX,
+    ];
+
+    if shared { &SHARED } else { &EXCLUSIVE }
+}
 
 fn report_failed_release(result: io::Result<()>) {
     #[cfg(feature = "logging")]
@@ -82,7 +103,7 @@ impl FileBackend {
         if File::CONFLICTS_WITH_STD_FILE_LOCK.is_none()
             && self
                 .file
-                .query_lock(NAMESPACE_PROBE_BYTE..NAMESPACE_PROBE_BYTE + 1)
+                .query_lock(byte_range(NAMESPACE_PROBE_BYTE))
                 .unwrap_or(false)
         {
             // Prefer range locks, so release the whole-file lock which maps to the range lock
@@ -106,7 +127,7 @@ impl FileBackend {
 
     /// The ranges alone, which is what a namespace shared with the whole-file lock calls for
     fn lock_protocol_ranges(&self, shared: bool) -> io::Result<bool> {
-        for (taken, range) in PROTOCOL_RANGES.into_iter().enumerate() {
+        for (taken, range) in protocol_ranges(shared).iter().enumerate() {
             let acquired = if shared {
                 self.file.try_lock_shared_range(range.clone())
             } else {
@@ -114,8 +135,8 @@ impl FileBackend {
             };
             // Another handle has the database open, holding either kind of lock
             if !matches!(acquired, Ok(true)) {
-                for range in PROTOCOL_RANGES.into_iter().take(taken) {
-                    report_failed_release(self.unlock_range(range));
+                for range in protocol_ranges(shared).iter().take(taken) {
+                    report_failed_release(self.unlock_range(range.clone()));
                 }
                 return acquired;
             }
@@ -188,6 +209,10 @@ impl InternalStorageBackend for FileBackend {
         }
         self.locked_ranges.lock().unwrap().remove(&range);
         self.file.unlock_range(range)
+    }
+
+    fn query_lock_range(&self, range: Range<u64>) -> io::Result<bool> {
+        self.file.query_lock(range)
     }
 }
 
@@ -342,7 +367,9 @@ fn write_all_at(file: &File, mut buf: &[u8], mut offset: u64) -> io::Result<()> 
 
 #[cfg(all(test, any(target_os = "linux", target_vendor = "apple", windows)))]
 mod range_lock_tests {
-    use super::{FULL_RANGE, FileBackend, InternalStorageBackend, NAMESPACE_PROBE_BYTE, RangeLock};
+    #[cfg(not(feature = "experimental-api-5"))]
+    use super::NAMESPACE_PROBE_BYTE;
+    use super::{FULL_RANGE, FileBackend, InternalStorageBackend, RangeLock};
     #[cfg(not(all(feature = "experimental-api-5", target_os = "linux")))]
     use std::fs::TryLockError;
     use std::fs::{File, OpenOptions};
@@ -515,12 +542,12 @@ mod range_lock_tests {
         drop(kept_by_the_caller);
     }
 
-    /// The question the namespace answer is asked with. An implementation blind to the locks
-    /// another handle holds would report every filesystem as keeping the two kinds apart.
+    /// The question the protocol's probes are asked with. An implementation blind to the locks
+    /// another handle holds would answer every one of them free.
     #[test]
     fn a_query_reports_the_locks_another_handle_holds() {
         let tmpfile = crate::create_tempfile();
-        let byte = NAMESPACE_PROBE_BYTE..NAMESPACE_PROBE_BYTE + 1;
+        let byte = BASE + 4..BASE + 5;
         let asking = reopen(tmpfile.path());
         assert!(!asking.query_lock(byte.clone()).unwrap());
 
@@ -569,6 +596,7 @@ mod range_lock_tests {
         for offset in PROTOCOL_OFFSETS {
             assert!(!byte_is_free(&observer, offset, false), "offset {offset}");
         }
+        #[cfg(not(feature = "experimental-api-5"))]
         assert!(byte_is_free(&observer, NAMESPACE_PROBE_BYTE, true));
         // Here the whole-file lock is a namespace of its own, so taking it proves it is unheld
         observer.try_lock().unwrap();
@@ -582,6 +610,7 @@ mod range_lock_tests {
 
     /// The byte the namespace probe asks at is left free by every open, whichever lock it holds:
     /// where the whole-file lock would cover it, the ranges are held in its place
+    #[cfg(not(feature = "experimental-api-5"))]
     #[test]
     fn the_probe_byte_is_free_while_a_backend_is_open() {
         let tmpfile = crate::create_tempfile();
@@ -656,10 +685,7 @@ mod range_lock_tests {
 
         // Mapped together, this test has nothing to say
         let asking = reopen(tmpfile.path());
-        if asking
-            .query_lock(NAMESPACE_PROBE_BYTE..NAMESPACE_PROBE_BYTE + 1)
-            .unwrap()
-        {
+        if !byte_is_free(&asking, 0, true) {
             return;
         }
 

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1,5 +1,9 @@
 use crate::CacheStats;
-use crate::db::{FULL_RANGE, InternalStorageBackend};
+use crate::db::{
+    ConcurrencyMode, FULL_RANGE, InternalStorageBackend, SHARED_WRITER_BYTE, byte_range,
+};
+#[cfg(feature = "experimental-multiprocess")]
+use crate::db::{IMMUTABLE_READER_BYTE, SHARED_READER_BYTE, WRITER_BYTE};
 use crate::io;
 use crate::sync::Mutex;
 use crate::transaction_tracker::TransactionId;
@@ -526,6 +530,23 @@ pub(crate) struct TransactionalMemory {
 }
 
 impl TransactionalMemory {
+    /// The locks a handle holds for as long as the database is open, taken before anything is
+    /// read from the storage.
+    fn lock_for_open(
+        storage: &PagedCachedFile,
+        read_only: bool,
+        concurrency_mode: ConcurrencyMode,
+    ) -> Result<(), DatabaseError> {
+        match concurrency_mode {
+            ConcurrencyMode::SingleProcess => Self::lock_whole_storage(storage, read_only),
+            #[cfg(feature = "experimental-multiprocess")]
+            mode => Self::lock_mode_bytes(storage, read_only, mode),
+            // The shared modes are only reachable through the feature-gated setter
+            #[cfg(not(feature = "experimental-multiprocess"))]
+            _ => unreachable!(),
+        }
+    }
+
     fn lock_whole_storage(storage: &PagedCachedFile, read_only: bool) -> Result<(), DatabaseError> {
         // A caller-supplied backend has no locks, which is not a platform limitation
         if !storage.locks_expected() {
@@ -539,17 +560,67 @@ impl TransactionalMemory {
         };
 
         match result {
-            Ok(true) => Ok(()),
-            Ok(false) => Err(DatabaseError::DatabaseAlreadyOpen),
+            Ok(true) => {}
+            Ok(false) => return Err(DatabaseError::DatabaseAlreadyOpen),
             Err(err) if io::is_unsupported(&err) => {
                 #[cfg(feature = "logging")]
                 warn!(
                     "File locks not supported on this platform. You must ensure that only a single process opens the database file, at a time"
                 );
 
-                Ok(())
+                return Ok(());
             }
-            Err(err) => Err(err.into()),
+            Err(err) => return Err(err.into()),
+        }
+
+        // A multi-writer cohort holds nothing a read-only open's shared locks conflict with, so
+        // the open probes for one, which its own ranges leave uncovered for the purpose
+        if read_only {
+            match Self::locked_for_multi_process_writing(storage) {
+                Ok(true) => return Err(DatabaseError::DatabaseAlreadyOpen),
+                Ok(false) => {}
+                // Without byte-range locks there is no multi-process handle to find
+                Err(ref err) if io::is_unsupported(err) => {}
+                Err(err) => return Err(err.into()),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Whether a multi-writer cohort has the database open. Not gated on the feature that forms
+    /// one: the cohort is another process, which may have been built with it when this was not.
+    fn locked_for_multi_process_writing(storage: &PagedCachedFile) -> Result<bool, io::Error> {
+        storage.query_lock_range(byte_range(SHARED_WRITER_BYTE))
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_mode_bytes(
+        storage: &PagedCachedFile,
+        read_only: bool,
+        concurrency_mode: ConcurrencyMode,
+    ) -> Result<(), DatabaseError> {
+        let acquired = if read_only {
+            storage.try_lock_shared_range(byte_range(SHARED_READER_BYTE))?
+        } else {
+            match concurrency_mode {
+                ConcurrencyMode::SingleProcess => unreachable!(),
+                ConcurrencyMode::SingleWriterProcess => {
+                    storage.try_lock_range(byte_range(SHARED_WRITER_BYTE))?
+                        && storage.try_lock_range(byte_range(WRITER_BYTE))?
+                }
+                ConcurrencyMode::MultiWriterProcess => {
+                    storage.try_lock_shared_range(byte_range(SHARED_WRITER_BYTE))?
+                        // Ensure we didn't race with an Immutable open of the database
+                        && !storage.query_lock_range(byte_range(IMMUTABLE_READER_BYTE))?
+                }
+            }
+        };
+
+        if acquired {
+            Ok(())
+        } else {
+            Err(DatabaseError::DatabaseAlreadyOpen)
         }
     }
 
@@ -561,6 +632,7 @@ impl TransactionalMemory {
         requested_region_size: Option<u64>,
         cache_size: usize,
         read_only: bool,
+        concurrency_mode: ConcurrencyMode,
     ) -> Result<Self, DatabaseError> {
         assert!(page_size.is_power_of_two() && page_size >= DB_HEADER_SIZE);
 
@@ -572,7 +644,8 @@ impl TransactionalMemory {
         assert!(region_size.is_power_of_two());
 
         let storage = PagedCachedFile::new(file, page_size as u64, cache_size);
-        Self::lock_whole_storage(&storage, read_only)?;
+        // Dropping the storage releases whatever this took, so an open that fails below does too
+        Self::lock_for_open(&storage, read_only, concurrency_mode)?;
 
         let initial_storage_len = storage.raw_file_len()?;
 
@@ -1794,6 +1867,7 @@ mod test {
             None,
             0,
             false,
+            crate::db::ConcurrencyMode::SingleProcess,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();
@@ -1836,6 +1910,7 @@ mod test {
             Some(64 * page_size as u64),
             0,
             false,
+            crate::db::ConcurrencyMode::SingleProcess,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();
@@ -1884,6 +1959,7 @@ mod test {
             Some(64 * page_size as u64),
             0,
             false,
+            crate::db::ConcurrencyMode::SingleProcess,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();
@@ -1927,6 +2003,7 @@ mod test {
             Some(region_size),
             0,
             false,
+            crate::db::ConcurrencyMode::SingleProcess,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();
@@ -1973,10 +2050,162 @@ mod test {
     }
 }
 
+/// The locking protocol an open runs before it reads anything, against real files. Only the
+/// platforms with byte-range locks can run it.
+#[cfg(all(test, any(target_os = "linux", target_vendor = "apple", windows)))]
+mod lock_protocol_test {
+    use super::TransactionalMemory;
+    use crate::DatabaseError;
+    use crate::db::ConcurrencyMode;
+    use crate::tree_store::page_store::cached_file::PagedCachedFile;
+    use crate::tree_store::page_store::file_backend::FileBackend;
+    use crate::tree_store::page_store::file_backend::range_lock::RangeLock;
+    use std::fs::{File, OpenOptions};
+    use std::path::Path;
+
+    fn reopen(path: &Path) -> File {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap()
+    }
+
+    /// The locks an open takes. A failure drops the storage, which is what releases whatever it
+    /// had taken.
+    fn open_file(
+        file: File,
+        read_only: bool,
+        concurrency_mode: ConcurrencyMode,
+    ) -> Result<PagedCachedFile, DatabaseError> {
+        let storage = PagedCachedFile::new(Box::new(FileBackend::new(file)?), 4096, 0);
+        TransactionalMemory::lock_for_open(&storage, read_only, concurrency_mode)?;
+
+        Ok(storage)
+    }
+
+    fn open(
+        path: &Path,
+        read_only: bool,
+        concurrency_mode: ConcurrencyMode,
+    ) -> Result<PagedCachedFile, DatabaseError> {
+        open_file(reopen(path), read_only, concurrency_mode)
+    }
+
+    fn single_process(path: &Path, read_only: bool) -> Result<PagedCachedFile, DatabaseError> {
+        open(path, read_only, ConcurrencyMode::SingleProcess)
+    }
+
+    fn refused(result: Result<PagedCachedFile, DatabaseError>) -> bool {
+        matches!(result, Err(DatabaseError::DatabaseAlreadyOpen))
+    }
+
+    /// The cohort is another process, which may have been built with the multi-process feature
+    /// when this one was not, so the probe is not gated on being able to form one
+    #[test]
+    fn a_read_only_open_refuses_a_cohort_this_build_cannot_form() {
+        use crate::db::{SHARED_WRITER_BYTE, byte_range};
+
+        let tmpfile = crate::create_tempfile();
+        let cohort = reopen(tmpfile.path());
+        assert!(
+            cohort
+                .try_lock_shared_range(byte_range(SHARED_WRITER_BYTE))
+                .unwrap()
+        );
+
+        assert!(refused(single_process(tmpfile.path(), true)));
+    }
+
+    /// Only a multi-writer cohort admits a second writer, and every mode byte is free again once
+    /// its holder closes
+    #[cfg(feature = "experimental-multiprocess")]
+    #[test]
+    fn the_modes_exclude_each_other() {
+        use ConcurrencyMode::{MultiWriterProcess, SingleWriterProcess};
+
+        let tmpfile = crate::create_tempfile();
+        for (held, joining, admitted) in [
+            (SingleWriterProcess, SingleWriterProcess, false),
+            (SingleWriterProcess, MultiWriterProcess, false),
+            (MultiWriterProcess, SingleWriterProcess, false),
+            (MultiWriterProcess, MultiWriterProcess, true),
+        ] {
+            let first = open(tmpfile.path(), false, held).unwrap();
+            let second = open(tmpfile.path(), false, joining);
+            assert_eq!(second.is_ok(), admitted, "{held:?} then {joining:?}");
+
+            let reader = open(tmpfile.path(), true, MultiWriterProcess).unwrap();
+            reader.close().unwrap();
+            if let Ok(second) = second {
+                second.close().unwrap();
+            }
+            first.close().unwrap();
+        }
+    }
+
+    /// A single-process handle joins nothing, so it and a multi-process one refuse each other --
+    /// unless both are read-only, since neither holds a byte the other could find
+    #[cfg(feature = "experimental-multiprocess")]
+    #[test]
+    fn a_single_process_handle_and_a_multi_process_one_refuse_each_other() {
+        let tmpfile = crate::create_tempfile();
+        for mode in [
+            ConcurrencyMode::SingleWriterProcess,
+            ConcurrencyMode::MultiWriterProcess,
+        ] {
+            for read_only in [false, true] {
+                let plain = single_process(tmpfile.path(), read_only).unwrap();
+                assert!(refused(open(tmpfile.path(), false, mode)));
+                assert_eq!(refused(open(tmpfile.path(), true, mode)), !read_only);
+                plain.close().unwrap();
+
+                let held = open(tmpfile.path(), read_only, mode).unwrap();
+                assert!(refused(single_process(tmpfile.path(), false)));
+                assert_eq!(refused(single_process(tmpfile.path(), true)), !read_only);
+                held.close().unwrap();
+            }
+        }
+    }
+
+    /// Dropping the file does not suffice: a caller holding a `try_clone()` of the file it
+    /// handed over keeps the open file description, and so the locks, alive
+    #[cfg(feature = "experimental-multiprocess")]
+    #[test]
+    fn a_refused_open_releases_the_bytes_it_took() {
+        use crate::db::{SHARED_WRITER_BYTE, WRITER_BYTE, byte_range};
+
+        let tmpfile = crate::create_tempfile();
+        let holder = reopen(tmpfile.path());
+        assert!(holder.try_lock_range(byte_range(WRITER_BYTE)).unwrap());
+
+        // The shared writer byte is taken before the conflict on the writer byte
+        let file = reopen(tmpfile.path());
+        let kept_by_the_caller = file.try_clone().unwrap();
+        assert!(refused(open_file(
+            file,
+            false,
+            ConcurrencyMode::SingleWriterProcess
+        )));
+
+        let observer = reopen(tmpfile.path());
+        let byte = byte_range(SHARED_WRITER_BYTE);
+        assert!(observer.try_lock_range(byte.clone()).unwrap());
+        observer.unlock_range(byte).unwrap();
+        drop(kept_by_the_caller);
+
+        holder.unlock_range(byte_range(WRITER_BYTE)).unwrap();
+        open(tmpfile.path(), false, ConcurrencyMode::SingleWriterProcess)
+            .unwrap()
+            .close()
+            .unwrap();
+    }
+}
+
 #[cfg(test)]
 mod lock_failure_test {
     use super::TransactionalMemory;
-    use crate::db::{FULL_RANGE, InternalStorageBackend};
+    use crate::db::{ConcurrencyMode, FULL_RANGE, InternalStorageBackend};
     use crate::io;
     use crate::sync::Mutex;
     use crate::tree_store::InMemoryBackend;
@@ -2010,6 +2239,7 @@ mod lock_failure_test {
     struct AnsweringBackend {
         inner: InMemoryBackend,
         taking: Answer,
+        querying: Answer,
         held: Arc<Mutex<Vec<Range<u64>>>>,
         released: Arc<Mutex<Vec<Range<u64>>>>,
     }
@@ -2038,6 +2268,10 @@ mod lock_failure_test {
             self.held.lock().unwrap().retain(|held| *held != range);
             self.released.lock().unwrap().push(range);
             Ok(())
+        }
+
+        fn query_lock_range(&self, _range: Range<u64>) -> Result<bool, io::Error> {
+            self.querying.result()
         }
     }
 
@@ -2073,12 +2307,13 @@ mod lock_failure_test {
 
     type Released = Arc<Mutex<Vec<Range<u64>>>>;
 
-    fn storage(taking: Answer) -> (PagedCachedFile, Released) {
+    fn storage(taking: Answer, querying: Answer) -> (PagedCachedFile, Released) {
         let released: Released = Arc::new(Mutex::new(Vec::new()));
         let storage = PagedCachedFile::new(
             Box::new(AnsweringBackend {
                 inner: InMemoryBackend::new(),
                 taking,
+                querying,
                 held: Arc::new(Mutex::new(Vec::new())),
                 released: released.clone(),
             }),
@@ -2089,21 +2324,41 @@ mod lock_failure_test {
         (storage, released)
     }
 
-    fn open(read_only: bool, taking: Answer) -> Result<(), DatabaseError> {
-        TransactionalMemory::lock_whole_storage(&storage(taking).0, read_only)
+    fn open_as(
+        concurrency_mode: ConcurrencyMode,
+        read_only: bool,
+        taking: Answer,
+        querying: Answer,
+    ) -> Result<(), DatabaseError> {
+        TransactionalMemory::lock_for_open(
+            &storage(taking, querying).0,
+            read_only,
+            concurrency_mode,
+        )
+    }
+
+    fn open(read_only: bool, taking: Answer, querying: Answer) -> Result<(), DatabaseError> {
+        open_as(ConcurrencyMode::SingleProcess, read_only, taking, querying)
+    }
+
+    fn failed(result: Result<(), DatabaseError>) -> bool {
+        matches!(result, Err(DatabaseError::Storage(StorageError::Io(_))))
     }
 
     #[test]
     fn a_platform_without_locks_opens_anyway() {
-        open(false, Answer::Unsupported).unwrap();
-        open(true, Answer::Unsupported).unwrap();
+        open(false, Answer::Unsupported, Answer::Unsupported).unwrap();
+        open(true, Answer::Unsupported, Answer::Unsupported).unwrap();
+
+        // ... including one whose locks work but which cannot be asked about them
+        open(true, Answer::Acquired, Answer::Unsupported).unwrap();
     }
 
     #[test]
     fn a_conflicting_lock_reports_the_database_already_open() {
         for read_only in [false, true] {
             assert!(matches!(
-                open(read_only, Answer::Refused),
+                open(read_only, Answer::Refused, Answer::Acquired),
                 Err(DatabaseError::DatabaseAlreadyOpen)
             ));
         }
@@ -2111,19 +2366,39 @@ mod lock_failure_test {
 
     #[test]
     fn a_lock_that_fails_for_any_other_reason_fails_the_open() {
-        for read_only in [false, true] {
-            assert!(matches!(
-                open(read_only, Answer::Failed),
-                Err(DatabaseError::Storage(StorageError::Io(_)))
-            ));
+        assert!(failed(open(false, Answer::Failed, Answer::Acquired)));
+        assert!(failed(open(true, Answer::Failed, Answer::Acquired)));
+
+        // ... and so does a probe that fails, which only a read-only open makes
+        assert!(failed(open(true, Answer::Acquired, Answer::Failed)));
+        open(false, Answer::Acquired, Answer::Failed).unwrap();
+    }
+
+    // A read-only open included: its mode still declares writers that need the locks
+    #[cfg(feature = "experimental-multiprocess")]
+    #[test]
+    fn a_shared_mode_without_locks_fails_the_open() {
+        for mode in [
+            ConcurrencyMode::SingleWriterProcess,
+            ConcurrencyMode::MultiWriterProcess,
+        ] {
+            for read_only in [false, true] {
+                assert!(failed(open_as(
+                    mode,
+                    read_only,
+                    Answer::Unsupported,
+                    Answer::Unsupported
+                )));
+            }
         }
     }
 
     #[test]
     fn the_lock_is_released_at_close() {
         for taking in [Answer::Acquired, Answer::Unsupported] {
-            let (storage, released) = storage(taking);
-            TransactionalMemory::lock_whole_storage(&storage, false).unwrap();
+            let (storage, released) = storage(taking, Answer::Unsupported);
+            TransactionalMemory::lock_for_open(&storage, false, ConcurrencyMode::SingleProcess)
+                .unwrap();
             storage.close().unwrap();
 
             let expected: Vec<Range<u64>> = if taking == Answer::Acquired {

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -1,0 +1,51 @@
+#![cfg(feature = "experimental-multiprocess")]
+
+use redb::backends::InMemoryBackend;
+use redb::{ConcurrencyMode, Database, DatabaseError, StorageError};
+
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+#[test]
+fn the_concurrency_mode_excludes_incompatible_opens() {
+    fn create(path: &std::path::Path, mode: ConcurrencyMode) -> Result<Database, DatabaseError> {
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(mode);
+        builder.create(path)
+    }
+
+    let tmpfile = tempfile::NamedTempFile::new().unwrap();
+    let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+
+    let peer = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+    assert!(matches!(
+        create(tmpfile.path(), ConcurrencyMode::SingleWriterProcess),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+    assert!(matches!(
+        Database::open(tmpfile.path()),
+        Err(DatabaseError::DatabaseAlreadyOpen)
+    ));
+
+    drop(peer);
+    drop(db);
+    Database::open(tmpfile.path()).unwrap();
+}
+
+/// A caller-supplied backend has no locks to negotiate with, which is reported like a platform
+/// without them
+#[test]
+fn sharing_a_caller_supplied_backend_is_unsupported() {
+    let mut builder = Database::builder();
+    builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+    let err = builder
+        .create_with_backend(InMemoryBackend::new())
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        DatabaseError::Storage(StorageError::Io(err)) if err.kind() == std::io::ErrorKind::Unsupported
+    ));
+
+    // ... while the default mode opens on one as it always has
+    Database::builder()
+        .create_with_backend(InMemoryBackend::new())
+        .unwrap();
+}


### PR DESCRIPTION
Follows #1425, which moved the whole-storage lock into the core and is where the `cached_file.rs` refactor landed. This is the remainder: the modes themselves.

Behind the new `experimental-multiprocess` feature, `Builder::set_concurrency_mode()` opens a database that several processes share: one writing process with any number of read-only processes, or several writing processes taking turns.

The feature depends on `"std"` and `"experimental-api-5"`, which cargo can express, rather than on a platform with byte-range locks, which it cannot. Where the locks are missing the shared modes fail to open, and that includes a read-only open: its mode still declares writers that need them. Only the original modes work without byte-range locks -- an ordinary single-process open, and a read-only one. A caller-supplied backend says the same, since it has no locks to negotiate with.

## The mode bytes

A multi-process open takes no lock over the whole storage: that would exclude the other participants, and on Windows, where the locks are mandatory, block their I/O outright. What it takes instead are the mode bytes, held for as long as the database is open, which announce the mode and exclude an incompatible one -- refused rather than waited for, since a conflict means the database is already open in a mode this one cannot join.

| mode | holds |
|---|---|
| `SingleWriterProcess` | shared writer byte and writer byte, exclusively |
| `MultiWriterProcess` | shared writer byte, shared |
| read-only | shared reader byte, shared |

A single writer holds the shared writer byte exclusively, so no other writer of either kind can open; a multi-writer process holds it shared, so its cohort can. Read-only processes hold the shared reader byte, which no writer takes, so that an ordinary single-process open still conflicts with a live reader.

An ordinary read-only holder and a multi-writer cohort hold nothing the other's shared locks could conflict with, so each probes for the other: the multi-writer open probes the one byte only a whole-range lock covers, and the ordinary read-only open probes the multi-writer mode byte. Each probes after taking its own locks, so whichever opens second is the one that finds the other. `InternalStorageBackend` gains `query_lock_range()` for those probes.

The whole-storage lock leaves that mode byte free when it is taken shared, which both directions need: the probe has to have something to find, and two read-only opens must not read as one another's cohort. Taken exclusively it covers every byte, since an exclusive holder shares with nobody. It is the backend that punctures, since expressing `FULL_RANGE` is its job. Releasing records which of the two sets it took, because `UnlockFile` neither splits nor merges: on Windows a lock is released only by an unlock over the range it was taken over.

Neither the puncture nor the read-only probe is gated on the feature, and they have to agree: a cohort is always another process, which may have been built with the feature when this one was not. Gating only the probe would let a feature-disabled process open read-only underneath a cohort that a feature-enabled one is writing.

## Scope

This is the negotiation only. The header sections, cache invalidation and transaction pins the shared modes need are not here yet, so a database opened in one is not yet safe to actually share. The changelog entry and the `ConcurrencyMode` docs say as much.

Excluding pre-protocol handles is also out of scope: a redb 4 process holds only a whole-file lock, which a range-locking prober cannot always see, and a multi-process open cannot take a whole-file lock of either kind without excluding its own cohort. Mixing 4.0 and 5.0 binaries is unsupported.

## Testing

The set was chosen by mutation testing rather than by eye: each piece of the protocol was broken in turn -- the puncture removed or moved, the probe gated or pointed at the wrong byte, each mode byte taken with the wrong exclusivity, the plain-holder probe dropped, `Unsupported` swallowed, the release forgetting its recorded ranges, the mode not plumbed through `Builder` -- and only tests that caught something no other test caught were kept. Two that failed that bar were dropped; every mutation is still caught without them.

Four on the protocol where it now lives: a read-only open refusing a cohort this build cannot itself form, which takes the cohort's lock on a raw handle so it runs whether or not the feature is on, and is the only protocol test that runs in a feature-disabled build; the mode matrix over the four writer pairings, which also covers readers joining either mode and the bytes being free again after close; a single-process handle and a multi-process one refusing each other in both directions, over both modes and both values of `read_only`, except where both are read-only and neither holds a byte the other could find -- the sole catcher for dropping the plain-holder probe; and a refused open releasing the bytes it took, the sole catcher for a release that forgets which ranges it recorded. That last one keeps a `try_clone()` of the refused open's file, so what frees the ranges is the release rather than the description going away. They run wherever there are byte-range locks, Windows included.

`lock_failure_test` gains `a_shared_mode_without_locks_fails_the_open`, covering both shared modes against both values of `read_only` over a backend that answers `Unsupported`, and is the sole catcher for that error being swallowed. `a_lock_that_fails_for_any_other_reason_fails_the_open` gains the probe: a probe that fails rather than answers fails the open, which nothing else catches.

Plus `the_concurrency_mode_excludes_incompatible_opens` through the `Builder`, the sole catcher for the mode never reaching the lock, and `sharing_a_caller_supplied_backend_is_unsupported`.

The whole-storage puncture is left to `basic_tests::read_only`, which already asserts the same contract through the public API -- two read-only opens coexisting, a writer refused while they are live, and the handle `open_read_only` hands over, which carries read access alone.

`cargo fmt`, `cargo clippy` in four feature configurations, `cargo clippy --all --all-targets --all-features` as CI runs it, cross-clippy for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, the three `wasm32-unknown-unknown` variants, no_std on `thumbv7em-none-eabihf`, and `cargo test` in all three configurations that run tests -- no features, `experimental-multiprocess`, and `--all-features` -- all pass. The Windows tests were also run for `x86_64-pc-windows-gnu` under wine: 154/155 lib tests and both `multiprocess_tests` pass, the exception being `a_whole_file_lock_holder_reads_as_already_open`, which fails identically on unmodified master there because wine answers std's second `UnlockFile` with `ERROR_LOCK_VIOLATION` where Windows answers `ERROR_NOT_LOCKED`.