### PR TITLE
Add the consistent byte

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -541,7 +541,8 @@ The multi-process concurrency modes rely on file range locks and define the foll
 | `BASE + 1`              | shared writer byte                 |
 | `BASE + 2`              | shared reader byte                 |
 | `BASE + 3`              | immutable byte                     |
-| `BASE + 4..BASE + 1024` | reserved                           |
+| `BASE + 4`              | consistent byte                    |
+| `BASE + 5..BASE + 1024` | reserved                           |
 | `BASE + 1024`           | active transaction base (TXN_BASE) |
 | `TXN_BASE..2^63`        | active transaction range           |
 
@@ -566,6 +567,17 @@ prevents a non-multi-process writer from opening the database.
 Processes hold a shared lock on this byte when the database is open in Immutable mode.
 After locking this byte, they must check if the "shared writer byte" is locked -- which would
 indicate an idle writer (if the "writer byte" is unlocked).
+
+### "consistent byte"
+
+Writing processes hold a shared lock on this byte from the point their open is complete --
+recovery has run and the allocator state is loaded -- until they close.
+
+The recovery flag in the header means "unrepaired" before a writer's recovery runs and "a writer
+is live" after it.
+If the "shared writer lock" is held, readers should consult this byte to determine if the database
+is consistent and a writer is live. Otherwise, they may consult the recovery required bit in the
+database header.
 
 ## Header synchronization
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -99,6 +99,12 @@ pub(crate) const SHARED_WRITER_BYTE: u64 = LOCK_BASE + 1;
 pub(crate) const SHARED_READER_BYTE: u64 = LOCK_BASE + 2;
 #[cfg(feature = "experimental-multiprocess")]
 pub(crate) const IMMUTABLE_READER_BYTE: u64 = LOCK_BASE + 3;
+/// Held shared by a writing process from the moment its open is complete -- past recovery and
+/// the allocator load -- until it closes: the file is consistent, and the recovery flag, set from
+/// here on, means only that a writer is live. `SHARED_WRITER_BYTE` is taken before recovery, so
+/// it cannot say that; this byte can.
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) const CONSISTENT_BYTE: u64 = LOCK_BASE + 4;
 /// Base of the "active transaction range": a handle reading transaction `t` holds `TXN_BASE + t`
 /// shared for as long as it is reading it
 #[cfg(feature = "experimental-multiprocess")]
@@ -1340,6 +1346,9 @@ impl Database {
         }
 
         mem.begin_writable()?;
