### PR TITLE
Fail cached reads once the database is closed

### DIFF
--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -608,6 +608,10 @@ impl PagedCachedFile {
     // Read with caching. Caller must not read overlapping ranges without first calling invalidate_cache().
     // Doing so will not cause UB, but is a logic error.
     pub(super) fn read(&self, offset: u64, len: usize, hint: PageHint) -> Result<Arc<[u8]>> {
+        // Before the caches, which would otherwise serve a page the file can no longer be read
+        // for: a read transaction outliving its Database must see DatabaseClosed, not a snapshot
+        // of whatever happened to be cached
+        self.check_io_errors()?;
         debug_assert_eq!(0, offset % self.page_size);
         #[cfg(feature = "cache_metrics")]
         self.reads_total.fetch_add(1, Ordering::AcqRel);

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -194,6 +194,38 @@ fn deferred_close_invalidates_read_transactions() {
     ));
 }
 
+/// The guarantee above has to hold with a cache too: a warm page must not be served after the
+/// database is closed, or a read transaction outliving its handle keeps reading a snapshot no
+/// lock protects.
+#[test]
+fn a_warm_cache_does_not_outlive_the_database() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let setup_txn = db.begin_write().unwrap();
+    {
+        let mut table = setup_txn.open_table(STR_TABLE).unwrap();
+        table.insert("hello", "world").unwrap();
+    }
+    setup_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    // Read it once, so every page the read below needs is cached
+    let table = read_txn.open_table(STR_TABLE).unwrap();
+    assert_eq!(table.get("hello").unwrap().unwrap().value(), "world");
+    drop(table);
+
+    drop(db);
+
+    assert!(matches!(
+        read_txn.open_table(STR_TABLE).err().unwrap(),
+        TableError::Storage(StorageError::DatabaseClosed)
+    ));
+    assert!(matches!(
+        read_txn.list_tables().err().unwrap(),
+        StorageError::DatabaseClosed
+    ));
+}
+
 // Regression test for https://github.com/cberner/redb/issues/1072
 #[test]
 fn return_write_transaction_from_function() {


### PR DESCRIPTION
Your ruling from the #1428 thread: dropping a `Database` under a live read should still close it, and the read transaction should then raise the `DatabaseClosed` error that already exists.

It does not today, and the reason is narrow.

## What was wrong

`deferred_close_invalidates_read_transactions` already asserts exactly that behavior. It passes only because it sets `cache_size(0)`.

The check lives at the backend, in `CheckedBackend::read()` -> `check_failure()`, so a read that reaches the file after close does fail. But `PagedCachedFile::read()` serves a warm page out of the write buffer or read cache and returns before it ever gets there. With a normal cache, a read transaction that outlives its handle keeps reading a snapshot out of memory after `FileBackend::close()` has released every byte-range lock the process held.

Measured on the branch before the fix, holding a `ReadTransaction` across `drop(db)`:

```
before drop: get("hello") = Ok(Some("world"))
after drop:  get("hello") = Ok(Some("world"))   // should be DatabaseClosed
```

## The fix

One `check_io_errors()?` at the top of `PagedCachedFile::read()`, ahead of the caches.

That is an acquire load on the hottest read path, so it is worth being explicit about the cost: it sits immediately before a mutex or striped-`RwLock` acquisition the same function already makes, and it is the same latch every read that reaches the file already pays. I did not benchmark it -- say the word if you want numbers before this lands.

The alternative I considered and rejected was clearing the caches in `close()`, which would keep the read path untouched: a read would then miss and get the error from the backend. It is racy -- a read already in flight can repopulate a cache entry after the clear, and a later read hits it -- so the latch check is the one that actually holds.

## Testing

`a_warm_cache_does_not_outlive_the_database` in `basic_tests.rs`, next to the existing test, doing the same thing with a real cache: read once so every page the later read needs is warm, drop the database, then assert `DatabaseClosed` from both `open_table()` and `list_tables()`.

Mutation-checked: removing the added line fails that test and only that test.

Found by Codex on #1428, which flagged the multi-process consequence -- the active transaction byte disappears while the reader is still live. This is the general case underneath it, and it is a master bug rather than that PR's: `SHARED_WRITER_BYTE` goes the same way today.

`cargo fmt`, `cargo clippy --all --all-targets --all-features` and with no features as CI runs them, cross-clippy for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, the `wasm32` variants, both `thumbv7em-none-eabihf` no_std configurations, `cargo build --release`, and `cargo test` in all three configurations that run tests -- all pass.

No public API changes. The behavior change is that a read after close now errors where it previously returned stale data, which is the documented contract rather than a new one, so no changelog entry -- tell me if you would rather have one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_