### PR TITLE
Hold the writer byte for the duration of a write transaction

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,8 @@
 use crate::io;
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
 use crate::tree_store::LocklessBackend;
+#[cfg(feature = "experimental-multiprocess")]
+use crate::tree_store::MultiProcessWriterGuard;
 #[cfg(not(redb_no_std))]
 use crate::tree_store::ReadOnlyBackend;
 use crate::tree_store::{
@@ -351,6 +353,12 @@ pub(crate) enum TransactionGuard {
     Write {
         tracker: Arc<TransactionTracker>,
         transaction_id: TransactionId,
+        // Owned alongside the write slot so the two can be ordered against each other: a
+        // thread waiting on that slot takes the byte on this same file description the moment
+        // it is free, so the byte must be released first and taken after.
+        // None indicates that the writer lock is held at the database level -- i.e. in a single writer mode
+        #[cfg(feature = "experimental-multiprocess")]
+        multi_process_writer: Option<MultiProcessWriterGuard>,
     },
     // Used for internal accesses that happen outside of any tracked transaction,
     // such as opening the database, repairing it, and running integrity checks.
@@ -379,11 +387,27 @@ impl TransactionGuard {
     pub(crate) fn new_write(
         transaction_id: TransactionId,
         tracker: Arc<TransactionTracker>,
-    ) -> Self {
-        Self::Write {
+        #[cfg(feature = "experimental-multiprocess")] mem: &Arc<TransactionalMemory>,
+    ) -> Result<Self> {
+        #[allow(unused_mut)]
+        let mut guard = Self::Write {
             tracker,
             transaction_id,
+            #[cfg(feature = "experimental-multiprocess")]
+            multi_process_writer: None,
+        };
+        // After the guard owns the slot, so that a failure here releases it rather than
+        // leaving the tracker with a live write transaction nothing will ever end
+        #[cfg(feature = "experimental-multiprocess")]
+        if let Self::Write {
+            multi_process_writer,
+            ..
+        } = &mut guard
+        {
+            *multi_process_writer = TransactionalMemory::lock_multi_process_writer(mem)?;
         }
+
+        Ok(guard)
     }
 
     pub(crate) fn untracked() -> Self {
@@ -412,7 +436,13 @@ impl Drop for TransactionGuard {
             Self::Write {
                 tracker,
                 transaction_id,
+                #[cfg(feature = "experimental-multiprocess")]
+                    multi_process_writer: writer,
             } => {
+                // Drop the "writer byte" multi-process file lock, before our in-process lock.
+                // Otherwise, another transaction in our process could re-enter the file lock
+                #[cfg(feature = "experimental-multiprocess")]
+                drop(writer.take());
                 if let Some(mem) = tracker.end_write_transaction(*transaction_id) {
                     // The Database was dropped while this transaction was live, deferring
                     // the database close to the end of this transaction
@@ -1374,7 +1404,9 @@ fn begin_write_with_allocation_policy(
     let guard = TransactionGuard::new_write(
         transaction_tracker.start_write_transaction(),
         transaction_tracker.clone(),
-    );
+        #[cfg(feature = "experimental-multiprocess")]
+        mem,
+    )?;
     // Re-checked after acquiring the write slot: the writer this call blocked on can fail its
     // commit, latching an I/O error and discarding the allocator state. The I/O check comes
     // first so a backend failure is not misreported as corruption. Returning drops the guard,
@@ -2128,5 +2160,95 @@ mod test {
                 if err.kind() == ErrorKind::InvalidData => {}
             err => panic!("Unexpected error for empty file: {err}"),
         }
+    }
+}
+
+/// Probed directly, since the public API reports every lock conflict the same way and so
+/// cannot say which byte caused one.
+#[cfg(all(
+    test,
+    feature = "experimental-multiprocess",
+    any(target_os = "linux", target_vendor = "apple", windows)
+))]
+mod writer_byte_test {
+    use super::{ConcurrencyMode, Database, WRITER_BYTE, byte_range};
+    use crate::TableDefinition;
+    use crate::tree_store::file_backend::range_lock::RangeLock;
+    use std::fs::{File, OpenOptions};
+    use std::path::Path;
+
+    const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+    fn create(path: &Path, mode: ConcurrencyMode) -> Database {
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(mode);
+        builder.create(path).unwrap()
+    }
+
+    /// A separate description, so its locks conflict with the database's exactly as another
+    /// process's would
+    fn probe(path: &Path) -> File {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap()
+    }
+
+    fn commit_one(db: &Database) {
+        let write = db.begin_write().unwrap();
+        {
+            let mut table = write.open_table(TABLE).unwrap();
+            table.insert(0, 0).unwrap();
+        }
+        write.commit().unwrap();
+    }
+
+    /// Held for the transaction and no longer, which is what lets the next writer in
+    #[test]
+    fn a_multi_writer_transaction_holds_the_byte_and_gives_it_back() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let probe = probe(tmpfile.path());
+
+        let write = db.begin_write().unwrap();
+        assert!(
+            !probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap(),
+            "the byte was free while a write transaction was open"
+        );
+        write.commit().unwrap();
+
+        assert!(
+            probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap(),
+            "the byte was still held after the transaction ended"
+        );
+        probe.unlock_range(byte_range(WRITER_BYTE)).unwrap();
+    }
+
+    /// This mode settles who writes at open instead, so the byte is held from then until the
+    /// database closes. A transaction taking it again would convert that hold and drop what
+    /// remained on release, so it takes nothing.
+    #[test]
+    fn a_single_writer_open_holds_the_byte_for_its_lifetime() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::SingleWriterProcess);
+        let probe = probe(tmpfile.path());
+
+        assert!(
+            !probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap(),
+            "the open did not take the writer byte"
+        );
+        commit_one(&db);
+        assert!(
+            !probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap(),
+            "a write transaction punctured the open's hold on the writer byte"
+        );
+
+        drop(db);
+        assert!(
+            probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap(),
+            "the byte was still held after the database closed"
+        );
+        probe.unlock_range(byte_range(WRITER_BYTE)).unwrap();
     }
 }

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -23,6 +23,8 @@ pub(crate) use btree_iters::{AllPageNumbersBtreeIter, encode_bounds};
 pub(crate) use extract_if::BtreeExtractIf;
 pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multimap_btree_stats};
 pub(crate) use page_store::LocklessBackend;
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) use page_store::MultiProcessWriterGuard;
 #[cfg(not(redb_no_std))]
 pub(crate) use page_store::ReadOnlyBackend;
 #[cfg(not(redb_no_std))]

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -22,6 +22,8 @@ pub(crate) use backends::ReadOnlyBackend;
 pub(crate) use base::{MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTracker};
 pub(crate) use fast_hash::{PageNumberHashMap, PageNumberHashSet};
 pub(crate) use header::PAGE_SIZE;
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) use page_manager::MultiProcessWriterGuard;
 pub(crate) use page_manager::{
     AllocationPolicy, FILE_FORMAT_VERSION3, PageAllocator, PageResolver, ShrinkPolicy,
     TransactionalMemory, xxh3_checksum,

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -529,6 +529,20 @@ impl Drop for HeaderGuard<'_> {
     }
 }
 
