### PR TITLE
Lock the active transaction a read transaction is reading

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -99,6 +99,10 @@ pub(crate) const SHARED_WRITER_BYTE: u64 = LOCK_BASE + 1;
 pub(crate) const SHARED_READER_BYTE: u64 = LOCK_BASE + 2;
 #[cfg(feature = "experimental-multiprocess")]
 pub(crate) const IMMUTABLE_READER_BYTE: u64 = LOCK_BASE + 3;
+/// Base of the "active transaction range": a handle reading transaction `t` holds `TXN_BASE + t`
+/// shared for as long as it is reading it
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) const TXN_BASE: u64 = LOCK_BASE + 1024;
 
 pub(crate) fn byte_range(offset: u64) -> Range<u64> {
     offset..offset + 1
@@ -349,9 +353,10 @@ pub(crate) enum TransactionGuard {
     Read {
         tracker: Arc<TransactionTracker>,
         transaction_id: TransactionId,
-        // Cleared when a savepoint becomes persistent: the database record owns the
-        // transaction's reference from then on, and releases it when the savepoint is deleted
-        owns_reference: bool,
+        // `Some` while this guard owns the transaction's reference, carrying what the tracker
+        // needs to release it. `None` when a savepoint becomes persistent: the database
+        // owns the reference from then on and releases it when the savepoint is deleted
+        reference: Option<Arc<TransactionalMemory>>,
     },
     Write {
         tracker: Arc<TransactionTracker>,
@@ -372,11 +377,12 @@ impl TransactionGuard {
     pub(crate) fn new_read(
         transaction_id: TransactionId,
         tracker: Arc<TransactionTracker>,
+        mem: &Arc<TransactionalMemory>,
     ) -> Self {
         Self::Read {
             tracker,
             transaction_id,
-            owns_reference: true,
+            reference: Some(mem.clone()),
         }
     }
 
@@ -388,7 +394,7 @@ impl TransactionGuard {
         Self::Read {
             tracker,
             transaction_id,
-            owns_reference: false,
+            reference: None,
         }
     }
 
@@ -396,14 +402,14 @@ impl TransactionGuard {
     // reference count.
     // Dropping this guard then releases nothing.
     pub(crate) fn release_to_database(&mut self) {
-        let Self::Read { owns_reference, .. } = self else {
+        let Self::Read { reference, .. } = self else {
             unreachable!("only a read transaction's reference may be leaked")
         };
-        *owns_reference = false;
+        drop(reference.take());
     }
 
     pub(crate) fn owns_reference(&self) -> bool {
-        matches!(self, Self::Read { owns_reference, .. } if *owns_reference)
+        matches!(self, Self::Read { reference, .. } if reference.is_some())
     }
 
     pub(crate) fn tracker(&self) -> &Arc<TransactionTracker> {
@@ -415,10 +421,11 @@ impl TransactionGuard {
 
     pub(crate) fn allocate_read(
         tracker: Arc<TransactionTracker>,
-        mem: &TransactionalMemory,
+        mem: &Arc<TransactionalMemory>,
     ) -> Result<Self> {
         let id = tracker.register_read_transaction(mem)?;
-        Ok(Self::new_read(id, tracker))
+
+        Ok(Self::new_read(id, tracker, mem))
     }
 
     pub(crate) fn new_write(
@@ -469,10 +476,10 @@ impl Drop for TransactionGuard {
             Self::Read {
                 tracker,
                 transaction_id,
-                owns_reference,
+                reference,
             } => {
-                if *owns_reference {
-                    tracker.deallocate_read_transaction(*transaction_id);
+                if let Some(mem) = reference {
+                    tracker.deallocate_read_transaction(mem, *transaction_id);
                 }
             }
             Self::Write {
@@ -566,13 +573,9 @@ impl Sealed for ReadOnlyDatabase {}
 #[cfg(not(redb_no_std))]
 impl ReadableDatabase for ReadOnlyDatabase {
     fn begin_read(&self) -> Result<ReadTransaction, TransactionError> {
-        let id = self
-            .transaction_tracker
-            .register_read_transaction(&self.mem)?;
+        let guard = TransactionGuard::allocate_read(self.transaction_tracker.clone(), &self.mem)?;
         #[cfg(feature = "logging")]
-        debug!("Beginning read transaction id={id:?}");
-
-        let guard = TransactionGuard::new_read(id, self.transaction_tracker.clone());
+        debug!("Beginning read transaction id={:?}", guard.id());
 
         ReadTransaction::new(self.mem.clone(), guard)
     }
@@ -1362,7 +1365,7 @@ impl Database {
                 },
             };
             db.transaction_tracker
-                .register_persistent_savepoint(&savepoint);
+                .register_persistent_savepoint(&db.mem, &savepoint)?;
         }
         txn.abort()?;
 
@@ -2292,5 +2295,254 @@ mod writer_byte_test {
             "the byte was still held after the database closed"
         );
         probe.unlock_range(byte_range(WRITER_BYTE)).unwrap();
+    }
+}
+
+/// The "active transaction range" locks a read transaction publishes, probed directly: nothing
+/// consumes them yet, and a byte-range lock is invisible through the public API in any case
+#[cfg(all(
+    test,
+    feature = "experimental-multiprocess",
+    any(target_os = "linux", target_vendor = "apple", windows)
+))]
+mod active_transaction_test {
+    use super::{ConcurrencyMode, Database, ReadableDatabase, TXN_BASE, byte_range};
+    use crate::tree_store::file_backend::range_lock::RangeLock;
+    use crate::{Durability, TableDefinition};
+    use std::fs::{File, OpenOptions};
+    use std::path::Path;
+
+    const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+    // The ids a freshly created database can have committed
+    const SEARCHED: std::ops::Range<u64> = 0..8;
+
+    fn create(path: &Path, mode: ConcurrencyMode) -> Database {
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(mode);
+        let db = builder.create(path).unwrap();
+        let write = db.begin_write().unwrap();
+        {
+            let mut table = write.open_table(TABLE).unwrap();
+            table.insert(0, 0).unwrap();
+        }
+        write.commit().unwrap();
+        db
+    }
+
+    /// A separate description, so its locks conflict with the database's exactly as another
+    /// process's would
+    fn probe(path: &Path) -> File {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap()
+    }
+
+    /// Probed exclusively, since the byte is held shared and another process may hold the same
+    /// one. Reports the whole-file lock a single-process open holds as well, which is what
+    /// `a_single_process_read_does_not_puncture_the_whole_file_lock` relies on
+    fn is_held(probe: &File, id: u64) -> bool {
+        let free = probe.try_lock_range(byte_range(TXN_BASE + id)).unwrap();
+        if free {
+            probe.unlock_range(byte_range(TXN_BASE + id)).unwrap();
+        }
+        !free
+    }
+
+    fn held_ids(probe: &File) -> Vec<u64> {
+        SEARCHED.filter(|id| is_held(probe, *id)).collect()
+    }
+
+    #[test]
+    fn a_read_transaction_locks_the_id_it_reads_until_it_ends() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let probe = probe(tmpfile.path());
+        assert!(held_ids(&probe).is_empty());
+
+        let read = db.begin_read().unwrap();
+        assert_eq!(
+            held_ids(&probe).len(),
+            1,
+            "a read transaction locked {:?}",
+            held_ids(&probe)
+        );
+
+        drop(read);
+        assert!(
+            held_ids(&probe).is_empty(),
+            "a lock outlived the read transaction that took it"
+        );
+    }
+
+    /// Two readers of one snapshot take the byte once, since it does not nest through a single
+    /// file description: it is released only as the last of them ends
+    #[test]
+    fn concurrent_readers_of_one_snapshot_share_the_lock() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let probe = probe(tmpfile.path());
+
+        let first = db.begin_read().unwrap();
+        let second = db.begin_read().unwrap();
+        let held = held_ids(&probe);
+        assert_eq!(held.len(), 1, "expected one active id: {held:?}");
+
+        drop(first);
+        assert!(is_held(&probe, held[0]), "released early");
+        drop(second);
+        assert!(!is_held(&probe, held[0]), "never released");
+    }
+
+    /// A read-only handle is a participant like any other: its snapshot is exactly what a
+    /// writer in another process must not reclaim
+    #[test]
+    fn a_read_only_handle_locks_what_it_reads() {
+        let tmpfile = crate::create_tempfile();
+        // Dropped, so the read-only open is the only handle: it takes SHARED_READER_BYTE, and
+        // the writer that created the file would otherwise hold the whole storage
+        drop(create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess));
+        let probe = probe(tmpfile.path());
+
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        let db = builder.open_read_only(tmpfile.path()).unwrap();
+        let read = db.begin_read().unwrap();
+        assert_eq!(
+            held_ids(&probe).len(),
+            1,
+            "a read-only handle locked {:?}",
+            held_ids(&probe)
+        );
+
+        drop(read);
+        assert!(held_ids(&probe).is_empty(), "the lock outlived the reader");
+    }
+
+    /// A savepoint holds a read transaction live, so its snapshot stays active for as long as
+    /// the savepoint does
+    #[test]
+    fn an_ephemeral_savepoint_locks_the_snapshot_it_references() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let probe = probe(tmpfile.path());
+        assert!(held_ids(&probe).is_empty());
+
+        let write = db.begin_write().unwrap();
+        let savepoint = write.ephemeral_savepoint().unwrap();
+        write.commit().unwrap();
+        assert_eq!(
+            held_ids(&probe).len(),
+            1,
+            "a savepoint locked {:?}",
+            held_ids(&probe)
+        );
+
+        drop(savepoint);
+        assert!(
+            held_ids(&probe).is_empty(),
+            "the lock outlived the savepoint"
+        );
+    }
+
+    /// A persistent savepoint outlives its handle -- and the process -- so its lock goes to the
+    /// database with the reference rather than being released when the handle drops. Nothing
+    /// releases it yet: deletion and re-locking at open both belong with the scan
+    #[test]
+    fn a_persistent_savepoint_keeps_its_lock_after_its_handle_drops() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let probe = probe(tmpfile.path());
+
+        let write = db.begin_write().unwrap();
+        write.persistent_savepoint().unwrap();
+        write.commit().unwrap();
+
+        assert_eq!(
+            held_ids(&probe).len(),
+            1,
+            "a persistent savepoint left {:?} locked",
+            held_ids(&probe)
+        );
+    }
+
+    /// A persistent savepoint survives the process that made it, so reopening has to take its
+    /// byte again: the snapshot its record names is still one a peer must not reclaim
+    #[test]
+    fn reopening_locks_a_persistent_savepoints_snapshot() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let write = db.begin_write().unwrap();
+        write.persistent_savepoint().unwrap();
+        write.commit().unwrap();
+        drop(db);
+
+        let probe = probe(tmpfile.path());
+        assert!(
+            held_ids(&probe).is_empty(),
+            "the closed database left a lock"
+        );
+
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        let db = builder.open(tmpfile.path()).unwrap();
+        assert_eq!(
+            held_ids(&probe).len(),
+            1,
+            "reopening locked {:?}",
+            held_ids(&probe)
+        );
+        drop(db);
+    }
+
+    /// A non-durable commit is invisible to a peer, but the durable ancestor it builds on is not,
+    /// and its pages must survive until the commit is flushed
+    #[test]
+    fn a_non_durable_commit_locks_its_durable_ancestor() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let probe = probe(tmpfile.path());
+        assert!(held_ids(&probe).is_empty());
+
+        let mut write = db.begin_write().unwrap();
+        write.set_durability(Durability::None).unwrap();
+        {
+            let mut table = write.open_table(TABLE).unwrap();
+            table.insert(1, 1).unwrap();
+        }
+        write.commit().unwrap();
+        let ancestor = held_ids(&probe);
+        assert_eq!(
+            ancestor.len(),
+            1,
+            "a non-durable commit locked {ancestor:?}"
+        );
+
+        // The durable commit that flushes it releases the ancestor. Its own epilogue takes a
+        // reference on this commit in turn, so what is locked afterwards is a different id
+        let write = db.begin_write().unwrap();
+        write.commit().unwrap();
+        assert!(
+            !held_ids(&probe).contains(&ancestor[0]),
+            "the ancestor stayed locked after the commit that flushed it"
+        );
+    }
+
+    /// A single-process open holds the whole file, which covers these bytes. Locking one and
+    /// releasing it would punch a hole in that lock, so this mode locks nothing
+    #[test]
+    fn a_single_process_read_does_not_puncture_the_whole_file_lock() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::SingleProcess);
+        let probe = probe(tmpfile.path());
+
+        drop(db.begin_read().unwrap());
+
+        assert_eq!(
+            held_ids(&probe),
+            SEARCHED.collect::<Vec<_>>(),
+            "a read transaction punctured the whole-file lock"
+        );
     }
 }

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -100,21 +100,38 @@ struct State {
 }
 
 impl State {
-    // The reference count on `id` is what keeps the pages its snapshot reaches from being freed,
-    // so every holder takes one here and gives it back here
-    fn reference_transaction(&mut self, id: TransactionId) {
-        self.live_read_transactions
-            .entry(id)
-            .and_modify(|x| *x += 1)
-            .or_insert(1);
+    // Takes the "active transaction byte" as the first reference to `id` appears, and releases it
+    // as the last goes away, so a writer in another process sees exactly the transactions this one
+    // is still reading. Done under the lock that holds the count, so the two cannot disagree: a
+    // reference taken between the count reaching zero and the byte being released would otherwise
+    // read a snapshot nothing protects
+    fn reference_transaction(&mut self, mem: &TransactionalMemory, id: TransactionId) -> Result {
+        let count = self.live_read_transactions.entry(id).or_insert(0);
+        *count += 1;
+        #[cfg(feature = "experimental-multiprocess")]
+        if *count == 1
+            && let Err(err) = mem.lock_mp_transaction(id)
+        {
+            self.live_read_transactions.remove(&id);
+            return Err(err);
+        }
+        #[cfg(not(feature = "experimental-multiprocess"))]
+        let _ = mem;
+
+        Ok(())
     }
 
-    fn dereference_transaction(&mut self, id: TransactionId) {
+    fn dereference_transaction(&mut self, mem: &TransactionalMemory, id: TransactionId) {
         let count = self.live_read_transactions.get_mut(&id).unwrap();
         *count -= 1;
         if *count == 0 {
             self.live_read_transactions.remove(&id);
+            // Failing to release only leaves a peer reclaiming less than it could
+            #[cfg(feature = "experimental-multiprocess")]
+            let _ = mem.unlock_mp_transaction(id);
         }
+        #[cfg(not(feature = "experimental-multiprocess"))]
+        let _ = mem;
     }
 }
 
@@ -185,11 +202,11 @@ impl TransactionTracker {
         }
     }
 
-    pub(crate) fn clear_pending_non_durable_commits(&self) {
+    pub(crate) fn clear_pending_non_durable_commits(&self, memory: &TransactionalMemory) {
         let mut state = self.state.lock().unwrap();
         let ids = mem::take(&mut state.pending_non_durable_commits);
         for (_, durable_ancestor) in ids {
-            state.dereference_transaction(durable_ancestor);
+            state.dereference_transaction(memory, durable_ancestor);
         }
     }
 
@@ -222,12 +239,13 @@ impl TransactionTracker {
     // id becomes durable.
     pub(crate) fn register_non_durable_commit(
         &self,
+        mem: &TransactionalMemory,
         id: TransactionId,
         durable_ancestor: TransactionId,
         has_unprocessed_freed_pages: bool,
-    ) {
+    ) -> Result {
         let mut state = self.state.lock().unwrap();
-        state.reference_transaction(durable_ancestor);
+        state.reference_transaction(mem, durable_ancestor)?;
         assert!(
             state
                 .pending_non_durable_commits
@@ -237,6 +255,8 @@ impl TransactionTracker {
         if has_unprocessed_freed_pages {
             state.unprocessed_freed_non_durable_commits.insert(id);
         }
+
+        Ok(())
     }
 
     // Reserve a transaction id that was created without starting a new write transaction.
@@ -267,13 +287,19 @@ impl TransactionTracker {
         state.next_savepoint_id = next_savepoint;
     }
 
-    pub(crate) fn register_persistent_savepoint(&self, savepoint: &Savepoint) {
+    pub(crate) fn register_persistent_savepoint(
+        &self,
+        mem: &TransactionalMemory,
+        savepoint: &Savepoint,
+    ) -> Result {
         let mut state = self.state.lock().unwrap();
-        state.reference_transaction(savepoint.get_transaction_id());
+        state.reference_transaction(mem, savepoint.get_transaction_id())?;
         state
             .valid_savepoints
             .insert(savepoint.get_id(), savepoint.get_transaction_id());
         state.persistent_savepoints.insert(savepoint.get_id());
+
+        Ok(())
     }
 
     // Marks an already-registered savepoint as persistent
@@ -289,14 +315,14 @@ impl TransactionTracker {
     ) -> Result<TransactionId> {
         let mut state = self.state.lock()?;
         let id = mem.get_last_committed_transaction_id()?;
-        state.reference_transaction(id);
+        state.reference_transaction(mem, id)?;
 
         Ok(id)
     }
 
-    pub(crate) fn deallocate_read_transaction(&self, id: TransactionId) {
+    pub(crate) fn deallocate_read_transaction(&self, mem: &TransactionalMemory, id: TransactionId) {
         let mut state = self.state.lock().unwrap();
-        state.dereference_transaction(id);
+        state.dereference_transaction(mem, id);
     }
 
     pub(crate) fn any_savepoint_exists(&self) -> bool {
@@ -350,9 +376,14 @@ impl TransactionTracker {
     }
 
     // Deallocates the given savepoint and its matching reference count on the transcation
-    pub(crate) fn deallocate_savepoint(&self, savepoint: SavepointId, transaction: TransactionId) {
+    pub(crate) fn deallocate_savepoint(
+        &self,
+        mem: &TransactionalMemory,
+        savepoint: SavepointId,
+        transaction: TransactionId,
+    ) {
         self.remove_savepoint(savepoint);
-        self.deallocate_read_transaction(transaction);
+        self.deallocate_read_transaction(mem, transaction);
     }
 
     pub(crate) fn is_valid_savepoint(&self, id: SavepointId) -> bool {
@@ -434,14 +465,36 @@ impl TransactionTracker {
 mod test {
     use super::*;
 
+    // The tracker takes the "active transaction byte" through this, so it needs somewhere to
+    // take it. Opened SingleProcess, where that is a no-op
+    fn memory() -> TransactionalMemory {
+        use crate::tree_store::{InMemoryBackend, LocklessBackend, PAGE_SIZE};
+
+        TransactionalMemory::new(
+            LocklessBackend::boxed(InMemoryBackend::new()),
+            true,
+            PAGE_SIZE,
+            None,
+            0,
+            false,
+            crate::db::ConcurrencyMode::SingleProcess,
+        )
+        .unwrap()
+    }
+
     #[test]
     fn non_durable_commit_without_freed_pages_is_not_unprocessed() {
+        let mem = memory();
         let tracker = TransactionTracker::new(TransactionId::new(0));
 
-        tracker.register_non_durable_commit(TransactionId::new(1), TransactionId::new(0), false);
+        tracker
+            .register_non_durable_commit(&mem, TransactionId::new(1), TransactionId::new(0), false)
+            .unwrap();
         assert_eq!(None, tracker.oldest_unprocessed_non_durable_commit());
 
-        tracker.register_non_durable_commit(TransactionId::new(2), TransactionId::new(0), true);
+        tracker
+            .register_non_durable_commit(&mem, TransactionId::new(2), TransactionId::new(0), true)
+            .unwrap();
         assert_eq!(
             Some(TransactionId::new(2)),
             tracker.oldest_unprocessed_non_durable_commit()

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -855,11 +855,11 @@ impl SavepointTransactionState {
         !self.created_persistent.is_empty() || !self.deleted_persistent.is_empty()
     }
 
-    fn apply_on_commit(&mut self, tracker: &TransactionTracker) {
+    fn apply_on_commit(&mut self, mem: &TransactionalMemory, tracker: &TransactionTracker) {
         // Persistent savepoints whose on-disk entry was deleted: release their
         // tracker refcount now that the deletion is durable.
         for (savepoint, transaction) in self.deleted_persistent.drain(..) {
-            tracker.deallocate_savepoint(savepoint, transaction);
+            tracker.deallocate_savepoint(mem, savepoint, transaction);
         }
         // Savepoints that restore_savepoint() invalidated: remove them from the
         // shared valid_savepoints map. For persistent savepoints,
@@ -872,12 +872,12 @@ impl SavepointTransactionState {
         self.created_persistent.clear();
     }
 
-    fn apply_on_abort(&mut self, tracker: &TransactionTracker) {
+    fn apply_on_abort(&mut self, mem: &TransactionalMemory, tracker: &TransactionTracker) {
         // Persistent savepoints created during this transaction: their
         // on-disk entries will be rolled back by rollback_uncommitted_writes(),
         // but the shared tracker registration must be released explicitly.
         for (savepoint, transaction) in mem::take(&mut self.created_persistent) {
-            tracker.deallocate_savepoint(savepoint, transaction);
+            tracker.deallocate_savepoint(mem, savepoint, transaction);
         }
         // Deleted-persistent entries will be rolled back on disk, so the
         // tracker state must NOT be released (it is still valid).
@@ -1261,8 +1261,7 @@ impl WriteTransaction {
     }
 
     fn allocate_savepoint(&self) -> Result<(SavepointId, TransactionGuard)> {
-        // Built here rather than inside the savepoint, so that every holder of a read
-        // transaction gets its reference the same way
+        // Through the guard, so the savepoint's snapshot is held active like any other reader's
         let transaction =
             TransactionGuard::allocate_read(self.transaction_tracker.clone(), &self.mem)?;
         let id = self
@@ -1782,7 +1781,7 @@ impl WriteTransaction {
         self.savepoint_state
             .lock()
             .unwrap()
-            .apply_on_commit(&self.transaction_tracker);
+            .apply_on_commit(&self.mem, &self.transaction_tracker);
     }
 
     fn store_data_freed_pages(&self, freed_pages: Vec<PageNumber>) -> Result<bool> {
@@ -1960,7 +1959,7 @@ impl WriteTransaction {
         self.savepoint_state
             .lock()
             .unwrap()
-            .apply_on_abort(&self.transaction_tracker);
+            .apply_on_abort(&self.mem, &self.transaction_tracker);
         self.mem.check_io_errors()?;
         self.page_allocator().rollback_all();
         #[cfg(feature = "logging")]
@@ -2051,7 +2050,8 @@ impl WriteTransaction {
         let _ = page_allocator.take_allocated_since_commit();
 
         // Mark any pending non-durable commits as fully committed.
-        self.transaction_tracker.clear_pending_non_durable_commits();
+        self.transaction_tracker
+            .clear_pending_non_durable_commits(&self.mem);
 
         // Immediately free the pages that were freed from the system-tree. These are only
         // accessed by write transactions, so it's safe to free them as soon as the commit is done.
@@ -2142,10 +2142,11 @@ impl WriteTransaction {
         self.transaction_tracker
             .reserve_transaction_id(epilogue_transaction, self.transaction_id);
         self.transaction_tracker.register_non_durable_commit(
+            &self.mem,
             epilogue_transaction,
             self.transaction_id,
             stored_system_freed_pages,
-        );
+        )?;
         // The epilogue only extracts DATA_FREED_TABLE entries. It is still correct to clear these
         // ids from the non-durable scan set: ordinary non-durable commits filter unpersisted
         // system pages before writing SYSTEM_FREED_TABLE, and durable commits process any
@@ -2212,10 +2213,11 @@ impl WriteTransaction {
         // Register this as a non-durable transaction to ensure that freed pages are only processed
         // after this transaction has been persisted.
         self.transaction_tracker.register_non_durable_commit(
+            &self.mem,
             self.transaction_id,
             self.mem.get_last_durable_transaction_id()?,
             stored_freed_pages,
-        );
+        )?;
 
         for page in post_commit_frees {
             let removed = self.mem.free_if_unpersisted(page, &PageTracker::ignore());

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -3,7 +3,7 @@ use crate::db::{
     ConcurrencyMode, FULL_RANGE, InternalStorageBackend, SHARED_WRITER_BYTE, byte_range,
 };
 #[cfg(feature = "experimental-multiprocess")]
-use crate::db::{IMMUTABLE_READER_BYTE, SHARED_READER_BYTE, WRITER_BYTE};
+use crate::db::{IMMUTABLE_READER_BYTE, SHARED_READER_BYTE, TXN_BASE, WRITER_BYTE};
 use crate::io;
 use crate::sync::Mutex;
 use crate::transaction_tracker::TransactionId;
@@ -710,6 +710,61 @@ impl TransactionalMemory {
         mem.storage.lock_range(byte_range(WRITER_BYTE))?;
 
         Ok(Some(MultiProcessWriterGuard { mem: mem.clone() }))
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn active_transaction_byte(id: TransactionId) -> Result<u64> {
+        match TXN_BASE.checked_add(id.raw_id()) {
+            Some(offset) if offset < 1 << 63 => Ok(offset),
+            _ => Err(StorageError::Corrupted(format!(
+                "transaction id {} is outside the multi-process lock range",
+                id.raw_id()
+            ))),
+        }
+    }
+
+    /// Marks `id` active, keeping the pages its snapshot references from being reclaimed by any
+    /// process until [`Self::unlock_mp_transaction`]. The shared header hold orders this against
+    /// a writer's reclamation scan, which holds it exclusively: the scan either sees this lock
+    /// or ran entirely before it.
+    ///
+    /// Caller must not attempt to re-lock an already locked transaction.
+    ///
+    /// The caller must guarantee that `id` cannot already have been collected.
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn lock_mp_transaction(&self, id: TransactionId) -> Result {
+        // Nothing to publish to: a single-process writers lock the whole file
+        if !self.concurrency_mode.is_multi_process_writable() {
+            return Ok(());
+        }
+        let byte = Self::active_transaction_byte(id)?;
+        let _guard = Self::lock_header(
+            &self.storage,
+            &self.in_process_header_lock,
+            self.concurrency_mode,
+            false,
+        )?;
+        // Refused only by an exclusive holder, which the shared header hold excludes
+        if !self.storage.try_lock_shared_range(byte_range(byte))? {
+            return Err(StorageError::Corrupted(
+                "another process holds an active transaction byte exclusively".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Releases the byte. Taken without the header lock: releasing only widens what a scanning
+    /// writer may reclaim, and a scan that misses it reclaims less
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn unlock_mp_transaction(&self, id: TransactionId) -> Result {
+        if !self.concurrency_mode.is_multi_process_writable() {
+            return Ok(());
+        }
+        self.storage
+            .unlock_range(byte_range(Self::active_transaction_byte(id)?))?;
+
+        Ok(())
     }
 
     pub(crate) fn new(


### PR DESCRIPTION
The next slice after #1427's writer byte. A shared-mode handle now holds the "active transaction byte" -- `TXN_BASE + t` -- shared for every transaction it is keeping live, so a writer in another process can see the snapshots it must not reclaim.

Rebased onto master now that #1430 has merged, so this is one commit carrying only the lock.

## Where the lock is taken

#1430 gave `live_read_transactions` a single pair of accessors. The byte hangs off exactly those two transitions: taken as a count rises from zero, released as it returns there, both inside `State::reference_transaction()` / `dereference_transaction()` and so under the `state` lock that holds the count. There is no second counter.

Doing it under that lock is what makes it correct rather than merely tidy. Deciding inside the lock and locking outside it leaves a window where the count has reached zero but the byte is still held: another thread registers that id, sees 1 rather than 0, declines to lock, and starts reading -- then the first thread's release lands and the reader is unprotected. That is why the tracker takes the memory to lock through as an argument rather than returning a "reached zero" flag. It stores no reference of its own; every caller already had one.

`TransactionalMemory::lock_mp_transaction()` / `unlock_mp_transaction()` are therefore plain and uncounted. They take the byte under a shared header hold, which is what orders them against a writer's reclamation scan: the scan holds the header exclusively, so it either sees the lock or ran entirely before it.

## What that covers

Every reference in `live_read_transactions`, which is more than read transactions:

* read transactions and read-only handles;
* savepoints, which hold a read transaction through their own `TransactionGuard`;
* a persistent savepoint restored from its record at open;
* the durable ancestor a non-durable commit builds on.

Wiring only the read-transaction pair and leaving the rest sharing the counter would be worse than a separate counter, not better: a reference taken first by one of the others leaves the count at 1, so the read transaction that follows sees no zero-to-one transition and never locks. The other two need protecting from a peer's reclamation in their own right, so this is the right side to err on.

## The guard

`TransactionGuard::Read` carries one field where it used to carry two:

```rust
reference: Option<Arc<TransactionalMemory>>,
```

`Some` means this guard owns a reference and carries what the tracker releases it through; `None` means it owns none -- a savepoint deserialized from its record, or one whose reference the database has taken over. `owns_reference()` is `reference.is_some()`, `release_to_database()` is `reference.take()`, and drop releases through the tracker.

A persistent savepoint's snapshot staying locked after its handle drops now falls out of that rather than being arranged: the handle is dropped inside `persistent_savepoint()` itself while its record still names the snapshot, and taking the reference is exactly what stops the drop from releasing it.

The byte does not nest through one file description -- a second acquisition is absorbed and one release drops whatever remains -- which is why the count decides and the lock is plain.

## Which modes take it

Only the shared ones. A single-process open holds the whole file, which covers these bytes; locking one and releasing it would punch a hole in that lock, the same hazard as the header lock and the writer byte.

## What is not here

Nothing consumes these locks. The scan that reads them -- and the reclamation bound it feeds -- follows separately, because it only makes sense with its consumer. A database opened in a shared mode still is not safe to actually share: the reader takes its id from this handle's cached header rather than rereading it under the hold, which the transaction-level reload closes.

Separately, a `ReadTransaction` outliving its `Database` loses this byte, because `Database::drop` defers only for a live write transaction and `FileBackend::close()` releases the whole range. That is a master bug rather than this PR's -- `SHARED_WRITER_BYTE` goes the same way -- and the open thread on this PR has the reproduction and a proposed fix to `Database::drop`.

## What this replaces

This branch previously carried a `Coordinator` in a new `src/multiprocess.rs`, holding its own file handle and its own copies of the header lock, `HEADER_LOCK`, `LOCK_BASE` and `byte_range`. It predated the header lock landing in `TransactionalMemory`, and could not work against master: `FileBackend` owns a plain `File`, so nothing could hand the coordinator the description the storage does its I/O through, and two header-lock implementations with two serializers over one description would dismantle each other's holds.

Rewritten onto the merged layering, which also removed:

* a second `Query` enum threaded through `RangeLock`, `InternalStorageBackend` and both backends, so the Unix scan could descend by conflict offset. Bisection is correct on both platforms and is what Windows already did, so one path replaces two and `query_lock_range` stays a `bool`. `range_lock.rs` and `optimized.rs` are untouched by this PR now.
* a `redb_multiprocess` cfg computed in `build.rs`. Nothing needs it once the code lives beside the rest of the protocol.

## Testing

Eight tests in `db::active_transaction_test`, probing the byte from a second file description, which conflicts with the database's exactly as another process's would:

* `a_read_transaction_locks_the_id_it_reads_until_it_ends`: no byte held before, exactly one while the transaction is open, none after.
* `concurrent_readers_of_one_snapshot_share_the_lock`: two readers, one byte; still held when the first ends, released when the second does.
* `a_read_only_handle_locks_what_it_reads`.
* `an_ephemeral_savepoint_locks_the_snapshot_it_references`.
* `a_persistent_savepoint_keeps_its_lock_after_its_handle_drops`: still held after `persistent_savepoint()` returns.
* `reopening_locks_a_persistent_savepoints_snapshot`: nothing held once the database closes, one byte held again once it reopens.
* `a_non_durable_commit_locks_its_durable_ancestor`, and the durable commit that flushes it releases the ancestor.
* `a_single_process_read_does_not_puncture_the_whole_file_lock`.

Mutation-tested rather than assumed, seven mutations, each caught by the test that names it: never locking; never releasing; locking and releasing on every reference instead of at zero (caught by the shared-lock test); `release_to_database()` keeping the reference (caught by the persistent-savepoint test); removing both single-process gates; and registering a persistent savepoint or a non-durable commit without locking -- the narrow version above -- caught by the two tests for those paths.

One correction worth recording: my first draft of `a_non_durable_commit_locks_its_durable_ancestor` asserted that nothing was held after the following durable commit. It is not: that commit's epilogue takes a reference on its own id, cleared by the commit after it. The test asserts what is actually true -- the ancestor is released -- rather than what I assumed.

`cargo fmt`, the justfile's `cargo clippy --all-targets --all-features` and `cargo clippy --all --all-targets --all-features` as CI runs them, clippy with no features, cross-clippy for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, the four `wasm32` variants, both `thumbv7em-none-eabihf` no_std configurations CI checks, `cargo build --release` with the feature, and `cargo test` in all three configurations that run tests -- all pass.

Also run for `x86_64-pc-windows-gnu` under wine, where all eight tests pass. The suite's one failure there, `a_whole_file_lock_holder_reads_as_already_open`, fails identically on master.

No public API changes, so no changelog entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_