### PR TITLE
Lock the header while a shared-mode process reads or writes it

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -116,6 +116,14 @@ pub(crate) trait InternalStorageBackend: StorageBackend {
     /// `Ok(false)` means a conflicting lock is held elsewhere.
     fn try_lock_shared_range(&self, range: Range<u64>) -> core::result::Result<bool, io::Error>;
 
+    /// Waits for the range rather than reporting a conflict. Only the multi-process header
+    /// lock waits: the ranges an open takes are refused rather than queued.
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_range(&self, range: Range<u64>) -> core::result::Result<(), io::Error>;
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_shared_range(&self, range: Range<u64>) -> core::result::Result<(), io::Error>;
+
     fn unlock_range(&self, range: Range<u64>) -> core::result::Result<(), io::Error>;
 
     /// Whether an exclusive lock over the range would conflict with one held elsewhere.
@@ -1500,6 +1508,15 @@ pub enum ConcurrencyMode {
     /// Any number of processes may, concurrently open the database for reading and writing.
     /// Only one write transaction may be open at a time.
     MultiWriterProcess,
+}
+
+#[cfg(feature = "experimental-multiprocess")]
+impl ConcurrencyMode {
+    /// Whether another process may have the database open, concurrently, and one process
+    /// (possibly this one) is a writer
+    pub(crate) fn is_multi_process_writable(self) -> bool {
+        !matches!(self, ConcurrencyMode::SingleProcess)
+    }
 }
 
 /// Configuration builder of a redb [Database].

--- a/src/tree_store/page_store/backends.rs
+++ b/src/tree_store/page_store/backends.rs
@@ -62,6 +62,16 @@ impl InternalStorageBackend for LocklessBackend {
         Err(unsupported())
     }
 
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_range(&self, _range: Range<u64>) -> Result<(), io::Error> {
+        Err(unsupported())
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_shared_range(&self, _range: Range<u64>) -> Result<(), io::Error> {
+        Err(unsupported())
+    }
+
     fn unlock_range(&self, _range: Range<u64>) -> Result<(), io::Error> {
         Err(unsupported())
     }
@@ -101,6 +111,16 @@ impl InternalStorageBackend for ReadOnlyBackend {
 
     fn try_lock_shared_range(&self, range: Range<u64>) -> Result<bool, Error> {
         self.inner.try_lock_shared_range(range)
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_range(&self, range: Range<u64>) -> Result<(), Error> {
+        self.inner.lock_range(range)
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_shared_range(&self, range: Range<u64>) -> Result<(), Error> {
+        self.inner.lock_shared_range(range)
     }
 
     fn unlock_range(&self, range: Range<u64>) -> Result<(), Error> {
@@ -230,6 +250,10 @@ mod test {
         for result in [
             backend.try_lock_range(FULL_RANGE).err(),
             backend.try_lock_shared_range(FULL_RANGE).err(),
+            #[cfg(feature = "experimental-multiprocess")]
+            backend.lock_range(FULL_RANGE).err(),
+            #[cfg(feature = "experimental-multiprocess")]
+            backend.lock_shared_range(FULL_RANGE).err(),
             backend.unlock_range(FULL_RANGE).err(),
             backend.query_lock_range(FULL_RANGE).err(),
         ] {

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -159,6 +159,21 @@ impl CheckedBackend {
         self.file.try_lock_shared_range(range)
     }
 
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_range(&self, range: Range<u64>) -> Result<(), io::Error> {
+        self.file.lock_range(range)
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_shared_range(&self, range: Range<u64>) -> Result<(), io::Error> {
+        self.file.lock_shared_range(range)
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn unlock_range(&self, range: Range<u64>) -> Result<(), io::Error> {
+        self.file.unlock_range(range)
+    }
+
     fn query_lock_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
         self.file.query_lock_range(range)
     }
@@ -351,6 +366,21 @@ impl PagedCachedFile {
 
     pub(crate) fn try_lock_shared_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
         self.file.try_lock_shared_range(range)
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn lock_range(&self, range: Range<u64>) -> Result<(), io::Error> {
+        self.file.lock_range(range)
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn lock_shared_range(&self, range: Range<u64>) -> Result<(), io::Error> {
+        self.file.lock_shared_range(range)
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn unlock_range(&self, range: Range<u64>) -> Result<(), io::Error> {
+        self.file.unlock_range(range)
     }
 
     /// Whether an exclusive lock over the range would conflict with one held elsewhere.
@@ -549,6 +579,14 @@ impl PagedCachedFile {
         if self.write_buffer_bytes.load(Ordering::Acquire) > 0 {
             self.committed_pages_buffered.store(true, Ordering::Release);
         }
+    }
+
+    // Write directly to the file, bypassing the write buffer, so the bytes are on the file when
+    // this returns rather than whenever the buffer is next flushed
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(super) fn write_direct(&self, offset: u64, data: &[u8]) -> Result<()> {
+        self.invalidate_cache(offset, data.len());
+        self.file.write(offset, data)
     }
 
     // Read directly from the file, ignoring any cached data

--- a/src/tree_store/page_store/file_backend/fallback.rs
+++ b/src/tree_store/page_store/file_backend/fallback.rs
@@ -72,6 +72,16 @@ impl InternalStorageBackend for FileBackend {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_range(&self, _range: Range<u64>) -> Result<(), io::Error> {
+        Err(unsupported())
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_shared_range(&self, _range: Range<u64>) -> Result<(), io::Error> {
+        Err(unsupported())
+    }
+
     fn query_lock_range(&self, _range: Range<u64>) -> Result<bool, io::Error> {
         Err(unsupported())
     }

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -203,12 +203,33 @@ impl InternalStorageBackend for FileBackend {
         Ok(acquired)
     }
 
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_range(&self, range: Range<u64>) -> io::Result<()> {
+        debug_assert!(range != FULL_RANGE);
+        self.file.lock_range(range.clone())?;
+        self.locked_ranges.lock().unwrap().insert(range);
+        Ok(())
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_shared_range(&self, range: Range<u64>) -> io::Result<()> {
+        debug_assert!(range != FULL_RANGE);
+        self.file.lock_shared_range(range.clone())?;
+        self.locked_ranges.lock().unwrap().insert(range);
+        Ok(())
+    }
+
     fn unlock_range(&self, range: Range<u64>) -> io::Result<()> {
         if range == FULL_RANGE {
             return self.release_all_locks();
         }
-        self.locked_ranges.lock().unwrap().remove(&range);
-        self.file.unlock_range(range)
+        // Forgotten only once it is really released, so that a failure leaves the range for
+        // close() to retry rather than leaving it held with nothing left to release it
+        let released = self.file.unlock_range(range.clone());
+        if released.is_ok() {
+            self.locked_ranges.lock().unwrap().remove(&range);
+        }
+        released
     }
 
     fn query_lock_range(&self, range: Range<u64>) -> io::Result<bool> {

--- a/src/tree_store/page_store/file_backend/range_lock.rs
+++ b/src/tree_store/page_store/file_backend/range_lock.rs
@@ -21,6 +21,17 @@ pub(crate) trait RangeLock {
         Err(unsupported())
     }
 
+    /// Waits for the range. No deadlock detection, like the whole-file locks.
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_range(&self, _range: Range<u64>) -> io::Result<()> {
+        Err(unsupported())
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_shared_range(&self, _range: Range<u64>) -> io::Result<()> {
+        Err(unsupported())
+    }
+
     fn unlock_range(&self, _range: Range<u64>) -> io::Result<()> {
         Err(unsupported())
     }
@@ -62,6 +73,8 @@ mod windows_imp {
     const LOCKFILE_FAIL_IMMEDIATELY: Dword = 0x0000_0001;
     const LOCKFILE_EXCLUSIVE_LOCK: Dword = 0x0000_0002;
     const ERROR_LOCK_VIOLATION: i32 = 33;
+    #[cfg(feature = "experimental-multiprocess")]
+    const ERROR_IO_PENDING: i32 = 997;
 
     #[repr(C)]
     struct Overlapped {
@@ -89,6 +102,22 @@ mod windows_imp {
             bytes_low: Dword,
             bytes_high: Dword,
         ) -> Bool;
+        #[cfg(feature = "experimental-multiprocess")]
+        fn CreateEventW(
+            attributes: *mut core::ffi::c_void,
+            manual_reset: Bool,
+            initial_state: Bool,
+            name: *const u16,
+        ) -> Handle;
+        #[cfg(feature = "experimental-multiprocess")]
+        fn GetOverlappedResult(
+            file: Handle,
+            overlapped: *mut Overlapped,
+            transferred: *mut Dword,
+            wait: Bool,
+        ) -> Bool;
+        #[cfg(feature = "experimental-multiprocess")]
+        fn CloseHandle(handle: Handle) -> Bool;
     }
 
     // The Win32 calls take 64-bit offsets and lengths as dword halves
@@ -140,6 +169,64 @@ mod windows_imp {
         }
     }
 
+    // Waits for the range, the way std's own File::lock waits for the whole file. A handle
+    // opened for asynchronous I/O answers ERROR_IO_PENDING and completes the request later,
+    // which is what the event is for: waiting on it settles the request before this returns,
+    // so the overlapped structure is safe on the stack.
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_blocking(file: &File, exclusive: bool, range: Range<u64>) -> io::Result<()> {
+        debug_assert!(!range.is_empty());
+        let flags = if exclusive {
+            LOCKFILE_EXCLUSIVE_LOCK
+        } else {
+            0
+        };
+        let len = range.end - range.start;
+        let handle = file.as_raw_handle();
+        unsafe {
+            let event = CreateEventW(core::ptr::null_mut(), 0, 0, core::ptr::null());
+            if event.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+            let mut overlapped = Overlapped {
+                internal: 0,
+                internal_high: 0,
+                offset: low_dword(range.start),
+                offset_high: high_dword(range.start),
+                event,
+            };
+            let acquired = LockFileEx(
+                handle,
+                flags,
+                0,
+                low_dword(len),
+                high_dword(len),
+                &raw mut overlapped,
+            );
+
+            let result = if acquired != 0 {
+                Ok(())
+            } else {
+                let err = io::Error::last_os_error();
+                if err.raw_os_error() == Some(ERROR_IO_PENDING) {
+                    let mut transferred: Dword = 0;
+                    let completed =
+                        GetOverlappedResult(handle, &raw mut overlapped, &raw mut transferred, 1);
+                    if completed != 0 {
+                        Ok(())
+                    } else {
+                        Err(io::Error::last_os_error())
+                    }
+                } else {
+                    Err(err)
+                }
+            };
+            CloseHandle(event);
+
+            result
+        }
+    }
+
     impl RangeLock for File {
         // std's whole-file lock is itself a LockFileEx over every byte, so it is one of these
         const CONFLICTS_WITH_STD_FILE_LOCK: Option<bool> = Some(true);
@@ -150,6 +237,16 @@ mod windows_imp {
 
         fn try_lock_shared_range(&self, range: Range<u64>) -> io::Result<bool> {
             try_lock(self, false, range)
+        }
+
+        #[cfg(feature = "experimental-multiprocess")]
+        fn lock_range(&self, range: Range<u64>) -> io::Result<()> {
+            lock_blocking(self, true, range)
+        }
+
+        #[cfg(feature = "experimental-multiprocess")]
+        fn lock_shared_range(&self, range: Range<u64>) -> io::Result<()> {
+            lock_blocking(self, false, range)
         }
 
         // UnlockFile rather than its Ex form, as std's unlock uses: it takes the range as
@@ -249,6 +346,30 @@ fn set_lock(file: &File, exclusive: bool, range: Range<u64>) -> io::Result<bool>
     }
 }
 
+// EINTR is the caller's signal handler having run, not a failure to take the lock.
+#[cfg(all(
+    feature = "experimental-multiprocess",
+    any(target_os = "linux", target_vendor = "apple")
+))]
+fn set_lock_blocking(file: &File, exclusive: bool, range: Range<u64>) -> io::Result<()> {
+    let kind = lock_type(if exclusive {
+        libc::F_WRLCK
+    } else {
+        libc::F_RDLCK
+    });
+    loop {
+        let mut lock = flock_struct(kind, range.clone());
+        let rc = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_OFD_SETLKW, &raw mut lock) };
+        if rc == 0 {
+            return Ok(());
+        }
+        let err = io::Error::last_os_error();
+        if err.kind() != io::ErrorKind::Interrupted {
+            return Err(err);
+        }
+    }
+}
+
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 impl RangeLock for File {
     // The Apple platforms answer flock() with the same locks fcntl() takes; Linux keeps them
@@ -265,6 +386,16 @@ impl RangeLock for File {
 
     fn try_lock_shared_range(&self, range: Range<u64>) -> io::Result<bool> {
         set_lock(self, false, range)
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_range(&self, range: Range<u64>) -> io::Result<()> {
+        set_lock_blocking(self, true, range)
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_shared_range(&self, range: Range<u64>) -> io::Result<()> {
+        set_lock_blocking(self, false, range)
     }
 
     fn unlock_range(&self, range: Range<u64>) -> io::Result<()> {

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -31,6 +31,8 @@ use core::cmp::{max, min};
 use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem;
+#[cfg(feature = "experimental-multiprocess")]
+use core::ops::Range;
 use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg(feature = "logging")]
 use log::warn;
@@ -506,6 +508,27 @@ impl UnpersistedState {
     }
 }
 
+/// The header bytes themselves rather than a byte standing for them, so that Windows' mandatory
+/// locks hold back another process's read of them.
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) const HEADER_LOCK: Range<u64> = 0..DB_HEADER_SIZE as u64;
+
+/// A hold on the header lock, released when it drops.
+#[cfg(feature = "experimental-multiprocess")]
+struct HeaderGuard<'a> {
+    storage: Option<&'a PagedCachedFile>,
+    _in_process: crate::sync::MutexGuard<'a, ()>,
+}
+
+#[cfg(feature = "experimental-multiprocess")]
+impl Drop for HeaderGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(storage) = self.storage {
+            let _ = storage.unlock_range(HEADER_LOCK);
+        }
+    }
+}
+
 pub(crate) struct TransactionalMemory {
     unpersisted: Mutex<UnpersistedState>,
     storage: PagedCachedFile,
@@ -522,6 +545,14 @@ pub(crate) struct TransactionalMemory {
     // While set, no allocator state is persisted and shutdowns are not recorded as clean,
     // forcing the next open to rebuild the state from the committed trees
     needs_repair: AtomicBool,
+    #[cfg(feature = "experimental-multiprocess")]
+    concurrency_mode: ConcurrencyMode,
+    // Held for the duration of every header file lock. Ensures in-process threads do not overlap
+    // acquiring the lock. Because it's an OFD lock on a single FD, only one may take it at a time.
+    // TODO: This could probably be optimized, so that multiple threads can read at once, by making
+    // this a counter or RwLock
+    #[cfg(feature = "experimental-multiprocess")]
+    in_process_header_lock: Mutex<()>,
     page_size: u32,
     // We store these separately from the layout because they're static, and accessed on the get_page()
     // code path where there is no locking
@@ -624,6 +655,34 @@ impl TransactionalMemory {
         }
     }
 
+    /// Takes the storage and the mutex rather than `&self`, so that the open path can hold the
+    /// header before there is a `TransactionalMemory` to hold it from.
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_header<'a>(
+        storage: &'a PagedCachedFile,
+        in_process: &'a Mutex<()>,
+        concurrency_mode: ConcurrencyMode,
+        exclusive: bool,
+    ) -> Result<HeaderGuard<'a>> {
+        let guard = in_process.lock().unwrap();
+        if !concurrency_mode.is_multi_process_writable() {
+            return Ok(HeaderGuard {
+                storage: None,
+                _in_process: guard,
+            });
+        }
+        if exclusive {
+            storage.lock_range(HEADER_LOCK)?;
+        } else {
+            storage.lock_shared_range(HEADER_LOCK)?;
+        }
+
+        Ok(HeaderGuard {
+            storage: Some(storage),
+            _in_process: guard,
+        })
+    }
+
     pub(crate) fn new(
         file: Box<dyn InternalStorageBackend>,
         // Allow initializing a new database in an empty file
@@ -646,11 +705,16 @@ impl TransactionalMemory {
         let storage = PagedCachedFile::new(file, page_size as u64, cache_size);
         // Dropping the storage releases whatever this took, so an open that fails below does too
         Self::lock_for_open(&storage, read_only, concurrency_mode)?;
+        #[cfg(feature = "experimental-multiprocess")]
+        let in_process_header_lock = Mutex::new(());
 
         let initial_storage_len = storage.raw_file_len()?;
 
         let magic_number: [u8; MAGICNUMBER.len()] =
             if initial_storage_len >= MAGICNUMBER.len() as u64 {
+                #[cfg(feature = "experimental-multiprocess")]
+                let _guard =
+                    Self::lock_header(&storage, &in_process_header_lock, concurrency_mode, false)?;
                 storage
                     .read_direct(0, MAGICNUMBER.len())?
                     .try_into()
@@ -714,21 +778,35 @@ impl TransactionalMemory {
 
             header.recovery_required = false;
             header.two_phase_commit = true;
-            storage
-                .write(0, DB_HEADER_SIZE, true)?
-                .mem_mut()
-                .copy_from_slice(&header.to_bytes(false));
-
-            storage.flush()?;
+            {
+                #[cfg(feature = "experimental-multiprocess")]
+                let _guard =
+                    Self::lock_header(&storage, &in_process_header_lock, concurrency_mode, true)?;
+                storage
+                    .write(0, DB_HEADER_SIZE, true)?
+                    .mem_mut()
+                    .copy_from_slice(&header.to_bytes(false));
+                storage.flush()?;
+            }
             // Write the magic number only after the data structure is initialized and written to disk
             // to ensure that it's crash safe
-            storage
-                .write(0, DB_HEADER_SIZE, true)?
-                .mem_mut()
-                .copy_from_slice(&header.to_bytes(true));
-            storage.flush()?;
+            {
+                #[cfg(feature = "experimental-multiprocess")]
+                let _guard =
+                    Self::lock_header(&storage, &in_process_header_lock, concurrency_mode, true)?;
+                storage
+                    .write(0, DB_HEADER_SIZE, true)?
+                    .mem_mut()
+                    .copy_from_slice(&header.to_bytes(true));
+                storage.flush()?;
+            }
         }
-        let header_bytes = storage.read_direct(0, DB_HEADER_SIZE)?;
+        let header_bytes = {
+            #[cfg(feature = "experimental-multiprocess")]
+            let _guard =
+                Self::lock_header(&storage, &in_process_header_lock, concurrency_mode, false)?;
+            storage.read_direct(0, DB_HEADER_SIZE)?
+        };
         let unrepaired =
             UnrepairedDatabaseHeader::from_bytes(&header_bytes, page_size.try_into().unwrap())?;
         let file_len = storage.raw_file_len()?;
@@ -738,6 +816,9 @@ impl TransactionalMemory {
         }
         let (header, _) = unrepaired.finalize(file_len)?;
         if needs_recovery {
+            #[cfg(feature = "experimental-multiprocess")]
+            let _guard =
+                Self::lock_header(&storage, &in_process_header_lock, concurrency_mode, true)?;
             storage
                 .write(0, DB_HEADER_SIZE, true)?
                 .mem_mut()
@@ -764,6 +845,10 @@ impl TransactionalMemory {
             #[cfg(debug_assertions)]
             allocated_pages: Arc::new(Mutex::new(PageNumberHashSet::default())),
             needs_repair: AtomicBool::new(false),
+            #[cfg(feature = "experimental-multiprocess")]
+            concurrency_mode,
+            #[cfg(feature = "experimental-multiprocess")]
+            in_process_header_lock,
             page_size: page_size.try_into().unwrap(),
             region_size,
             region_header_with_padding_size: region_header_size,
@@ -847,14 +932,20 @@ impl TransactionalMemory {
         self.storage.invalidate_cache_all();
         self.storage.sync_file()?;
 
-        let header_bytes = self.storage.read_direct(0, DB_HEADER_SIZE)?;
+        let header_bytes = {
+            #[cfg(feature = "experimental-multiprocess")]
+            let _guard = Self::lock_header(
+                &self.storage,
+                &self.in_process_header_lock,
+                self.concurrency_mode,
+                false,
+            )?;
+            self.storage.read_direct(0, DB_HEADER_SIZE)?
+        };
         let unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes, self.page_size)?;
         let (header, was_clean) = unrepaired.finalize(self.storage.raw_file_len()?)?;
         if !was_clean {
-            self.storage
-                .write(0, DB_HEADER_SIZE, true)?
-                .mem_mut()
-                .copy_from_slice(&header.to_bytes(true));
+            self.write_header(&header)?;
             self.storage.flush()?;
         }
 
@@ -986,6 +1077,19 @@ impl TransactionalMemory {
     }
 
     fn write_header(&self, header: &DatabaseHeader) -> Result {
+        #[cfg(feature = "experimental-multiprocess")]
+        if self.concurrency_mode.is_multi_process_writable() {
+            // Write directly, while holding the header lock, so that other processes cannot observe
+            // a torn write.
+            let bytes = header.to_bytes(true);
+            let _guard = Self::lock_header(
+                &self.storage,
+                &self.in_process_header_lock,
+                self.concurrency_mode,
+                true,
+            )?;
+            return self.storage.write_direct(0, &bytes);
+        }
         self.storage
             .write(0, DB_HEADER_SIZE, true)?
             .mem_mut()
@@ -1368,7 +1472,16 @@ impl TransactionalMemory {
     // True if the on-disk durable primary slot's checksum is corrupt. Read from disk, since the
     // in-memory copy of an originally-clean slot wouldn't show external/failed-commit corruption.
     pub(crate) fn durable_primary_slot_corrupt(&self) -> Result<bool, DatabaseError> {
-        let header_bytes = self.storage.read_direct(0, DB_HEADER_SIZE)?;
+        let header_bytes = {
+            #[cfg(feature = "experimental-multiprocess")]
+            let _guard = Self::lock_header(
+                &self.storage,
+                &self.in_process_header_lock,
+                self.concurrency_mode,
+                false,
+            )?;
+            self.storage.read_direct(0, DB_HEADER_SIZE)?
+        };
         let disk_header = UnrepairedDatabaseHeader::from_bytes(&header_bytes, self.page_size)?;
         Ok(disk_header.primary_corrupted())
     }
@@ -2050,6 +2163,191 @@ mod test {
     }
 }
 
+/// The header lock, against real files.
+#[cfg(all(
+    test,
+    feature = "experimental-multiprocess",
+    any(target_os = "linux", target_vendor = "apple", windows)
+))]
+mod header_lock_test {
+    use super::{HeaderGuard, TransactionalMemory};
+    use crate::db::ConcurrencyMode;
+    use crate::tree_store::PAGE_SIZE;
+    use crate::tree_store::page_store::file_backend::FileBackend;
+    use crate::{DatabaseError, Result};
+    use alloc::sync::Arc;
+    use std::path::Path;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    fn hold(mem: &TransactionalMemory, exclusive: bool) -> Result<HeaderGuard<'_>> {
+        TransactionalMemory::lock_header(
+            &mem.storage,
+            &mem.in_process_header_lock,
+            mem.concurrency_mode,
+            exclusive,
+        )
+    }
+
+    fn open(path: &Path, mode: ConcurrencyMode) -> Result<Arc<TransactionalMemory>, DatabaseError> {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)?;
+        Ok(Arc::new(TransactionalMemory::new(
+            Box::new(FileBackend::new(file)?),
+            true,
+            PAGE_SIZE,
+            None,
+            0,
+            false,
+            mode,
+        )?))
+    }
+
+    fn open_read_only(
+        path: &Path,
+        mode: ConcurrencyMode,
+    ) -> Result<Arc<TransactionalMemory>, DatabaseError> {
+        let file = std::fs::OpenOptions::new().read(true).open(path)?;
+        Ok(Arc::new(TransactionalMemory::new(
+            Box::new(crate::tree_store::ReadOnlyBackend::new(Box::new(
+                FileBackend::new(file)?,
+            ))),
+            false,
+            PAGE_SIZE,
+            None,
+            0,
+            true,
+            mode,
+        )?))
+    }
+
+    /// Through the read-only backend the open wraps its storage in
+    #[test]
+    fn a_read_only_handle_takes_shared_holds() {
+        let tmpfile = crate::create_tempfile();
+        open(tmpfile.path(), ConcurrencyMode::SingleProcess).unwrap();
+
+        let reader = open_read_only(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let held = hold(&reader, false).unwrap();
+
+        let peer = open_read_only(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        drop(hold(&peer, false).unwrap());
+        drop(held);
+    }
+
+    /// The other half of the hold covering the write: the bytes are on the file when
+    /// `write_header()` returns, rather than waiting in the buffer for a flush outside the hold.
+    #[test]
+    fn the_header_reaches_the_file_before_write_header_returns() {
+        use super::DB_HEADER_SIZE;
+
+        let tmpfile = crate::create_tempfile();
+        let writer = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+
+        let mut header = writer.state.lock().unwrap().header.clone();
+        header.recovery_required = !header.recovery_required;
+        let expected = header.to_bytes(true);
+        writer.write_header(&header).unwrap();
+
+        // Read around redb entirely, and with no flush in between
+        let on_disk = std::fs::read(tmpfile.path()).unwrap();
+        assert_eq!(&on_disk[..DB_HEADER_SIZE], &expected[..]);
+    }
+
+    /// The hold has to cover the write reaching the file, which is what `write_header()` does
+    /// directly rather than leaving to whenever the buffer is next flushed.
+    #[test]
+    fn the_hold_covers_the_write_reaching_the_file() {
+        let tmpfile = crate::create_tempfile();
+        let writer = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let reader = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+
+        // Taken before the hold: another one in this process would wait on it
+        let header = writer.state.lock().unwrap().header.clone();
+        let held = hold(&reader, false).unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        let writing = thread::spawn(move || {
+            writer.write_header(&header).unwrap();
+            tx.send(()).unwrap();
+        });
+
+        assert!(
+            rx.recv_timeout(Duration::from_millis(200)).is_err(),
+            "the header reached the file while a reader held the lock"
+        );
+        drop(held);
+        rx.recv_timeout(Duration::from_secs(10))
+            .expect("the write never completed");
+        writing.join().unwrap();
+    }
+
+    /// Which is what keeps a header mid-write from being read in another process
+    #[test]
+    fn an_exclusive_hold_excludes_a_shared_one() {
+        let tmpfile = crate::create_tempfile();
+        let writer = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let reader = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+
+        let guard = hold(&writer, true).unwrap();
+        let (tx, rx) = mpsc::channel();
+        let waiting = thread::spawn(move || {
+            let _held = hold(&reader, false).unwrap();
+            tx.send(()).unwrap();
+        });
+
+        assert!(
+            rx.recv_timeout(Duration::from_millis(200)).is_err(),
+            "the reader entered its hold while the writer held one"
+        );
+        drop(guard);
+        rx.recv_timeout(Duration::from_secs(10))
+            .expect("the reader never entered its hold");
+        waiting.join().unwrap();
+    }
+
+    /// Only a write needs the header to itself
+    #[test]
+    fn shared_holds_admit_each_other() {
+        let tmpfile = crate::create_tempfile();
+        let first = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let second = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+
+        let held = hold(&first, false).unwrap();
+        let (tx, rx) = mpsc::channel();
+        let waiting = thread::spawn(move || {
+            let _also = hold(&second, false).unwrap();
+            tx.send(()).unwrap();
+        });
+
+        rx.recv_timeout(Duration::from_secs(10))
+            .expect("a second reader was held off");
+        waiting.join().unwrap();
+        drop(held);
+    }
+
+    /// It holds the whole storage, which covers the header bytes: a hold that locked and
+    /// released them would punch a hole in that lock.
+    #[test]
+    fn a_hold_does_not_puncture_the_whole_storage_lock() {
+        let tmpfile = crate::create_tempfile();
+        let held = open(tmpfile.path(), ConcurrencyMode::SingleProcess).unwrap();
+
+        for exclusive in [false, true] {
+            let guard = hold(&held, exclusive).unwrap();
+            drop(guard);
+        }
+
+        assert!(matches!(
+            open(tmpfile.path(), ConcurrencyMode::SingleProcess),
+            Err(DatabaseError::DatabaseAlreadyOpen)
+        ));
+    }
+}
+
 /// The locking protocol an open runs before it reads anything, against real files. Only the
 /// platforms with byte-range locks can run it.
 #[cfg(all(test, any(target_os = "linux", target_vendor = "apple", windows)))]
@@ -2262,6 +2560,16 @@ mod lock_failure_test {
 
         fn try_lock_shared_range(&self, range: Range<u64>) -> Result<bool, io::Error> {
             self.take(range)
+        }
+
+        #[cfg(feature = "experimental-multiprocess")]
+        fn lock_range(&self, range: Range<u64>) -> Result<(), io::Error> {
+            self.take(range).map(|_| ())
+        }
+
+        #[cfg(feature = "experimental-multiprocess")]
+        fn lock_shared_range(&self, range: Range<u64>) -> Result<(), io::Error> {
+            self.take(range).map(|_| ())
         }
 
         fn unlock_range(&self, range: Range<u64>) -> Result<(), io::Error> {


### PR DESCRIPTION
The next slice of the multi-process work, after #1419's concurrency modes. Those negotiate the open and then coordinate nothing, so two processes sharing a database can read a header the other is part way through writing. This is the first real coordination: every read of the header bytes runs inside a shared hold and every write inside an exclusive one.

Only the shared modes take it. A single-process handle holds the whole storage already, and there is no other process to exclude.

## Where the lock lives

The holds are taken in `TransactionalMemory`, at the eight places it reads or writes the header. `write_header()` is the only one of those that writes during normal operation, so the reload path's repair write goes through it too rather than writing the header itself.

The lock covers the header bytes themselves rather than a byte standing for them. That is what makes Windows' mandatory locks hold back another process's read of those bytes, rather than merely advising against it.

Covering the real bytes means the holder has to be the open file description performing the I/O it serializes -- on Windows, a lock taken on some other description would block this process's own header reads. So the lock is taken through the storage backend, which is that description by construction. `InternalStorageBackend` gains blocking `lock_range()` and `lock_shared_range()`, alongside the `try_` forms an open already uses; a custom backend can implement them, and the ones that have no locks report `Unsupported` as they do for the rest.

The alternative would be handing the hold its own `File` and trusting it to be the same description. Going through the backend removes that obligation.

## Getting the write inside the hold

`PagedCachedFile::write()` only fills the write buffer; the bytes reach the file later, from `flush_write_buffer()` or from an eviction under cache pressure. A hold around it would cover a memcpy and nothing else.

So `write_header()` writes directly instead, through a new `write_direct()` that mirrors the existing `read_direct()`: it drops the cached copy and hands the bytes to the backend. The fsync stays outside, in the flush that follows.

Writing the header publishes it -- a peer can read it as soon as the hold ends -- so the pages it names have to be on the file by then. That ordering comes from two-phase commit, which the shared modes require: the flush between `commit()`'s two `write_header()` calls puts the pages down before the primary slot swap is published. `write_header()` itself does not flush.

## The in-process mutex

Each hold also takes a mutex for its duration, which is not redundant with the byte lock. Both holds run on one file description, where a second acquisition converts the existing hold rather than conflicting with it, and one unlock then drops whatever remains -- so two overlapping holds in this process would dismantle each other. The mutex is what keeps them from overlapping.

The `state` mutex cannot serve instead. The commit path clones the header and drops it before writing, on purpose, so as not to hold it across the file I/O; `clear_cache_and_reload()` and `durable_primary_slot_corrupt()` do not hold it either; and the open path has no `TransactionalMemory` yet.

## Why a single-process handle takes nothing

The same mechanism, and it is the sharp edge here. A single-process open holds the whole storage. Locking the header bytes on that description and releasing them again would convert part of that hold and then drop it -- punching a hole in the whole-storage lock, and letting a second process open the database. `a_hold_does_not_puncture_the_whole_storage_lock` covers exactly that: it runs both kinds of hold on a single-process handle and then asserts a second open is still refused.

## What is not here

The header I/O is atomic; a multi-step read-modify-write over the header is not. An open that reads the header, decides it needs recovery and writes it back does so under two holds rather than one. What makes that safe against a live cohort is holding the writer byte across construction, which arrives with the rest of the concurrency-mode wiring.

Also still to come: the pin protocol, which is what a reclaiming writer needs in order to know what the other processes are still reading, and the transaction-level reload and cache invalidation. A database opened in a shared mode still is not safe to actually share.

## Testing

Six tests in `header_lock_test`, on real files, driving two `TransactionalMemory` handles over one path -- two open file descriptions contend exactly as two processes do:

* `an_exclusive_hold_excludes_a_shared_one`: the reader proceeds only once the writer's hold ends. Not vacuous -- stubbing the lock out so every mode takes nothing makes it fail with "the reader entered its hold while the writer held one".
* `shared_holds_admit_each_other`, since only a write needs the header to itself.
* `the_hold_covers_the_write_reaching_the_file`: a held shared hold blocks `write_header()` until it is released.
* `the_header_reaches_the_file_before_write_header_returns`: the other half of that, and the one that pins the direct write down. It reads the file around redb entirely, with no flush in between. The test above passes either way, since a buffered write blocks on the hold too; this one fails if the write is left to the next flush. I re-checked that by mutating `write_header()` back to the buffered shape, which fails this test alone.
* `a_read_only_handle_takes_shared_holds`, through the read-only backend an open wraps its storage in.
* `a_hold_does_not_puncture_the_whole_storage_lock`, the single-process case above.

`cargo fmt`, the justfile's `cargo clippy --all-targets --all-features` and `cargo clippy --all --all-targets --all-features` as CI runs them, clippy with no features, cross-clippy for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, the three `wasm32` variants, both `thumbv7em-none-eabihf` no_std configurations CI checks, and `cargo test` in all three configurations that run tests -- no features, `experimental-multiprocess`, and `--all-features` -- all pass.

Also run for `x86_64-pc-windows-gnu` under wine, where all six header-lock tests pass. Two tests in the wider suite fail there and fail identically on this branch's merge base, so neither is this change's: `a_whole_file_lock_holder_reads_as_already_open`, because wine answers std's second `UnlockFile` with `ERROR_LOCK_VIOLATION` where Windows answers `ERROR_NOT_LOCKED`, and `does_not_exist`, because a deleted-but-still-open file keeps its name on Windows.

No public API changes, so no changelog entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_