### PR TITLE
Drop a shared reader's cached pages when a peer commits

### DIFF
--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1145,10 +1145,18 @@ impl TransactionalMemory {
                 other => StorageError::Corrupted(other.to_string()),
             })?;
         let header = unrepaired.finalize_transaction_slots()?;
-        let mut state = self.state.lock()?;
-        state.header = header;
+        let (previous, current) = {
+            let mut state = self.state.lock()?;
+            let previous = state.header.primary_slot().transaction_id;
+            state.header = header;
+            (previous, state.header.primary_slot().transaction_id)
+        };
+        // The peer's commits may have freed and rewritten pages this handle cached
+        if current != previous {
+            self.clear_read_cache();
+        }
 
-        Ok(state.header.primary_slot().transaction_id)
+        Ok(current)
     }
 
     pub(crate) fn begin_writable(&self) -> Result {

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -36,6 +36,33 @@ mod shared_reader {
         table.get(0).unwrap().unwrap().value()
     }
 
+    /// Following a peer's commits means seeing its data, not only its newer id
+    #[test]
+    fn a_shared_reader_sees_a_peers_writes() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let writer = create(tmpfile.path());
+        let reader = shared().open_read_only(tmpfile.path()).unwrap();
+
+        // Caches the page the value lives on
+        assert_eq!(value(&reader), 0);
+
+        // Staleness needs the allocator to recycle the cached page, so churn until it does
+        for expected in 1..60u64 {
+            let write = writer.begin_write().unwrap();
+            {
+                let mut table = write.open_table(TABLE).unwrap();
+                table.insert(0, expected).unwrap();
+            }
+            write.commit().unwrap();
+
+            assert_eq!(
+                value(&reader),
+                expected,
+                "the reader served a cached page after the writer committed {expected}"
+            );
+        }
+    }
+
     /// A shared reader reads pages by the immutable geometry alone, so the region counts, which an
     /// unclean header leaves unvalidated, never reach it
     #[test]


### PR DESCRIPTION
#1432, the per-read reload this builds on, is merged, so this is based on master and the diff is only the invalidation. Stacked above: #1413.

## Why the id is not enough

#1432 lets a shared reader pick up a peer's transaction id and roots. That is not enough to read the data: redb is copy-on-write, so an overwrite lands on a fresh page and no cache can be stale about it -- but the freed page comes back out of the allocator a few commits later holding something else entirely. A reader that cached it then walks the *current* tree through *stale* bytes.

The failure is not a stale value. With the invalidation removed, the test's `table.get(0)` returns `None`: the reader follows a current root into a page it cached three generations ago, and the key it is looking for is not in there.

## The change

A reader that adopts a newer id drops its read cache. The comparison is against the id the handle held before adopting, so this is free where nothing has changed -- the common case, since a reader usually follows a file no one is writing to at that moment.

The state lock is released before the cache is cleared. Anything read after that point comes from the file as it is now, so only what was already cached needs dropping.

A read in flight across the clear belongs to a live transaction, whose pages its pin keeps in place, so what it publishes afterwards is still what the file holds. An earlier revision carried a generation guard against that late insert; it defended only the window that exists while nothing consumes the pins, which #1413 closes, so it is gone.

## Merge order: do not land this far ahead of #1413

Between this merging and #1413 merging, a shared read transaction that outlives a peer's commits has no reclamation floor: reclamation is bounded by `TransactionTracker::oldest_live_read_transaction()`, which is per-handle, and a peer writer consults its own rather than this handle's. That is already true on master -- nothing consumes the active-transaction locks yet, as `db.rs` says at the `active_transaction_test` header -- so this PR does not introduce it. But it does make it easier to hit, because before this clear a small database's pages simply stayed cached and an older reader was protected by accident.

#1413 closes it, with `cross_process_free_floor()` scanning the active-transaction byte range so a writer's `process_freed_pages` stops at the oldest transaction any process is reading. `a_readers_pin_survives_heavy_reclamation` is its test.

## Testing

`shared_reader::a_shared_reader_sees_a_peers_writes` in `tests/multiprocess_tests.rs`: a read-only participant reads a value, caching the page it lives on, then a writer in the cohort overwrites it repeatedly and the reader has to see each new value.

Sixty rounds, and the count is load-bearing: my first version did three, and it **passed with the invalidation disabled**. Copy-on-write meant each new value went to a page the reader had never cached, so nothing was stale. The test only means something once the allocator has recycled what the reader cached, which takes churn.

Mutation-tested. Removing the invalidation fails the test. Making it unconditional does *not* fail it, and should not: the `current != previous` guard is an optimization, not a correctness property -- invalidating on every read transaction would be correct and merely wasteful. I am not claiming coverage for that line.

The full local check set passes: `cargo fmt`, both clippy configurations CI runs under `-Dwarnings`, cross-clippy for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, the `wasm32` variants, both `thumbv7em-none-eabihf` no_std configurations, and `cargo test` in every configuration that runs tests.

No public API changes, so no changelog entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_