### PR TITLE
Bound reclamation by the transactions other processes are reading

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2487,8 +2487,8 @@ mod consistent_byte_test {
     }
 }
 
-/// The "active transaction range" locks a read transaction publishes, probed directly: nothing
-/// consumes them yet, and a byte-range lock is invisible through the public API in any case
+/// The "active transaction range" locks a read transaction publishes, probed directly: a
+/// byte-range lock is invisible through the public API
 #[cfg(all(
     test,
     feature = "experimental-multiprocess",
@@ -2869,5 +2869,53 @@ mod active_transaction_test {
             SEARCHED.collect::<Vec<_>>(),
             "a read transaction punctured the whole-file lock"
         );
+    }
+
+    /// The floor is the older of this process's oldest read and a peer's pin, and a peer's pin
+    /// only matters below the former, which is where the scan looks
+    #[test]
+    fn the_oldest_active_transaction_is_the_lower_of_ours_and_a_peers() {
+        for mode in [
+            ConcurrencyMode::SingleWriterProcess,
+            ConcurrencyMode::MultiWriterProcess,
+        ] {
+            let tmpfile = crate::create_tempfile();
+            let db = create(tmpfile.path(), mode);
+            let first = db.mem.get_last_committed_transaction_id().unwrap();
+            assert_eq!(db.mem.oldest_active_transaction(None).unwrap(), None);
+
+            // A peer pins the last committed transaction, as its read of the header would
+            let probe = probe(tmpfile.path());
+            probe
+                .lock_shared_range(byte_range(TXN_BASE + first.raw_id()))
+                .unwrap();
+            assert_eq!(
+                db.mem.oldest_active_transaction(None).unwrap(),
+                Some(first),
+                "{mode:?}"
+            );
+
+            let write = db.begin_write().unwrap();
+            {
+                let mut table = write.open_table(TABLE).unwrap();
+                table.insert(1, 1).unwrap();
+            }
+            write.commit().unwrap();
+            let second = db.mem.get_last_committed_transaction_id().unwrap();
+            assert!(first < second);
+            assert_eq!(
+                db.mem.oldest_active_transaction(Some(second)).unwrap(),
+                Some(first),
+                "{mode:?}"
+            );
+            probe
+                .unlock_range(byte_range(TXN_BASE + first.raw_id()))
+                .unwrap();
+            assert_eq!(
+                db.mem.oldest_active_transaction(Some(second)).unwrap(),
+                Some(second),
+                "{mode:?}"
+            );
+        }
     }
 }

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -469,7 +469,7 @@ impl TransactionTracker {
             .map(|(id, txn_id)| (*id, *txn_id))
     }
 
