### PR TITLE
Drop the whole-file lock where it shares a namespace with the ranges

### DIFF
--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -34,8 +34,8 @@ fn report_failed_release(result: io::Result<()>) {
 /// Stores a database as a file on-disk.
 #[derive(Debug)]
 pub struct FileBackend {
-    lock_supported: bool,
-    range_lock_supported: bool,
+    whole_file_locked: bool,
+    ranges_locked: bool,
     file: File,
 }
 
@@ -46,49 +46,74 @@ impl FileBackend {
     }
 
     pub(crate) fn new_internal(file: File, read_only: bool) -> Result<Self, DatabaseError> {
-        let lock_supported = Self::try_whole_file_lock(&file, read_only)?;
+        // Prefer range locks
+        if File::CONFLICTS_WITH_STD_FILE_LOCK == Some(true) {
+            return Self::new_holding_ranges(file, read_only);
+        }
 
-        if !lock_supported {
+        let whole_file_locked = Self::try_whole_file_lock(&file, read_only)?;
+
+        if !whole_file_locked {
             return Ok(Self {
-                lock_supported: false,
-                range_lock_supported: false,
+                whole_file_locked: false,
+                ranges_locked: false,
                 file,
             });
         }
 
-        let conflicts = match File::CONFLICTS_WITH_STD_FILE_LOCK {
-            Some(known) => known,
-            None => file
+        if File::CONFLICTS_WITH_STD_FILE_LOCK.is_none()
+            && file
                 .query_lock(NAMESPACE_PROBE_BYTE..NAMESPACE_PROBE_BYTE + 1)
-                .unwrap_or(false),
-        };
+                .unwrap_or(false)
+        {
+            // Prefer range locks, so release the whole-file lock which maps to the range lock
+            file.unlock()?;
+            return Self::new_holding_ranges(file, read_only);
+        }
 
-        let range_lock_supported = if conflicts {
-            false
-        } else {
-            match Self::try_lock_protocol_ranges(&file, read_only) {
-                Ok(true) => true,
-                // A multi-process handle has the database open
-                Ok(false) => {
-                    report_failed_release(file.unlock());
-                    return Err(DatabaseError::DatabaseAlreadyOpen);
-                }
-                Err(err) if err.kind() == io::ErrorKind::Unsupported => {
-                    // no-op. If range locks are not supported, then multi-process access is not possible
-                    false
-                }
-                Err(err) => {
-                    report_failed_release(file.unlock());
-                    return Err(err.into());
-                }
+        let ranges_locked = match Self::try_lock_protocol_ranges(&file, read_only) {
+            Ok(true) => true,
+            // A multi-process handle has the database open
+            Ok(false) => {
+                report_failed_release(file.unlock());
+                return Err(DatabaseError::DatabaseAlreadyOpen);
+            }
+            Err(err) if err.kind() == io::ErrorKind::Unsupported => {
+                // no-op. If range locks are not supported, then multi-process access is not possible
+                false
+            }
+            Err(err) => {
+                report_failed_release(file.unlock());
+                return Err(err.into());
             }
         };
 
         Ok(Self {
-            lock_supported,
-            range_lock_supported,
+            whole_file_locked,
+            ranges_locked,
             file,
         })
+    }
+
+    fn new_holding_ranges(file: File, read_only: bool) -> Result<Self, DatabaseError> {
+        match Self::try_lock_protocol_ranges(&file, read_only) {
+            Ok(true) => Ok(Self {
+                whole_file_locked: false,
+                ranges_locked: true,
+                file,
+            }),
+            // Another handle has the database open, holding either kind of lock
+            Ok(false) => Err(DatabaseError::DatabaseAlreadyOpen),
+            Err(err) if err.kind() == io::ErrorKind::Unsupported => {
+                let whole_file_locked = Self::try_whole_file_lock(&file, read_only)?;
+                Ok(Self {
+                    whole_file_locked,
+                    ranges_locked: false,
+                    file,
+                })
+            }
+            Err(err) => Err(err.into()),
+        }
     }
 
     fn try_lock_protocol_ranges(file: &File, read_only: bool) -> io::Result<bool> {
@@ -215,12 +240,12 @@ impl StorageBackend for FileBackend {
         // Every lock is released even where one fails: a lock left behind outlives this
         // backend wherever the description is shared
         let mut result = Ok(());
-        if self.range_lock_supported {
+        if self.ranges_locked {
             for range in PROTOCOL_RANGES {
                 result = result.and(self.file.unlock_range(range));
             }
         }
-        if self.lock_supported {
+        if self.whole_file_locked {
             result = result.and(self.file.unlock());
         }
 
@@ -429,7 +454,7 @@ mod range_lock_tests {
     }
 
     /// An ordinary Linux filesystem keeps the whole-file lock out of the range locks' table,
-    /// so an open holds both, and leaves the byte it asked at free for the next one to ask
+    /// so an open holds both: only the whole-file lock itself can refuse the observer's
     #[cfg(target_os = "linux")]
     #[test]
     fn an_ordinary_filesystem_answers_that_the_two_kinds_are_separate() {
@@ -440,9 +465,48 @@ mod range_lock_tests {
         let observer = reopen(tmpfile.path());
         assert!(matches!(observer.try_lock(), Err(TryLockError::WouldBlock)));
         assert!(!byte_is_free(&observer, BASE, true));
-        assert!(byte_is_free(&observer, NAMESPACE_PROBE_BYTE, true));
 
         backend.close().unwrap();
+    }
+
+    /// The open a platform whose two kinds of lock conflict takes, holding the ranges in place of
+    /// a whole-file lock that is never taken -- which only a separate namespace can observe, so
+    /// the check belongs here rather than where the open is actually reached
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_open_holding_the_ranges_takes_no_whole_file_lock() {
+        let tmpfile = crate::create_tempfile();
+        let backend = FileBackend::new_holding_ranges(reopen(tmpfile.path()), false).unwrap();
+
+        let observer = reopen(tmpfile.path());
+        for offset in PROTOCOL_OFFSETS {
+            assert!(!byte_is_free(&observer, offset, false), "offset {offset}");
+        }
+        assert!(byte_is_free(&observer, NAMESPACE_PROBE_BYTE, true));
+        // Here the whole-file lock is a namespace of its own, so taking it proves it is unheld
+        observer.try_lock().unwrap();
+        observer.unlock().unwrap();
+
+        backend.close().unwrap();
+        for offset in PROTOCOL_OFFSETS {
+            assert!(byte_is_free(&observer, offset, true), "offset {offset}");
+        }
+    }
+
+    /// The byte the namespace probe asks at is left free by every open, whichever lock it holds:
+    /// where the whole-file lock would cover it, the ranges are held in its place
+    #[test]
+    fn the_probe_byte_is_free_while_a_backend_is_open() {
+        let tmpfile = crate::create_tempfile();
+        let observer = reopen(tmpfile.path());
+
+        let writable = FileBackend::new_internal(reopen(tmpfile.path()), false).unwrap();
+        assert!(byte_is_free(&observer, NAMESPACE_PROBE_BYTE, true));
+        writable.close().unwrap();
+
+        let reader = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
+        assert!(byte_is_free(&observer, NAMESPACE_PROBE_BYTE, true));
+        reader.close().unwrap();
     }
 
     /// The whole-file lock is all an older version of redb takes, so an open must keep
@@ -464,5 +528,33 @@ mod range_lock_tests {
         reader.close().unwrap();
 
         observer.try_lock().unwrap();
+    }
+
+    /// ... and be excluded by one: the same older version, having opened the database first
+    #[test]
+    fn a_whole_file_lock_holder_reads_as_already_open() {
+        let tmpfile = crate::create_tempfile();
+        let holder = reopen(tmpfile.path());
+        holder.try_lock().unwrap();
+
+        assert!(matches!(
+            FileBackend::new_internal(reopen(tmpfile.path()), false),
+            Err(crate::DatabaseError::DatabaseAlreadyOpen)
+        ));
+        assert!(matches!(
+            FileBackend::new_internal(reopen(tmpfile.path()), true),
+            Err(crate::DatabaseError::DatabaseAlreadyOpen)
+        ));
+
+        // Held shared it is an older read-only holder, which only a writable open conflicts with
+        holder.unlock().unwrap();
+        holder.try_lock_shared().unwrap();
+        assert!(matches!(
+            FileBackend::new_internal(reopen(tmpfile.path()), false),
+            Err(crate::DatabaseError::DatabaseAlreadyOpen)
+        ));
+        let reader = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
+        reader.close().unwrap();
+        holder.unlock().unwrap();
     }
 }


### PR DESCRIPTION
An open takes the multi-process protocol's byte ranges beside the whole-file lock, in the two pieces that leave the namespace probe byte free -- that being a byte no range covers, for the namespace question to be asked at. Where the two kinds of lock share one namespace it took the whole-file lock alone, since they cannot both be held there. But that lock covers every byte, the probe byte included, so nothing is left for the multi-process modes to probe at: a read-only holder would answer its own probe for the multi-writer cohort it has to refuse. That is the exclusion #1419 leaves for a later slice; this is that slice.

## The change

The ranges are taken alone there instead. Excluding a redb version old enough to take only the whole-file lock is what that lock was for, and where the two share a namespace the ranges do it themselves: such a version refuses them, and is refused by them, exactly as it was by the whole-file lock.

| platform | before | after |
|---|---|---|
| Apple | whole-file lock alone | the ranges alone |
| Linux, ordinary filesystem | whole-file lock and the ranges | unchanged |
| Linux, filesystem emulating one kind with the other | whole-file lock alone | the ranges alone |
| Windows | whole-file lock alone | unchanged -- there are no range locks to take instead |

The Apple platforms and Windows answer the namespace question for themselves, so an open there does not take the whole-file lock at all -- unless the ranges turn out to be unsupported, which is every open on Windows until range locks are implemented for it, and the whole-file lock alone is then what is held, as before. Elsewhere the answer belongs to the filesystem and the whole-file lock is still taken first, to ask the question with; an open told that the two conflict swaps it for the ranges. Another open may take the whole-file lock in the moment it is released, and is then the one that finds the ranges held: one of the two succeeds, which is all either promised.

The two fields become `whole_file_locked` and `ranges_locked`: `lock_supported == false` no longer means the locks are unsupported.

## Testing

Three tests added:

* `the_probe_byte_is_free_while_a_backend_is_open` -- ungated, and the point of the change: before, only a separate namespace left that byte free.
* `a_whole_file_lock_holder_reads_as_already_open` -- the exclusion in the other direction, shared and exclusive, standing in for the older version that takes only that lock. Its counterpart, `the_whole_file_lock_is_refused_while_a_backend_is_open`, was already there and is now load-bearing on the Apple platforms.
* `an_open_holding_the_ranges_takes_no_whole_file_lock` -- Linux-gated, calling the ranges-only open directly. Only a separate namespace can observe the *absence* of a whole-file lock, so the check belongs where that open is not otherwise reached; it is also the only coverage the new path gets on Linux.

`cargo fmt --check`, `cargo clippy --all-targets --all-features -Dwarnings` and `cargo test --all-features` pass, as do cross-target clippy for `aarch64-apple-darwin` and `x86_64-pc-windows-msvc` and a `wasm32-wasip1` check. `cargo deny` was not run -- no dependency changed.

## What this unblocks

Rebased on this, #1419's read-only open holds the punctured ranges on the Apple platforms too, so its probe of the multi-writer mode byte is answered by a cohort rather than by its own lock, and `the cohort and an ordinary read-only holder refusing each other` should no longer need its Linux gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_