### PR TITLE
Refuse Durability::None when the file is shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@
   alone, rather than also with the whole-file lock earlier versions take.
 * Add the `experimental-multiprocess` feature flag, under which `Builder::set_concurrency_mode()`
   takes a `ConcurrencyMode` configuring how processes may share the database.
-  When `SingleWriterProcess` or `MultiWriterProcess` is configured, commits are always 2-phase.
+  When `SingleWriterProcess` or `MultiWriterProcess` is configured, commits are always 2-phase, and
+  `Durability::None` is refused.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/db.rs
+++ b/src/db.rs
@@ -2472,7 +2472,7 @@ mod consistent_byte_test {
 mod active_transaction_test {
     use super::{ConcurrencyMode, Database, ReadableDatabase, TXN_BASE, byte_range};
     use crate::tree_store::file_backend::range_lock::RangeLock;
-    use crate::{Durability, TableDefinition};
+    use crate::{Durability, SetDurabilityError, TableDefinition};
     use std::fs::{File, OpenOptions};
     use std::path::Path;
 
@@ -2660,37 +2660,17 @@ mod active_transaction_test {
         drop(db);
     }
 
-    /// A non-durable commit is invisible to a peer, but the durable ancestor it builds on is not,
-    /// and its pages must survive until the commit is flushed
+    /// A non-durable commit exists only in this process's memory, so a shared mode refuses it
     #[test]
-    fn a_non_durable_commit_locks_its_durable_ancestor() {
+    fn a_shared_mode_refuses_durability_none() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
-        let probe = probe(tmpfile.path());
-        assert!(held_ids(&probe).is_empty());
+        let db = create(tmpfile.path(), ConcurrencyMode::SingleWriterProcess);
 
         let mut write = db.begin_write().unwrap();
-        write.set_durability(Durability::None).unwrap();
-        {
-            let mut table = write.open_table(TABLE).unwrap();
-            table.insert(1, 1).unwrap();
-        }
-        write.commit().unwrap();
-        let ancestor = held_ids(&probe);
-        assert_eq!(
-            ancestor.len(),
-            1,
-            "a non-durable commit locked {ancestor:?}"
-        );
-
-        // The durable commit that flushes it releases the ancestor. Its own epilogue takes a
-        // reference on this commit in turn, so what is locked afterwards is a different id
-        let write = db.begin_write().unwrap();
-        write.commit().unwrap();
-        assert!(
-            !held_ids(&probe).contains(&ancestor[0]),
-            "the ancestor stayed locked after the commit that flushed it"
-        );
+        assert!(matches!(
+            write.set_durability(Durability::None),
+            Err(SetDurabilityError::NonDurableCommitUnsupported)
+        ));
     }
 
     /// Sharing the file forces 2-phase, whatever the transaction asked for

--- a/src/error.rs
+++ b/src/error.rs
@@ -404,12 +404,15 @@ impl core::error::Error for CompactionError {}
 pub enum SetDurabilityError {
     /// A persistent savepoint was modified
     PersistentSavepointModified,
+    /// A non-durable commit would be invisible to the other processes sharing the database
+    NonDurableCommitUnsupported,
 }
 
 impl From<SetDurabilityError> for Error {
     fn from(err: SetDurabilityError) -> Error {
         match err {
             SetDurabilityError::PersistentSavepointModified => Error::PersistentSavepointModified,
+            SetDurabilityError::NonDurableCommitUnsupported => Error::NonDurableCommitUnsupported,
         }
     }
 }
@@ -421,6 +424,12 @@ impl Display for SetDurabilityError {
                 write!(
                     f,
                     "Persistent savepoint modified. Cannot reduce transaction durability"
+                )
+            }
+            SetDurabilityError::NonDurableCommitUnsupported => {
+                write!(
+                    f,
+                    "Non-durable commits are not supported when the database is shared with other processes"
                 )
             }
         }
@@ -546,6 +555,8 @@ pub enum Error {
     RepairAborted,
     /// A persistent savepoint was modified
     PersistentSavepointModified,
+    /// A non-durable commit would be invisible to the other processes sharing the database
+    NonDurableCommitUnsupported,
     /// A persistent savepoint exists
     PersistentSavepointExists,
     /// An Ephemeral savepoint exists
@@ -612,6 +623,12 @@ impl Display for Error {
         match self {
             Error::Corrupted(msg) => {
                 write!(f, "DB corrupted: {msg}")
+            }
+            Error::NonDurableCommitUnsupported => {
+                write!(
+                    f,
+                    "Non-durable commits are not supported when the database is shared with other processes"
+                )
             }
             Error::UpgradeRequired(actual) => {
                 write!(

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1456,6 +1456,11 @@ impl WriteTransaction {
     ///
     /// If a persistent savepoint has been created or deleted, in this transaction, the durability may not
     /// be reduced below [`Durability::Immediate`]
+    #[cfg_attr(
+        feature = "experimental-multiprocess",
+        doc = "",
+        doc = "[`Durability::None`] is refused, with [`SetDurabilityError::NonDurableCommitUnsupported`], in the multi-process concurrency modes: a commit held only in this process's memory would be invisible to the other processes. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
+    )]
     pub fn set_durability(&mut self, durability: Durability) -> Result<(), SetDurabilityError> {
         let persistent_modified = self
             .savepoint_state
@@ -1464,6 +1469,13 @@ impl WriteTransaction {
             .has_created_or_deleted();
         if persistent_modified && !matches!(durability, Durability::Immediate) {
             return Err(SetDurabilityError::PersistentSavepointModified);
+        }
+        // A non-durable commit exists only in this process's memory
+        #[cfg(feature = "experimental-multiprocess")]
+        if matches!(durability, Durability::None)
+            && self.mem.concurrency_mode().is_multi_process_writable()
+        {
+            return Err(SetDurabilityError::NonDurableCommitUnsupported);
         }
 
         self.durability = match durability {


### PR DESCRIPTION
Split out of #1413 as its own small PR on master.

## What it does

A non-durable commit exists only in this process's memory until a durable commit flushes it, so when the file is shared it is a commit the other processes cannot see. In `SingleWriterProcess` and `MultiWriterProcess` mode, `set_durability(Durability::None)` now returns the new `SetDurabilityError::NonDurableCommitUnsupported`, and `Error` gains the matching variant:

```rust
// A non-durable commit exists only in this process's memory
#[cfg(feature = "experimental-multiprocess")]
if matches!(durability, Durability::None)
    && self.mem.concurrency_mode().is_multi_process_writable()
{
    return Err(SetDurabilityError::NonDurableCommitUnsupported);
}
```

`a_non_durable_commit_locks_its_durable_ancestor`, from #1428, committed non-durably in a shared mode to check that the commit locked its durable ancestor. What it exercised is refused now, so it goes.

## The decisions this isolates

1. **Refuse rather than support.** The alternative is defining what a pending non-durable commit means to the other processes.
2. **The variant, and where the check lives.** `NonDurableCommitUnsupported` on `SetDurabilityError`, mirrored on `Error`, refused at `set_durability()` rather than at commit, so the caller learns before writing anything.

## Testing

`a_shared_mode_refuses_durability_none`. The full local check set passes, and `cargo doc --all-features` for the new doc line on `set_durability()`.

The `experimental-multiprocess` changelog bullet gains the sentence. #1413 carries the same change today and drops it on its next restack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_