### PR TITLE
Let a read-only handle open a database another process is writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@
   alone, rather than also with the whole-file lock earlier versions take.
 * Add the `experimental-multiprocess` feature flag, under which `Builder::set_concurrency_mode()`
   takes a `ConcurrencyMode` configuring how processes may share the database.
-  When `SingleWriterProcess` or `MultiWriterProcess` is configured, commits are always 2-phase, and
-  `Durability::None` is refused.
+  When `SingleWriterProcess` or `MultiWriterProcess` is configured, commits are always 2-phase,
+  `Durability::None` is refused, and the database may be opened read-only while another process has
+  it open for writing.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/db.rs
+++ b/src/db.rs
@@ -533,6 +533,11 @@ pub trait ReadableDatabase: SealedInApi5 {
 ///
 /// Multiple processes may open a [`ReadOnlyDatabase`], but it may not be opened concurrently
 /// with a [`Database`].
+#[cfg_attr(
+    feature = "experimental-multiprocess",
+    doc = "",
+    doc = "The multi-process concurrency modes are the exception: a reader shares the file with the writer. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
+)]
 ///
 /// # Examples
 ///
@@ -620,17 +625,24 @@ impl ReadOnlyDatabase {
             concurrency_mode,
         )?;
         let mem = Arc::new(mem);
