### PR TITLE
Take the range locks alone under the redb 5 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   the `experimental-api-5` feature flag, returning a `MultimapCursor` pointing at a gap between
   entries. The type reserves the constructors' signatures in the trait; navigation methods will
   be added behind the `experimental_cursor` feature flag, like the table cursors' were.
+* Under the `experimental-api-5` feature flag, a database file is locked with byte-range locks
+  alone, rather than also with the whole-file lock earlier versions take.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -51,8 +51,17 @@ impl FileBackend {
         })
     }
 
+    #[cfg(feature = "experimental-api-5")]
+    fn lock_whole_storage(&self, shared: bool) -> io::Result<bool> {
+        match self.lock_protocol_ranges(shared) {
+            Err(err) if err.kind() == io::ErrorKind::Unsupported => self.lock_whole_file(shared),
+            result => result,
+        }
+    }
+
     /// The whole storage, locked with the protocol ranges and -- where those are a namespace of
     /// their own -- the whole-file lock an older redb takes as well.
+    #[cfg(not(feature = "experimental-api-5"))]
     fn lock_whole_storage(&self, shared: bool) -> io::Result<bool> {
         // Prefer range locks, which cover the whole-file lock as well where the two conflict
         if File::CONFLICTS_WITH_STD_FILE_LOCK == Some(true) {
@@ -327,7 +336,9 @@ fn write_all_at(file: &File, mut buf: &[u8], mut offset: u64) -> io::Result<()> 
 #[cfg(all(test, any(target_os = "linux", target_vendor = "apple", windows)))]
 mod range_lock_tests {
     use super::{FULL_RANGE, FileBackend, InternalStorageBackend, NAMESPACE_PROBE_BYTE, RangeLock};
-    use std::fs::{File, OpenOptions, TryLockError};
+    #[cfg(not(all(feature = "experimental-api-5", target_os = "linux")))]
+    use std::fs::TryLockError;
+    use std::fs::{File, OpenOptions};
     use std::path::Path;
 
     // Offsets docs/design.md assigns: the header lock, the coordination bytes at BASE, the
@@ -500,7 +511,7 @@ mod range_lock_tests {
 
     /// An ordinary Linux filesystem keeps the whole-file lock out of the range locks' table,
     /// so an open holds both: only the whole-file lock itself can refuse the observer's
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", not(feature = "experimental-api-5")))]
     #[test]
     fn an_ordinary_filesystem_answers_that_the_two_kinds_are_separate() {
         assert!(File::CONFLICTS_WITH_STD_FILE_LOCK.is_none());
@@ -564,6 +575,7 @@ mod range_lock_tests {
 
     /// The whole-file lock is all an older version of redb takes, so an open must keep
     /// excluding it however the namespace question is answered
+    #[cfg(not(all(feature = "experimental-api-5", target_os = "linux")))]
     #[test]
     fn the_whole_file_lock_is_refused_while_a_backend_is_open() {
         let tmpfile = crate::create_tempfile();
@@ -584,6 +596,7 @@ mod range_lock_tests {
     }
 
     /// ... and be excluded by one: the same older version, having opened the database first
+    #[cfg(not(all(feature = "experimental-api-5", target_os = "linux")))]
     #[test]
     fn a_whole_file_lock_holder_reads_as_already_open() {
         let tmpfile = crate::create_tempfile();
@@ -609,5 +622,35 @@ mod range_lock_tests {
         let reader = open(tmpfile.path(), true).unwrap();
         close(&reader);
         holder.unlock().unwrap();
+    }
+
+    #[cfg(all(feature = "experimental-api-5", target_os = "linux"))]
+    #[test]
+    fn an_older_redb_is_neither_excluded_nor_excluding_where_the_two_kinds_are_separate() {
+        let tmpfile = crate::create_tempfile();
+        let holder = reopen(tmpfile.path());
+        holder.try_lock().unwrap();
+
+        // Mapped together, this test has nothing to say
+        let asking = reopen(tmpfile.path());
+        if asking
+            .query_lock(NAMESPACE_PROBE_BYTE..NAMESPACE_PROBE_BYTE + 1)
+            .unwrap()
+        {
+            return;
+        }
+
+        let backend = open(tmpfile.path(), false).unwrap();
+        holder.unlock().unwrap();
+
+        let observer = reopen(tmpfile.path());
+        observer.try_lock().unwrap();
+        observer.unlock().unwrap();
+
+        assert!(matches!(
+            open(tmpfile.path(), false),
+            Err(crate::DatabaseError::DatabaseAlreadyOpen)
+        ));
+        close(&backend);
     }
 }

--- a/src/tree_store/page_store/file_backend/range_lock.rs
+++ b/src/tree_store/page_store/file_backend/range_lock.rs
@@ -8,6 +8,7 @@ pub(crate) trait RangeLock {
     /// Whether these locks and [`File::lock`]'s conflict.
     /// `None` indicates that it can only be determined at runtime, e.g. because it is filesystem
     /// dependent.
+    #[cfg_attr(feature = "experimental-api-5", allow(dead_code))]
     const CONFLICTS_WITH_STD_FILE_LOCK: Option<bool> = None;
 
     /// `Ok(false)` means a conflicting lock is held elsewhere. An end of `u64::MAX` covers
@@ -26,6 +27,7 @@ pub(crate) trait RangeLock {
 
     /// Whether an exclusive lock over the range would conflict with one already held.
     /// [`File::lock`] is included wherever it would in fact block a range lock
+    #[cfg_attr(feature = "experimental-api-5", allow(dead_code))]
     fn query_lock(&self, _range: Range<u64>) -> io::Result<bool> {
         Err(unsupported())
     }


### PR DESCRIPTION
Second prep for #1419, rebased onto master now that #1423 has landed.

Under `experimental-api-5`, `optimized.rs` does not hold a whole-file lock *alongside* the protocol ranges. It still falls back to one where the ranges report themselves unsupported.

## Why it can go

The whole-file lock is only ever there to coordinate with a redb too old to take the ranges, and keeping older binaries out is deferred past the 5.0 release. Where the ranges work, they already exclude every other range-locking open, so a whole-file lock held next to them is a duplicate of an exclusion already in hand. Under the flag it is not taken:

* not on the filesystems that answer the two kinds separately, where redb 4 holds both, and
* not on the strength of the runtime probe that decided whether the two collide, which goes with it.

What it is still taken for is the case where the ranges are unavailable -- `ErrorKind::Unsupported` from `lock_protocol_ranges` -- and it is the one exclusion left rather than a second copy of one. That covers a filesystem that refuses byte-range locks and a Linux kernel older than 3.15, which has no OFD locks at all. A platform with no locks of any kind is unchanged: it opens without them, as it always has.

`CONFLICTS_WITH_STD_FILE_LOCK` loses its last caller under the flag, and `query_lock` with it, so both carry a `cfg_attr` allow until #1419 puts `query_lock` back to use.

The ranges still leave the namespace probe byte free. That puncture is not about redb's own whole-file lock -- it is what lets a handle tell a range-locking holder from one holding a lock over *every* byte, which an older redb still is, and #1419's cohort probe depends on it.

## What changes for users

Only on filesystems that keep the two kinds apart, which in practice means Linux.

| | redb 4 open | redb 5 open |
|---|---|---|
| Apple, Windows (one namespace) | excluded | excluded |
| Linux (two namespaces) | excluded | **not excluded** |
| any platform, ranges unsupported | excluded (whole-file) | excluded (whole-file) |

On the Apple platforms and Windows a whole-file lock is itself a lock over every byte, so the ranges exclude an older redb exactly as before and nothing changes. On Linux a redb 4 process and a redb 5 process can now open the same file at the same time. That is the deferred old-binary exclusion, stated in the changelog entry.

## Testing

The three tests that assumed a whole-file lock are handled by what they actually assert, rather than gated wholesale:

* `an_ordinary_filesystem_answers_that_the_two_kinds_are_separate` asserts the open holds both locks, which is a redb 4 statement -- gated to `not(experimental-api-5)`.
* `the_whole_file_lock_is_refused_while_a_backend_is_open` and `a_whole_file_lock_holder_reads_as_already_open` stay true under redb 5 wherever the two kinds share a namespace, so they keep running on Apple and Windows and are gated off only on Linux.
* New `an_older_redb_is_neither_excluded_nor_excluding_where_the_two_kinds_are_separate` pins the change on Linux in both directions, and checks that the ranges still exclude a second redb 5 open. It asks the filesystem whether the two kinds are separate rather than assuming, since `CONFLICTS_WITH_STD_FILE_LOCK` is `None` on Linux precisely because that is a property of the mount.

The restored fallback arm is the same one the non-flag path has, and is no more reachable on CI than it was there -- it needs a mount whose range locks are refused.

Note that `crates/redb-bench` enables `experimental_cursor`, so any workspace-wide build unifies `experimental-api-5` on -- CI's `cargo clippy --all --all-targets` and `cargo test --all --all-features` both exercise the redb 5 path. I ran the redb 4 path explicitly with `cargo clippy -p redb --all-targets` and `cargo test -p redb`, and both are clean.

Locally: `cargo fmt`; clippy for the workspace with and without `--all-features`, and for `redb` alone in two feature configurations; cross-clippy with `--all-targets --all-features` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`; wasm32, `wasm32-wasip1`, no_std; and the test suite in all three of `-p redb`, `-p redb --features experimental-api-5`, and `--all --all-features`.