### PR TITLE
Read and lock a transaction under one header hold

### DIFF
--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -1,4 +1,6 @@
 use crate::sync::{Condvar, Mutex};
+#[cfg(feature = "experimental-multiprocess")]
+use crate::tree_store::HeaderGuard;
 use crate::tree_store::TransactionalMemory;
 use crate::{Key, Result, Savepoint, TypeName, Value};
 use alloc::collections::BTreeSet;
@@ -105,12 +107,17 @@ impl State {
     // is still reading. Done under the lock that holds the count, so the two cannot disagree: a
     // reference taken between the count reaching zero and the byte being released would otherwise
     // read a snapshot nothing protects
-    fn reference_transaction(&mut self, mem: &TransactionalMemory, id: TransactionId) -> Result {
+    fn reference_transaction(
+        &mut self,
+        mem: &TransactionalMemory,
+        id: TransactionId,
+        #[cfg(feature = "experimental-multiprocess")] header: &HeaderGuard<'_>,
+    ) -> Result {
         let count = self.live_read_transactions.entry(id).or_insert(0);
         *count += 1;
         #[cfg(feature = "experimental-multiprocess")]
         if *count == 1
-            && let Err(err) = mem.lock_mp_transaction(id)
+            && let Err(err) = mem.lock_mp_transaction(id, header)
         {
             self.live_read_transactions.remove(&id);
             return Err(err);
@@ -244,8 +251,15 @@ impl TransactionTracker {
         durable_ancestor: TransactionId,
         has_unprocessed_freed_pages: bool,
     ) -> Result {
+        #[cfg(feature = "experimental-multiprocess")]
+        let header = mem.lock_header_shared()?;
         let mut state = self.state.lock().unwrap();
-        state.reference_transaction(mem, durable_ancestor)?;
+        state.reference_transaction(
+            mem,
+            durable_ancestor,
+            #[cfg(feature = "experimental-multiprocess")]
+            &header,
+        )?;
         assert!(
             state
                 .pending_non_durable_commits
@@ -292,8 +306,15 @@ impl TransactionTracker {
         mem: &TransactionalMemory,
         savepoint: &Savepoint,
     ) -> Result {
+        #[cfg(feature = "experimental-multiprocess")]
+        let header = mem.lock_header_shared()?;
         let mut state = self.state.lock().unwrap();
-        state.reference_transaction(mem, savepoint.get_transaction_id())?;
+        state.reference_transaction(
+            mem,
+            savepoint.get_transaction_id(),
+            #[cfg(feature = "experimental-multiprocess")]
+            &header,
+        )?;
         state
             .valid_savepoints
             .insert(savepoint.get_id(), savepoint.get_transaction_id());
@@ -313,9 +334,16 @@ impl TransactionTracker {
         &self,
         mem: &TransactionalMemory,
     ) -> Result<TransactionId> {
-        let mut state = self.state.lock()?;
+        #[cfg(feature = "experimental-multiprocess")]
+        let header = mem.lock_header_shared()?;
         let id = mem.get_last_committed_transaction_id()?;
-        state.reference_transaction(mem, id)?;
+        let mut state = self.state.lock()?;
+        state.reference_transaction(
+            mem,
+            id,
+            #[cfg(feature = "experimental-multiprocess")]
+            &header,
+        )?;
 
         Ok(id)
     }

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -22,6 +22,8 @@ pub(crate) use btree_cursor_range::BtreeCursorRange;
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, encode_bounds};
 pub(crate) use extract_if::BtreeExtractIf;
 pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multimap_btree_stats};
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) use page_store::HeaderGuard;
 pub(crate) use page_store::LocklessBackend;
 #[cfg(feature = "experimental-multiprocess")]
 pub(crate) use page_store::MultiProcessWriterGuard;

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -23,6 +23,8 @@ pub(crate) use base::{MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNum
 pub(crate) use fast_hash::{PageNumberHashMap, PageNumberHashSet};
 pub(crate) use header::PAGE_SIZE;
 #[cfg(feature = "experimental-multiprocess")]
+pub(crate) use page_manager::HeaderGuard;
+#[cfg(feature = "experimental-multiprocess")]
 pub(crate) use page_manager::MultiProcessWriterGuard;
 pub(crate) use page_manager::{
     AllocationPolicy, FILE_FORMAT_VERSION3, PageAllocator, PageResolver, ShrinkPolicy,

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -515,7 +515,7 @@ pub(crate) const HEADER_LOCK: Range<u64> = 0..DB_HEADER_SIZE as u64;
 
 /// A hold on the header lock, released when it drops.
 #[cfg(feature = "experimental-multiprocess")]
-struct HeaderGuard<'a> {
+pub(crate) struct HeaderGuard<'a> {
     storage: Option<&'a PagedCachedFile>,
     _in_process: crate::sync::MutexGuard<'a, ()>,
 }
@@ -723,28 +723,36 @@ impl TransactionalMemory {
         }
     }
 
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn lock_header_shared(&self) -> Result<HeaderGuard<'_>> {
+        Self::lock_header(
+            &self.storage,
+            &self.in_process_header_lock,
+            self.concurrency_mode,
+            false,
+        )
+    }
+
     /// Marks `id` active, keeping the pages its snapshot references from being reclaimed by any
-    /// process until [`Self::unlock_mp_transaction`]. The shared header hold orders this against
-    /// a writer's reclamation scan, which holds it exclusively: the scan either sees this lock
-    /// or ran entirely before it.
+    /// process until [`Self::unlock_mp_transaction`]. The caller's shared header hold orders this
+    /// against a writer's reclamation scan, which holds it exclusively: the scan either sees this
+    /// lock or ran entirely before `id` was read, so the hold must cover that read too.
     ///
     /// Caller must not attempt to re-lock an already locked transaction.
     ///
     /// The caller must guarantee that `id` cannot already have been collected.
     #[cfg(feature = "experimental-multiprocess")]
-    pub(crate) fn lock_mp_transaction(&self, id: TransactionId) -> Result {
+    pub(crate) fn lock_mp_transaction(
+        &self,
+        id: TransactionId,
+        _header: &HeaderGuard<'_>,
+    ) -> Result {
         // Nothing to publish to: a single-process writers lock the whole file
         if !self.concurrency_mode.is_multi_process_writable() {
             return Ok(());
         }
         let byte = Self::active_transaction_byte(id)?;
-        let _guard = Self::lock_header(
-            &self.storage,
-            &self.in_process_header_lock,
-            self.concurrency_mode,
-            false,
-        )?;
-        // Refused only by an exclusive holder, which the shared header hold excludes
+        // Refused only by an exclusive holder, which the caller's shared header hold excludes
         if !self.storage.try_lock_shared_range(byte_range(byte))? {
             return Err(StorageError::Corrupted(
                 "another process holds an active transaction byte exclusively".to_string(),


### PR DESCRIPTION
The refactoring you asked for on #1432, split out to land first.

## The invariant

The active transaction byte only means something if the transaction it names was chosen under the same header hold that takes it. A writer's reclamation scan holds the header exclusively, so a byte taken under a shared hold is seen by that scan either entirely before it or entirely after it. An id settled on *outside* the hold gives the scan a window: it runs in between, finds no byte for a transaction that is about to have one, and reclaims exactly the pages the byte was going to protect.

`lock_mp_transaction()` took its own hold, which begins one call too late — after the caller has already chosen the id.

## The change

`lock_mp_transaction()` now takes a `&HeaderGuard` instead of acquiring one, so reading the id under that same hold is the caller's job. That is the part worth having: the invariant used to live in a doc comment, and now there is no way to reach the byte without producing a hold to pass. The hold comes from `lock_header_shared()`, the first caller outside `page_manager` to need one.

Every reference to a transaction now takes a hold, not only a read transaction's. A persistent savepoint's and a non-durable commit's durable ancestor's go through the same `reference_transaction()`, and giving one of them a hold but not the others would leave the header lock and the tracker's state lock taken in one order here and the other order there. So all three take the hold before the state lock — the single order this establishes, and the reverse of the old one, where the state lock came first and the hold appeared underneath it inside `lock_mp_transaction()`.

## No behavior change

This handle's committed transaction id comes from its own memory, which nothing else moves, so choosing it inside the hold rather than outside cannot pick a different one. The window this closes is not reachable on master.

What it is for is the reader that follows another process's commits — which reads the id from the *file*, where a peer's writer can move it. That is #1432, and this is its prerequisite, landed separately so the window never exists in a released state.

## Testing

No new test, and I would rather say why than add one that looks like coverage.

On master this is behaviour-preserving by construction, so nothing can distinguish it: the id is read from memory either way, and an exclusive header holder blocked `begin_read` before this change too, since `lock_mp_transaction()` took a hold of its own. A test that discriminates needs the id to come from the file, which is #1432's change and belongs there.

What does hold the invariant is the signature. `lock_mp_transaction()` cannot be called without a `&HeaderGuard`, so a future caller cannot reacquire the id outside the hold without the borrow checker asking where the guard came from. That check is compile-time and permanent, which a test would not be.

The evidence that it is behaviour-preserving is the suite passing unchanged: `cargo fmt`, both clippy configurations CI runs under `-Dwarnings`, cross-clippy for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, the `wasm32` variants, both `thumbv7em-none-eabihf` no_std configurations, `cargo build --release`, and `cargo test` in every configuration that runs tests. Also under wine for `x86_64-pc-windows-gnu`.

No public API changes, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_