### PR TITLE
Hold a savepoint's transaction with a TransactionGuard

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -349,6 +349,9 @@ pub(crate) enum TransactionGuard {
     Read {
         tracker: Arc<TransactionTracker>,
         transaction_id: TransactionId,
+        // Cleared when a savepoint becomes persistent: the database record owns the
+        // transaction's reference from then on, and releases it when the savepoint is deleted
+        owns_reference: bool,
     },
     Write {
         tracker: Arc<TransactionTracker>,
@@ -373,6 +376,40 @@ impl TransactionGuard {
         Self::Read {
             tracker,
             transaction_id,
+            owns_reference: true,
+        }
+    }
+
+    // A guard for a transaction whose reference the database already owns
+    pub(crate) fn new_read_unowned(
+        transaction_id: TransactionId,
+        tracker: Arc<TransactionTracker>,
+    ) -> Self {
+        Self::Read {
+            tracker,
+            transaction_id,
+            owns_reference: false,
+        }
+    }
+
+    // Leak the reference to the transaction. The caller becomes responsible for decrementing the
+    // reference count.
+    // Dropping this guard then releases nothing.
+    pub(crate) fn release_to_database(&mut self) {
+        let Self::Read { owns_reference, .. } = self else {
+            unreachable!("only a read transaction's reference may be leaked")
+        };
+        *owns_reference = false;
+    }
+
+    pub(crate) fn owns_reference(&self) -> bool {
+        matches!(self, Self::Read { owns_reference, .. } if *owns_reference)
+    }
+
+    pub(crate) fn tracker(&self) -> &Arc<TransactionTracker> {
+        match self {
+            Self::Read { tracker, .. } | Self::Write { tracker, .. } => tracker,
+            Self::Untracked => unreachable!("an untracked guard has no tracker"),
         }
     }
 
@@ -432,7 +469,12 @@ impl Drop for TransactionGuard {
             Self::Read {
                 tracker,
                 transaction_id,
-            } => tracker.deallocate_read_transaction(*transaction_id),
+                owns_reference,
+            } => {
+                if *owns_reference {
+                    tracker.deallocate_read_transaction(*transaction_id);
+                }
+            }
             Self::Write {
                 tracker,
                 transaction_id,

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -346,13 +346,16 @@ impl TransactionTracker {
         id
     }
 
+    // Forgets the savepoint, leaving the transaction's reference to whoever owns it
+    pub(crate) fn remove_savepoint(&self, savepoint: SavepointId) {
+        let mut state = self.state.lock().unwrap();
+        state.valid_savepoints.remove(&savepoint);
+        state.persistent_savepoints.remove(&savepoint);
+    }
+
     // Deallocates the given savepoint and its matching reference count on the transcation
     pub(crate) fn deallocate_savepoint(&self, savepoint: SavepointId, transaction: TransactionId) {
-        {
-            let mut state = self.state.lock().unwrap();
-            state.valid_savepoints.remove(&savepoint);
-            state.persistent_savepoints.remove(&savepoint);
-        }
+        self.remove_savepoint(savepoint);
         self.deallocate_read_transaction(transaction);
     }
 

--- a/src/tree_store/page_store/savepoint.rs
+++ b/src/tree_store/page_store/savepoint.rs
@@ -1,3 +1,4 @@
+use crate::db::TransactionGuard;
 use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker};
 use crate::tree_store::page_store::page_manager::FILE_FORMAT_VERSION3;
 use crate::tree_store::{BtreeHeader, TransactionalMemory};
@@ -28,10 +29,8 @@ pub struct Savepoint {
     id: SavepointId,
     // Each savepoint has an associated read transaction id to ensure that any pages it references
     // are not freed
-    transaction_id: TransactionId,
+    transaction: TransactionGuard,
     user_root: Option<BtreeHeader>,
-    transaction_tracker: Arc<TransactionTracker>,
-    ephemeral: bool,
 }
 
 impl Savepoint {
@@ -45,11 +44,9 @@ impl Savepoint {
     ) -> Self {
         Self {
             id,
-            transaction_id,
             version: mem.get_version(),
             user_root,
-            transaction_tracker,
-            ephemeral: true,
+            transaction: TransactionGuard::new_read(transaction_id, transaction_tracker),
         }
     }
 
@@ -62,7 +59,7 @@ impl Savepoint {
     }
 
     pub(crate) fn get_transaction_id(&self) -> TransactionId {
-        self.transaction_id
+        self.transaction.id()
     }
 
     pub(crate) fn get_user_root(&self) -> Option<BtreeHeader> {
@@ -70,20 +67,22 @@ impl Savepoint {
     }
 
     pub(crate) fn db_address(&self) -> *const TransactionTracker {
-        core::ptr::from_ref(self.transaction_tracker.as_ref())
+        core::ptr::from_ref(self.transaction.tracker().as_ref())
     }
 
     pub(crate) fn set_persistent(&mut self) {
-        self.ephemeral = false;
+        self.transaction.release_to_database();
     }
 }
 
 impl Drop for Savepoint {
     fn drop(&mut self) {
-        if self.ephemeral {
-            self.transaction_tracker
-                .deallocate_savepoint(self.get_id(), self.get_transaction_id());
+        // A persistent savepoint outlives its handle: the database record owns both its entry
+        // and the transaction's reference until the savepoint is deleted
+        if self.transaction.owns_reference() {
+            self.transaction.tracker().remove_savepoint(self.id);
         }
+        // The guard releases the transaction as it drops
     }
 }
 
@@ -98,7 +97,7 @@ impl SerializedSavepoint<'_> {
         assert_eq!(savepoint.version, FILE_FORMAT_VERSION3);
         let mut result = vec![savepoint.version];
         result.extend(savepoint.id.0.to_le_bytes());
-        result.extend(savepoint.transaction_id.raw_id().to_le_bytes());
+        result.extend(savepoint.get_transaction_id().raw_id().to_le_bytes());
 
         if let Some(header) = savepoint.user_root {
             result.push(1);
@@ -175,10 +174,11 @@ impl SerializedSavepoint<'_> {
         Ok(Savepoint {
             version,
             id: SavepointId(id),
-            transaction_id: TransactionId::new(transaction_id),
             user_root,
-            transaction_tracker,
-            ephemeral: false,
+            transaction: TransactionGuard::new_read_unowned(
+                TransactionId::new(transaction_id),
+                transaction_tracker,
+            ),
         })
     }
 }


### PR DESCRIPTION
Prep for #1428. A savepoint holds a transaction live, which is exactly what `TransactionGuard` is for, but it open-coded the job: a `transaction_id`, a `transaction_tracker`, and an `ephemeral` flag deciding whether `Drop` released the transaction. It holds a guard instead and sheds all three fields.

No behaviour change. This is a refactor of savepoint lifetime, independent of the multi-process work.

## The ownership the flag was encoding

There is one `live_read_transactions` reference per savepoint, and `ephemeral` said who owned it:

* while ephemeral, the `Savepoint` handle owns it and releases it on drop;
* `set_persistent()` hands it to the database record, which owns it until the savepoint is deleted -- `Savepoint::drop` then deliberately does nothing, and `to_savepoint()` builds a handle that owns nothing at all.

That is what `TransactionGuard` expresses, so the flag moves onto the guard, where `Drop` can act on it: `Read` gains `owns_reference`, `release_to_database()` clears it, and `new_read_unowned()` builds the handle a savepoint read back from its record needs. RAII cannot model the transfer directly -- the reference outlives the handle, and for a persistent savepoint it outlives the process -- so the flag is still a flag. It is just in the one place that can honour it.

## The one thing that did not move

`deallocate_savepoint()` did two jobs: forget the savepoint, and release the transaction. The guard now does the second, so the first is separate as `remove_savepoint()`. `deallocate_savepoint()` still does both, for the paths where the database owns the reference -- deleting a persistent savepoint, and rolling one back on abort.

## Testing

No new tests: this is a refactor with no behaviour change, and the savepoint lifecycle is already covered -- persistent savepoint create/delete/restore across commit and abort, `restore_and_delete_redb2_6_persistent_savepoint` for a savepoint read back from an old file, and the ephemeral paths through `check_integrity()`.

I mutation-tested the three ownership decisions rather than trusting that:

* `release_to_database()` made a no-op, so a persistent savepoint's guard still releases: over-release, panicking in `deallocate_read_transaction()`.
* `new_read_unowned()` made owning, so a savepoint read back from its record releases a reference it never took: fails `savepoint::test::corrupted_record_errors`.
* the drop-side `owns_reference()` made unconditional, so a persistent savepoint forgets itself from the tracker when its handle drops: fails `restore_and_delete_redb2_6_persistent_savepoint`.

Each is caught, and by a different test.

`cargo fmt`, the justfile's `cargo clippy --all-targets --all-features` and `cargo clippy --all --all-targets --all-features` as CI runs them, clippy with no features, cross-clippy for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, the three `wasm32` variants, both `thumbv7em-none-eabihf` no_std configurations CI checks, `cargo build --release` with the multi-process feature, and `cargo test` in all three configurations that run tests -- all pass.

## Why #1428 wants this

Pinning lives on `TransactionGuard` there, so a savepoint that holds one gets pinned with no extra machinery -- closing a gap in that PR, where savepoints pin nothing because they never build a guard. The alternative was moving the pinning into `TransactionTracker`, which does not work: `Database::check_integrity()` uses `Arc::get_mut(&mut self.mem)` both as its liveness test and to get the `&mut TransactionalMemory` that `clear_cache_and_reload()` needs, and a reference held there defeats it -- a `Weak` too, since `Arc::get_mut` requires the weak count to be zero as well.

Persistent savepoints still will not pin after this: their reference outlives the process, so it has to be re-taken at open, in the pass that already restores them. That belongs with the change that consumes the pins.

No public API changes, so no changelog entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_