### PR TITLE
Refactor read transaction reference counting

### DIFF
--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -99,6 +99,25 @@ struct State {
     deferred_close: Option<Arc<TransactionalMemory>>,
 }
 
+impl State {
+    // The reference count on `id` is what keeps the pages its snapshot reaches from being freed,
+    // so every holder takes one here and gives it back here
+    fn reference_transaction(&mut self, id: TransactionId) {
+        self.live_read_transactions
+            .entry(id)
+            .and_modify(|x| *x += 1)
+            .or_insert(1);
+    }
+
+    fn dereference_transaction(&mut self, id: TransactionId) {
+        let count = self.live_read_transactions.get_mut(&id).unwrap();
+        *count -= 1;
+        if *count == 0 {
+            self.live_read_transactions.remove(&id);
+        }
+    }
+}
+
 pub(crate) struct TransactionTracker {
     state: Mutex<State>,
     live_write_transaction_available: Condvar,
@@ -170,14 +189,7 @@ impl TransactionTracker {
         let mut state = self.state.lock().unwrap();
         let ids = mem::take(&mut state.pending_non_durable_commits);
         for (_, durable_ancestor) in ids {
-            let ref_count = state
-                .live_read_transactions
-                .get_mut(&durable_ancestor)
-                .unwrap();
-            *ref_count -= 1;
-            if *ref_count == 0 {
-                state.live_read_transactions.remove(&durable_ancestor);
-            }
+            state.dereference_transaction(durable_ancestor);
         }
     }
 
@@ -215,11 +227,7 @@ impl TransactionTracker {
         has_unprocessed_freed_pages: bool,
     ) {
         let mut state = self.state.lock().unwrap();
-        state
-            .live_read_transactions
-            .entry(durable_ancestor)
-            .and_modify(|x| *x += 1)
-            .or_insert(1);
+        state.reference_transaction(durable_ancestor);
         assert!(
             state
                 .pending_non_durable_commits
@@ -261,11 +269,7 @@ impl TransactionTracker {
 
     pub(crate) fn register_persistent_savepoint(&self, savepoint: &Savepoint) {
         let mut state = self.state.lock().unwrap();
-        state
-            .live_read_transactions
-            .entry(savepoint.get_transaction_id())
-            .and_modify(|x| *x += 1)
-            .or_insert(1);
+        state.reference_transaction(savepoint.get_transaction_id());
         state
             .valid_savepoints
             .insert(savepoint.get_id(), savepoint.get_transaction_id());
@@ -285,22 +289,14 @@ impl TransactionTracker {
     ) -> Result<TransactionId> {
         let mut state = self.state.lock()?;
         let id = mem.get_last_committed_transaction_id()?;
-        state
-            .live_read_transactions
-            .entry(id)
-            .and_modify(|x| *x += 1)
-            .or_insert(1);
+        state.reference_transaction(id);
 
         Ok(id)
     }
 
     pub(crate) fn deallocate_read_transaction(&self, id: TransactionId) {
         let mut state = self.state.lock().unwrap();
-        let ref_count = state.live_read_transactions.get_mut(&id).unwrap();
-        *ref_count -= 1;
-        if *ref_count == 0 {
-            state.live_read_transactions.remove(&id);
-        }
+        state.dereference_transaction(id);
     }
 
     pub(crate) fn any_savepoint_exists(&self) -> bool {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1260,12 +1260,15 @@ impl WriteTransaction {
         Ok(savepoints.into_iter())
     }
 
-    fn allocate_savepoint(&self) -> Result<(SavepointId, TransactionId)> {
-        let transaction_id = self
+    fn allocate_savepoint(&self) -> Result<(SavepointId, TransactionGuard)> {
+        // Built here rather than inside the savepoint, so that every holder of a read
+        // transaction gets its reference the same way
+        let transaction =
+            TransactionGuard::allocate_read(self.transaction_tracker.clone(), &self.mem)?;
+        let id = self
             .transaction_tracker
-            .register_read_transaction(&self.mem)?;
-        let id = self.transaction_tracker.allocate_savepoint(transaction_id);
-        Ok((id, transaction_id))
+            .allocate_savepoint(transaction.id());
+        Ok((id, transaction))
     }
 
     /// Creates a snapshot of the current database state, which can be used to rollback the database
@@ -1282,7 +1285,7 @@ impl WriteTransaction {
         // allocation tracking -- leaving a live savepoint with tracking `Ignore`d. A later
         // `restore_savepoint()` would then fail to free this transaction's pages, leaking them
         // (reclaimed only by a full repair).
-        let (id, transaction_id) = {
+        let (id, transaction) = {
             let _tables = self.tables.lock().unwrap();
             if self.dirty.load(Ordering::Acquire) {
                 return Err(SavepointError::InvalidSavepoint);
@@ -1290,16 +1293,13 @@ impl WriteTransaction {
             self.allocate_savepoint()?
         };
         #[cfg(feature = "logging")]
-        debug!("Creating savepoint id={id:?}, txn_id={transaction_id:?}");
+        debug!(
+            "Creating savepoint id={id:?}, txn_id={:?}",
+            transaction.id()
+        );
 
         let root = self.mem.get_data_root();
-        let savepoint = Savepoint::new_ephemeral(
-            &self.mem,
-            self.transaction_tracker.clone(),
-            id,
-            transaction_id,
-            root,
-        );
+        let savepoint = Savepoint::new_ephemeral(&self.mem, id, transaction, root);
 
         Ok(savepoint)
     }

--- a/src/tree_store/page_store/savepoint.rs
+++ b/src/tree_store/page_store/savepoint.rs
@@ -34,19 +34,17 @@ pub struct Savepoint {
 }
 
 impl Savepoint {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_ephemeral(
         mem: &TransactionalMemory,
-        transaction_tracker: Arc<TransactionTracker>,
         id: SavepointId,
-        transaction_id: TransactionId,
+        transaction: TransactionGuard,
         user_root: Option<BtreeHeader>,
     ) -> Self {
         Self {
             id,
             version: mem.get_version(),
+            transaction,
             user_root,
-            transaction: TransactionGuard::new_read(transaction_id, transaction_tracker),
         }
     }
 


### PR DESCRIPTION
Split out of #1428 at your request: the refactoring parts, with no behavior change and nothing multi-process about them. #1428 rebases onto this and keeps only the lock.

## The tracker's refcount

`live_read_transactions` was mutated at five sites, each hand-rolling the same arithmetic -- three incrementing with `entry().and_modify().or_insert(1)`, two decrementing and removing at zero. `State::reference_transaction()` and `State::dereference_transaction()` are now the only places that touch the map, and the five callers are one line each.

That is worth doing on its own, and it is also what the multi-process work needs: the "active transaction byte" hangs off exactly these two transitions, so there needs to be one place to hook rather than five.

Worth noting what the five sites are, since I had assumed two:

* `register_read_transaction()` / `deallocate_read_transaction()` -- read transactions, read-only handles, and savepoints.
* `register_non_durable_commit()` / `clear_pending_non_durable_commits()` -- the durable ancestor a non-durable commit builds on.
* `register_persistent_savepoint()` -- a persistent savepoint restored from its record at open.

## The savepoint constructor

`Savepoint::new_ephemeral()` took a tracker and a transaction id and built its own `TransactionGuard` internally. It takes the guard instead, and `allocate_savepoint()` builds it through `TransactionGuard::allocate_read()` -- the same path every other holder of a read transaction uses, rather than a second way of getting one.

Fewer arguments, so the `clippy::too_many_arguments` exemption goes too.

## Testing

No new tests: nothing here is a new behavior, and the existing suite covers the paths -- `deallocate_savepoint()`, the non-durable commit refcount, and persistent savepoint create/delete/restore all run through the two helpers now.

`cargo fmt`, `cargo clippy --all --all-targets --all-features` and with no features as CI runs them, cross-clippy for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, the `wasm32` variants, both `thumbv7em-none-eabihf` no_std configurations, `cargo build --release`, and `cargo test` in all three configurations that run tests -- all pass.

No public API changes, so no changelog entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_