### PR TITLE
Refuse compaction while the file is shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@
 * Add the `experimental-multiprocess` feature flag, under which `Builder::set_concurrency_mode()`
   takes a `ConcurrencyMode` configuring how processes may share the database.
   When `SingleWriterProcess` or `MultiWriterProcess` is configured, commits are always 2-phase,
-  `Durability::None` is refused, and the database may be opened read-only while another process has
-  it open for writing; each new read transaction then sees that process's durable commits.
+  `Durability::None` and `Database::compact()` are refused, and the database may be opened read-only
+  while another process has it open for writing; each new read transaction then sees that process's
+  durable commits.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/db.rs
+++ b/src/db.rs
@@ -965,7 +965,21 @@ impl Database {
     /// Compacts the database file
     ///
     /// Returns `true` if compaction was performed, and `false` if no futher compaction was possible
+    ///
+    /// Under the `experimental-multiprocess` feature, a database opened in a shared
+    /// `ConcurrencyMode` refuses compaction with [`CompactionError::Storage`] wrapping an I/O
+    /// error of kind `Unsupported`: the read transactions of other processes are invisible to it.
     pub fn compact(&mut self) -> Result<bool, CompactionError> {
+        // The checks below see only this process's read transactions
+        #[cfg(feature = "experimental-multiprocess")]
+        if self.mem.concurrency_mode().is_multi_process_writable() {
+            return Err(CompactionError::Storage(StorageError::Io(
+                crate::io::unsupported(
+                    "Compaction is not supported when the database is shared with other processes",
+                ),
+            )));
+        }
+
         // These checks must run before begin_write(): the caller may legally hold an open
         // WriteTransaction (it is not lifetime-bound to the Database), and if that transaction
         // created a savepoint, blocking in begin_write() below would deadlock. Savepoints must

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -309,3 +309,54 @@ fn sharing_a_caller_supplied_backend_is_unsupported() {
         .create_with_backend(InMemoryBackend::new())
         .unwrap();
 }
+
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+mod compaction {
+    use super::*;
+    use redb::{ReadableDatabase, TableDefinition};
+
+    const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+
+    /// Compaction checks only this process's read transactions, and relocates and frees pages
+    /// out from under a peer's, so it is refused while the file is shared
+    #[test]
+    fn compaction_is_refused_while_the_file_is_shared() {
+        for mode in [
+            ConcurrencyMode::SingleWriterProcess,
+            ConcurrencyMode::MultiWriterProcess,
+        ] {
+            let tmpfile = tempfile::NamedTempFile::new().unwrap();
+            let mut writer = Database::builder()
+                .set_concurrency_mode(mode)
+                .create(tmpfile.path())
+                .unwrap();
+            let txn = writer.begin_write().unwrap();
+            {
+                let mut t = txn.open_table(TABLE).unwrap();
+                t.insert(&0, [1u8; 512].as_slice()).unwrap();
+            }
+            txn.commit().unwrap();
+
+            let reader = Database::builder()
+                .set_concurrency_mode(mode)
+                .open_read_only(tmpfile.path())
+                .unwrap();
+            let pinned = reader.begin_read().unwrap();
+            // Frees the pinned snapshot's pages, which compaction would drain and reuse
+            let txn = writer.begin_write().unwrap();
+            {
+                let mut t = txn.open_table(TABLE).unwrap();
+                t.insert(&0, [2u8; 512].as_slice()).unwrap();
+            }
+            txn.commit().unwrap();
+
+            match writer.compact().unwrap_err() {
+                redb::CompactionError::Storage(StorageError::Io(err)) => {
+                    assert_eq!(err.kind(), std::io::ErrorKind::Unsupported, "{mode:?}");
+                }
+                other => panic!("{mode:?}: unexpected error {other:?}"),
+            }
+            drop(pinned);
+        }
+    }
+}


### PR DESCRIPTION
One of the refusals from #1413, cut as its own change on master: `Database::compact()` is refused in `SingleWriterProcess` and `MultiWriterProcess`.

## Why

`compact()` checks for live read transactions and savepoints in this process's tracker alone, so a read transaction in another process is invisible to it: its snapshot's pages would be relocated and freed under it. And once the writer bounds reclamation by the pins those transactions hold (#1441), the drain `compact()` begins with, which commits until no free is pending, would wait on a peer's pin for as long as it holds; Codex found that on #1441. Either way compaction cannot proceed while the file is shared, so the shared modes refuse it before any of its checks.

#1441 should merge after this one, or be rebased onto it: without the refusal, `compact()` beside a reading peer hangs there.

## The decisions this isolates

1. **Refuse, rather than compact around a peer.** A drain that stops when a commit reclaims nothing would let `compact_pages()` run with frees pending, and `compact()` would return with the file not compacted; refusing keeps its contract.
2. **The error is `CompactionError::Storage(StorageError::Io(_))` of kind `Unsupported`**, as #1413 reports it and as a shared mode on a caller-supplied backend is reported today. The alternative is a `CompactionError` variant of its own; the enum is `#[non_exhaustive]`, so one can still be added. The method's doc comment names the error and the reason.

## Testing

`compaction_is_refused_while_the_file_is_shared`: in each shared mode, a read-only handle on a second file description holds a read transaction while the writer overwrites its data, then `compact()` returns the unsupported error. Without the refusal the test fails at `unwrap_err()` on master, where compaction proceeds over the peer; on #1441 it hangs in the drain. The changelog bullet names the refusal. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9