### PR TITLE
Force 2-phase commits when the file is shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   alone, rather than also with the whole-file lock earlier versions take.
 * Add the `experimental-multiprocess` feature flag, under which `Builder::set_concurrency_mode()`
   takes a `ConcurrencyMode` configuring how processes may share the database.
+  When `SingleWriterProcess` or `MultiWriterProcess` is configured, commits are always 2-phase.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/db.rs
+++ b/src/db.rs
@@ -2693,6 +2693,26 @@ mod active_transaction_test {
         );
     }
 
+    /// Sharing the file forces 2-phase, whatever the transaction asked for
+    #[test]
+    fn a_shared_commit_is_two_phase() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+
+        let mut write = db.begin_write().unwrap();
+        write.set_two_phase_commit(false);
+        {
+            let mut table = write.open_table(TABLE).unwrap();
+            table.insert(1, 1).unwrap();
+        }
+        write.commit().unwrap();
+
+        assert!(
+            db.mem.used_two_phase_commit(),
+            "a shared commit published without the flush between the header writes"
+        );
+    }
+
     /// A single-process open holds the whole file, which covers these bytes. Locking one and
     /// releasing it would punch a hole in that lock, so this mode locks nothing
     #[test]

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1513,6 +1513,11 @@ impl WriteTransaction {
     /// database process to crash, can cause the database to crash with the god byte primary bit
     /// pointing to an invalid commit slot, leaving the database in an invalid, potentially attacker-
     /// controlled state.
+    #[cfg_attr(
+        feature = "experimental-multiprocess",
+        doc = "",
+        doc = "Disabling it has no effect in the multi-process concurrency modes, which always commit in 2 phases. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
+    )]
     pub fn set_two_phase_commit(&mut self, enabled: bool) {
         self.two_phase_commit = enabled;
     }
@@ -1702,6 +1707,13 @@ impl WriteTransaction {
     fn commit_inner_helper(&mut self) -> Result<(), CommitError> {
         // Quick-repair requires 2-phase commit
         if self.quick_repair {
+            self.two_phase_commit = true;
+        }
+        // Multi-process modes with a writer require 2-phase commit: a 1-phase commit publishes the
+        // secondary slot before flushing the pages it names, which a reader in another process
+        // would then follow
+        #[cfg(feature = "experimental-multiprocess")]
+        if self.mem.concurrency_mode().is_multi_process_writable() {
             self.two_phase_commit = true;
         }
 

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1067,6 +1067,12 @@ impl TransactionalMemory {
         self.storage.flush()
     }
 
+    /// Whether another process may have this database open while one process writes.
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn concurrency_mode(&self) -> ConcurrencyMode {
+        self.concurrency_mode
+    }
+
     pub(crate) fn used_two_phase_commit(&self) -> bool {
         self.state.lock().unwrap().header.two_phase_commit
     }


### PR DESCRIPTION
The first of three pieces cut from #1432, which was carrying too many decisions for one review. This is the writer-side rule the other two rest on.

## What it does

A transaction on a database in one of the multi-process concurrency modes commits in 2 phases whatever it asked for. `commit_inner_helper()` forces it whenever the file is shared, alongside the existing quick-repair case, and `set_two_phase_commit()` documents that disabling it has no effect in these modes.

## Why

A 1-phase commit calls `write_header()` before the flush, so the file's header names a transaction whose pages are still buffered. Nothing can observe that gap while one process holds the file, but a reader in another process can: it would follow the new slot into pages the file does not hold yet. Forcing 2-phase means a slot is only ever published after its pages are durable, which is what lets the shared reader in #1438 take the primary slot as recorded.

## The decision this isolates

A transaction that asked for 1-phase is silently upgraded, and the doc says so. The alternative is refusing the request with an error. I recommend the silent upgrade: nothing about the transaction's contents changes, only the flush between the two header writes, and a caller opting out of 2-phase on a shared file is asking for something the mode cannot honour.

## Testing

`a_shared_commit_is_two_phase` opts out on a multi-writer database and checks that the commit still went through 2 phases. The full local check set passes: fmt, both clippy configurations under `-Dwarnings`, cross-clippy for Windows and macOS, the `wasm32` variants, both no_std configurations, docs, and `cargo test --all --all-features`.

Nothing shares the file yet, so there is no user-visible change until the next piece. Stacked above: #1438 (the shared reader's open path), then #1432 (the per-read reload), then #1433 and #1413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9