-    pub(crate) fn oldest_live_read_transaction(&self) -> Option<TransactionId> {
+    pub(crate) fn oldest_local_read_transaction(&self) -> Option<TransactionId> {
         self.state
             .lock()
             .unwrap()

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2003,8 +2003,8 @@ impl WriteTransaction {
         }
 
         let free_until_transaction = self
-            .transaction_tracker
-            .oldest_live_read_transaction()
+            .mem
+            .oldest_active_transaction(self.transaction_tracker.oldest_local_read_transaction())?
             .map_or(self.transaction_id, |x| x.next());
         self.process_freed_pages(free_until_transaction)?;
         // Flush allocated pages (including previously unpersisted allocations that are now
@@ -2087,7 +2087,14 @@ impl WriteTransaction {
 
         self.apply_savepoint_state_on_commit();
 
-        if self.post_commit_free == PostCommitFree::Enabled {
+        // The post-commit pass runs after publication, where a peer's pin on the transaction just
+        // superseded lands below any floor the scan above produced, so a multi-process writer's
+        // pages wait for the next durable commit
+        #[cfg(feature = "experimental-multiprocess")]
+        let multiprocess_writer = self.mem.concurrency_mode().is_multi_process_writable();
+        #[cfg(not(feature = "experimental-multiprocess"))]
+        let multiprocess_writer = false;
+        if self.post_commit_free == PostCommitFree::Enabled && !multiprocess_writer {
             self.process_data_freed_pages_after_commit(
                 user_root,
                 &page_allocator,
@@ -2107,10 +2114,10 @@ impl WriteTransaction {
         let epilogue_transaction = self.transaction_id.next();
         let mut free_until = self
             .transaction_tracker
-            .oldest_live_read_transaction()
+            .oldest_local_read_transaction()
             .map_or(epilogue_transaction, |x| x.next());
         // Clamp the free horizon to the savepoint horizon captured during the purge. A savepoint
-        // is also a live read, so absent concurrency `oldest_live_read_transaction()` never
+        // is also a live read, so absent concurrency `oldest_local_read_transaction()` never
         // exceeds it and this is a no-op. But an ephemeral `Savepoint::drop` racing this commit
         // (legal since `WriteTransaction: Sync`) can land between the purge and here, advancing
         // the oldest live read past the savepoint the purge kept entries for. Freeing those pages
@@ -2323,7 +2330,7 @@ impl WriteTransaction {
         let page_allocator = self.page_allocator();
         let mut free_page = |page| {
             // These pages cannot be unpersisted: free_until is bounded by
-            // oldest_live_read_transaction, which pins back to the durable_ancestor of every
+            // oldest_local_read_transaction, which pins back to the durable_ancestor of every
             // pending non-durable commit (see register_non_durable_commit). As a result, no entry
             // whose pages are still unpersisted is eligible for processing here.
             debug_assert!(!self.mem.unpersisted(page));

--- a/src/tree_store/page_store/active_transactions.rs
+++ b/src/tree_store/page_store/active_transactions.rs
@@ -1,0 +1,133 @@
+//! The active transaction range of the multi-process locking protocol (`docs/design.md`): a
+//! handle reading transaction `t` holds the byte `TXN_BASE + t` shared for as long as it reads
+//! it, and a writer about to reclaim pages asks which of those bytes other processes hold.
+
+use crate::db::TXN_BASE;
+use core::ops::Range;
+
+/// The lowest id in `low..=high` whose byte `query` reports held, if any. The bytes cannot be
+/// listed, only probed over a range, so the id is found by bisection, after a probe of `low`
+/// alone: a scan starts from what the one before it found, which is the likeliest answer.
+pub(super) fn lowest_held<E>(
+    query: impl Fn(Range<u64>) -> Result<bool, E>,
+    mut low: u64,
+    mut high: u64,
+) -> Result<Option<u64>, E> {
+    if low > high {
+        return Ok(None);
+    }
+    if query(bytes(low, low))? {
+        return Ok(Some(low));
+    }
+    if low == high || !query(bytes(low + 1, high))? {
+        return Ok(None);
+    }
+    low += 1;
+    while low < high {
+        let mid = low + (high - low) / 2;
+        if query(bytes(low, mid))? {
+            high = mid;
+        } else {
+            low = mid + 1;
+        }
+    }
+    Ok(Some(low))
+}
+
+/// The bytes of the ids `low..=high`
+fn bytes(low: u64, high: u64) -> Range<u64> {
+    let end = TXN_BASE + high + 1;
+    TXN_BASE + low..end
+}
+
+#[cfg(all(test, any(target_os = "linux", target_vendor = "apple", windows)))]
+mod test {
+    use super::lowest_held;
+    use crate::db::{TXN_BASE, byte_range};
+    use crate::tree_store::file_backend::range_lock::RangeLock;
+    use alloc::vec::Vec;
+    use std::fs::{File, OpenOptions};
+    use std::path::Path;
+
+    fn reopen(path: &Path) -> File {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap()
+    }
+
+    // Stands in for a read transaction's lock: the scan only cares that the byte is held
+    fn pin(file: &File, id: u64) {
+        assert!(
+            file.try_lock_shared_range(byte_range(TXN_BASE + id))
+                .unwrap()
+        );
+    }
+
+    fn unpin(file: &File, id: u64) {
+        file.unlock_range(byte_range(TXN_BASE + id)).unwrap();
+    }
+
+    #[test]
+    fn the_scan_finds_the_lowest_held_byte_from_its_start() {
+        let tmpfile = crate::create_tempfile();
+        let scanning = reopen(tmpfile.path());
+        let other = reopen(tmpfile.path());
+        let scan = |low| lowest_held(|range| scanning.query_lock(range), low, 1 << 20).unwrap();
+
+        assert_eq!(scan(0), None);
+
+        // The oldest of another handle's pins is what bounds reclamation, wherever they sit
+        pin(&other, 77777);
+        pin(&other, 1234);
+        assert_eq!(scan(0), Some(1234));
+        assert_eq!(scan(1234), Some(1234));
+        // Nothing below the start is looked at
+        assert_eq!(scan(1235), Some(77777));
+        assert_eq!(scan(77778), None);
+
+        // ... and the scan follows them up as the older ones are released
+        unpin(&other, 1234);
+        assert_eq!(scan(0), Some(77777));
+        unpin(&other, 77777);
+        assert_eq!(scan(0), None);
+    }
+
+    #[test]
+    fn the_scan_finds_the_oldest_of_many() {
+        let tmpfile = crate::create_tempfile();
+        let scanning = reopen(tmpfile.path());
+        let span = 1u64 << 30;
+        let scan = || lowest_held(|range| scanning.query_lock(range), 0, span).unwrap();
+
+        // A deliberately unseeded multiplicative generator: the ids only need to be spread
+        let mut state = 0x5eed_1234_9876_4321u64;
+        let mut next = move || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            state >> 34
+        };
+
+        for _ in 0..50 {
+            let mut holders = Vec::new();
+            for _ in 0..=next() % 5 {
+                let id = next() % span;
+                let holder = reopen(tmpfile.path());
+                if holder
+                    .try_lock_shared_range(byte_range(TXN_BASE + id))
+                    .unwrap()
+                {
+                    holders.push((holder, id));
+                }
+            }
+            assert_eq!(scan(), holders.iter().map(|(_, id)| *id).min());
+
+            for (holder, id) in &holders {
+                holder.unlock_range(byte_range(TXN_BASE + id)).unwrap();
+            }
+            assert_eq!(scan(), None);
+        }
+    }
+}

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "experimental-multiprocess")]
+mod active_transactions;
 mod backends;
 mod base;
 mod bitmap;

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -11,6 +11,8 @@ use crate::sync::Mutex;
 use crate::transaction_tracker::TransactionId;
 use crate::transactions::{AllocatorStateKey, AllocatorStateTree, AllocatorStateTreeMut};
 use crate::tree_store::btree_base::{BtreeHeader, Checksum};
+#[cfg(feature = "experimental-multiprocess")]
+use crate::tree_store::page_store::active_transactions;
 use crate::tree_store::page_store::base::{MAX_PAGE_INDEX, PageHint};
 use crate::tree_store::page_store::buddy_allocator::BuddyAllocator;
 use crate::tree_store::page_store::cached_file::PagedCachedFile;
@@ -571,6 +573,10 @@ pub(crate) struct TransactionalMemory {
     // this a counter or RwLock
     #[cfg(feature = "experimental-multiprocess")]
     in_process_header_lock: Mutex<()>,
+    // Where the next scan of the active transaction range starts: a pin lands only at or above
+    // the ceiling of the scan before it, since every handle reads the id it pins from the file
+    #[cfg(feature = "experimental-multiprocess")]
+    scan_from: Mutex<u64>,
     page_size: u32,
     // We store these separately from the layout because they're static, and accessed on the get_page()
     // code path where there is no locking
@@ -812,6 +818,58 @@ impl TransactionalMemory {
         )
     }
 
+    #[cfg(feature = "experimental-multiprocess")]
+    fn lock_header_exclusive(&self) -> Result<HeaderGuard<'_>> {
+        Self::lock_header(
+            &self.storage,
+            &self.in_process_header_lock,
+            self.concurrency_mode,
+            true,
+        )
+    }
+
+    /// The oldest transaction still being read in any process, given `local`, the oldest this
+    /// process reads. Where the file is shared it is found under the exclusive header hold, which
+    /// every registration waits behind, so no pin lands below what this reports.
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn oldest_active_transaction(
+        &self,
+        local: Option<TransactionId>,
+    ) -> Result<Option<TransactionId>> {
+        if self.concurrency_mode.is_multi_process_writable() {
+            let _guard = self.lock_header_exclusive()?;
+            let ceiling = self.get_last_committed_transaction_id()?;
+            // Every id scanned is at most the ceiling, so this bounds the whole scan's offsets
+            Self::active_transaction_byte(ceiling)?;
+            let mut scan_from = self.scan_from.lock().unwrap();
+            // Only a byte below this process's own oldest read can lower the answer, and only
+            // there is a held byte another process's: on Windows a probe sees this description's
+            // own locks too
+            let high = local.map_or(Some(ceiling.raw_id()), |id| id.raw_id().checked_sub(1));
+            let peer = match high {
+                Some(high) => active_transactions::lowest_held(
+                    |range| self.storage.query_lock_range(range),
+                    *scan_from,
+                    high,
+                )?,
+                None => None,
+            };
+            let oldest = peer.map(TransactionId::new).or(local);
+            *scan_from = oldest.unwrap_or(ceiling).raw_id();
+            return Ok(oldest);
+        }
+        Ok(local)
+    }
+
+    #[cfg(not(feature = "experimental-multiprocess"))]
+    #[allow(clippy::unnecessary_wraps, clippy::unused_self)]
+    pub(crate) fn oldest_active_transaction(
+        &self,
+        local: Option<TransactionId>,
+    ) -> Result<Option<TransactionId>> {
+        Ok(local)
+    }
+
     /// Marks `id` active, keeping the pages its snapshot references from being reclaimed by any
     /// process until [`Self::unlock_mp_transaction`]. The caller's shared header hold orders this
     /// against a writer's reclamation scan, which holds it exclusively: the scan either sees this
@@ -1006,6 +1064,8 @@ impl TransactionalMemory {
             read_only,
             #[cfg(feature = "experimental-multiprocess")]
             in_process_header_lock,
+            #[cfg(feature = "experimental-multiprocess")]
+            scan_from: Mutex::new(0),
             page_size: page_size.try_into().unwrap(),
             region_size,
             region_header_with_padding_size: region_header_size,

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -309,3 +309,70 @@ fn sharing_a_caller_supplied_backend_is_unsupported() {
         .create_with_backend(InMemoryBackend::new())
         .unwrap();
 }
+
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+mod reclamation {
+    use super::*;
+    use redb::{ReadableDatabase, ReadableTable, TableDefinition};
+
+    const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+
+    /// A read transaction in another process pins its snapshot: the writer's reclamation stops
+    /// at it, however many commits go by
+    #[test]
+    fn a_readers_pin_survives_heavy_reclamation() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let writer = Database::builder()
+            .set_concurrency_mode(ConcurrencyMode::SingleWriterProcess)
+            .create(tmpfile.path())
+            .unwrap();
+
+        let value = vec![7u8; 512];
+        let txn = writer.begin_write().unwrap();
+        {
+            let mut t = txn.open_table(TABLE).unwrap();
+            for key in 0..128u64 {
+                t.insert(&key, value.as_slice()).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+
+        let reader = Database::builder()
+            .set_concurrency_mode(ConcurrencyMode::SingleWriterProcess)
+            .open_read_only(tmpfile.path())
+            .unwrap();
+        let pinned = reader.begin_read().unwrap();
+
+        // Every round frees the previous round's pages; without the reader's pin bounding the
+        // writer's reclamation, the pinned snapshot's pages would be reused under it
+        for round in 0..20u8 {
+            let overwrite = vec![round; 512];
+            let txn = writer.begin_write().unwrap();
+            {
+                let mut t = txn.open_table(TABLE).unwrap();
+                for key in 0..128u64 {
+                    t.insert(&key, overwrite.as_slice()).unwrap();
+                }
+            }
+            txn.commit().unwrap();
+        }
+
+        let t = pinned.open_table(TABLE).unwrap();
+        for key in 0..128u64 {
+            assert_eq!(t.get(&key).unwrap().unwrap().value(), value.as_slice());
+        }
+        drop(t);
+        drop(pinned);
+
+        // With the pin gone the writer keeps going, and a fresh read sees the last round
+        let txn = writer.begin_write().unwrap();
+        {
+            let mut t = txn.open_table(TABLE).unwrap();
+            t.insert(&0, [0u8; 4].as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+        let read = reader.begin_read().unwrap();
+        let t = read.open_table(TABLE).unwrap();
+        assert_eq!(t.get(&0).unwrap().unwrap().value(), [0u8; 4].as_slice());
+    }
+}


### PR DESCRIPTION
The scan slice from #1413, cut as its own change. It closes the gap the merged reader slices (#1438, #1432, #1433) flag in their bodies: a read transaction in another process pins its transaction id by holding a byte in the active transaction range (#1428), but no writer consulted those bytes, so its snapshot could be reclaimed and reused under it.

Compaction is refused while the file is shared in #1442, cut on master rather than folded in here: without it, `compact()` beside a reading peer would spin in the drain it begins with once this floor holds, which Codex found on this PR. Merge #1442 first, or rebase this onto it.

## What it does

A durable commit's reclamation floor is now the oldest transaction still being read in any process, rather than in this one:

```rust
let free_until_transaction = self
    .mem
    .oldest_active_transaction(self.transaction_tracker.oldest_local_read_transaction())?
    .map_or(self.transaction_id, |x| x.next());
```

`TransactionalMemory::oldest_active_transaction()` takes this process's oldest read and returns the older of it and a peer's oldest pin. It looks for that pin under the exclusive header hold, which every registration waits behind, so no pin lands below what it reports, and reads the ceiling, the last committed transaction, under the same hold. Only a byte below this process's own oldest read can lower the answer, so only that range is probed; that is also why this process's own locks, which a probe on Windows sees, never come into it. The bytes cannot be listed, only probed over a range, so `active_transactions::lowest_held()` bisects. Each scan starts from what the one before it found: a pin only ever lands at or above the ceiling of the scan before it, since every handle reads the id it pins from the file, so the remembered id is probed alone first. A lingering reader costs one probe, an idle file two, and a reader that moved up about `log2` of the distance.

The post-commit free pass is skipped where the file is shared. It runs after publication, where a peer's pin on the transaction just superseded can land below any floor the scan produced; those pages are reclaimed by the next durable commit instead.

## The decisions this isolates

1. **Bisection on every platform, rather than descending along the conflict offsets `F_OFD_GETLK` reports.** #1413 did the latter on POSIX and bisected only on Windows, which cannot report an offset. With the remembered start the common cases are one or two probes on either, each a syscall that costs nothing next to the commit's fsync. One algorithm, no `Query` type on the lock trait, no platform branch, and the storage's existing boolean probe is enough.
2. **The scan is bounded by this process's oldest read, rather than stepping over its own pins.** #1413 handed the scan the set of this process's read ids to skip, since a Windows probe sees its own locks. Nothing at or above the local oldest read can lower the floor, so the scan stops below it, and the set, the step-over and the sampling race between the two are gone.
3. **The post-commit pass waits, rather than rescanning.** A second exclusive hold and scan after publication would let it run; skipping it costs a shared writer one transaction of delay before it reuses the pages the previous one freed.
4. **Both shared modes scan, and both remember where the last scan stopped.** A `SingleWriterProcess` writer has no writing peers, but its read-only peers pin all the same. The remembered start relies on a pin never landing below the previous scan's ceiling, which holds because every handle reads the id it pins from the file; a writable multi-writer handle that has not refreshed is unusable whatever the floor until the writer-side reload in #1413, so the mode makes no difference here.

## Testing

`a_readers_pin_survives_heavy_reclamation`: twenty rounds overwriting all 128 keys under a live reader on a second open file description, asserting the pinned snapshot still reads its own values, and that a fresh read after the pin is dropped sees the last round. Mutation-checked: without the foreign floor it fails at the pinned read, and so does it with the post-commit pass left on. The scan itself has `the_scan_finds_the_lowest_held_byte_from_its_start`, which also checks that nothing below the start is looked at, and `the_scan_finds_the_oldest_of_many`, over raw file descriptions holding bytes at random ids. `the_oldest_active_transaction_is_the_lower_of_ours_and_a_peers` drives `oldest_active_transaction()` through a peer's pin on a second description: the pin bounds the floor while it is older than this process's read, and this process's read does once it is released. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_