### PR TITLE
Let a shared reader follow the file it is reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
   takes a `ConcurrencyMode` configuring how processes may share the database.
   When `SingleWriterProcess` or `MultiWriterProcess` is configured, commits are always 2-phase,
   `Durability::None` is refused, and the database may be opened read-only while another process has
-  it open for writing.
+  it open for writing; each new read transaction then sees that process's durable commits.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/db.rs
+++ b/src/db.rs
@@ -536,7 +536,7 @@ pub trait ReadableDatabase: SealedInApi5 {
 #[cfg_attr(
     feature = "experimental-multiprocess",
     doc = "",
-    doc = "The multi-process concurrency modes are the exception: a reader shares the file with the writer. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
+    doc = "The multi-process concurrency modes are the exception: a reader shares the file with the writer and follows its commits. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
 )]
 ///
 /// # Examples
@@ -576,6 +576,10 @@ pub trait ReadableDatabase: SealedInApi5 {
 pub struct ReadOnlyDatabase {
     mem: Arc<TransactionalMemory>,
     transaction_tracker: Arc<TransactionTracker>,
+    // Serializes beginning a read, so that the id a transaction locks and the root it then
+    // reads come from the same state
+    #[cfg(feature = "experimental-multiprocess")]
+    begin_read: crate::sync::Mutex<()>,
 }
 
 #[cfg(not(redb_no_std))]
@@ -584,6 +588,8 @@ impl Sealed for ReadOnlyDatabase {}
 #[cfg(not(redb_no_std))]
 impl ReadableDatabase for ReadOnlyDatabase {
     fn begin_read(&self) -> Result<ReadTransaction, TransactionError> {
+        #[cfg(feature = "experimental-multiprocess")]
+        let _begin = self.begin_read.lock().unwrap();
         let guard = TransactionGuard::allocate_read(self.transaction_tracker.clone(), &self.mem)?;
         #[cfg(feature = "logging")]
         debug!("Beginning read transaction id={:?}", guard.id());
@@ -649,6 +655,8 @@ impl ReadOnlyDatabase {
         let db = Self {
             mem,
             transaction_tracker: Arc::new(TransactionTracker::new(next_transaction_id)),
+            #[cfg(feature = "experimental-multiprocess")]
+            begin_read: crate::sync::Mutex::new(()),
         };
 
         Ok(db)
@@ -1743,7 +1751,7 @@ impl Builder {
     #[cfg_attr(
         feature = "experimental-multiprocess",
         doc = "",
-        doc = "Only a single-process writer is refused: in the multi-process concurrency modes a reader opened in the same mode as the writer shares the file with it. See [`Self::set_concurrency_mode`]."
+        doc = "Only a single-process writer is refused: in the multi-process concurrency modes a reader opened in the same mode as the writer shares the file with it and picks up its commits. See [`Self::set_concurrency_mode`]."
     )]
     #[cfg(not(redb_no_std))]
     pub fn open_read_only(
@@ -2690,6 +2698,46 @@ mod active_transaction_test {
         ));
     }
 
+    /// A read-only participant sees what another process committed, not the header it read at open
+    #[test]
+    fn a_read_only_participant_picks_up_a_peers_commit() {
+        let tmpfile = crate::create_tempfile();
+        let writer = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        let reader = builder.open_read_only(tmpfile.path()).unwrap();
+        let probe = probe(tmpfile.path());
+
+        let read = reader.begin_read().unwrap();
+        let before = held_ids(&probe);
+        assert_eq!(before.len(), 1, "expected one active id: {before:?}");
+        let before = before[0];
+        drop(read);
+
+        let write = writer.begin_write().unwrap();
+        {
+            let mut table = write.open_table(TABLE).unwrap();
+            table.insert(1, 1).unwrap();
+        }
+        write.commit().unwrap();
+        drop(writer);
+        assert!(
+            held_ids(&probe).is_empty(),
+            "the closed writer left {:?} locked",
+            held_ids(&probe)
+        );
+
+        let read = reader.begin_read().unwrap();
+        let after = held_ids(&probe);
+        assert_eq!(after.len(), 1, "expected one active id: {after:?}");
+        assert!(
+            after[0] > before,
+            "the reader stayed at {before} after the writer committed"
+        );
+        drop(read);
+    }
+
     /// A read-only participant takes the primary as recorded: choosing between the slots is a
     /// repairing writer's job, and a newer secondary it can see is a commit whose pages are not in
     /// the file yet, or one a repair has just rolled back
@@ -2702,6 +2750,7 @@ mod active_transaction_test {
 
         let mut builder = Database::builder();
         builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        let reader = builder.open_read_only(tmpfile.path()).unwrap();
 
         // A newer commit whose pages this file never received: made in a copy, then its slot
         // spliced into this file's secondary slot
@@ -2740,13 +2789,17 @@ mod active_transaction_test {
         assert!(id(&spliced, 1 - primary) > id(&spliced, primary));
         let probe = probe(tmpfile.path());
 
-        let opened = builder.open_read_only(tmpfile.path()).unwrap();
-        let read = opened.begin_read().unwrap();
+        // Reloading into that state, and opening in it
+        let read = reader.begin_read().unwrap();
         assert_eq!(
             held_ids(&probe),
             vec![id(&spliced, primary)],
             "the reader adopted a slot whose pages the file never received"
         );
+        drop(read);
+        let opened = builder.open_read_only(tmpfile.path()).unwrap();
+        let read = opened.begin_read().unwrap();
+        assert_eq!(held_ids(&probe), vec![id(&spliced, primary)]);
         drop(read);
     }
 

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -336,7 +336,10 @@ impl TransactionTracker {
     ) -> Result<TransactionId> {
         #[cfg(feature = "experimental-multiprocess")]
         let header = mem.lock_header_shared()?;
-        let id = mem.get_last_committed_transaction_id()?;
+        let id = mem.latest_committed_transaction_id(
+            #[cfg(feature = "experimental-multiprocess")]
+            &header,
+        )?;
         let mut state = self.state.lock()?;
         state.reference_transaction(
             mem,

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -563,6 +563,8 @@ pub(crate) struct TransactionalMemory {
     needs_repair: AtomicBool,
     #[cfg(feature = "experimental-multiprocess")]
     concurrency_mode: ConcurrencyMode,
+    #[cfg(feature = "experimental-multiprocess")]
+    read_only: bool,
     // Held for the duration of every header file lock. Ensures in-process threads do not overlap
     // acquiring the lock. Because it's an OFD lock on a single FD, only one may take it at a time.
     // TODO: This could probably be optimized, so that multiple threads can read at once, by making
@@ -1001,6 +1003,8 @@ impl TransactionalMemory {
             #[cfg(feature = "experimental-multiprocess")]
             concurrency_mode,
             #[cfg(feature = "experimental-multiprocess")]
+            read_only,
+            #[cfg(feature = "experimental-multiprocess")]
             in_process_header_lock,
             page_size: page_size.try_into().unwrap(),
             region_size,
@@ -1116,6 +1120,35 @@ impl TransactionalMemory {
         self.unpersisted.lock().unwrap().clear();
 
         Ok(was_clean)
+    }
+
+    /// The latest committed transaction id, read from the file by a shared reader since a peer
+    /// may have committed. The caller's `header` hold must also cover locking the id returned.
+    pub(crate) fn latest_committed_transaction_id(
+        &self,
+        #[cfg(feature = "experimental-multiprocess")] header: &HeaderGuard<'_>,
+    ) -> Result<TransactionId> {
+        #[cfg(feature = "experimental-multiprocess")]
+        if self.read_only && self.concurrency_mode.is_multi_process_writable() {
+            return self.reload_header(header);
+        }
+        self.get_last_committed_transaction_id()
+    }
+
+    /// Adopts the header another process has written. Returns the transaction id now visible.
+    #[cfg(feature = "experimental-multiprocess")]
+    fn reload_header(&self, _header: &HeaderGuard<'_>) -> Result<TransactionId> {
+        let header_bytes = self.storage.read_direct(0, DB_HEADER_SIZE)?;
+        let unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes, self.page_size)
+            .map_err(|err| match err {
+                DatabaseError::Storage(err) => err,
+                other => StorageError::Corrupted(other.to_string()),
+            })?;
+        let header = unrepaired.finalize_transaction_slots()?;
+        let mut state = self.state.lock()?;
+        state.header = header;
+
+        Ok(state.header.primary_slot().transaction_id)
     }
 
     pub(crate) fn begin_writable(&self) -> Result {


### PR DESCRIPTION
The third of three pieces cut from this PR's original scope. #1437 (the forced 2-phase commit) and #1438 (the shared reader's open path) are merged, so this is based on master. Stacked above: #1433 (cache invalidation) and #1413.

## What it fixes

A read-only handle of a database another process may be writing took its transaction id from the header it read at open, so a peer's commits were invisible to it -- the gap Codex flagged on #1428.

## What it does

Such a handle reads the header straight from the file on each new transaction, under a shared header hold so a writer's exclusive hold cannot tear it, and adopts it. `latest_committed_transaction_id()` takes the caller's hold and hands it to `reload_header()`, which replaces the in-memory header with the file's. Nothing on a read-only handle consults the layout, so the adopted one is inert there.

## Locking the id it read

Reading the id from the file is what makes the hold's *extent* matter. A writer's reclamation scan holds the header exclusively, so a byte taken under a shared hold is seen by that scan either entirely before it or entirely after it -- but only if the id was chosen under that same hold. Choose it outside, and the scan runs in between, finds no byte for a transaction about to have one, and reclaims exactly the pages that byte was going to protect. #1434 moved the hold to the caller so that can be arranged; `in_process_header_lock` is a plain non-reentrant `Mutex`, so nesting was never an option.

`ReadOnlyDatabase::begin_read()` is serialized by a mutex for the same reason: the id a transaction locks and the root it then reads must come from one state.

## The decisions this isolates

1. **Reload does not re-check the recovery flag.** It relies on the invariant #1438 establishes: a shared reader's primary always names pages that are in the file, since a shared writer's swap follows its flush and a clean or repaired file's primary has been verified. The alternative is refusing reloads while a peer is mid-repair, which makes a read fail transiently.
2. **The per-read cost.** Every read transaction on a shared reader reads the header from the file, and readers in one process serialize briefly on the mutex.
3. **The header-hold ordering has no discriminating test.** The churn test does not reach the window, and a shared-mode reader's backend is not caller-supplied, so there is no seam to force it. It rests on the lock ordering above.

## What is not here

**A writable handle keeps its own header.** Adopting a peer's commits without also reloading the allocator leaves it allocating pages the adopted trees still reference. The allocator reload comes with the writable reload in #1413.

**Cache invalidation** is #1433: a reader that picks up a newer id must also drop the pages it cached under the old one.

## Testing

`a_read_only_participant_picks_up_a_peers_commit`: the id the reader locks is the observable, and the writer is closed before the probe, so the reader has had nothing but the file to learn the new id from. `a_read_only_participant_takes_the_primary_as_recorded` gains its reload half here. Both mutation-checked. The full local check set passes.

The changelog bullet gains the sentence that each new read transaction sees the writer's durable commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9