### PR TITLE
Give the backends a locking interface of their own

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,6 @@
 use crate::io;
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
+use crate::tree_store::LocklessBackend;
 #[cfg(not(redb_no_std))]
 use crate::tree_store::ReadOnlyBackend;
 use crate::tree_store::{
@@ -20,6 +21,7 @@ use core::fmt::{Debug, Display, Formatter};
 
 use alloc::sync::Arc;
 use core::marker::PhantomData;
+use core::ops::Range;
 #[cfg(not(redb_no_std))]
 use std::fs::{File, OpenOptions};
 #[cfg(not(redb_no_std))]
@@ -69,6 +71,26 @@ pub trait StorageBackend: 'static + Debug + Send + Sync {
     fn close(&self) -> core::result::Result<(), io::Error> {
         Ok(())
     }
+}
+
+#[cfg_attr(redb_no_std, allow(dead_code))]
+pub(crate) const FULL_RANGE: Range<u64> = 0..u64::MAX;
+
+/// A range reaching [`u64::MAX`] covers the entire storage.
+#[cfg_attr(redb_no_std, allow(dead_code))]
+pub(crate) trait InternalStorageBackend: StorageBackend {
+    /// Whether this backend has locks to take at all -- custom backends do not.
+    fn locks_expected(&self) -> bool {
+        true
+    }
+
+    /// `Ok(false)` means a conflicting lock is held elsewhere.
+    fn try_lock_range(&self, range: Range<u64>) -> core::result::Result<bool, io::Error>;
+
+    /// `Ok(false)` means a conflicting lock is held elsewhere.
+    fn try_lock_shared_range(&self, range: Range<u64>) -> core::result::Result<bool, io::Error>;
+
+    fn unlock_range(&self, range: Range<u64>) -> core::result::Result<(), io::Error>;
 }
 
 pub trait TableHandle: Sealed {
@@ -460,7 +482,7 @@ impl ReadOnlyDatabase {
     }
 
     fn new(
-        file: Box<dyn StorageBackend>,
+        file: Box<dyn InternalStorageBackend>,
         page_size: usize,
         region_size: Option<u64>,
         cache_size: usize,
@@ -1154,7 +1176,7 @@ impl Database {
     }
 
     fn new(
-        file: Box<dyn StorageBackend>,
+        file: Box<dyn InternalStorageBackend>,
         allow_initialize: bool,
         page_size: usize,
         region_size: Option<u64>,
@@ -1543,7 +1565,7 @@ impl Builder {
         let file = OpenOptions::new().read(true).open(path)?;
 
         ReadOnlyDatabase::new(
-            Box::new(FileBackend::new_internal(file, true)?),
+            Box::new(FileBackend::new(file)?),
             self.page_size,
             None,
             self.cache_size,
@@ -1571,7 +1593,7 @@ impl Builder {
         backend: impl StorageBackend,
     ) -> Result<Database, DatabaseError> {
         Database::new(
-            Box::new(backend),
+            LocklessBackend::boxed(backend),
             true,
             self.page_size,
             self.region_size,

--- a/src/io.rs
+++ b/src/io.rs
@@ -35,6 +35,29 @@ pub(crate) fn invalid_input(message: &str) -> Error {
     }
 }
 
+pub(crate) fn unsupported(message: &str) -> Error {
+    #[cfg(not(redb_no_std))]
+    {
+        Error::new(std::io::ErrorKind::Unsupported, message)
+    }
+    #[cfg(redb_no_std)]
+    {
+        Error::other(message)
+    }
+}
+
+pub(crate) fn is_unsupported(err: &Error) -> bool {
+    #[cfg(not(redb_no_std))]
+    {
+        err.kind() == std::io::ErrorKind::Unsupported
+    }
+    #[cfg(redb_no_std)]
+    {
+        let _ = err;
+        false
+    }
+}
+
 // Compiled for test builds as well, so that the tests below run as part of the normal test suite
 // rather than only in the no_std configuration.
 #[cfg(any(redb_no_std, test))]

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -1430,11 +1430,11 @@ mod tests {
     fn test_cycle_detection_in_btree() {
         use crate::tree_store::btree_base::RawBranchBuilder;
         use crate::tree_store::{
-            AllocationPolicy, InMemoryBackend, PAGE_SIZE, TransactionalMemory,
+            AllocationPolicy, InMemoryBackend, LocklessBackend, PAGE_SIZE, TransactionalMemory,
         };
 
         let mem = TransactionalMemory::new(
-            Box::new(InMemoryBackend::new()),
+            LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             PAGE_SIZE,
             None,

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -2281,7 +2281,9 @@ impl<'b> BranchMutator<'b> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tree_store::{AllocationPolicy, InMemoryBackend, PAGE_SIZE, TransactionalMemory};
+    use crate::tree_store::{
+        AllocationPolicy, InMemoryBackend, LocklessBackend, PAGE_SIZE, TransactionalMemory,
+    };
 
     const MAX_PAIRS: usize = u16::MAX as usize;
 
@@ -2291,7 +2293,7 @@ mod tests {
 
     fn make_allocator_with_page_size(page_size: usize) -> PageAllocator {
         let mem = TransactionalMemory::new(
-            Box::new(InMemoryBackend::new()),
+            LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             page_size,
             None,

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -2455,11 +2455,13 @@ fn park_bound<K: Key + 'static, V: Value + 'static>(
 mod tests {
     use super::*;
     use crate::tree_store::btree_base::{DEFERRED, LeafBuilder};
-    use crate::tree_store::{AllocationPolicy, InMemoryBackend, PAGE_SIZE, TransactionalMemory};
+    use crate::tree_store::{
+        AllocationPolicy, InMemoryBackend, LocklessBackend, PAGE_SIZE, TransactionalMemory,
+    };
 
     fn test_page_allocator() -> PageAllocator {
         let mem = TransactionalMemory::new(
-            Box::new(InMemoryBackend::new()),
+            LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             PAGE_SIZE,
             None,

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -1831,7 +1831,9 @@ impl<'a, 'b, K: Key + 'static, V: Value + 'static> MutateHelper<'a, 'b, K, V> {
 #[cfg(all(test, feature = "experimental_cursor"))]
 mod tests {
     use super::*;
-    use crate::tree_store::{AllocationPolicy, InMemoryBackend, TransactionalMemory};
+    use crate::tree_store::{
+        AllocationPolicy, InMemoryBackend, LocklessBackend, TransactionalMemory,
+    };
 
     const MAX_KEYS: usize = u16::MAX as usize;
 
@@ -1841,7 +1843,7 @@ mod tests {
 
     fn make_allocator_with_page_size(page_size: usize) -> PageAllocator {
         let mem = TransactionalMemory::new(
-            Box::new(InMemoryBackend::new()),
+            LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             page_size,
             None,

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -22,6 +22,7 @@ pub(crate) use btree_cursor_range::BtreeCursorRange;
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, encode_bounds};
 pub(crate) use extract_if::BtreeExtractIf;
 pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multimap_btree_stats};
+pub(crate) use page_store::LocklessBackend;
 #[cfg(not(redb_no_std))]
 pub(crate) use page_store::ReadOnlyBackend;
 #[cfg(not(redb_no_std))]

--- a/src/tree_store/page_store/backends.rs
+++ b/src/tree_store/page_store/backends.rs
@@ -1,23 +1,106 @@
 use crate::StorageBackend;
+use crate::db::InternalStorageBackend;
 use crate::io;
 #[cfg(not(redb_no_std))]
 use crate::io::Error;
 use crate::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-#[cfg(not(redb_no_std))]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::{Debug, Formatter};
+use core::ops::Range;
+
+/// A backend supplied by a caller, which has only the public [`StorageBackend`], and no locks.
+#[derive(Debug)]
+pub(crate) struct LocklessBackend {
+    inner: Box<dyn StorageBackend>,
+}
+
+impl LocklessBackend {
+    pub(crate) fn boxed(inner: impl StorageBackend) -> Box<dyn InternalStorageBackend> {
+        Box::new(Self {
+            inner: Box::new(inner),
+        })
+    }
+}
+
+impl StorageBackend for LocklessBackend {
+    fn len(&self) -> Result<u64, io::Error> {
+        self.inner.len()
+    }
+
+    fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), io::Error> {
+        self.inner.read(offset, out)
+    }
+
+    fn set_len(&self, len: u64) -> Result<(), io::Error> {
+        self.inner.set_len(len)
+    }
+
+    fn sync_data(&self) -> Result<(), io::Error> {
+        self.inner.sync_data()
+    }
+
+    fn write(&self, offset: u64, data: &[u8]) -> Result<(), io::Error> {
+        self.inner.write(offset, data)
+    }
+
+    fn close(&self) -> Result<(), io::Error> {
+        self.inner.close()
+    }
+}
+
+impl InternalStorageBackend for LocklessBackend {
+    fn locks_expected(&self) -> bool {
+        false
+    }
+
+    fn try_lock_range(&self, _range: Range<u64>) -> Result<bool, io::Error> {
+        Err(unsupported())
+    }
+
+    fn try_lock_shared_range(&self, _range: Range<u64>) -> Result<bool, io::Error> {
+        Err(unsupported())
+    }
+
+    fn unlock_range(&self, _range: Range<u64>) -> Result<(), io::Error> {
+        Err(unsupported())
+    }
+}
+
+#[cfg_attr(redb_no_std, allow(dead_code))]
+fn unsupported() -> io::Error {
+    io::unsupported("this storage backend does not support file locks")
+}
 
 #[cfg(not(redb_no_std))]
 #[derive(Debug)]
 pub(crate) struct ReadOnlyBackend {
-    inner: Box<dyn StorageBackend>,
+    inner: Box<dyn InternalStorageBackend>,
 }
 
 #[cfg(not(redb_no_std))]
 impl ReadOnlyBackend {
-    pub fn new(inner: Box<dyn StorageBackend>) -> Self {
+    pub fn new(inner: Box<dyn InternalStorageBackend>) -> Self {
         Self { inner }
+    }
+}
+
+#[cfg(not(redb_no_std))]
+impl InternalStorageBackend for ReadOnlyBackend {
+    fn locks_expected(&self) -> bool {
+        self.inner.locks_expected()
+    }
+
+    fn try_lock_range(&self, range: Range<u64>) -> Result<bool, Error> {
+        self.inner.try_lock_range(range)
+    }
+
+    fn try_lock_shared_range(&self, range: Range<u64>) -> Result<bool, Error> {
+        self.inner.try_lock_shared_range(range)
+    }
+
+    fn unlock_range(&self, range: Range<u64>) -> Result<(), Error> {
+        self.inner.unlock_range(range)
     }
 }
 
@@ -128,8 +211,30 @@ impl StorageBackend for InMemoryBackend {
 
 #[cfg(test)]
 mod test {
-    use super::InMemoryBackend;
+    use super::{InMemoryBackend, LocklessBackend};
     use crate::StorageBackend;
+    use crate::db::FULL_RANGE;
+
+    /// A caller's backend has no locks to offer, so a database on one is a single process's
+    #[test]
+    fn a_caller_supplied_backend_reports_the_locks_unsupported() {
+        let backend = LocklessBackend::boxed(InMemoryBackend::new());
+        for result in [
+            backend.try_lock_range(FULL_RANGE).err(),
+            backend.try_lock_shared_range(FULL_RANGE).err(),
+            backend.unlock_range(FULL_RANGE).err(),
+        ] {
+            let err = result.expect("the locks are unsupported");
+            assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+        }
+
+        // ... and it is not a platform limitation worth reporting
+        assert!(!backend.locks_expected());
+
+        // ... and the storage underneath it still works
+        backend.set_len(1024).unwrap();
+        assert_eq!(backend.len().unwrap(), 1024);
+    }
 
     #[test]
     fn debug_reports_length_not_contents() {

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -1,7 +1,9 @@
+use crate::db::{FULL_RANGE, InternalStorageBackend};
+use crate::io;
 use crate::sync::{Mutex, MutexGuard, RwLock};
 use crate::tree_store::page_store::base::PageHint;
 use crate::tree_store::page_store::lru_cache::LRUCache;
-use crate::{CacheStats, DatabaseError, Result, StorageBackend, StorageError};
+use crate::{CacheStats, DatabaseError, Result, StorageError};
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec;
@@ -11,6 +13,8 @@ use core::slice::SliceIndex;
 #[cfg(feature = "cache_metrics")]
 use core::sync::atomic::AtomicU64;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+#[cfg(feature = "logging")]
+use log::warn;
 
 // Allocates an `Arc<[u8]>` in one step. `Arc::<[u8]>::from(vec![0; len])` would
 // allocate the Vec and then allocate a new Arc and memcpy into it.
@@ -121,7 +125,7 @@ impl LRUWriteCache {
 
 #[derive(Debug)]
 struct CheckedBackend {
-    file: Box<dyn StorageBackend>,
+    file: Box<dyn InternalStorageBackend>,
     io_failed: AtomicBool,
     closed: AtomicBool,
 }
@@ -131,17 +135,57 @@ struct CheckedBackend {
 impl Drop for CheckedBackend {
     fn drop(&mut self) {
         if !self.closed.load(Ordering::Acquire) {
+            let _ = self.release_storage();
             let _ = self.file.close();
         }
     }
 }
 
 impl CheckedBackend {
-    fn new(file: Box<dyn StorageBackend>) -> Self {
-        Self {
+    fn new(file: Box<dyn InternalStorageBackend>, read_only: bool) -> Result<Self, DatabaseError> {
+        let backend = Self {
             file,
             io_failed: AtomicBool::new(false),
             closed: AtomicBool::new(false),
+        };
+        backend.lock_storage(read_only)?;
+
+        Ok(backend)
+    }
+
+    /// The whole storage is locked for as long as the database is open
+    fn lock_storage(&self, read_only: bool) -> Result<(), DatabaseError> {
+        if !self.file.locks_expected() {
+            return Ok(());
+        }
+
+        let acquired = if read_only {
+            self.file.try_lock_shared_range(FULL_RANGE)
+        } else {
+            self.file.try_lock_range(FULL_RANGE)
+        };
+        match acquired {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(DatabaseError::DatabaseAlreadyOpen),
+            Err(err) if io::is_unsupported(&err) => {
+                #[cfg(feature = "logging")]
+                warn!(
+                    "File locks not supported on this platform. You must ensure that only a single process opens the database file, at a time"
+                );
+
+                Ok(())
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    fn release_storage(&self) -> Result<(), io::Error> {
+        if !self.file.locks_expected() {
+            return Ok(());
+        }
+        match self.file.unlock_range(FULL_RANGE) {
+            Err(err) if io::is_unsupported(&err) => Ok(()),
+            result => result,
         }
     }
 
@@ -160,6 +204,7 @@ impl CheckedBackend {
     fn close(&self) -> Result {
         self.closed.store(true, Ordering::Release);
         self.io_failed.store(true, Ordering::Release);
+        self.release_storage()?;
         self.file.close()?;
 
         Ok(())
@@ -289,9 +334,10 @@ pub(super) struct PagedCachedFile {
 
 impl PagedCachedFile {
     pub(super) fn new(
-        file: Box<dyn StorageBackend>,
+        file: Box<dyn InternalStorageBackend>,
         page_size: u64,
         max_cache_size: usize,
+        read_only: bool,
     ) -> Result<Self, DatabaseError> {
         let read_cache = (0..Self::lock_stripes())
             .map(|_| RwLock::new(LRUCache::new()))
@@ -301,7 +347,7 @@ impl PagedCachedFile {
             .collect();
 
         Ok(Self {
-            file: CheckedBackend::new(file),
+            file: CheckedBackend::new(file, read_only)?,
             page_size,
             read_cache_bytes: AtomicUsize::new(0),
             write_buffer_bytes: AtomicUsize::new(0),
@@ -852,6 +898,7 @@ impl PagedCachedFile {
 mod test {
     use crate::StorageBackend;
     use crate::backends::InMemoryBackend;
+    use crate::tree_store::LocklessBackend;
     use crate::tree_store::PageHint;
     use crate::tree_store::page_store::cached_file::PagedCachedFile;
     use alloc::sync::Arc;
@@ -905,7 +952,8 @@ mod test {
     fn cache_leak() {
         let backend = InMemoryBackend::new();
         backend.set_len(1024).unwrap();
-        let cached_file = PagedCachedFile::new(Box::new(backend), 128, 1024).unwrap();
+        let cached_file =
+            PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 1024, false).unwrap();
         let cached_file = Arc::new(cached_file);
 
         let t1 = {
@@ -942,8 +990,13 @@ mod test {
         let page_size: usize = 128;
         let max_cache_size = 1024;
         let budget = max_cache_size / 2;
-        let cached_file =
-            PagedCachedFile::new(Box::new(backend), page_size as u64, max_cache_size).unwrap();
+        let cached_file = PagedCachedFile::new(
+            LocklessBackend::boxed(backend),
+            page_size as u64,
+            max_cache_size,
+            false,
+        )
+        .unwrap();
 
         // Dirty twice as many pages as the write budget holds. Consecutive page offsets land in
         // different stripes, so each over-budget write finds its own stripe empty and must cover
@@ -970,7 +1023,8 @@ mod test {
     fn resize_preserves_cached_pages() {
         let backend = InMemoryBackend::new();
         backend.set_len(1024).unwrap();
-        let cached_file = PagedCachedFile::new(Box::new(backend), 128, 4096).unwrap();
+        let cached_file =
+            PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 4096, false).unwrap();
 
         // Populate the read cache with two pages from opposite ends of the file.
         cached_file.read(0, 128, PageHint::None).unwrap();
@@ -993,7 +1047,8 @@ mod test {
     #[test]
     fn write_barrier_issues_no_file_writes() {
         let (backend, writes) = CountingBackend::new(1024);
-        let cached_file = PagedCachedFile::new(Box::new(backend), 128, 1024).unwrap();
+        let cached_file =
+            PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 1024, false).unwrap();
 
         let mut page = cached_file.write(0, 128, true).unwrap();
         page.mem_mut().fill(0xAB);
@@ -1025,7 +1080,8 @@ mod test {
     #[test]
     fn discard_write_buffer_drops_buffered_pages() {
         let (backend, writes) = CountingBackend::new(1024);
-        let cached_file = PagedCachedFile::new(Box::new(backend), 128, 1024).unwrap();
+        let cached_file =
+            PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 1024, false).unwrap();
 
         let mut page = cached_file.write(0, 128, true).unwrap();
         page.mem_mut().fill(0xCD);
@@ -1051,7 +1107,13 @@ mod test {
         const FILE_LEN: u64 = 16 * 1024;
 
         let (backend, _writes) = CountingBackend::new(FILE_LEN);
-        let cached_file = PagedCachedFile::new(Box::new(backend), PAGE as u64, MAX_CACHE).unwrap();
+        let cached_file = PagedCachedFile::new(
+            LocklessBackend::boxed(backend),
+            PAGE as u64,
+            MAX_CACHE,
+            false,
+        )
+        .unwrap();
 
         // Fill the write buffer to its half-of-cache cap, then commit non-durably so the pages
         // stay buffered
@@ -1089,7 +1151,8 @@ mod test {
     #[test]
     fn zero_size_cache_stays_empty_after_reclaim() {
         let (backend, _writes) = CountingBackend::new(1024);
-        let cached_file = PagedCachedFile::new(Box::new(backend), 128, 0).unwrap();
+        let cached_file =
+            PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 0, false).unwrap();
 
         let mut page = cached_file.write(0, 128, true).unwrap();
         page.mem_mut().fill(0x22);
@@ -1108,7 +1171,8 @@ mod test {
     fn buffered_pages_spill_under_pressure() {
         let (backend, writes) = CountingBackend::new(1024);
         // A two page budget caps the buffer at one page, so each write() spills an earlier one
-        let cached_file = PagedCachedFile::new(Box::new(backend), 128, 256).unwrap();
+        let cached_file =
+            PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 256, false).unwrap();
 
         for i in 0..4u8 {
             let offset = u64::from(i) * 128;

--- a/src/tree_store/page_store/file_backend/fallback.rs
+++ b/src/tree_store/page_store/file_backend/fallback.rs
@@ -1,51 +1,83 @@
+use crate::db::{FULL_RANGE, InternalStorageBackend};
 use crate::{DatabaseError, Result, StorageBackend};
-#[cfg(feature = "logging")]
-use log::warn;
 use std::fs::{File, TryLockError};
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::ops::Range;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Stores a database as a file on-disk.
 #[derive(Debug)]
 pub struct FileBackend {
-    lock_supported: bool,
+    whole_file_locked: AtomicBool,
     file: Mutex<File>,
 }
 
 impl FileBackend {
     /// Creates a new backend which stores data to the given file.
     pub fn new(file: File) -> Result<Self, DatabaseError> {
-        Self::new_internal(file, false)
+        Ok(Self {
+            whole_file_locked: AtomicBool::new(false),
+            file: Mutex::new(file),
+        })
     }
 
-    pub(crate) fn new_internal(file: File, read_only: bool) -> Result<Self, DatabaseError> {
-        let result = if read_only {
+    fn lock_whole_file(&self, shared: bool) -> Result<bool, io::Error> {
+        let file = self.file.lock().unwrap();
+        let result = if shared {
             file.try_lock_shared()
         } else {
             file.try_lock()
         };
 
         match result {
-            Ok(()) => Ok(Self {
-                lock_supported: true,
-                file: Mutex::new(file),
-            }),
-            Err(TryLockError::WouldBlock) => Err(DatabaseError::DatabaseAlreadyOpen),
-            Err(TryLockError::Error(err)) if err.kind() == io::ErrorKind::Unsupported => {
-                #[cfg(feature = "logging")]
-                warn!(
-                    "File locks not supported on this platform. You must ensure that only a single process opens the database file, at a time"
-                );
-
-                Ok(Self {
-                    lock_supported: false,
-                    file: Mutex::new(file),
-                })
+            Ok(()) => {
+                self.whole_file_locked.store(true, Ordering::Release);
+                Ok(true)
             }
-            Err(TryLockError::Error(err)) => Err(err.into()),
+            Err(TryLockError::WouldBlock) => Ok(false),
+            Err(TryLockError::Error(err)) => Err(err),
         }
     }
+}
+
+/// This backend has no byte-range locks. Only the whole storage can be locked, which a whole-file
+/// lock does, so that is the one range it supports.
+impl InternalStorageBackend for FileBackend {
+    fn try_lock_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
+        if range == FULL_RANGE {
+            self.lock_whole_file(false)
+        } else {
+            Err(unsupported())
+        }
+    }
+
+    fn try_lock_shared_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
+        if range == FULL_RANGE {
+            self.lock_whole_file(true)
+        } else {
+            Err(unsupported())
+        }
+    }
+
+    fn unlock_range(&self, range: Range<u64>) -> Result<(), io::Error> {
+        if range != FULL_RANGE {
+            return Err(unsupported());
+        }
+        if self.whole_file_locked.swap(false, Ordering::AcqRel) {
+            self.file.lock().unwrap().unlock()?;
+        }
+
+        Ok(())
+    }
+}
+
+fn unsupported() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        "byte-range locks are not supported on this platform",
+    )
 }
 
 impl StorageBackend for FileBackend {
@@ -72,13 +104,5 @@ impl StorageBackend for FileBackend {
         let mut file = self.file.lock().unwrap();
         file.seek(SeekFrom::Start(offset))?;
         file.write_all(data)
-    }
-
-    fn close(&self) -> Result<(), io::Error> {
-        if self.lock_supported {
-            self.file.lock().unwrap().unlock()?;
-        }
-
-        Ok(())
     }
 }

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -1,7 +1,9 @@
+use crate::db::{FULL_RANGE, InternalStorageBackend};
 use crate::{DatabaseError, Result, StorageBackend};
 use std::fs::{File, TryLockError};
 use std::io;
 use std::ops::Range;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(feature = "logging")]
 use log::warn;
@@ -34,131 +36,145 @@ fn report_failed_release(result: io::Result<()>) {
 /// Stores a database as a file on-disk.
 #[derive(Debug)]
 pub struct FileBackend {
-    whole_file_locked: bool,
-    ranges_locked: bool,
+    whole_file_locked: AtomicBool,
+    ranges_locked: AtomicBool,
     file: File,
 }
 
 impl FileBackend {
     /// Creates a new backend which stores data to the given file.
     pub fn new(file: File) -> Result<Self, DatabaseError> {
-        Self::new_internal(file, false)
-    }
-
-    pub(crate) fn new_internal(file: File, read_only: bool) -> Result<Self, DatabaseError> {
-        // Prefer range locks
-        if File::CONFLICTS_WITH_STD_FILE_LOCK == Some(true) {
-            return Self::new_holding_ranges(file, read_only);
-        }
-
-        let whole_file_locked = Self::try_whole_file_lock(&file, read_only)?;
-
-        if !whole_file_locked {
-            return Ok(Self {
-                whole_file_locked: false,
-                ranges_locked: false,
-                file,
-            });
-        }
-
-        if File::CONFLICTS_WITH_STD_FILE_LOCK.is_none()
-            && file
-                .query_lock(NAMESPACE_PROBE_BYTE..NAMESPACE_PROBE_BYTE + 1)
-                .unwrap_or(false)
-        {
-            // Prefer range locks, so release the whole-file lock which maps to the range lock
-            file.unlock()?;
-            return Self::new_holding_ranges(file, read_only);
-        }
-
-        let ranges_locked = match Self::try_lock_protocol_ranges(&file, read_only) {
-            Ok(true) => true,
-            // A multi-process handle has the database open
-            Ok(false) => {
-                report_failed_release(file.unlock());
-                return Err(DatabaseError::DatabaseAlreadyOpen);
-            }
-            Err(err) if err.kind() == io::ErrorKind::Unsupported => {
-                // no-op. If range locks are not supported, then multi-process access is not possible
-                false
-            }
-            Err(err) => {
-                report_failed_release(file.unlock());
-                return Err(err.into());
-            }
-        };
-
         Ok(Self {
-            whole_file_locked,
-            ranges_locked,
+            whole_file_locked: AtomicBool::new(false),
+            ranges_locked: AtomicBool::new(false),
             file,
         })
     }
 
-    fn new_holding_ranges(file: File, read_only: bool) -> Result<Self, DatabaseError> {
-        match Self::try_lock_protocol_ranges(&file, read_only) {
-            Ok(true) => Ok(Self {
-                whole_file_locked: false,
-                ranges_locked: true,
-                file,
-            }),
-            // Another handle has the database open, holding either kind of lock
-            Ok(false) => Err(DatabaseError::DatabaseAlreadyOpen),
-            Err(err) if err.kind() == io::ErrorKind::Unsupported => {
-                let whole_file_locked = Self::try_whole_file_lock(&file, read_only)?;
-                Ok(Self {
-                    whole_file_locked,
-                    ranges_locked: false,
-                    file,
-                })
+    /// The whole storage, locked with the protocol ranges and -- where those are a namespace of
+    /// their own -- the whole-file lock an older redb takes as well.
+    fn lock_whole_storage(&self, shared: bool) -> io::Result<bool> {
+        // Prefer range locks
+        if File::CONFLICTS_WITH_STD_FILE_LOCK == Some(true) {
+            return match self.lock_protocol_ranges(shared) {
+                // Windows, whose range locks are not implemented yet and whose whole-file lock is
+                // itself one over every byte
+                Err(err) if err.kind() == io::ErrorKind::Unsupported => {
+                    self.lock_whole_file(shared)
+                }
+                result => result,
+            };
+        }
+
+        if !self.lock_whole_file(shared)? {
+            return Ok(false);
+        }
+
+        if File::CONFLICTS_WITH_STD_FILE_LOCK.is_none()
+            && self
+                .file
+                .query_lock(NAMESPACE_PROBE_BYTE..NAMESPACE_PROBE_BYTE + 1)
+                .unwrap_or(false)
+        {
+            // Prefer range locks, so release the whole-file lock which maps to the range lock
+            self.release_whole_storage()?;
+            return self.lock_protocol_ranges(shared);
+        }
+
+        let acquired = self.lock_protocol_ranges(shared);
+        match acquired {
+            Ok(true) => Ok(true),
+            // Without range locks there is no multi-process access to exclude, and the whole-file
+            // lock already keeps every other process out
+            Err(ref err) if err.kind() == io::ErrorKind::Unsupported => Ok(true),
+            // A multi-process handle has the database open
+            _ => {
+                report_failed_release(self.release_whole_storage());
+                acquired
             }
-            Err(err) => Err(err.into()),
         }
     }
 
-    fn try_lock_protocol_ranges(file: &File, read_only: bool) -> io::Result<bool> {
+    /// The ranges alone, which is what a namespace shared with the whole-file lock calls for
+    fn lock_protocol_ranges(&self, shared: bool) -> io::Result<bool> {
         for (taken, range) in PROTOCOL_RANGES.into_iter().enumerate() {
-            let acquired = if read_only {
-                file.try_lock_shared_range(range)
+            let acquired = if shared {
+                self.file.try_lock_shared_range(range)
             } else {
-                file.try_lock_range(range)
+                self.file.try_lock_range(range)
             };
+            // Another handle has the database open, holding either kind of lock
             if !matches!(acquired, Ok(true)) {
-                Self::release_protocol_ranges(file, taken);
+                for range in PROTOCOL_RANGES.into_iter().take(taken) {
+                    report_failed_release(self.file.unlock_range(range));
+                }
                 return acquired;
             }
         }
+        self.ranges_locked.store(true, Ordering::Release);
+
         Ok(true)
     }
 
-    /// The first `taken` ranges of an open that is failing.
-    fn release_protocol_ranges(file: &File, taken: usize) {
-        for range in PROTOCOL_RANGES.into_iter().take(taken) {
-            report_failed_release(file.unlock_range(range));
+    fn release_whole_storage(&self) -> io::Result<()> {
+        // Every lock is released even where one fails: a lock left behind outlives this
+        // backend wherever the description is shared
+        let mut result = Ok(());
+        if self.ranges_locked.swap(false, Ordering::AcqRel) {
+            for range in PROTOCOL_RANGES {
+                result = result.and(self.file.unlock_range(range));
+            }
         }
+        if self.whole_file_locked.swap(false, Ordering::AcqRel) {
+            result = result.and(self.file.unlock());
+        }
+
+        result
     }
 
-    /// `Ok(false)` means the platform does not support file locks at all, which is reported
-    /// once rather than failing the open.
-    fn try_whole_file_lock(file: &File, read_only: bool) -> Result<bool, DatabaseError> {
-        let result = if read_only {
-            file.try_lock_shared()
+    fn lock_whole_file(&self, shared: bool) -> io::Result<bool> {
+        let result = if shared {
+            self.file.try_lock_shared()
         } else {
-            file.try_lock()
+            self.file.try_lock()
         };
 
         match result {
-            Ok(()) => Ok(true),
-            Err(TryLockError::WouldBlock) => Err(DatabaseError::DatabaseAlreadyOpen),
-            Err(TryLockError::Error(err)) if err.kind() == io::ErrorKind::Unsupported => {
-                #[cfg(feature = "logging")]
-                warn!(
-                    "File locks not supported on this platform. You must ensure that only a single process opens the database file, at a time"
-                );
-
-                Ok(false)
+            Ok(()) => {
+                self.whole_file_locked.store(true, Ordering::Release);
+                Ok(true)
             }
-            Err(TryLockError::Error(err)) => Err(err.into()),
+            Err(TryLockError::WouldBlock) => Ok(false),
+            Err(TryLockError::Error(err)) => Err(err),
+        }
+    }
+}
+
+/// The whole storage is what a single-process open locks, and the whole-file lock an older redb
+/// takes covers exactly that, so both kinds are held for that one range. Any other range is a
+/// byte-range lock alone.
+impl InternalStorageBackend for FileBackend {
+    fn try_lock_range(&self, range: Range<u64>) -> io::Result<bool> {
+        if range == FULL_RANGE {
+            self.lock_whole_storage(false)
+        } else {
+            self.file.try_lock_range(range)
+        }
+    }
+
+    fn try_lock_shared_range(&self, range: Range<u64>) -> io::Result<bool> {
+        if range == FULL_RANGE {
+            self.lock_whole_storage(true)
+        } else {
+            self.file.try_lock_shared_range(range)
+        }
+    }
+
+    fn unlock_range(&self, range: Range<u64>) -> io::Result<()> {
+        if range == FULL_RANGE {
+            self.release_whole_storage()
+        } else {
+            self.file.unlock_range(range)
         }
     }
 }
@@ -235,22 +251,6 @@ impl StorageBackend for FileBackend {
         }
         Ok(())
     }
-
-    fn close(&self) -> Result<(), io::Error> {
-        // Every lock is released even where one fails: a lock left behind outlives this
-        // backend wherever the description is shared
-        let mut result = Ok(());
-        if self.ranges_locked {
-            for range in PROTOCOL_RANGES {
-                result = result.and(self.file.unlock_range(range));
-            }
-        }
-        if self.whole_file_locked {
-            result = result.and(self.file.unlock());
-        }
-
-        result
-    }
 }
 
 // TODO: replace these with wasi::FileExt when https://github.com/rust-lang/rust/issues/71213
@@ -326,8 +326,7 @@ fn write_all_at(file: &File, mut buf: &[u8], mut offset: u64) -> io::Result<()> 
 
 #[cfg(all(test, any(target_os = "linux", target_vendor = "apple")))]
 mod range_lock_tests {
-    use super::{FileBackend, NAMESPACE_PROBE_BYTE, RangeLock};
-    use crate::StorageBackend;
+    use super::{FULL_RANGE, FileBackend, InternalStorageBackend, NAMESPACE_PROBE_BYTE, RangeLock};
     use std::fs::{File, OpenOptions, TryLockError};
     use std::path::Path;
 
@@ -344,6 +343,30 @@ mod range_lock_tests {
             .unwrap()
     }
 
+    /// The whole-storage lock the core takes at open, mapped as the core maps it
+    fn open_file(file: File, read_only: bool) -> Result<FileBackend, crate::DatabaseError> {
+        let backend = FileBackend::new(file).unwrap();
+        let acquired = if read_only {
+            backend.try_lock_shared_range(FULL_RANGE)
+        } else {
+            backend.try_lock_range(FULL_RANGE)
+        };
+        match acquired {
+            Ok(true) => Ok(backend),
+            Ok(false) => Err(crate::DatabaseError::DatabaseAlreadyOpen),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    fn open(path: &Path, read_only: bool) -> Result<FileBackend, crate::DatabaseError> {
+        open_file(reopen(path), read_only)
+    }
+
+    /// ... and releases at close
+    fn close(backend: &FileBackend) {
+        backend.unlock_range(FULL_RANGE).unwrap();
+    }
+
     fn byte_is_free(file: &File, offset: u64, exclusive: bool) -> bool {
         let byte = offset..offset + 1;
         let acquired = if exclusive {
@@ -357,10 +380,35 @@ mod range_lock_tests {
         acquired
     }
 
+    /// Only the whole storage is locked with both kinds. A range short of it is the byte-range
+    /// lock alone, which is what the concurrency protocols take
+    #[test]
+    fn a_range_short_of_the_whole_storage_is_a_byte_range_lock_alone() {
+        let tmpfile = crate::create_tempfile();
+        let backend = open(tmpfile.path(), false).unwrap();
+        let byte = BASE..BASE + 1;
+        // Held by the open already, so it is released first: the same file description's locks
+        // replace each other rather than conflicting
+        backend.unlock_range(byte.clone()).unwrap();
+
+        let observer = reopen(tmpfile.path());
+        assert!(backend.try_lock_range(byte.clone()).unwrap());
+        assert!(!byte_is_free(&observer, BASE, false));
+        backend.unlock_range(byte.clone()).unwrap();
+        assert!(byte_is_free(&observer, BASE, true));
+
+        assert!(backend.try_lock_shared_range(byte.clone()).unwrap());
+        assert!(byte_is_free(&observer, BASE, false));
+        assert!(!byte_is_free(&observer, BASE, true));
+        backend.unlock_range(byte).unwrap();
+
+        close(&backend);
+    }
+
     #[test]
     fn a_writable_backend_holds_every_protocol_byte_exclusively() {
         let tmpfile = crate::create_tempfile();
-        let backend = FileBackend::new_internal(reopen(tmpfile.path()), false).unwrap();
+        let backend = open(tmpfile.path(), false).unwrap();
 
         let observer = reopen(tmpfile.path());
         for offset in PROTOCOL_OFFSETS {
@@ -369,7 +417,7 @@ mod range_lock_tests {
         }
 
         // ... and releases them all at close
-        backend.close().unwrap();
+        close(&backend);
         for offset in PROTOCOL_OFFSETS {
             assert!(byte_is_free(&observer, offset, true), "offset {offset}");
         }
@@ -378,7 +426,7 @@ mod range_lock_tests {
     #[test]
     fn read_only_backends_share_the_protocol_bytes_with_each_other() {
         let tmpfile = crate::create_tempfile();
-        let first = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
+        let first = open(tmpfile.path(), true).unwrap();
 
         let observer = reopen(tmpfile.path());
         for offset in PROTOCOL_OFFSETS {
@@ -386,9 +434,9 @@ mod range_lock_tests {
             assert!(!byte_is_free(&observer, offset, true), "offset {offset}");
         }
 
-        let second = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
-        first.close().unwrap();
-        second.close().unwrap();
+        let second = open(tmpfile.path(), true).unwrap();
+        close(&first);
+        close(&second);
     }
 
     #[test]
@@ -400,17 +448,17 @@ mod range_lock_tests {
         // A held byte anywhere in the range stands in for a multi-process handle having
         // the database open
         assert!(matches!(
-            FileBackend::new_internal(reopen(tmpfile.path()), false),
+            open(tmpfile.path(), false),
             Err(crate::DatabaseError::DatabaseAlreadyOpen)
         ));
         assert!(matches!(
-            FileBackend::new_internal(reopen(tmpfile.path()), true),
+            open(tmpfile.path(), true),
             Err(crate::DatabaseError::DatabaseAlreadyOpen)
         ));
 
         holder.unlock_range(BASE..BASE + 1).unwrap();
-        let backend = FileBackend::new_internal(reopen(tmpfile.path()), false).unwrap();
-        backend.close().unwrap();
+        let backend = open(tmpfile.path(), false).unwrap();
+        close(&backend);
     }
 
     /// Dropping the file does not suffice: a caller holding a `try_clone()` of the file it
@@ -425,7 +473,7 @@ mod range_lock_tests {
         let file = reopen(tmpfile.path());
         let kept_by_the_caller = file.try_clone().unwrap();
         assert!(matches!(
-            FileBackend::new_internal(file, false),
+            open_file(file, false),
             Err(crate::DatabaseError::DatabaseAlreadyOpen)
         ));
 
@@ -460,13 +508,13 @@ mod range_lock_tests {
     fn an_ordinary_filesystem_answers_that_the_two_kinds_are_separate() {
         assert!(File::CONFLICTS_WITH_STD_FILE_LOCK.is_none());
         let tmpfile = crate::create_tempfile();
-        let backend = FileBackend::new_internal(reopen(tmpfile.path()), false).unwrap();
+        let backend = open(tmpfile.path(), false).unwrap();
 
         let observer = reopen(tmpfile.path());
         assert!(matches!(observer.try_lock(), Err(TryLockError::WouldBlock)));
         assert!(!byte_is_free(&observer, BASE, true));
 
-        backend.close().unwrap();
+        close(&backend);
     }
 
     /// The open a platform whose two kinds of lock conflict takes, holding the ranges in place of
@@ -475,8 +523,16 @@ mod range_lock_tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn an_open_holding_the_ranges_takes_no_whole_file_lock() {
+        use super::AtomicBool;
+
         let tmpfile = crate::create_tempfile();
-        let backend = FileBackend::new_holding_ranges(reopen(tmpfile.path()), false).unwrap();
+        let file = reopen(tmpfile.path());
+        let backend = FileBackend {
+            whole_file_locked: AtomicBool::new(false),
+            ranges_locked: AtomicBool::new(false),
+            file,
+        };
+        assert!(backend.lock_protocol_ranges(false).unwrap());
 
         let observer = reopen(tmpfile.path());
         for offset in PROTOCOL_OFFSETS {
@@ -487,7 +543,7 @@ mod range_lock_tests {
         observer.try_lock().unwrap();
         observer.unlock().unwrap();
 
-        backend.close().unwrap();
+        close(&backend);
         for offset in PROTOCOL_OFFSETS {
             assert!(byte_is_free(&observer, offset, true), "offset {offset}");
         }
@@ -500,13 +556,13 @@ mod range_lock_tests {
         let tmpfile = crate::create_tempfile();
         let observer = reopen(tmpfile.path());
 
-        let writable = FileBackend::new_internal(reopen(tmpfile.path()), false).unwrap();
+        let writable = open(tmpfile.path(), false).unwrap();
         assert!(byte_is_free(&observer, NAMESPACE_PROBE_BYTE, true));
-        writable.close().unwrap();
+        close(&writable);
 
-        let reader = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
+        let reader = open(tmpfile.path(), true).unwrap();
         assert!(byte_is_free(&observer, NAMESPACE_PROBE_BYTE, true));
-        reader.close().unwrap();
+        close(&reader);
     }
 
     /// The whole-file lock is all an older version of redb takes, so an open must keep
@@ -516,16 +572,16 @@ mod range_lock_tests {
         let tmpfile = crate::create_tempfile();
         let observer = reopen(tmpfile.path());
 
-        let writable = FileBackend::new_internal(reopen(tmpfile.path()), false).unwrap();
+        let writable = open(tmpfile.path(), false).unwrap();
         assert!(matches!(
             observer.try_lock_shared(),
             Err(TryLockError::WouldBlock)
         ));
-        writable.close().unwrap();
+        close(&writable);
 
-        let reader = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
+        let reader = open(tmpfile.path(), true).unwrap();
         assert!(matches!(observer.try_lock(), Err(TryLockError::WouldBlock)));
-        reader.close().unwrap();
+        close(&reader);
 
         observer.try_lock().unwrap();
     }
@@ -538,11 +594,11 @@ mod range_lock_tests {
         holder.try_lock().unwrap();
 
         assert!(matches!(
-            FileBackend::new_internal(reopen(tmpfile.path()), false),
+            open(tmpfile.path(), false),
             Err(crate::DatabaseError::DatabaseAlreadyOpen)
         ));
         assert!(matches!(
-            FileBackend::new_internal(reopen(tmpfile.path()), true),
+            open(tmpfile.path(), true),
             Err(crate::DatabaseError::DatabaseAlreadyOpen)
         ));
 
@@ -550,11 +606,11 @@ mod range_lock_tests {
         holder.unlock().unwrap();
         holder.try_lock_shared().unwrap();
         assert!(matches!(
-            FileBackend::new_internal(reopen(tmpfile.path()), false),
+            open(tmpfile.path(), false),
             Err(crate::DatabaseError::DatabaseAlreadyOpen)
         ));
-        let reader = FileBackend::new_internal(reopen(tmpfile.path()), true).unwrap();
-        reader.close().unwrap();
+        let reader = open(tmpfile.path(), true).unwrap();
+        close(&reader);
         holder.unlock().unwrap();
     }
 }

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -16,6 +16,7 @@ mod savepoint;
 mod xxh3;
 
 pub use backends::InMemoryBackend;
+pub(crate) use backends::LocklessBackend;
 #[cfg(not(redb_no_std))]
 pub(crate) use backends::ReadOnlyBackend;
 pub(crate) use base::{MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTracker};

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1,3 +1,5 @@
+use crate::CacheStats;
+use crate::db::InternalStorageBackend;
 use crate::io;
 use crate::sync::Mutex;
 use crate::transaction_tracker::TransactionId;
@@ -14,7 +16,6 @@ use crate::tree_store::page_store::layout::DatabaseLayout;
 use crate::tree_store::page_store::region::{Allocators, RegionTracker};
 use crate::tree_store::page_store::{PageImpl, PageMut, hash128_with_seed};
 use crate::tree_store::{Page, PageNumber, PageTracker};
-use crate::{CacheStats, StorageBackend};
 use crate::{DatabaseError, Result, StorageError};
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
@@ -524,7 +525,7 @@ pub(crate) struct TransactionalMemory {
 
 impl TransactionalMemory {
     pub(crate) fn new(
-        file: Box<dyn StorageBackend>,
+        file: Box<dyn InternalStorageBackend>,
         // Allow initializing a new database in an empty file
         allow_initialize: bool,
         page_size: usize,
@@ -541,7 +542,7 @@ impl TransactionalMemory {
         );
         assert!(region_size.is_power_of_two());
 
-        let storage = PagedCachedFile::new(file, page_size as u64, cache_size)?;
+        let storage = PagedCachedFile::new(file, page_size as u64, cache_size, read_only)?;
 
         let initial_storage_len = storage.raw_file_len()?;
 
@@ -1754,11 +1755,17 @@ mod test {
     #[cfg(panic = "unwind")]
     fn invalidate_allocator_state_tolerates_poison() {
         use super::TransactionalMemory;
-        use crate::tree_store::InMemoryBackend;
+        use crate::tree_store::{InMemoryBackend, LocklessBackend};
 
-        let mem =
-            TransactionalMemory::new(Box::new(InMemoryBackend::new()), true, 4096, None, 0, false)
-                .unwrap();
+        let mem = TransactionalMemory::new(
+            LocklessBackend::boxed(InMemoryBackend::new()),
+            true,
+            4096,
+            None,
+            0,
+            false,
+        )
+        .unwrap();
         mem.reset_allocator_state().unwrap();
 
         std::thread::scope(|s| {
@@ -1789,11 +1796,11 @@ mod test {
         use super::{MAX_PAGE_INDEX, TransactionalMemory};
         use crate::StorageError;
         use crate::tree_store::page_store::base::MAX_REGIONS;
-        use crate::tree_store::{InMemoryBackend, PageNumber};
+        use crate::tree_store::{InMemoryBackend, LocklessBackend, PageNumber};
 
         let page_size = 4096;
         let mem = TransactionalMemory::new(
-            Box::new(InMemoryBackend::new()),
+            LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             page_size,
             Some(64 * page_size as u64),
@@ -1837,11 +1844,11 @@ mod test {
         use super::TransactionalMemory;
         use crate::StorageError;
         use crate::tree_store::page_store::base::PageHint;
-        use crate::tree_store::{InMemoryBackend, Page, PageNumber, PageTracker};
+        use crate::tree_store::{InMemoryBackend, LocklessBackend, Page, PageNumber, PageTracker};
 
         let page_size = 4096;
         let mem = TransactionalMemory::new(
-            Box::new(InMemoryBackend::new()),
+            LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             page_size,
             Some(64 * page_size as u64),
@@ -1878,13 +1885,13 @@ mod test {
     #[test]
     fn free_merge_remarks_region_tracker() {
         use super::TransactionalMemory;
-        use crate::tree_store::{InMemoryBackend, Page, PageTracker};
+        use crate::tree_store::{InMemoryBackend, LocklessBackend, Page, PageTracker};
 
         // Small pages and regions keep the reproduction cheap to set up.
         let page_size = 128 * 1024;
         let region_size = 16 * page_size as u64;
         let mem = TransactionalMemory::new(
-            Box::new(InMemoryBackend::new()),
+            LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             page_size,
             Some(region_size),


### PR DESCRIPTION
The locking a database does is a file backend's business today: each decides which locks to take, holds them for as long as the database is open, and releases them at close, which is the same decision written twice. The concurrency protocols of `docs/design.md` belong to redb rather than to a backend, and they need only one thing from one: the ability to lock a range of the storage.

So `InternalStorageBackend`, which requires `StorageBackend` and adds exactly that -- lock, lock shared, unlock -- and which the core takes in place of a `StorageBackend` from here on: `Database::new` and `ReadOnlyDatabase::new` through `TransactionalMemory::new` to `PagedCachedFile`.

It is not public. A backend a caller supplies has only the public trait to offer, so `create_with_backend` wraps it in `LocklessBackend`, which reports every lock unsupported. `create_with_backend` keeps taking `impl StorageBackend`, so there is no public API change.

## Taking the lock is the core's

`CheckedBackend` locks the whole storage when it is built and releases it at close, so a refused open is one place rather than two, and a backend is left to say only what it can do.

Whether it has locks to offer at all is the trait's to say. `locks_expected()` is true of everything but the caller's wrapper, whose absent locks are neither asked for nor reported -- `create_with_backend` does no locking, and that is expected, so it is not what the "File locks not supported on this platform" warning is about. That warning now has one site instead of one per backend.

A trait constant would say `locks_expected` without a receiver, but an associated constant makes a trait dyn-incompatible, and the core holds a `dyn InternalStorageBackend`, so it is a defaulted method.

## What the backends are left with

The platform reasoning alone:

| backend | whole storage | a narrower range |
|---|---|---|
| `optimized` | the protocol ranges, and -- where those are a namespace of their own -- the whole-file lock an older redb takes as well | the byte-range lock alone |
| `fallback` | the whole-file lock, which is all it has | unsupported |
| a caller's, wrapped | unsupported | unsupported |

The whole storage is the range a single-process open locks, and the whole-file lock covers exactly that, which is why both kinds are held for it and only for it. `FULL_RANGE` names it. Which locks are held became state rather than a constructor's result, since the interface takes them by shared reference.

**One fallback is left, and it is a question for review.** `lock_protocol_ranges` no longer falls back to the whole-file lock when range locks are unsupported. What remains is one arm in the `CONFLICTS_WITH_STD_FILE_LOCK == Some(true)` branch, the only place it can still be reached, which is Windows: its `RangeLock` impl is const-only, so `try_lock_range` returns `Unsupported` there, and that arm is what locks the database on Windows today. Removing it outright opens Windows unlocked and turns `basic_tests`' `DatabaseAlreadyOpen` assertions red. It should go the moment `RangeLock` is implemented for Windows.

## Scope

No behavior changes. The protocols move into the core in a later change, which is what the narrower ranges and the signal are for; #1419 rebases onto this and drives the trait rather than holding its locks itself.

## Testing

Two tests, one property each: a caller-supplied backend reports the locks unsupported and says that is expected, with the storage underneath it still working; and a range short of the whole storage is a byte-range lock alone, which is the interface the protocols will use. The existing lock tests cover the whole-storage range through a helper that does what the core does, since the backends no longer lock when they are built.

`cargo fmt`, `cargo clippy --all-targets` in four feature configurations (including `--features logging` alone, where the reporting is compiled differently), cross-clippy for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, wasm32 in three configurations -- which is where `fallback.rs` actually compiles -- `wasm32-wasip1`, no_std in two, `cargo doc`, and `cargo test --all-features` all pass. `cargo deny` was not run; no dependency changed. The WASI test run is the one thing local validation here cannot do, and it is what caught an earlier revision.