### PR TITLE
Give Windows the byte-range locks it has always had

### DIFF
--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -54,11 +54,11 @@ impl FileBackend {
     /// The whole storage, locked with the protocol ranges and -- where those are a namespace of
     /// their own -- the whole-file lock an older redb takes as well.
     fn lock_whole_storage(&self, shared: bool) -> io::Result<bool> {
-        // Prefer range locks
+        // Prefer range locks, which cover the whole-file lock as well where the two conflict
         if File::CONFLICTS_WITH_STD_FILE_LOCK == Some(true) {
             return match self.lock_protocol_ranges(shared) {
-                // Windows, whose range locks are not implemented yet and whose whole-file lock is
-                // itself one over every byte
+                // A filesystem with no byte-range locks, whatever the platform has: the
+                // whole-file lock is the only exclusion left to take
                 Err(err) if err.kind() == io::ErrorKind::Unsupported => {
                     self.lock_whole_file(shared)
                 }
@@ -324,7 +324,7 @@ fn write_all_at(file: &File, mut buf: &[u8], mut offset: u64) -> io::Result<()> 
     Ok(())
 }
 
-#[cfg(all(test, any(target_os = "linux", target_vendor = "apple")))]
+#[cfg(all(test, any(target_os = "linux", target_vendor = "apple", windows)))]
 mod range_lock_tests {
     use super::{FULL_RANGE, FileBackend, InternalStorageBackend, NAMESPACE_PROBE_BYTE, RangeLock};
     use std::fs::{File, OpenOptions, TryLockError};
@@ -385,11 +385,10 @@ mod range_lock_tests {
     #[test]
     fn a_range_short_of_the_whole_storage_is_a_byte_range_lock_alone() {
         let tmpfile = crate::create_tempfile();
-        let backend = open(tmpfile.path(), false).unwrap();
+        // No whole-storage lock: on the platforms whose locks do not split, a range it covered
+        // could not be locked or released on its own
+        let backend = FileBackend::new(reopen(tmpfile.path())).unwrap();
         let byte = BASE..BASE + 1;
-        // Held by the open already, so it is released first: the same file description's locks
-        // replace each other rather than conflicting
-        backend.unlock_range(byte.clone()).unwrap();
 
         let observer = reopen(tmpfile.path());
         assert!(backend.try_lock_range(byte.clone()).unwrap());
@@ -401,8 +400,6 @@ mod range_lock_tests {
         assert!(byte_is_free(&observer, BASE, false));
         assert!(!byte_is_free(&observer, BASE, true));
         backend.unlock_range(byte).unwrap();
-
-        close(&backend);
     }
 
     #[test]

--- a/src/tree_store/page_store/file_backend/range_lock.rs
+++ b/src/tree_store/page_store/file_backend/range_lock.rs
@@ -41,10 +41,148 @@ fn unsupported() -> io::Error {
 #[cfg(not(any(target_os = "linux", target_vendor = "apple", windows)))]
 impl RangeLock for File {}
 
-// std's whole-file lock is itself a LockFileEx over every byte, so it is one of these
+// LockFileEx region locks: per-handle, so they carry the same ownership model as open file
+// description locks, and mandatory rather than advisory. Unlike fcntl's, they do not split or
+// merge -- a lock is released only by an unlock over the range it was taken over, and a range
+// this handle already holds cannot be locked again -- so each range is taken and released whole.
+// The calls are the ones std's own whole-file locks use, made over a range rather than the file.
 #[cfg(windows)]
-impl RangeLock for File {
-    const CONFLICTS_WITH_STD_FILE_LOCK: Option<bool> = Some(true);
+mod windows_imp {
+    use super::{File, RangeLock};
+    use std::io;
+    use std::ops::Range;
+    use std::os::windows::io::AsRawHandle;
+
+    type Handle = *mut core::ffi::c_void;
+    type Dword = u32;
+    type Bool = i32;
+
+    const LOCKFILE_FAIL_IMMEDIATELY: Dword = 0x0000_0001;
+    const LOCKFILE_EXCLUSIVE_LOCK: Dword = 0x0000_0002;
+    const ERROR_LOCK_VIOLATION: i32 = 33;
+
+    #[repr(C)]
+    struct Overlapped {
+        internal: usize,
+        internal_high: usize,
+        offset: Dword,
+        offset_high: Dword,
+        event: Handle,
+    }
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn LockFileEx(
+            file: Handle,
+            flags: Dword,
+            reserved: Dword,
+            bytes_low: Dword,
+            bytes_high: Dword,
+            overlapped: *mut Overlapped,
+        ) -> Bool;
+        fn UnlockFile(
+            file: Handle,
+            offset_low: Dword,
+            offset_high: Dword,
+            bytes_low: Dword,
+            bytes_high: Dword,
+        ) -> Bool;
+    }
+
+    // The Win32 calls take 64-bit offsets and lengths as dword halves
+    fn low_dword(value: u64) -> Dword {
+        Dword::try_from(value & u64::from(Dword::MAX)).unwrap()
+    }
+
+    fn high_dword(value: u64) -> Dword {
+        Dword::try_from(value >> 32).unwrap()
+    }
+
+    fn try_lock(file: &File, exclusive: bool, range: Range<u64>) -> io::Result<bool> {
+        debug_assert!(!range.is_empty());
+        let flags = if exclusive {
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY
+        } else {
+            LOCKFILE_FAIL_IMMEDIATELY
+        };
+        let len = range.end - range.start;
+        // Only the offset is carried, and the struct is left on the stack, as std's try_lock
+        // does: LOCKFILE_FAIL_IMMEDIATELY is answered rather than queued, so nothing completes
+        // into it after the call returns
+        let mut overlapped = Overlapped {
+            internal: 0,
+            internal_high: 0,
+            offset: low_dword(range.start),
+            offset_high: high_dword(range.start),
+            event: core::ptr::null_mut(),
+        };
+        let ok = unsafe {
+            LockFileEx(
+                file.as_raw_handle(),
+                flags,
+                0,
+                low_dword(len),
+                high_dword(len),
+                &raw mut overlapped,
+            )
+        };
+        if ok != 0 {
+            return Ok(true);
+        }
+
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(ERROR_LOCK_VIOLATION) {
+            Ok(false)
+        } else {
+            Err(err)
+        }
+    }
+
+    impl RangeLock for File {
+        // std's whole-file lock is itself a LockFileEx over every byte, so it is one of these
+        const CONFLICTS_WITH_STD_FILE_LOCK: Option<bool> = Some(true);
+
+        fn try_lock_range(&self, range: Range<u64>) -> io::Result<bool> {
+            try_lock(self, true, range)
+        }
+
+        fn try_lock_shared_range(&self, range: Range<u64>) -> io::Result<bool> {
+            try_lock(self, false, range)
+        }
+
+        // UnlockFile rather than its Ex form, as std's unlock uses: it takes the range as
+        // arguments, so there is no overlapped structure for a queued request to complete into.
+        // One call releases the lock because the protocol takes one per range, where std has to
+        // unlock twice for a handle that took both an exclusive and a shared lock.
+        fn unlock_range(&self, range: Range<u64>) -> io::Result<()> {
+            debug_assert!(!range.is_empty());
+            let len = range.end - range.start;
+            let ok = unsafe {
+                UnlockFile(
+                    self.as_raw_handle(),
+                    low_dword(range.start),
+                    high_dword(range.start),
+                    low_dword(len),
+                    high_dword(len),
+                )
+            };
+            if ok != 0 {
+                Ok(())
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        }
+
+        // There is no query operation, so the range is acquired and released again to answer
+        fn query_lock(&self, range: Range<u64>) -> io::Result<bool> {
+            if try_lock(self, true, range.clone())? {
+                self.unlock_range(range)?;
+                Ok(false)
+            } else {
+                Ok(true)
+            }
+        }
+    }
 }
 
 // The lock-type constants are c_int on Linux and already c_short on the Apple platforms


### PR DESCRIPTION
Prep for #1419. The `RangeLock` impl for Windows was `CONFLICTS_WITH_STD_FILE_LOCK` alone, so every call reported the locks unsupported and a single-process open fell back to the whole-file lock. `LockFileEx`/`UnlockFile` are what that fallback was waiting for.

## Shaped like std's

These are the same two calls `File::lock` and `File::unlock` are made of, made over a range rather than the whole file, and `sys/fs/windows.rs` is worth reading beside this:

* The lock sets `LOCKFILE_FAIL_IMMEDIATELY` and leaves its `OVERLAPPED` **on the stack**, exactly as std's `try_lock` does. With that flag the request is answered rather than queued, so nothing completes into the structure after the call returns -- which is why std does not bother with an event there either, and only its *blocking* `acquire_lock` sets one up and waits with `GetOverlappedResult`.
* The unlock is **`UnlockFile`, not `UnlockFileEx`**, again as std's `unlock` does. It takes the range as plain arguments, so there is no `OVERLAPPED` at all on the one path that has no fail-immediately flag to keep it from queueing.
* `ERROR_LOCK_VIOLATION` means the lock is held elsewhere, matching std's `WouldBlock`; everything else is the raw OS error.

One unlock call releases the lock, where std unlocks twice to cover a handle that took both an exclusive and a shared lock on the same region -- the protocol only ever takes one lock per range.

Two Win32 calls did not seem to earn a dependency, so they are declared in the module.

There is no query operation, so `query_lock` acquires the range and releases it again. That counts *this* handle's own locks as a conflict, unlike `F_OFD_GETLK`, so a query may only ask about a range this handle leaves unlocked -- which is exactly what the protocol's probe bytes are. The trait's doc comment now says so.

## What had to change

These locks do not split or merge: a lock is released only by an unlock over the range it was taken over, and a range this handle already holds cannot be locked again. Every range the protocol takes is already taken and released whole, so the only casualty was `a_range_short_of_the_whole_storage_is_a_byte_range_lock_alone`, which used to take the whole-storage lock and then release one byte out of it. It takes the byte on its own now, which tests the same property without relying on fcntl's splitting.

## The whole-file fallback stays

I first removed `lock_whole_storage`'s fallback to the whole-file lock, per your review on #1419 -- with Windows answering, every `CONFLICTS_WITH_STD_FILE_LOCK == Some(true)` platform has a `RangeLock` implementation, so the reason it was written for is gone. That was wrong, and Codex caught it: the arm covers a second case that outlives the first. `lock_error()` maps `EINVAL`/`ENOTSUP`/`EOPNOTSUPP` to `ErrorKind::Unsupported`, so a *filesystem* that refuses byte-range locks -- a property of the mount, not the platform -- reaches it too, and `CheckedBackend::lock_storage`'s unsupported arm would then warn and open with no exclusion at all where the parent took a whole-file lock. Not Apple-only either: Rust maps `ERROR_NOT_SUPPORTED` to `Unsupported`, so a Windows share that refuses `LockFileEx` lands in the same place.

So the arm is unchanged in behaviour; only its comment moves, from "Windows, whose range locks are not implemented yet" to what it actually covers. #1424 is where it goes away, under `experimental-api-5`.

No changelog entry: a second open on Windows was refused before and is refused now, over the same bytes -- std's whole-file lock is itself a `LockFileEx` over every byte.

## Testing

`range_lock_tests` now compiles on Windows as well, so nine of its tests run there.

I have no Windows machine, so I built the test binaries for `x86_64-pc-windows-gnu` with mingw-w64 and ran them under wine 9.0. That is a real link (the FFI declarations resolve against kernel32) plus a real execution of `LockFileEx`/`UnlockFile`:

| suite | result |
|---|---|
| `range_lock_tests` | 8 of 9 |
| lib unit tests | 123 of 124 |
| `basic_tests` | 121 of 121 |
| `integration_tests` | 109 of 110 |
| everything else | all pass |

Both failures are wine's, not the diff's:

* `a_whole_file_lock_holder_reads_as_already_open` fails inside std's `File::unlock`. std unlocks twice, tolerating only `ERROR_NOT_LOCKED` on the second call; wine returns `ERROR_LOCK_VIOLATION` there instead, so std reports failure. I checked the pieces directly under wine: `LockFileEx` over a range followed by `UnlockFileEx`, and the same followed by `UnlockFile`, both succeed -- it is only that second, already-unlocked call whose error code wine gets wrong. Nothing this PR does is affected, which is why `basic_tests` is clean.
* `does_not_exist` expects `ErrorKind::NotFound` from opening a missing path, which never reaches lock code at all.

Windows CI is the real check for both, and has passed on every head.

Locally: `cargo fmt`, `cargo clippy --all --all-targets` with and without `--all-features`, cross-clippy with `--all-targets --all-features` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, wasm32 in three configurations, `wasm32-wasip1`, no_std in two, `cargo doc`, and `cargo test --all --all-features`.