### PR TITLE
Check integrity under the writer lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,9 @@
   In `MultiWriterProcess`, every commit records the allocator state, for the next writer to load;
   compaction's own commits are the exception, and `Database::compact()` ends with one that does.
   Ephemeral savepoints are refused there, with `SavepointError::EphemeralSavepointUnsupported`,
-  and a write transaction begins from the file as another process last committed it, as does the
-  close.
+  and a write transaction begins from the file as another process last committed it, as do the
+  close and `Database::check_integrity()`, which waits for a write transaction in another process
+  to end.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/db.rs
+++ b/src/db.rs
@@ -791,11 +791,17 @@ impl Database {
     /// and `Err(Corrupted)` if the check failed and the file could not be repaired.
     ///
     /// Returns [`DatabaseError::TransactionInProgress`] if any read or write transaction, or an
-    /// ephemeral [`Savepoint`](crate::Savepoint), is still alive when this method is called.
+    /// ephemeral [`Savepoint`](crate::Savepoint), is still alive on this handle when this method
+    /// is called.
     ///
     /// Transactions committed with [`Durability::None`](crate::Durability::None) that have not yet
     /// been made durable are made durable if the check passes, or rolled back if the database must
     /// be repaired.
+    #[cfg_attr(
+        feature = "experimental-multiprocess",
+        doc = "",
+        doc = "In the multi-process concurrency modes the check holds the writer lock: it waits for a write transaction in another process to end, and no other process writes to the file until it returns. A read transaction in another process neither blocks the check nor is disturbed by it. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
+    )]
     pub fn check_integrity(&mut self) -> Result<bool, DatabaseError> {
         if Arc::get_mut(&mut self.mem).is_none() {
             return Err(DatabaseError::TransactionInProgress);
@@ -818,17 +824,26 @@ impl Database {
             .into());
         }
 
+        // Held until the check returns, so the file it reloads is the file it repairs
+        #[cfg(feature = "experimental-multiprocess")]
+        let writer_lock = self.mem.lock_writer()?;
         // Repairing rebuilds the allocator state, so a failure part way through leaves one that
         // describes neither the file nor anything else. Holding an allocator state must continue
         // to mean it describes the file.
-        let result = self.check_integrity_inner();
+        let result = self.check_integrity_inner(
+            #[cfg(feature = "experimental-multiprocess")]
+            &writer_lock,
+        );
         if result.is_err() {
             self.mem.invalidate_allocator_state();
         }
         result
     }
 