-        // If the last transaction used 2-phase commit and updated the allocator state table, then
-        // we can just load the allocator state from there. Otherwise, we need a full repair
-        if let Some(tree) = Database::get_allocator_state_table(&mem)? {
-            mem.load_allocator_state(&tree)?;
-        } else {
-            #[cfg(feature = "logging")]
-            warn!(
-                "Database {:?} not shutdown cleanly. Repair required",
-                &file_path
-            );
-            return Err(DatabaseError::RepairAborted);
+        // A reader beside a multi-process writer never allocates, so it loads no allocator state
+        #[cfg(feature = "experimental-multiprocess")]
+        let multiprocess_writer = concurrency_mode.is_multi_process_writable();
+        #[cfg(not(feature = "experimental-multiprocess"))]
+        let multiprocess_writer = false;
+        if !multiprocess_writer {
+            // If the last transaction used 2-phase commit and updated the allocator state table, then
+            // we can just load the allocator state from there. Otherwise, we need a full repair
+            if let Some(tree) = Database::get_allocator_state_table(&mem)? {
+                mem.load_allocator_state(&tree)?;
+            } else {
+                #[cfg(feature = "logging")]
+                warn!(
+                    "Database {:?} not shutdown cleanly. Repair required",
+                    &file_path
+                );
+                return Err(DatabaseError::RepairAborted);
+            }
         }
 
         let next_transaction_id = mem.get_last_committed_transaction_id()?.next();
@@ -1728,6 +1740,11 @@ impl Builder {
     /// If the file has been opened for writing (i.e. as a [`Database`]) [`DatabaseError::DatabaseAlreadyOpen`]
     /// will be returned on platforms which support file locks (macOS, Windows, Linux). On other platforms,
     /// the caller MUST avoid calling this method when the database is open for writing.
+    #[cfg_attr(
+        feature = "experimental-multiprocess",
+        doc = "",
+        doc = "Only a single-process writer is refused: in the multi-process concurrency modes a reader opened in the same mode as the writer shares the file with it. See [`Self::set_concurrency_mode`]."
+    )]
     #[cfg(not(redb_no_std))]
     pub fn open_read_only(
         &self,
@@ -2477,8 +2494,8 @@ mod active_transaction_test {
     use std::path::Path;
 
     const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
-    // The ids a freshly created database can have committed
-    const SEARCHED: std::ops::Range<u64> = 0..8;
+    // The ids a freshly created database can have committed, with room for a few more commits
+    const SEARCHED: std::ops::Range<u64> = 0..16;
 
     fn create(path: &Path, mode: ConcurrencyMode) -> Database {
         let mut builder = Database::builder();
@@ -2673,6 +2690,66 @@ mod active_transaction_test {
         ));
     }
 
+    /// A read-only participant takes the primary as recorded: choosing between the slots is a
+    /// repairing writer's job, and a newer secondary it can see is a commit whose pages are not in
+    /// the file yet, or one a repair has just rolled back
+    #[test]
+    fn a_read_only_participant_takes_the_primary_as_recorded() {
+        use std::io::{Read, Write};
+
+        let tmpfile = crate::create_tempfile();
+        drop(create(tmpfile.path(), ConcurrencyMode::SingleProcess));
+
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+
+        // A newer commit whose pages this file never received: made in a copy, then its slot
+        // spliced into this file's secondary slot
+        let copy = crate::create_tempfile();
+        std::fs::copy(tmpfile.path(), copy.path()).unwrap();
+        let db = Database::open(copy.path()).unwrap();
+        let write = db.begin_write().unwrap();
+        {
+            let mut table = write.open_table(TABLE).unwrap();
+            table.insert(0, 1).unwrap();
+        }
+        write.commit().unwrap();
+        drop(db);
+
+        let header = |path: &Path| -> Vec<u8> {
+            let mut header = vec![0u8; 320];
+            File::open(path).unwrap().read_exact(&mut header).unwrap();
+            header
+        };
+        let slot = |index: usize| 64 + index * 128..64 + (index + 1) * 128;
+        let id = |header: &[u8], index: usize| {
+            u64::from_le_bytes(header[slot(index)][104..112].try_into().unwrap())
+        };
+        let newer = header(copy.path());
+        let mut spliced = header(tmpfile.path());
+        let primary = usize::from(spliced[9] & 1);
+        spliced[slot(1 - primary)].copy_from_slice(&newer[slot(usize::from(newer[9] & 1))]);
+        // The god byte a repair leaves on a 1-phase history: recovery clear, 2-phase clear
+        spliced[9] &= !6;
+        OpenOptions::new()
+            .write(true)
+            .open(tmpfile.path())
+            .unwrap()
+            .write_all(&spliced)
+            .unwrap();
+        assert!(id(&spliced, 1 - primary) > id(&spliced, primary));
+        let probe = probe(tmpfile.path());
+
+        let opened = builder.open_read_only(tmpfile.path()).unwrap();
+        let read = opened.begin_read().unwrap();
+        assert_eq!(
+            held_ids(&probe),
+            vec![id(&spliced, primary)],
+            "the reader adopted a slot whose pages the file never received"
+        );
+        drop(read);
+    }
+
     /// Sharing the file forces 2-phase, whatever the transaction asked for
     #[test]
     fn a_shared_commit_is_two_phase() {
@@ -2691,6 +2768,37 @@ mod active_transaction_test {
             db.mem.used_two_phase_commit(),
             "a shared commit published without the flush between the header writes"
         );
+    }
+
+    /// With no writer holding the file, an unclean one is refused: nothing is coming to repair it
+    #[test]
+    fn a_shared_read_refuses_an_unclean_file_with_no_writer() {
+        use std::io::{Read, Seek, SeekFrom, Write};
+
+        let tmpfile = crate::create_tempfile();
+        drop(create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess));
+
+        // The god byte's recovery-required bit, which a clean shutdown clears
+        {
+            let mut file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(tmpfile.path())
+                .unwrap();
+            let mut byte = [0u8; 1];
+            file.seek(SeekFrom::Start(9)).unwrap();
+            file.read_exact(&mut byte).unwrap();
+            byte[0] |= 2;
+            file.seek(SeekFrom::Start(9)).unwrap();
+            file.write_all(&byte).unwrap();
+        }
+
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        assert!(matches!(
+            builder.open_read_only(tmpfile.path()),
+            Err(crate::DatabaseError::RepairAborted)
+        ));
     }
 
     /// A single-process open holds the whole file, which covers these bytes. Locking one and

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -213,6 +213,12 @@ impl UnrepairedDatabaseHeader {
         self.inner.recovery_required || self.inner.layout().len() != file_len
     }
 
+    // The last writer did not shut down cleanly
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(super) fn unclean(&self) -> bool {
+        self.inner.recovery_required
+    }
+
     // Consume self, reconcile the layout against the actual file length, and select a primary slot
     // (repairing if necessary). Returns the usable DatabaseHeader along with a `clean` flag that is
     // true only when nothing had to be reconciled: the primary was kept and the stored layout