+        // Past recovery, so a reader finding this byte held knows the flag means a live writer
+        #[cfg(feature = "experimental-multiprocess")]
+        mem.mark_consistent()?;
         let next_transaction_id = mem.get_last_committed_transaction_id()?.next();
 
         let db = Database {
@@ -2295,6 +2304,161 @@ mod writer_byte_test {
             "the byte was still held after the database closed"
         );
         probe.unlock_range(byte_range(WRITER_BYTE)).unwrap();
+    }
+}
+
+/// The consistent byte, probed directly: a byte-range lock is invisible through the public API.
+#[cfg(all(
+    test,
+    feature = "experimental-multiprocess",
+    any(target_os = "linux", target_vendor = "apple", windows)
+))]
+mod consistent_byte_test {
+    use super::{CONSISTENT_BYTE, ConcurrencyMode, Database, byte_range};
+    use crate::backends::FileBackend;
+    use crate::tree_store::file_backend::range_lock::RangeLock;
+    use crate::{StorageBackend, TableDefinition};
+    use std::fs::{File, OpenOptions};
+    use std::path::Path;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+    fn builder(mode: ConcurrencyMode) -> crate::Builder {
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(mode);
+        builder
+    }
+
+    /// A separate description, so its locks conflict with the database's exactly as another
+    /// process's would
+    fn probe(path: &Path) -> File {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap()
+    }
+
+    /// True when some writer asserts the database is consistent
+    fn held(probe: &File) -> bool {
+        let taken = probe.try_lock_range(byte_range(CONSISTENT_BYTE)).unwrap();
+        if taken {
+            probe.unlock_range(byte_range(CONSISTENT_BYTE)).unwrap();
+        }
+        !taken
+    }
+
+    /// Power loss: once armed, every write silently does nothing, so the close writes neither
+    /// the allocator record nor the clean-shutdown header
+    #[derive(Debug)]
+    struct CrashBackend {
+        inner: FileBackend,
+        dead: Arc<AtomicBool>,
+    }
+
+    impl StorageBackend for CrashBackend {
+        fn len(&self) -> Result<u64, std::io::Error> {
+            self.inner.len()
+        }
+        fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
+            self.inner.read(offset, out)
+        }
+        fn set_len(&self, len: u64) -> Result<(), std::io::Error> {
+            if self.dead.load(Ordering::SeqCst) {
+                return Ok(());
+            }
+            self.inner.set_len(len)
+        }
+        fn sync_data(&self) -> Result<(), std::io::Error> {
+            if self.dead.load(Ordering::SeqCst) {
+                return Ok(());
+            }
+            self.inner.sync_data()
+        }
+        fn write(&self, offset: u64, data: &[u8]) -> Result<(), std::io::Error> {
+            if self.dead.load(Ordering::SeqCst) {
+                return Ok(());
+            }
+            self.inner.write(offset, data)
+        }
+    }
+
+    /// Leaves the file as a crashed writer would: a committed transaction, no allocator record
+    /// and the recovery flag still set, so the next open has to repair it. Built through a
+    /// caller-supplied backend, which takes no locks, so nothing of this handle outlives it.
+    fn dirty(path: &Path) {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+        let dead = Arc::new(AtomicBool::new(false));
+        let db = Database::builder()
+            .create_with_backend(CrashBackend {
+                inner: FileBackend::new(file).unwrap(),
+                dead: Arc::clone(&dead),
+            })
+            .unwrap();
+        let write = db.begin_write().unwrap();
+        {
+            let mut table = write.open_table(TABLE).unwrap();
+            table.insert(0, 0).unwrap();
+        }
+        write.commit().unwrap();
+        // Nothing this handle does from here on reaches the file, its close included
+        dead.store(true, Ordering::SeqCst);
+        drop(db);
+    }
+
+    #[test]
+    fn a_shared_writable_open_asserts_consistency_until_it_closes() {
+        for mode in [
+            ConcurrencyMode::SingleWriterProcess,
+            ConcurrencyMode::MultiWriterProcess,
+        ] {
+            let tmpfile = crate::create_tempfile();
+            let db = builder(mode).create(tmpfile.path()).unwrap();
+            let probe = probe(tmpfile.path());
+            assert!(held(&probe), "{mode:?} open did not take the byte");
+
+            drop(db);
+            assert!(!held(&probe), "{mode:?} close did not release the byte");
+        }
+    }
+
+    /// The byte's whole purpose. `SHARED_WRITER_BYTE` is taken before recovery runs, so during a
+    /// repair it says a writer is here while the file is still the one the last writer left. This
+    /// byte is taken after, so it says nothing until the file is consistent.
+    #[test]
+    fn a_repairing_open_asserts_consistency_only_once_the_repair_is_done() {
+        let tmpfile = crate::create_tempfile();
+        dirty(tmpfile.path());
+
+        let probe = Arc::new(Mutex::new(probe(tmpfile.path())));
+        let during: Arc<Mutex<Option<bool>>> = Arc::new(Mutex::new(None));
+
+        let db = {
+            let probe = probe.clone();
+            let during = during.clone();
+            let mut builder = builder(ConcurrencyMode::MultiWriterProcess);
+            builder.set_repair_callback(move |_| {
+                let mut during = during.lock().unwrap();
+                if during.is_none() {
+                    *during = Some(held(&probe.lock().unwrap()));
+                }
+            });
+            builder.open(tmpfile.path()).unwrap()
+        };
+
+        assert_eq!(
+            during.lock().unwrap().take(),
+            Some(false),
+            "the byte was held while the open was still repairing"
+        );
+        assert!(held(&probe.lock().unwrap()), "the open never took the byte");
+        drop(db);
     }
 }
 

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1,9 +1,11 @@
 use crate::CacheStats;