-    fn check_integrity_inner(&mut self) -> Result<bool, DatabaseError> {
+    fn check_integrity_inner(
+        &mut self,
+        #[cfg(feature = "experimental-multiprocess")] writer_lock: &Arc<WriterLock>,
+    ) -> Result<bool, DatabaseError> {
         // A pending Durability::None commit is acknowledged, live data that the reload below would
         // discard. If the live state verifies, promote it to durable rather than losing it -- even
         // if the durable state it replaces turns out to be corrupt, in which case we recover from
@@ -864,10 +879,32 @@ impl Database {
 
         // No pending commit, or fall-through: verify and repair the durable state. Capture the
         // allocator hash to compare against the rebuild below; with the pending case handled above,
-        // the live and durable states are identical here, so this is a valid check.
-        let allocator_hash = self.mem.allocator_hash();
+        // the live and durable states are identical here, so this is a valid check. When the reload
+        // finds another process's commit, the snapshot it recorded is compared instead: that is
+        // what the next open trusts.
+        let own_allocator_hash = self.mem.allocator_hash();
         let mem = Arc::get_mut(&mut self.mem).unwrap();
-        let mut was_clean = mem.clear_cache_and_reload()?;
+        let (mut was_clean, peer_committed) = mem.clear_cache_and_reload()?;
+        let allocator_hash = if peer_committed {
+            match Self::get_allocator_state_table(&self.mem)? {
+                Some(tree) => {
+                    self.mem.load_allocator_state(&tree)?;
+                    Some(self.mem.allocator_hash())
+                }
+                None => None,
+            }
+        } else {
+            Some(own_allocator_hash)
+        };
+        // Every multi-writer commit records the allocator state, so one that did not is a commit
+        // the next writer refuses: not clean, so the repair below records it
+        #[cfg(feature = "experimental-multiprocess")]
+        if peer_committed
+            && allocator_hash.is_none()
+            && self.mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess
+        {
+            was_clean = false;
+        }
 
         let old_roots = [self.mem.get_data_root(), self.mem.get_system_root()];
 
@@ -877,7 +914,7 @@ impl Database {
         })?;
 
         if old_roots != new_roots
-            || allocator_hash != self.mem.allocator_hash()
+            || allocator_hash.is_some_and(|hash| hash != self.mem.allocator_hash())
             || rolling_back_non_durable
         {
             was_clean = false;
@@ -906,11 +943,30 @@ impl Database {
         self.mem.clear_needs_repair();
         self.mem.begin_writable()?;
 
+        // The tracker holds the persistent savepoints the reloaded tables hold, as the open's does
+        if peer_committed {
+            self.sync_persistent_savepoints(
+                #[cfg(feature = "experimental-multiprocess")]
+                Some(writer_lock),
+            )?;
+        }
+        // In multi-writer mode a repair ends with a commit recording the allocator state, as the
+        // open's does; after the savepoints are held, since a commit frees what nothing pins
+        #[cfg(feature = "experimental-multiprocess")]
+        if !was_clean && self.mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess {
+            ensure_allocator_state_table_and_trim(
+                &self.transaction_tracker,
+                &self.mem,
+                Some(writer_lock),
+                None,
+            )?;
+        }
+
         Ok(was_clean)
     }
 
-    // Synchronizes the tracker state for the file's persistent savepoints. `writer_lock` is the
-    // lock the open holds, which the transaction this begins is lent
+    // Synchronizes the tracker state for the file's persistent savepoints. The transaction this
+    // begins is lent `writer_lock`, when the caller holds one
     fn sync_persistent_savepoints(
         &self,
         #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
@@ -1538,7 +1594,7 @@ impl Database {
             writer_lock.as_ref(),
         )?;
         // In multi-writer mode a repair ends with a commit recording the allocator state, as
-        // compaction does, so that the next open, in any process, loads it
+        // compaction and the integrity check do, so that the next open, in any process, loads it
         #[cfg(feature = "experimental-multiprocess")]
         if repaired && concurrency_mode == ConcurrencyMode::MultiWriterProcess {
             ensure_allocator_state_table_and_trim(
@@ -1782,8 +1838,9 @@ fn begin_write_with_allocation_policy(
 }
 
 // Records the allocator state in a commit that also trims the file: the close's last commit,
-// and compaction's. `writer_lock` and `header_lock` where the caller lends the ones it holds, as
-// compaction does; nothing is waiting on the write slot in either case
+// compaction's, and the one ending a repair in the open or the integrity check. `writer_lock`
+// and `header_lock` are the ones the caller lends, when it holds them; nothing is waiting on the
+// write slot in any of these cases
 fn ensure_allocator_state_table_and_trim(
     transaction_tracker: &Arc<TransactionTracker>,
     mem: &Arc<TransactionalMemory>,
@@ -3344,6 +3401,62 @@ mod active_transaction_test {
         ));
         write.persistent_savepoint().unwrap();
         write.commit().unwrap();
+    }
+
+    /// A process that crashed between a repair's commit and the commit recording the allocator
+    /// state leaves a commit the next writer refuses. The check records it rather than passing a
+    /// file no peer can write to.
+    #[test]
+    fn an_integrity_check_records_a_peers_unrecorded_commit() {
+        let tmpfile = crate::create_tempfile();
+        let mut db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let peer = Database::builder()
+            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .open(tmpfile.path())
+            .unwrap();
+        // A commit recording no allocator state, as a repair's does. The peer stays open, since
+        // its close would record
+        let mut write = peer.begin_write().unwrap();
+        write.skip_allocator_state_record();
+        write.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+        write.commit().unwrap();
+
+        assert!(!db.check_integrity().unwrap());
+        assert!(
+            Database::get_allocator_state_table(&db.mem)
+                .unwrap()
+                .is_some()
+        );
+        drop(peer);
+    }
+
+    /// A leak another process left in the file is repaired, and the repair records the allocator
+    /// state for the next writer to load
+    #[test]
+    fn an_integrity_check_repairs_a_leak_a_peer_recorded() {
+        use crate::tree_store::{AllocationPolicy, PageAllocator, PageTracker};
+
+        let tmpfile = crate::create_tempfile();
+        let mut db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let peer = Database::builder()
+            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .open(tmpfile.path())
+            .unwrap();
+        // A page the peer allocates and neither frees nor references: a leak its close's snapshot
+        // records as allocated
+        let allocator = PageAllocator::new(peer.mem.clone(), AllocationPolicy::Default);
+        drop(allocator.allocate(64, &PageTracker::ignore()).unwrap());
+        drop(allocator);
+        drop(peer);
+
+        assert!(!db.check_integrity().unwrap());
+        // The repair recorded the allocator state, for a peer to load
+        assert!(
+            Database::get_allocator_state_table(&db.mem)
+                .unwrap()
+                .is_some()
+        );
+        assert!(db.check_integrity().unwrap());
     }
 
     /// A read-only participant sees what another process committed, not the header it read at open

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1267,7 +1267,7 @@ impl TransactionalMemory {
         self.storage.invalidate_cache_all();
     }
 
-    pub(crate) fn clear_cache_and_reload(&mut self) -> Result<bool, DatabaseError> {
+    pub(crate) fn clear_cache_and_reload(&mut self) -> Result<(bool, bool), DatabaseError> {
         // The in-memory state is being discarded for the on-disk state, so buffered writes --
         // which can only belong to the discarded state -- are dropped rather than written out;
         // after an external truncation, writing them could even fail beyond the end of the file.
@@ -1299,20 +1299,23 @@ impl TransactionalMemory {
             self.storage.flush()?;
         }
 
-        {
+        let changed = {
             let mut state = self.state.lock().unwrap();
+            let changed =
+                header.primary_slot().transaction_id != state.header.primary_slot().transaction_id;
             state.header = header;
             state.read_from_secondary = false;
             // Drop the previous allocator state -- it described the layout that was in memory
             // before the reload. The caller is required to repopulate it (via reset_allocator_state or
             // load_allocator_state) before any allocation/free path runs.
             state.allocators = None;
-        }
+            changed
+        };
         // Reloading from disk discards in-memory roots, so drop volatile allocation state
         // that belonged only to those roots.
         self.unpersisted.lock().unwrap().clear();
 
-        Ok(was_clean)
+        Ok((was_clean, changed))
     }
 
     /// The latest committed transaction id, read from the file by a shared reader since a peer

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -290,6 +290,148 @@ fn the_concurrency_mode_excludes_incompatible_opens() {
     Database::open(tmpfile.path()).unwrap();
 }
 
+/// A multi-writer check runs on the file as another process last committed it, and the handle
+/// goes on from there: fresh savepoint ids, and a close that commits after what it synced to
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+#[test]
+fn an_integrity_check_syncs_to_a_peers_commits() {
+    use redb::{ReadableDatabase, ReadableTable, TableDefinition};
+    const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+    let tmpfile = tempfile::NamedTempFile::new().unwrap();
+    let mut db = Database::builder()
+        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .create(tmpfile.path())
+        .unwrap();
+    let peer = Database::builder()
+        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .open(tmpfile.path())
+        .unwrap();
+    let txn = peer.begin_write().unwrap();
+    txn.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+    txn.commit().unwrap();
+    let txn = peer.begin_write().unwrap();
+    let peers_savepoint = txn.persistent_savepoint().unwrap();
+    txn.commit().unwrap();
+    drop(peer);
+
+    assert!(db.check_integrity().unwrap());
+    let read = db.begin_read().unwrap();
+    let table = read.open_table(TABLE).unwrap();
+    assert_eq!(table.get(1).unwrap().unwrap().value(), 1);
+    drop(table);
+    drop(read);
+    let txn = db.begin_write().unwrap();
+    let own_savepoint = txn.persistent_savepoint().unwrap();
+    assert_ne!(own_savepoint, peers_savepoint);
+    txn.commit().unwrap();
+    drop(db);
+
+    let db = Database::builder()
+        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .open(tmpfile.path())
+        .unwrap();
+    let read = db.begin_read().unwrap();
+    let table = read.open_table(TABLE).unwrap();
+    assert_eq!(table.get(1).unwrap().unwrap().value(), 1);
+    let txn = db.begin_write().unwrap();
+    let mut savepoints: Vec<u64> = txn.list_persistent_savepoints().unwrap().collect();
+    savepoints.sort_unstable();
+    assert_eq!(savepoints, vec![peers_savepoint, own_savepoint]);
+}
+
+/// A shared commit is 2-phase, so a corrupt primary slot is corruption rather than a torn write
+/// to fall back from: the check repairs nothing from under a process reading that slot
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+#[test]
+fn a_corrupt_primary_is_not_repaired_from_under_a_peers_read() {
+    use redb::{ReadableDatabase, ReadableTable, TableDefinition};
+    use std::io::{Read, Seek, SeekFrom, Write};
+    const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+    let tmpfile = tempfile::NamedTempFile::new().unwrap();
+    let mut db = Database::builder()
+        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .create(tmpfile.path())
+        .unwrap();
+    for key in [1, 2] {
+        let txn = db.begin_write().unwrap();
+        txn.open_table(TABLE).unwrap().insert(key, key).unwrap();
+        txn.commit().unwrap();
+    }
+    let peer = Database::builder()
+        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .open_read_only(tmpfile.path())
+        .unwrap();
+    let read = peer.begin_read().unwrap();
+
+    // The header: the god byte at 9, whose low bit names the primary of the two 128-byte commit
+    // slots at 64 and 192, each ending in a 16-byte checksum
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(tmpfile.path())
+        .unwrap();
+    let mut god_byte = [0u8];
+    file.seek(SeekFrom::Start(9)).unwrap();
+    file.read_exact(&mut god_byte).unwrap();
+    let checksum = 64 + 128 * u64::from(god_byte[0] & 1) + 112;
+    let mut bytes = [0u8; 16];
+    file.seek(SeekFrom::Start(checksum)).unwrap();
+    file.read_exact(&mut bytes).unwrap();
+    for byte in &mut bytes {
+        *byte ^= 0xFF;
+    }
+    file.seek(SeekFrom::Start(checksum)).unwrap();
+    file.write_all(&bytes).unwrap();
+    file.sync_all().unwrap();
+    drop(file);
+
+    assert!(matches!(
+        db.check_integrity(),
+        Err(DatabaseError::Storage(StorageError::Corrupted(_)))
+    ));
+    let table = read.open_table(TABLE).unwrap();
+    assert_eq!(table.get(1).unwrap().unwrap().value(), 1);
+    assert_eq!(table.get(2).unwrap().unwrap().value(), 2);
+}
+
+/// The check waits for another process's write transaction to end, as a write transaction would
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+#[test]
+fn an_integrity_check_waits_for_a_peers_write_transaction() {
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    let tmpfile = tempfile::NamedTempFile::new().unwrap();
+    let mut db = Database::builder()
+        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .create(tmpfile.path())
+        .unwrap();
+    let peer = Database::builder()
+        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .open(tmpfile.path())
+        .unwrap();
+    let txn = peer.begin_write().unwrap();
+
+    let (tx, rx) = mpsc::channel();
+    let checking = thread::spawn(move || {
+        tx.send(db.check_integrity().unwrap()).unwrap();
+        db
+    });
+    assert!(
+        rx.recv_timeout(Duration::from_millis(200)).is_err(),
+        "the check ran under another process's write transaction"
+    );
+    txn.abort().unwrap();
+    assert!(
+        rx.recv_timeout(Duration::from_secs(10))
+            .expect("the check never ran")
+    );
+    checking.join().unwrap();
+}
+
 /// A multi-writer handle's write transaction begins from the file as another process last
 /// committed it, and so does the commit its close makes.
 #[cfg(any(target_os = "linux", target_vendor = "apple", windows))]


### PR DESCRIPTION
The last of the writer-side reload's pieces, on master now that #1462 is merged, after #1449 and #1462. `Database::check_integrity()` works in `MultiWriterProcess`, by running under the writer lock, rather than being refused there.

## What it does

A multi-writer handle holds the writer byte only for the span of a write transaction, and an integrity check is not one: another process could commit between the check's reload and its repair commit. The check now takes the writer lock through `lock_writer()`, after the checks that decide nothing will be written, and holds it until it returns, so the file it reloads is the file it repairs. It waits for a write transaction in another process to end, as a write transaction would, and with #1462 on master nothing in another process writes to the file meanwhile, an open included. It needs no write slot: `Arc::get_mut()` has found no transaction live, and none can begin under `&mut self`. In `SingleWriterProcess` and `SingleProcess` the lock is the open's own, so nothing changes there.

When its reload finds another process's commit, the check syncs to it as a write transaction does after #1449. `clear_cache_and_reload()` now also returns whether the commit is another than the one the handle had, by its id. The check then holds the persistent savepoints the reloaded tables hold, through `sync_persistent_savepoints()`, in a transaction lent the check's writer lock, since a second lock on the byte from this file description is the same lock and the transaction's end would release the check's. And it compares the rebuild against the allocator state that commit recorded, which is what the next open would trust, rather than against the handle's own allocator, which lagged that commit and reported a current file not clean.

Every multi-writer commit records the allocator state, so a commit that did not is one the next writer refuses in `load_synced_allocator_state()` -- a process that crashed between a repair's commit and the commit recording it. The check reports that file not clean and records it, rather than passing a file no peer can write to. The other modes require no such record, so a commit without one is not a fault there.

A repair's commit records no allocator state, and in multi-writer mode a write transaction's does, for the next writer in any process to load rather than rebuild from the trees: a repair there ends with one, under the same writer lock, through the same `ensure_allocator_state_table_and_trim()` the open's repair, compaction and the close use. It comes after the savepoints are held, since a commit frees what nothing pins.

The doc comment gets its multi-process paragraph behind the feature flag, as the other shared-mode notes are: the check holds the writer lock, a read transaction in another process neither blocks it nor is disturbed by it, and the transaction-in-progress refusal is for this handle's transactions. The changelog bullet says the check waits for a write transaction in another process.

## The decisions this isolates

1. **Hold the writer lock, not the header lock.** The check's writes take their own short header holds, as every commit does, and a reader in another process pins a transaction the rebuild keeps allocated. The exclusive header lock could not be held across the check anyway: the check takes the memory by `Arc::get_mut()`, which a borrowed guard would forbid.
2. **Compare the allocator that would be trusted.** Whether the file's commit is the one this handle had is whether its id is, since #1449 issues a write transaction's id past the file's latest commit. Where it is, the handle's own allocator described the file and is compared as before; where it is not, the peer commit's recorded snapshot is what an open would load, so that is what the rebuild is checked against.
3. **A missing snapshot is a fault only in multi-writer mode.** That is the mode whose invariant says every commit records one, and whose writers refuse a commit without one. An ordinary commit in the other modes deletes the table, so a missing snapshot says nothing there.
4. **The recording commit is multi-writer only.** In the modes with one writer the close's commit records, and an unclean exit is repaired by the next open as today; only in multi-writer mode is a live peer waiting to sync to the repair, and a full rebuild is what it would otherwise pay.
5. **No guard against externally modified files.** A file replaced from a copy under a live handle can put another commit or savepoint under an id this handle knows; that is the user's doing and gets whatever behaviour it gets, so the tests that built such files are gone.

## What changed in the rebase onto #1462

- **The open's repair is no longer the writer left outside the lock.** That was the one thread left open on this PR, deferred to the open protocol; #1462 is that protocol, so the check's lock now excludes every writer and the doc comment says so.
- **The transaction-id reservation after the reload is gone.** It reserved ids past the reloaded header so the handle's next commit would not reuse one. Since #1449, `issue_write_transaction_id()` ratchets on the file's latest commit itself, and the repair's own `mem.commit()` computes its id from the reloaded header, so nothing was left for it to do: removing it leaves the whole suite green, where before #1449 it tripped the ordering assertion at the close.
- **The repair's recording commit goes through `ensure_allocator_state_table_and_trim()`** rather than a hand-rolled `begin_write().commit()`, so the check's repair ends exactly as the open's does.
- **A commit that recorded no allocator state is not clean**, per the review thread on the earlier head: the check used to report such a file clean and leave it, while a peer writer refused the same commit as corrupt.
- **`an_integrity_check_validates_a_peers_allocator_snapshot` is renamed** to `an_integrity_check_repairs_a_leak_a_peer_recorded`, for what it actually pins. It claimed to pin the snapshot comparison, but passes either way: the peer's commit leaves this handle's own allocator stale too, so both report the file not clean. The comparison is pinned by `an_integrity_check_syncs_to_a_peers_commits` in the other direction, which is the one that matters -- comparing the handle's own allocator there reports a current file not clean.

## Testing

`an_integrity_check_syncs_to_a_peers_commits`: a peer inserts a row, creates a persistent savepoint and closes; the stale handle's check passes, its next read sees the row, its next persistent savepoint gets a fresh id, and its close commit lands, which a reopen listing both savepoints confirms. Comparing the stale allocator regardless fails the check, and skipping the savepoint sync hands out the peer's id again -- both re-checked by mutating this branch. `an_integrity_check_waits_for_a_peers_write_transaction`: with a peer's write transaction open, the check does not run until it ends. `a_corrupt_primary_is_not_repaired_from_under_a_peers_read`: with a peer reading the primary slot and that slot's checksum flipped on disk, the check reports corruption rather than falling back to the secondary, since every shared commit is 2-phase, and the peer's read is intact. `an_integrity_check_repairs_a_leak_a_peer_recorded`: a peer allocates a page it never references and closes, so the snapshot its close records carries a leak; the stale handle's check reports the file not clean and repairs it, leaves a snapshot a peer can load, and a second check is clean -- dropping the recording commit fails it. `an_integrity_check_records_a_peers_unrecorded_commit`: a peer commits with no allocator state, as a repair's commit does, and stays open so its close does not record; the check reports the file not clean and leaves a snapshot, where before it reported it clean and left none.

`cargo fmt --check`, `cargo clippy --all --all-targets --all-features` under `--deny warnings`, `cargo clippy --all --all-targets` with default features, `cargo doc --all --no-deps` and `cargo test --all --all-features` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9BSFJKvzsERy8jjeMxwjD