@@ -333,6 +339,19 @@ impl UnrepairedDatabaseHeader {
         }
 
         Ok(true)
+    }
+
+    // Keeps the primary as recorded. Choosing between the slots is a repairing writer's job: a
+    // newer secondary is a commit whose pages may not be in the file yet, or one a repair has
+    // rolled back.
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(super) fn finalize_transaction_slots(self) -> Result<DatabaseHeader> {
+        if self.primary_corrupted {
+            return Err(StorageError::Corrupted(
+                "Primary commit slot is corrupted".to_string(),
+            ));
+        }
+        Ok(self.inner)
     }
 }
 

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -700,7 +700,7 @@ impl TransactionalMemory {
     }
 
     /// Reads the header, reconciling the layout against the file's length and writing back a
-    /// repair if one was needed.
+    /// repair if one was needed. A shared reader does neither: see `read_shared_header()`.
     fn read_header(
         storage: &PagedCachedFile,
         #[cfg(feature = "experimental-multiprocess")] in_process_header_lock: &Mutex<()>,
@@ -708,6 +708,15 @@ impl TransactionalMemory {
         page_size: usize,
         read_only: bool,
     ) -> Result<DatabaseHeader, DatabaseError> {
+        #[cfg(feature = "experimental-multiprocess")]
+        if read_only && concurrency_mode.is_multi_process_writable() {
+            return Self::read_shared_header(
+                storage,
+                in_process_header_lock,
+                concurrency_mode,
+                page_size,
+            );
+        }
         let header_bytes = {
             #[cfg(feature = "experimental-multiprocess")]
             let _guard =
@@ -735,6 +744,34 @@ impl TransactionalMemory {
         assert_eq!(header.layout().len(), storage.raw_file_len()?);
 
         Ok(header)
+    }
+
+    /// Reads the header for a shared reader. It consults neither the layout nor the file's length:
+    /// it never allocates, and reads pages by the immutable geometry alone. A writer publishes the
+    /// recovery flag under its exclusive hold, and holds `CONSISTENT_BYTE` only while that flag
+    /// means a live writer.
+    #[cfg(feature = "experimental-multiprocess")]
+    fn read_shared_header(
+        storage: &PagedCachedFile,
+        in_process_header_lock: &Mutex<()>,
+        concurrency_mode: ConcurrencyMode,
+        page_size: usize,
+    ) -> Result<DatabaseHeader, DatabaseError> {
+        let (header_bytes, consistent) = {
+            let _guard =
+                Self::lock_header(storage, in_process_header_lock, concurrency_mode, false)?;
+            (
+                storage.read_direct(0, DB_HEADER_SIZE)?,
+                storage.query_lock_range(byte_range(CONSISTENT_BYTE))?,
+            )
+        };
+        let unrepaired =
+            UnrepairedDatabaseHeader::from_bytes(&header_bytes, page_size.try_into().unwrap())?;
+        // An unclean file is a live writer's to repair, if there is one
+        if unrepaired.unclean() && !consistent {
+            return Err(DatabaseError::RepairAborted);
+        }
+        Ok(unrepaired.finalize_transaction_slots()?)
     }
 
     /// Acquire the multi-process writer lock

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -4,6 +4,161 @@ use redb::backends::InMemoryBackend;
 use redb::{ConcurrencyMode, Database, DatabaseError, StorageError};
 
 #[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+mod shared_reader {
+    use super::*;
+    use redb::{ReadableDatabase, ReadableTable, TableDefinition};
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+    fn shared() -> redb::Builder {
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder
+    }
+
+    fn create(path: &Path) -> Database {
+        let db = shared().create(path).unwrap();
+        let write = db.begin_write().unwrap();
+        {
+            let mut table = write.open_table(TABLE).unwrap();
+            table.insert(0, 0).unwrap();
+        }
+        write.commit().unwrap();
+        db
+    }
+
+    fn value(db: &impl ReadableDatabase) -> u64 {
+        let read = db.begin_read().unwrap();
+        let table = read.open_table(TABLE).unwrap();
+        table.get(0).unwrap().unwrap().value()
+    }
+
+    /// A shared reader reads pages by the immutable geometry alone, so the region counts, which an
+    /// unclean header leaves unvalidated, never reach it
+    #[test]
+    fn a_shared_reader_ignores_the_layout() {
+        use std::io::{Seek, SeekFrom, Write};
+
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let writer = create(tmpfile.path());
+        let write = writer.begin_write().unwrap();
+        {
+            let mut table = write.open_table(TABLE).unwrap();
+            table.insert(0, 7).unwrap();
+        }
+        write.commit().unwrap();
+
+        // The region counts, torn to zero under the live writer
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(tmpfile.path())
+            .unwrap();
+        file.seek(SeekFrom::Start(24)).unwrap();
+        file.write_all(&[0u8; 8]).unwrap();
+        drop(file);
+
+        let reader = shared().open_read_only(tmpfile.path()).unwrap();
+        assert_eq!(value(&reader), 7);
+        // Its close would rewrite the header, which is not what this tests
+        std::mem::forget(writer);
+    }
+
+    /// Simulates power loss: once `dead`, every write is dropped
+    #[derive(Debug)]
+    struct CrashBackend {
+        inner: redb::backends::FileBackend,
+        dead: Arc<AtomicBool>,
+    }
+
+    impl redb::StorageBackend for CrashBackend {
+        fn len(&self) -> Result<u64, std::io::Error> {
+            self.inner.len()
+        }
+        fn read(&self, offset: u64, out: &mut [u8]) -> Result<(), std::io::Error> {
+            self.inner.read(offset, out)
+        }
+        fn set_len(&self, len: u64) -> Result<(), std::io::Error> {
+            if self.dead.load(Ordering::SeqCst) {
+                return Ok(());
+            }
+            self.inner.set_len(len)
+        }
+        fn sync_data(&self) -> Result<(), std::io::Error> {
+            if self.dead.load(Ordering::SeqCst) {
+                return Ok(());
+            }
+            self.inner.sync_data()
+        }
+        fn write(&self, offset: u64, data: &[u8]) -> Result<(), std::io::Error> {
+            if self.dead.load(Ordering::SeqCst) {
+                return Ok(());
+            }
+            self.inner.write(offset, data)
+        }
+    }
+
+    /// A writer takes `SHARED_WRITER_BYTE` before `do_repair()` runs, so a reader admitted on that
+    /// byte alone would walk a tree the repair is discarding. The consistent byte keeps it out
+    #[test]
+    fn a_repairing_writer_does_not_admit_a_shared_reader() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+
+        // Crashed after a commit, so the next open has to repair it
+        let dead = Arc::new(AtomicBool::new(false));
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(tmpfile.path())
+            .unwrap();
+        let db = Database::builder()
+            .create_with_backend(CrashBackend {
+                inner: redb::backends::FileBackend::new(file).unwrap(),
+                dead: Arc::clone(&dead),
+            })
+            .unwrap();
+        let write = db.begin_write().unwrap();
+        {
+            let mut table = write.open_table(TABLE).unwrap();
+            table.insert(0, 9).unwrap();
+        }
+        write.commit().unwrap();
+        dead.store(true, Ordering::SeqCst);
+        drop(db);
+
+        // The repair callback fires inside do_repair()
+        let path = tmpfile.path().to_path_buf();
+        let during: Arc<std::sync::Mutex<Option<String>>> = Arc::new(std::sync::Mutex::new(None));
+        let recorder = Arc::clone(&during);
+
+        let mut builder = shared();
+        builder.set_repair_callback(move |_| {
+            let mut recorded = recorder.lock().unwrap();
+            if recorded.is_some() {
+                return;
+            }
+            *recorded = Some(match shared().open_read_only(&path) {
+                Ok(_) => "opened".to_string(),
+                Err(err) => format!("{err:?}"),
+            });
+        });
+        let repaired = builder.open(tmpfile.path()).unwrap();
+
+        assert_eq!(
+            during.lock().unwrap().take().as_deref(),
+            Some("RepairAborted"),
+            "a shared reader was admitted while the database was still being repaired"
+        );
+
+        let reader = shared().open_read_only(tmpfile.path()).unwrap();
+        assert_eq!(value(&reader), 9);
+        drop(repaired);
+    }
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
 mod writer_byte {
     use super::*;
     use redb::TableDefinition;


### PR DESCRIPTION
The second of three pieces cut from #1432. #1437 (forced 2-phase commits), #1439 (the `Durability::None` refusal) and #1440 (the refactor that moves the header read into `read_header()`) are merged, so this is based on master and its own change to that function is the shared reader's branch; stacked above it are #1432 (the per-read reload), #1433 and #1413.

## What it fixes

A read-only open refuses a file whose recovery flag is set, and a writable handle sets that flag for as long as it is open, so a database another process was writing could not be opened read-only at all.

## What it does

Opening such a file is a different job from opening a file this process owns, so `read_shared_header()` does it separately rather than threading the difference through the owned path:

```rust
let (header_bytes, consistent) = {
    let _guard = Self::lock_header(storage, in_process_header_lock, concurrency_mode, false)?;
    (
        storage.read_direct(0, DB_HEADER_SIZE)?,
        storage.query_lock_range(byte_range(CONSISTENT_BYTE))?,
    )
};
let unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes, page_size.try_into().unwrap())?;
if unrepaired.unclean() && !consistent {
    return Err(DatabaseError::RepairAborted);
}
Ok(unrepaired.finalize_transaction_slots()?)
```

The only refusal is an unclean file with no writer holding the consistent byte from #1436: a writer publishes the recovery flag under its exclusive hold and holds the byte only while that flag means a live writer rather than an unrepaired file. Such a handle repairs nothing, loads no allocator state, and consults neither the layout nor the file's length. It never allocates, and the read path addresses pages through the immutable geometry alone (the static region size and region header size, not the region counts), so torn counts never reach it, and a page the file no longer holds fails at the read rather than at the open. This replaces the layout and length checks earlier revisions carried.

One platform caveat. On Windows a probe answers by taking the range it queries, so two readers opening at the same instant can each read the other's probe as a live writer and admit an unclean file that no writer holds. Such a reader still reads correctly: a primary that verifies is a commit whose pages were flushed before the header that published it, 2-phase or not, and a torn one is refused. The probes cannot be serialized under an exclusive header hold: a read-only descriptor cannot take one on POSIX, and `a_read_only_handle_takes_shared_holds` pins that.

It still reads the header once, at open. Following the writer's later commits is #1432.

## The decisions this isolates

1. **The primary slot is taken as recorded.** `finalize_transaction_slots()` never chooses the newer slot the way a writer's `finalize()` does. Choosing between the slots is a repairing writer's job: a newer secondary a shared reader can see is a commit whose pages have not reached the file yet, or one a repair has rolled back and republished with the recovery flag already clear. This came out of a Codex finding on the reload path, and the open path ran the same selection. The alternative is a writer-side change to what a repair republishes.
2. **The refusal error.** An unclean file with no writer, and a writer mid-repair, return `RepairAborted`. A distinct variant meaning "retry" is the alternative.
3. **Merging while cross-process pins are not yet consumed.** Before this PR no reader could be open beside a shared writer, so the unconsumed active transaction bytes from #1428 were unreachable. After it, a writer can reclaim pages a reader in another process is reading, until the scan slice from #1413 lands. Either merge behind the experimental flag with that stated, or hold this until the scan is out.

## Testing

`a_shared_read_refuses_an_unclean_file_with_no_writer`; `a_repairing_writer_does_not_admit_a_shared_reader`, where a shared reader probing from inside `do_repair()` is refused and admitted once the repair is done, with the panic it prevents in #1436's sweep; `a_read_only_participant_takes_the_primary_as_recorded`, where a newer slot whose pages the file never received is spliced into the secondary under the god byte a repair leaves and the id the reader locks is the primary's; and `a_shared_reader_ignores_the_layout`, which tears the region counts to zero under a live writer and reads through them. The timing smoke test and the four truncation and torn-layout tests are gone with the checks they covered. The full local check set passes.

The `experimental-multiprocess` changelog bullet gains the read-only-open sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9