+#[cfg(feature = "experimental-multiprocess")]
+use crate::db::{
+    CONSISTENT_BYTE, IMMUTABLE_READER_BYTE, SHARED_READER_BYTE, TXN_BASE, WRITER_BYTE,
+};
 use crate::db::{
     ConcurrencyMode, FULL_RANGE, InternalStorageBackend, SHARED_WRITER_BYTE, byte_range,
 };
-#[cfg(feature = "experimental-multiprocess")]
-use crate::db::{IMMUTABLE_READER_BYTE, SHARED_READER_BYTE, TXN_BASE, WRITER_BYTE};
 use crate::io;
 use crate::sync::Mutex;
 use crate::transaction_tracker::TransactionId;
@@ -1975,6 +1977,18 @@ impl TransactionalMemory {
 
     pub(crate) fn get_page_size(&self) -> usize {
         self.page_size.try_into().unwrap()
+    }
+
+    /// Asserts that the file is consistent and this handle a live writer: see `CONSISTENT_BYTE`.
+    /// Shared, since a multi-writer cohort has several, and released with every other range by
+    /// `close()`.
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn mark_consistent(&self) -> Result {
+        if self.concurrency_mode.is_multi_process_writable() {
+            self.storage
+                .lock_shared_range(byte_range(CONSISTENT_BYTE))?;
+        }
+        Ok(())
     }
 
     pub(crate) fn close(&self) -> Result {


### PR DESCRIPTION
Prep for #1432, the way #1434 went: the mechanism lands first, so the window it closes never exists in merged history. Nothing consumes the byte here.

## The problem

`recovery_required` means **two different things** at two points of a writable open, and a shared reader cannot tell which one it is looking at.

```
TransactionalMemory::new()      <- takes SHARED_WRITER_BYTE.
                                   Flag set = the last writer crashed. UNREPAIRED.
do_repair()                     <- may swap_primary_slot(), rebuilding from the roots
mem.clear_recovery_required()
mem.begin_writable()            <- sets the flag again.
                                   Flag set = a writer is live. HEALTHY.
```

The bypass a shared reader needs exists entirely for the second meaning: a healthy writer leaves the flag set for its whole life, so a read-only open cannot simply refuse an unclean file. #1432 therefore has it consult a byte:

```rust
if unrepaired.truncated(file_len) || (unrepaired.unclean() && !consistent) {
    return Err(DatabaseError::RepairAborted);
}
```

But `SHARED_WRITER_BYTE` is taken *before* `do_repair()`. So in the window between those two lines the flag has its first meaning while the byte already says "a writer is here", and the reader admits itself to a database that is mid-repair.

## What that costs, measured rather than argued

I built the interleaving deterministically instead of reasoning about it, using the repair callback as the seam -- it fires inside `do_repair()`, which is exactly the window. The file is a plain single-process database with two 1-phase generations (all keys `111`, then all keys `222`), cut short by a backend that stops writing partway through publishing the second, then reopened in `MultiWriterProcess`.

`writes` is how many writes of that second commit reached the file before the machine died:

```
writes=  0  plain=[{111}]  plain_ro=[REFUSED]  shared reader during repair=[{111}]        after=[{111}]
writes=  1  plain=[{111}]  plain_ro=[REFUSED]  shared reader during repair=[PANIC]        after=[{111}]
writes=  2  plain=[{111}]  plain_ro=[REFUSED]  shared reader during repair=[PANIC]        after=[{111}]
writes=  3  plain=[{111}]  plain_ro=[REFUSED]  shared reader during repair=[PANIC]        after=[{111}]
writes=  4  plain=[{111}]  plain_ro=[REFUSED]  shared reader during repair=[PANIC]        after=[{111}]
writes=  5  plain=[{222}]  plain_ro=[REFUSED]  shared reader during repair=[{222}]        after=[{222}]
```

The band that matters is `writes=1..4`: the header for the second commit landed but some of its pages did not, so the primary does not verify and `repair_primary_corrupted()` rolls back to `111`. There:

* **`plain`** -- an ordinary read-write reopen -- repairs correctly and reads `111`. The recovery path is fine; this PR does not touch it.
* **`plain_ro`** -- an ordinary read-only open, no shared mode, no writer present -- is **refused** with `RepairAborted`. It will not touch an unrepaired file, which is correct.
* **the shared reader**, admitted because the byte is held, **panics**:

```
internal error: entered unreachable code
  src/tree_store/btree.rs:1112
```

That is the `_ => unreachable!()` arm of the page-type match during a btree descent. The reader followed the doomed primary into a page that was never written, so the page-type byte is neither `LEAF` nor `BRANCH`. It is not a spurious `Corrupted` error -- it takes down the reading process.

Two things worth separating out. The `unreachable!()` is reachable only because something walks an unrepaired tree, which nothing does today; it is a robustness question of its own and I have not touched it here. And `writes>=5` shows the milder shape of the same window: the reader binds to a transaction that happens to survive, so it sees the right data by luck rather than by the protocol.

I checked this rather than trusting the description because the last time I filed a window of this shape (#1435) it turned out crash recovery already covered it, and I closed the PR.

## The byte

`CONSISTENT_BYTE`, at `BASE + 4`. It names a state of the file, not an intent of the writer's: past recovery the database is consistent, and the recovery flag means only that a writer is live. A writing process takes it **shared** -- a multi-writer cohort has several writers asserting it -- once its open is complete, past recovery and the allocator load, and holds it until close:

```rust
mem.begin_writable()?;
#[cfg(feature = "experimental-multiprocess")]
mem.mark_consistent()?;
```

| flag | consistent byte | means | shared read |
|---|---|---|---|
| set | held | a live writer owns the file | share it |
| set | free | unrepaired, or a writer still repairing | refuse |
| clear | either | clean file | share it |

A reader hitting the middle row during someone's repair is refused transiently and succeeds on retry, which is correct: the file genuinely is not readable yet.

Release needs no code. `FileBackend::close()` already unlocks `FULL_RANGE`, which covers this byte along with every other range the description holds, and it runs after the shutdown header is written -- so a reader never sees a writer stop announcing itself while it is still writing. That path has its own test (`close_releases_while_the_backend_is_still_alive`), whose rationale is this exact case: a read transaction outliving the database keeps the backend, and so the file, alive past the close. I had written an explicit unlock and removed it once I found that; a mutation test is what showed it was doing nothing.

I considered the alternatives and they are worse. Probing `WRITER_BYTE` cannot distinguish "mid-open" from "mid-transaction", so it would refuse or block on every ordinary write. Verifying the primary in the reader is a full tree scan per open. Waiting on the existing byte serializes every shared open behind the current write transaction.

## Also settles the close side

`take_sole_writer_for_close()` in #1413 claims `SHARED_WRITER_BYTE` exclusively across the allocator commit and the shutdown flush, which a compatible multi-writer opener cannot distinguish from a `SingleWriterProcess` handle's lifetime hold -- so it is refused with `DatabaseAlreadyOpen` instead of waiting out a close. It cannot simply block on the byte, because the other thing holding it exclusively is the case that genuinely must be refused. Once a closing handle drops the consistent byte before taking that claim, an opener that finds the mode byte busy and the consistent byte free knows it is looking at an open or a close and can wait; one that finds the consistent byte held knows to refuse. Same distinction, so one byte rather than two. That change belongs with #1413, where the close path lives.

## Testing

`consistent_byte_test` in `src/db.rs`, probing the byte directly on a second file description, the way `writer_byte_test` does -- a byte-range lock is invisible through the public API.

* `a_shared_writable_open_asserts_consistency_until_it_closes` -- held after a `SingleWriterProcess` and a `MultiWriterProcess` open, free after each closes.
* `a_repairing_open_asserts_consistency_only_once_the_repair_is_done` -- the point of the byte. A crashed database, reopened with a repair callback that probes from inside `do_repair()`: free there, held once the open returns.

Mutation-tested. Moving `mark_consistent()` above the repair branch fails the second test. There is no test for a `SingleProcess` open not taking the byte, and there cannot be a useful one: that mode holds a whole-file lock, so a probe conflicts with it whatever this byte does.

`cargo fmt`, both clippy configurations CI runs under `-Dwarnings`, cross-clippy for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, the three `wasm32` variants, both `thumbv7em-none-eabihf` no_std configurations, and `cargo test --all` in both feature configurations -- all pass.

No public API change and no behavior change for anything that exists today, so no changelog entry; the user-visible effect arrives with the reader in #1432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9