+/// A hold on the writer byte, released when it drops. Owns its handle, unlike `HeaderGuard`,
+/// since a write transaction outlives the call that takes it.
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) struct MultiProcessWriterGuard {
+    mem: Arc<TransactionalMemory>,
+}
+
+#[cfg(feature = "experimental-multiprocess")]
+impl Drop for MultiProcessWriterGuard {
+    fn drop(&mut self) {
+        let _ = self.mem.storage.unlock_range(byte_range(WRITER_BYTE));
+    }
+}
+
 pub(crate) struct TransactionalMemory {
     unpersisted: Mutex<UnpersistedState>,
     storage: PagedCachedFile,
@@ -681,6 +695,21 @@ impl TransactionalMemory {
             storage: Some(storage),
             _in_process: guard,
         })
+    }
+
+    /// Acquire the multi-process writer lock
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn lock_multi_process_writer(
+        mem: &Arc<Self>,
+    ) -> Result<Option<MultiProcessWriterGuard>> {
+        // The other modes settle who writes when the database is opened: a single-writer holds this byte
+        // for its lifetime, and taking it again here would convert that hold and then drop it.
+        if !matches!(mem.concurrency_mode, ConcurrencyMode::MultiWriterProcess) {
+            return Ok(None);
+        }
+        mem.storage.lock_range(byte_range(WRITER_BYTE))?;
+
+        Ok(Some(MultiProcessWriterGuard { mem: mem.clone() }))
     }
 
     pub(crate) fn new(

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -4,6 +4,84 @@ use redb::backends::InMemoryBackend;
 use redb::{ConcurrencyMode, Database, DatabaseError, StorageError};
 
 #[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+mod writer_byte {
+    use super::*;
+    use redb::TableDefinition;
+    use std::path::Path;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+    fn create(path: &Path, mode: ConcurrencyMode) -> Result<Database, DatabaseError> {
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(mode);
+        builder.create(path)
+    }
+
+    /// Which is what makes one write transaction at a time across the cohort
+    #[test]
+    fn a_write_transaction_excludes_another_process() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let peer = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+
+        let held = db.begin_write().unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        let waiting = thread::spawn(move || {
+            let write = peer.begin_write().unwrap();
+            tx.send(()).unwrap();
+            write.abort().unwrap();
+        });
+
+        assert!(
+            rx.recv_timeout(Duration::from_millis(200)).is_err(),
+            "a second process began a write transaction while the first was open"
+        );
+        held.commit().unwrap();
+        rx.recv_timeout(Duration::from_secs(10))
+            .expect("the waiting process never began its transaction");
+        waiting.join().unwrap();
+    }
+
+    /// The byte is released by the whole transaction ending, not by the commit alone
+    #[test]
+    fn an_aborted_transaction_releases_the_byte() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let peer = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+
+        db.begin_write().unwrap().abort().unwrap();
+        // Dropped rather than aborted, which aborts through Drop
+        drop(db.begin_write().unwrap());
+
+        let write = peer.begin_write().unwrap();
+        write.commit().unwrap();
+    }
+
+    /// It locks the whole file, which covers the writer byte
+    #[test]
+    fn a_single_process_transaction_does_not_puncture_the_whole_file_lock() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let db = create(tmpfile.path(), ConcurrencyMode::SingleProcess).unwrap();
+
+        let write = db.begin_write().unwrap();
+        {
+            let mut table = write.open_table(TABLE).unwrap();
+            table.insert(0, 0).unwrap();
+        }
+        write.commit().unwrap();
+
+        assert!(matches!(
+            Database::open(tmpfile.path()),
+            Err(DatabaseError::DatabaseAlreadyOpen)
+        ));
+    }
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
 #[test]
 fn the_concurrency_mode_excludes_incompatible_opens() {
     fn create(path: &std::path::Path, mode: ConcurrencyMode) -> Result<Database, DatabaseError> {


### PR DESCRIPTION
The next slice after #1426's header lock. That made header I/O atomic; this makes the cohort take turns. `MultiWriterProcess` negotiates its open and then lets every process write at once, so a write transaction now holds the writer byte from the moment it begins until it is over, and only one runs anywhere at a time.

## Where the hold lives

`TransactionalMemory::lock_writer()` takes the byte and returns a `WriterGuard`, which `TransactionGuard` owns for the `Write` variant -- the same object that owns this process's write slot.

That pairing is the point. Two orderings have to hold at once, and each fails differently:

* The byte must outlive the transaction's work. `WriteTransaction` holds an `Arc<TransactionGuard>`, so the byte survives until the transaction is finished -- past the `storage.resize()` at the end of `commit()`, and past `abort_inner()`, which runs in `WriteTransaction::drop` before any field is dropped. A peer therefore cannot begin writing until the shrink has happened, so it never sees a file length disagreeing with the layout the published header names.
* The byte must be released *before* the in-process write slot. `TransactionGuard::drop` does both, byte first. Otherwise a thread waiting on that slot takes the byte on this same file description the moment the slot frees, and the outgoing transaction's release then drops the hold that thread believes it has -- leaving another process free to write alongside it.

The guard owns an `Arc<TransactionalMemory>` rather than borrowing, unlike `HeaderGuard`: a write transaction outlives the call that takes the byte.

## Which modes take it

Only `MultiWriterProcess`, which is what `ConcurrencyMode::writes_under_the_writer_byte()` answers.

A `SingleWriterProcess` open already holds the byte exclusively for the process's lifetime, settled at open. Taking it again per transaction would convert that hold, and releasing it at the end of the transaction would then drop whatever remained -- letting a second writer open the database while this one is still running. Same mechanism as the header lock's single-process case. `SingleProcess` holds the whole file, which covers the byte.

## No in-process mutex

The header lock needs one because its holds are taken at points that do not otherwise exclude each other. This does not: the caller already holds this process's write slot, which is what keeps two of its write transactions from overlapping on the byte. Both would run on one open file description and dismantle each other's holds otherwise. The byte is taken after the slot for exactly that reason, and released before it for the reason above.

## What is not here

The state reload. In the finished protocol, taking the writer byte is followed by picking up what other processes have committed -- rereading the commit slots, revalidating the cache, and reloading the allocator state when the file has moved on. This change is the exclusion alone; a `MultiWriterProcess` handle still does not see another process's commits, and a database opened in a shared mode is still not safe to actually share.

Also still to come: the pin protocol, and holding the writer byte across a writable open rather than only across transactions.

## Testing

Two unit tests in `db::writer_byte_test` lock the byte directly from a second file description, which conflicts with the database's exactly as another process's would. The public API cannot see this: it reports every conflict as `DatabaseAlreadyOpen`, whatever byte caused it.

* `a_multi_writer_transaction_holds_the_byte_and_gives_it_back`: the byte is refused while a transaction is open and free once it commits.
* `a_single_writer_transaction_does_not_puncture_the_process_hold`: the byte is still held after a single-writer transaction commits.

Three more in `tests/multiprocess_tests.rs` drive it through the public API, two handles over one path:

* `a_write_transaction_excludes_another_process`: a second handle's `begin_write()` blocks until the first commits, then proceeds.
* `an_aborted_transaction_releases_the_byte`, for both an explicit `abort()` and a drop.
* `a_single_process_transaction_does_not_puncture_the_whole_file_lock`.

I mutation-tested the mode predicate rather than trusting the tests. Making it always `false` fails `a_multi_writer_transaction_holds_the_byte_and_gives_it_back`; making it `is_multi_process_writable()`, so single-writer takes the byte too, fails `a_single_writer_transaction_does_not_puncture_the_process_hold`. Each mutation is caught by exactly one test.

Two things I could not cover, stated plainly:

* The release-ordering bug above has no regression test. The window is between `notify_one()` and the unlock a few instructions later, and a waiting thread has to complete a condvar wakeup inside it. I reintroduced the reversed order and it survived a two-thread contention test every run, and eight threads over 500 transactions each. Forcing it needs the drop path instrumented, which is more machinery than this PR should carry, so the ordering is verifiable by reading rather than by test. I dropped the contention test rather than keep one that cannot fail on the bug it names.
* An earlier version of the single-writer test went through the public API and asserted `DatabaseAlreadyOpen` on a second open. That passes either way, since `SHARED_WRITER_BYTE` refuses the open long before `WRITER_BYTE` is tested. It proved nothing and the direct probe replaced it.

`cargo fmt`, the justfile's `cargo clippy --all-targets --all-features` and `cargo clippy --all --all-targets --all-features` as CI runs them, clippy with no features, cross-clippy for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, the three `wasm32` variants, both `thumbv7em-none-eabihf` no_std configurations CI checks, `cargo build --release` with the feature, and `cargo test` in all three configurations that run tests -- no features, `experimental-multiprocess`, and `--all-features` -- all pass.

Also run for `x86_64-pc-windows-gnu` under wine, where both unit tests and all five multiprocess tests pass. The suite's one failure there, `a_whole_file_lock_holder_reads_as_already_open`, fails identically on master: wine answers std's second `UnlockFile` with `ERROR_LOCK_VIOLATION` where Windows answers `ERROR_NOT_LOCKED`.

No public API changes, so no changelog entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_