### PR TITLE
Move file locking to core instead of the backend

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -76,6 +76,13 @@ pub trait StorageBackend: 'static + Debug + Send + Sync {
 #[cfg_attr(redb_no_std, allow(dead_code))]
 pub(crate) const FULL_RANGE: Range<u64> = 0..u64::MAX;
 
+#[cfg(any(windows, unix, target_os = "wasi"))]
+const LOCK_BASE: u64 = 1 << 62;
+/// An offset that is not used in the multi-process locking protocol. Used to detect whether
+/// `flock()` and range locks share the same namespace.
+#[cfg(any(windows, unix, target_os = "wasi"))]
+pub(crate) const NAMESPACE_PROBE_BYTE: u64 = LOCK_BASE - 2;
+
 /// A range reaching [`u64::MAX`] covers the entire storage.
 #[cfg_attr(redb_no_std, allow(dead_code))]
 pub(crate) trait InternalStorageBackend: StorageBackend {

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -1,21 +1,18 @@
-use crate::db::{FULL_RANGE, InternalStorageBackend};
+use crate::db::InternalStorageBackend;
 use crate::io;
 use crate::sync::{Mutex, MutexGuard, RwLock};
 use crate::tree_store::page_store::base::PageHint;
 use crate::tree_store::page_store::lru_cache::LRUCache;
-use crate::{CacheStats, DatabaseError, Result, StorageError};
+use crate::{CacheStats, Result, StorageError};
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::ops::{Index, IndexMut};
+use core::ops::{Index, IndexMut, Range};
 use core::slice::SliceIndex;
 #[cfg(feature = "cache_metrics")]
 use core::sync::atomic::AtomicU64;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-#[cfg(feature = "logging")]
-use log::warn;
-
 // Allocates an `Arc<[u8]>` in one step. `Arc::<[u8]>::from(vec![0; len])` would
 // allocate the Vec and then allocate a new Arc and memcpy into it.
 fn zero_filled_arc(len: usize) -> Arc<[u8]> {
@@ -135,58 +132,30 @@ struct CheckedBackend {
 impl Drop for CheckedBackend {
     fn drop(&mut self) {
         if !self.closed.load(Ordering::Acquire) {
-            let _ = self.release_storage();
             let _ = self.file.close();
         }
     }
 }
 
 impl CheckedBackend {
-    fn new(file: Box<dyn InternalStorageBackend>, read_only: bool) -> Result<Self, DatabaseError> {
-        let backend = Self {
+    fn new(file: Box<dyn InternalStorageBackend>) -> Self {
+        Self {
             file,
             io_failed: AtomicBool::new(false),
             closed: AtomicBool::new(false),
-        };
-        backend.lock_storage(read_only)?;
-
-        Ok(backend)
-    }
-
-    /// The whole storage is locked for as long as the database is open
-    fn lock_storage(&self, read_only: bool) -> Result<(), DatabaseError> {
-        if !self.file.locks_expected() {
-            return Ok(());
-        }
-
-        let acquired = if read_only {
-            self.file.try_lock_shared_range(FULL_RANGE)
-        } else {
-            self.file.try_lock_range(FULL_RANGE)
-        };
-        match acquired {
-            Ok(true) => Ok(()),
-            Ok(false) => Err(DatabaseError::DatabaseAlreadyOpen),
-            Err(err) if io::is_unsupported(&err) => {
-                #[cfg(feature = "logging")]
-                warn!(
-                    "File locks not supported on this platform. You must ensure that only a single process opens the database file, at a time"
-                );
-
-                Ok(())
-            }
-            Err(err) => Err(err.into()),
         }
     }
 
-    fn release_storage(&self) -> Result<(), io::Error> {
-        if !self.file.locks_expected() {
-            return Ok(());
-        }
-        match self.file.unlock_range(FULL_RANGE) {
-            Err(err) if io::is_unsupported(&err) => Ok(()),
-            result => result,
-        }
+    fn locks_expected(&self) -> bool {
+        self.file.locks_expected()
+    }
+
+    fn try_lock_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
+        self.file.try_lock_range(range)
+    }
+
+    fn try_lock_shared_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
+        self.file.try_lock_shared_range(range)
     }
 
     fn check_failure(&self) -> Result<()> {
@@ -204,7 +173,6 @@ impl CheckedBackend {
     fn close(&self) -> Result {
         self.closed.store(true, Ordering::Release);
         self.io_failed.store(true, Ordering::Release);
-        self.release_storage()?;
         self.file.close()?;
 
         Ok(())
@@ -337,8 +305,7 @@ impl PagedCachedFile {
         file: Box<dyn InternalStorageBackend>,
         page_size: u64,
         max_cache_size: usize,
-        read_only: bool,
-    ) -> Result<Self, DatabaseError> {
+    ) -> Self {
         let read_cache = (0..Self::lock_stripes())
             .map(|_| RwLock::new(LRUCache::new()))
             .collect();
@@ -346,8 +313,8 @@ impl PagedCachedFile {
             .map(|_| Arc::new(Mutex::new(LRUWriteCache::new())))
             .collect();
 
-        Ok(Self {
-            file: CheckedBackend::new(file, read_only)?,
+        Self {
+            file: CheckedBackend::new(file),
             page_size,
             read_cache_bytes: AtomicUsize::new(0),
             write_buffer_bytes: AtomicUsize::new(0),
@@ -366,7 +333,19 @@ impl PagedCachedFile {
             evictions: AtomicU64::default(),
             read_cache,
             write_buffer,
-        })
+        }
+    }
+
+    pub(crate) fn locks_expected(&self) -> bool {
+        self.file.locks_expected()
+    }
+
+    pub(crate) fn try_lock_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
+        self.file.try_lock_range(range)
+    }
+
+    pub(crate) fn try_lock_shared_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
+        self.file.try_lock_shared_range(range)
     }
 
     fn write_buffer_stripe(&self, offset: u64) -> &Arc<Mutex<LRUWriteCache>> {
@@ -952,8 +931,7 @@ mod test {
     fn cache_leak() {
         let backend = InMemoryBackend::new();
         backend.set_len(1024).unwrap();
-        let cached_file =
-            PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 1024, false).unwrap();
+        let cached_file = PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 1024);
         let cached_file = Arc::new(cached_file);
 
         let t1 = {
@@ -994,9 +972,7 @@ mod test {
             LocklessBackend::boxed(backend),
             page_size as u64,
             max_cache_size,
-            false,
-        )
-        .unwrap();
+        );
 
         // Dirty twice as many pages as the write budget holds. Consecutive page offsets land in
         // different stripes, so each over-budget write finds its own stripe empty and must cover
@@ -1023,8 +999,7 @@ mod test {
     fn resize_preserves_cached_pages() {
         let backend = InMemoryBackend::new();
         backend.set_len(1024).unwrap();
-        let cached_file =
-            PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 4096, false).unwrap();
+        let cached_file = PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 4096);
 
         // Populate the read cache with two pages from opposite ends of the file.
         cached_file.read(0, 128, PageHint::None).unwrap();
@@ -1047,8 +1022,7 @@ mod test {
     #[test]
     fn write_barrier_issues_no_file_writes() {
         let (backend, writes) = CountingBackend::new(1024);
-        let cached_file =
-            PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 1024, false).unwrap();
+        let cached_file = PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 1024);
 
         let mut page = cached_file.write(0, 128, true).unwrap();
         page.mem_mut().fill(0xAB);
@@ -1080,8 +1054,7 @@ mod test {
     #[test]
     fn discard_write_buffer_drops_buffered_pages() {
         let (backend, writes) = CountingBackend::new(1024);
-        let cached_file =
-            PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 1024, false).unwrap();
+        let cached_file = PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 1024);
 
         let mut page = cached_file.write(0, 128, true).unwrap();
         page.mem_mut().fill(0xCD);
@@ -1107,13 +1080,8 @@ mod test {
         const FILE_LEN: u64 = 16 * 1024;
 
         let (backend, _writes) = CountingBackend::new(FILE_LEN);
-        let cached_file = PagedCachedFile::new(
-            LocklessBackend::boxed(backend),
-            PAGE as u64,
-            MAX_CACHE,
-            false,
-        )
-        .unwrap();
+        let cached_file =
+            PagedCachedFile::new(LocklessBackend::boxed(backend), PAGE as u64, MAX_CACHE);
 
         // Fill the write buffer to its half-of-cache cap, then commit non-durably so the pages
         // stay buffered
@@ -1151,8 +1119,7 @@ mod test {
     #[test]
     fn zero_size_cache_stays_empty_after_reclaim() {
         let (backend, _writes) = CountingBackend::new(1024);
-        let cached_file =
-            PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 0, false).unwrap();
+        let cached_file = PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 0);
 
         let mut page = cached_file.write(0, 128, true).unwrap();
         page.mem_mut().fill(0x22);
@@ -1171,8 +1138,7 @@ mod test {
     fn buffered_pages_spill_under_pressure() {
         let (backend, writes) = CountingBackend::new(1024);
         // A two page budget caps the buffer at one page, so each write() spills an earlier one
-        let cached_file =
-            PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 256, false).unwrap();
+        let cached_file = PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 256);
 
         for i in 0..4u8 {
             let offset = u64::from(i) * 128;

--- a/src/tree_store/page_store/file_backend/fallback.rs
+++ b/src/tree_store/page_store/file_backend/fallback.rs
@@ -81,6 +81,10 @@ fn unsupported() -> io::Error {
 }
 
 impl StorageBackend for FileBackend {
+    fn close(&self) -> Result<(), io::Error> {
+        self.unlock_range(FULL_RANGE)
+    }
+
     fn len(&self) -> Result<u64, io::Error> {
         Ok(self.file.lock().unwrap().metadata()?.len())
     }

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -1,8 +1,10 @@
-use crate::db::{FULL_RANGE, InternalStorageBackend};
+use crate::db::{FULL_RANGE, InternalStorageBackend, NAMESPACE_PROBE_BYTE};
 use crate::{DatabaseError, Result, StorageBackend};
+use std::collections::HashSet;
 use std::fs::{File, TryLockError};
 use std::io;
 use std::ops::Range;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(feature = "logging")]
@@ -15,10 +17,6 @@ use std::os::unix::fs::FileExt;
 use std::os::windows::fs::FileExt;
 
 use super::range_lock::RangeLock;
-
-// An offset that is not used in the multi-process locking protocol. Used to detect whether flock()
-// and range locks share the same namespace.
-const NAMESPACE_PROBE_BYTE: u64 = (1 << 62) - 2;
 
 /// Every offset the multi-process locking protocol uses
 const PROTOCOL_RANGES: [Range<u64>; 2] =
@@ -37,7 +35,9 @@ fn report_failed_release(result: io::Result<()>) {
 #[derive(Debug)]
 pub struct FileBackend {
     whole_file_locked: AtomicBool,
-    ranges_locked: AtomicBool,
+    // Every range this handle holds, so that close() can release exactly what was taken:
+    // UnlockFile neither splits nor merges, so an unlock must cover the range it was locked over
+    locked_ranges: Mutex<HashSet<Range<u64>>>,
     file: File,
 }
 
@@ -46,7 +46,7 @@ impl FileBackend {
     pub fn new(file: File) -> Result<Self, DatabaseError> {
         Ok(Self {
             whole_file_locked: AtomicBool::new(false),
-            ranges_locked: AtomicBool::new(false),
+            locked_ranges: Mutex::new(HashSet::new()),
             file,
         })
     }
@@ -86,7 +86,7 @@ impl FileBackend {
                 .unwrap_or(false)
         {
             // Prefer range locks, so release the whole-file lock which maps to the range lock
-            self.release_whole_storage()?;
+            self.release_all_locks()?;
             return self.lock_protocol_ranges(shared);
         }
 
@@ -98,7 +98,7 @@ impl FileBackend {
             Err(ref err) if err.kind() == io::ErrorKind::Unsupported => Ok(true),
             // A multi-process handle has the database open
             _ => {
-                report_failed_release(self.release_whole_storage());
+                report_failed_release(self.release_all_locks());
                 acquired
             }
         }
@@ -108,31 +108,28 @@ impl FileBackend {
     fn lock_protocol_ranges(&self, shared: bool) -> io::Result<bool> {
         for (taken, range) in PROTOCOL_RANGES.into_iter().enumerate() {
             let acquired = if shared {
-                self.file.try_lock_shared_range(range)
+                self.file.try_lock_shared_range(range.clone())
             } else {
-                self.file.try_lock_range(range)
+                self.file.try_lock_range(range.clone())
             };
             // Another handle has the database open, holding either kind of lock
             if !matches!(acquired, Ok(true)) {
                 for range in PROTOCOL_RANGES.into_iter().take(taken) {
-                    report_failed_release(self.file.unlock_range(range));
+                    report_failed_release(self.unlock_range(range));
                 }
                 return acquired;
             }
+            self.locked_ranges.lock().unwrap().insert(range.clone());
         }
-        self.ranges_locked.store(true, Ordering::Release);
 
         Ok(true)
     }
 
-    fn release_whole_storage(&self) -> io::Result<()> {
-        // Every lock is released even where one fails: a lock left behind outlives this
-        // backend wherever the description is shared
+    fn release_all_locks(&self) -> io::Result<()> {
+        // A lock left behind outlives this backend wherever the description is shared
         let mut result = Ok(());
-        if self.ranges_locked.swap(false, Ordering::AcqRel) {
-            for range in PROTOCOL_RANGES {
-                result = result.and(self.file.unlock_range(range));
-            }
+        for range in self.locked_ranges.lock().unwrap().drain() {
+            result = result.and(self.file.unlock_range(range));
         }
         if self.whole_file_locked.swap(false, Ordering::AcqRel) {
             result = result.and(self.file.unlock());
@@ -165,30 +162,40 @@ impl FileBackend {
 impl InternalStorageBackend for FileBackend {
     fn try_lock_range(&self, range: Range<u64>) -> io::Result<bool> {
         if range == FULL_RANGE {
-            self.lock_whole_storage(false)
-        } else {
-            self.file.try_lock_range(range)
+            return self.lock_whole_storage(false);
         }
+        let acquired = self.file.try_lock_range(range.clone())?;
+        if acquired {
+            self.locked_ranges.lock().unwrap().insert(range);
+        }
+        Ok(acquired)
     }
 
     fn try_lock_shared_range(&self, range: Range<u64>) -> io::Result<bool> {
         if range == FULL_RANGE {
-            self.lock_whole_storage(true)
-        } else {
-            self.file.try_lock_shared_range(range)
+            return self.lock_whole_storage(true);
         }
+        let acquired = self.file.try_lock_shared_range(range.clone())?;
+        if acquired {
+            self.locked_ranges.lock().unwrap().insert(range);
+        }
+        Ok(acquired)
     }
 
     fn unlock_range(&self, range: Range<u64>) -> io::Result<()> {
         if range == FULL_RANGE {
-            self.release_whole_storage()
-        } else {
-            self.file.unlock_range(range)
+            return self.release_all_locks();
         }
+        self.locked_ranges.lock().unwrap().remove(&range);
+        self.file.unlock_range(range)
     }
 }
 
 impl StorageBackend for FileBackend {
+    fn close(&self) -> Result<(), io::Error> {
+        self.unlock_range(FULL_RANGE)
+    }
+
     fn len(&self) -> Result<u64, io::Error> {
         Ok(self.file.metadata()?.len())
     }
@@ -373,9 +380,25 @@ mod range_lock_tests {
         open_file(reopen(path), read_only)
     }
 
-    /// ... and releases at close
+    /// ... and releases at close, which is what the core relies on
     fn close(backend: &FileBackend) {
-        backend.unlock_range(FULL_RANGE).unwrap();
+        crate::StorageBackend::close(backend).unwrap();
+    }
+
+    /// `close()` has to release rather than leaving it to the file being dropped: a read
+    /// transaction outliving the database keeps the backend, and so the file, alive past it
+    #[test]
+    fn close_releases_while_the_backend_is_still_alive() {
+        let tmpfile = crate::create_tempfile();
+        let backend = open(tmpfile.path(), false).unwrap();
+        close(&backend);
+
+        let observer = reopen(tmpfile.path());
+        for offset in PROTOCOL_OFFSETS {
+            assert!(byte_is_free(&observer, offset, false), "offset {offset}");
+        }
+        assert!(observer.try_lock().is_ok());
+        drop(backend);
     }
 
     fn byte_is_free(file: &File, offset: u64, exclusive: bool) -> bool {
@@ -537,7 +560,7 @@ mod range_lock_tests {
         let file = reopen(tmpfile.path());
         let backend = FileBackend {
             whole_file_locked: AtomicBool::new(false),
-            ranges_locked: AtomicBool::new(false),
+            locked_ranges: super::Mutex::new(super::HashSet::new()),
             file,
         };
         assert!(backend.lock_protocol_ranges(false).unwrap());

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1,5 +1,5 @@
 use crate::CacheStats;
-use crate::db::InternalStorageBackend;
+use crate::db::{FULL_RANGE, InternalStorageBackend};
 use crate::io;
 use crate::sync::Mutex;
 use crate::transaction_tracker::TransactionId;
@@ -28,6 +28,8 @@ use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem;
 use core::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "logging")]
+use log::warn;
 
 // The region header is optional in the v3 file format
 // It's an artifact of the v2 file format, so we initialize new databases without headers to save space
@@ -524,6 +526,33 @@ pub(crate) struct TransactionalMemory {
 }
 
 impl TransactionalMemory {
+    fn lock_whole_storage(storage: &PagedCachedFile, read_only: bool) -> Result<(), DatabaseError> {
+        // A caller-supplied backend has no locks, which is not a platform limitation
+        if !storage.locks_expected() {
+            return Ok(());
+        }
+
+        let result = if read_only {
+            storage.try_lock_shared_range(FULL_RANGE)
+        } else {
+            storage.try_lock_range(FULL_RANGE)
+        };
+
+        match result {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(DatabaseError::DatabaseAlreadyOpen),
+            Err(err) if io::is_unsupported(&err) => {
+                #[cfg(feature = "logging")]
+                warn!(
+                    "File locks not supported on this platform. You must ensure that only a single process opens the database file, at a time"
+                );
+
+                Ok(())
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
     pub(crate) fn new(
         file: Box<dyn InternalStorageBackend>,
         // Allow initializing a new database in an empty file
@@ -542,7 +571,8 @@ impl TransactionalMemory {
         );
         assert!(region_size.is_power_of_two());
 
-        let storage = PagedCachedFile::new(file, page_size as u64, cache_size, read_only)?;
+        let storage = PagedCachedFile::new(file, page_size as u64, cache_size);
+        Self::lock_whole_storage(&storage, read_only)?;
 
         let initial_storage_len = storage.raw_file_len()?;
 
@@ -1940,5 +1970,168 @@ mod test {
             0,
             "order-1 allocation should reuse the merged free block in region 0"
         );
+    }
+}
+
+#[cfg(test)]
+mod lock_failure_test {
+    use super::TransactionalMemory;
+    use crate::db::{FULL_RANGE, InternalStorageBackend};
+    use crate::io;
+    use crate::sync::Mutex;
+    use crate::tree_store::InMemoryBackend;
+    use crate::tree_store::page_store::cached_file::PagedCachedFile;
+    use crate::{DatabaseError, StorageBackend, StorageError};
+    use alloc::boxed::Box;
+    use alloc::sync::Arc;
+    use alloc::vec::Vec;
+    use core::ops::Range;
+
+    #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+    enum Answer {
+        Acquired,
+        Refused,
+        Unsupported,
+        Failed,
+    }
+
+    impl Answer {
+        fn result(self) -> Result<bool, io::Error> {
+            match self {
+                Answer::Acquired => Ok(true),
+                Answer::Refused => Ok(false),
+                Answer::Unsupported => Err(io::unsupported("no byte-range locks here")),
+                Answer::Failed => Err(io::invalid_input("the lock could not be taken")),
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct AnsweringBackend {
+        inner: InMemoryBackend,
+        taking: Answer,
+        held: Arc<Mutex<Vec<Range<u64>>>>,
+        released: Arc<Mutex<Vec<Range<u64>>>>,
+    }
+
+    impl AnsweringBackend {
+        fn take(&self, range: Range<u64>) -> Result<bool, io::Error> {
+            let acquired = self.taking.result();
+            if matches!(acquired, Ok(true)) {
+                self.held.lock().unwrap().push(range);
+            }
+
+            acquired
+        }
+    }
+
+    impl InternalStorageBackend for AnsweringBackend {
+        fn try_lock_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
+            self.take(range)
+        }
+
+        fn try_lock_shared_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
+            self.take(range)
+        }
+
+        fn unlock_range(&self, range: Range<u64>) -> Result<(), io::Error> {
+            self.held.lock().unwrap().retain(|held| *held != range);
+            self.released.lock().unwrap().push(range);
+            Ok(())
+        }
+    }
+
+    impl StorageBackend for AnsweringBackend {
+        fn close(&self) -> Result<(), io::Error> {
+            for range in self.held.lock().unwrap().drain(..) {
+                self.released.lock().unwrap().push(range);
+            }
+
+            Ok(())
+        }
+
+        fn len(&self) -> Result<u64, io::Error> {
+            self.inner.len()
+        }
+
+        fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), io::Error> {
+            self.inner.read(offset, out)
+        }
+
+        fn set_len(&self, len: u64) -> Result<(), io::Error> {
+            self.inner.set_len(len)
+        }
+
+        fn sync_data(&self) -> Result<(), io::Error> {
+            self.inner.sync_data()
+        }
+
+        fn write(&self, offset: u64, data: &[u8]) -> Result<(), io::Error> {
+            self.inner.write(offset, data)
+        }
+    }
+
+    type Released = Arc<Mutex<Vec<Range<u64>>>>;
+
+    fn storage(taking: Answer) -> (PagedCachedFile, Released) {
+        let released: Released = Arc::new(Mutex::new(Vec::new()));
+        let storage = PagedCachedFile::new(
+            Box::new(AnsweringBackend {
+                inner: InMemoryBackend::new(),
+                taking,
+                held: Arc::new(Mutex::new(Vec::new())),
+                released: released.clone(),
+            }),
+            4096,
+            0,
+        );
+
+        (storage, released)
+    }
+
+    fn open(read_only: bool, taking: Answer) -> Result<(), DatabaseError> {
+        TransactionalMemory::lock_whole_storage(&storage(taking).0, read_only)
+    }
+
+    #[test]
+    fn a_platform_without_locks_opens_anyway() {
+        open(false, Answer::Unsupported).unwrap();
+        open(true, Answer::Unsupported).unwrap();
+    }
+
+    #[test]
+    fn a_conflicting_lock_reports_the_database_already_open() {
+        for read_only in [false, true] {
+            assert!(matches!(
+                open(read_only, Answer::Refused),
+                Err(DatabaseError::DatabaseAlreadyOpen)
+            ));
+        }
+    }
+
+    #[test]
+    fn a_lock_that_fails_for_any_other_reason_fails_the_open() {
+        for read_only in [false, true] {
+            assert!(matches!(
+                open(read_only, Answer::Failed),
+                Err(DatabaseError::Storage(StorageError::Io(_)))
+            ));
+        }
+    }
+
+    #[test]
+    fn the_lock_is_released_at_close() {
+        for taking in [Answer::Acquired, Answer::Unsupported] {
+            let (storage, released) = storage(taking);
+            TransactionalMemory::lock_whole_storage(&storage, false).unwrap();
+            storage.close().unwrap();
+
+            let expected: Vec<Range<u64>> = if taking == Answer::Acquired {
+                vec![FULL_RANGE]
+            } else {
+                vec![]
+            };
+            assert_eq!(*released.lock().unwrap(), expected);
+        }
     }
 }


### PR DESCRIPTION
Split out of #1419, which this is a prerequisite for. No behaviour change and no API change.

## What moves

`CheckedBackend` took the lock an open holds for the life of the database, and decided the policy with it: which range, shared or exclusive, and what an unsupported or a refused lock means. That is the locking protocol, and with the multi-process modes coming it stops being expressible there at all -- those take several ranges, chosen by a mode the backend has no way to know.

So `CheckedBackend` now records what it was asked to take and releases it at close, and `TransactionalMemory::lock_whole_storage` decides. `lock_storage`/`release_storage` become `try_lock_range(range, shared)`/`release_locks()`, over a recorded vector of ranges rather than a hardcoded `FULL_RANGE`.

Nothing about the result changes: the same single range, taken shared for a read-only open, `DatabaseAlreadyOpen` where it conflicts, a `logging` warning and an open that carries on where the platform has no locks, and a caller-supplied backend still passing without one.

Two consequences worth naming:

Constructing the backend no longer locks, so `CheckedBackend::new` and `PagedCachedFile::new` cannot fail and stop returning `Result`.

`release_locks()` drops the two `is_unsupported`/`locks_expected` guards `release_storage()` needed. They are unreachable now rather than removed: nothing is recorded unless the lock was actually acquired, so there is nothing to release in either case.

## The probe byte

`NAMESPACE_PROBE_BYTE` moves to `db.rs` alongside `FULL_RANGE`, expressed against a `LOCK_BASE` constant rather than a repeated `(1 << 62) - 2`. It describes an offset in the protocol but lived in one backend, where the core could not name it -- and the core is where the rest of the protocol's offsets are headed.

Both are gated on `any(windows, unix, target_os = "wasi")`, the same cfg as the file backend that uses them and as `range_lock` beside them: on wasm32 and thumbv7em there is no `optimized.rs`, so without the gate they are dead code and CI's `--deny warnings` rejects them.

I left `docs/design.md` alone. Adding the probe byte to the byte table was your call to make and you already made it on #1419: it is an implementation detail that goes away if the range locks become unconditional.

## Testing

`lock_failure_test` drives `lock_whole_storage` over a backend that answers as told, one test per outcome: unsupported opens anyway, a refused lock is `DatabaseAlreadyOpen`, any other error fails the open, and `the_lock_is_released_at_close` asserts that closing releases exactly the range that was taken -- and that nothing is released when the lock was never acquired, which is what makes dropping those two guards safe.

`cargo fmt --all -- --check`, `cargo clippy --all --all-targets --all-features` as CI runs it, clippy over `experimental-api-5`/`logging`/no features, cross-clippy for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, the three `wasm32-unknown-unknown` variants CI checks, no_std on `thumbv7em-none-eabihf`, and `cargo test` all pass, all with `RUSTFLAGS=--deny warnings`. Also run for `x86_64-pc-windows-gnu` under wine, where the only failure is `a_whole_file_lock_holder_reads_as_already_open`, which fails identically on unmodified master there: wine answers std's second `UnlockFile` with `ERROR_LOCK_VIOLATION` where Windows answers `ERROR_NOT_LOCKED`.

No changelog entry -- nothing here is visible to users.