### PR TITLE
Compact a shared database under the header lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@
   takes a `ConcurrencyMode` configuring how processes may share the database.
   When `SingleWriterProcess` or `MultiWriterProcess` is configured, commits are always 2-phase,
   `Durability::None` is refused, and the database may be opened read-only while another process has
-  it open for writing; each new read transaction then sees that process's durable commits.
+  it open for writing; each new read transaction then sees that process's durable commits, and
+  `Database::compact()` treats a read transaction in another process as a transaction in progress.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/docs/design.md
+++ b/docs/design.md
@@ -622,6 +622,11 @@ and scans the active transaction range stopping at the first byte it cannot lock
 efficiency a binary interval search is recommended.
 It then takes the minimum of this id and the lowest one referenced by a persistent savepoint.
 
+To compact the file, a writer takes the writer byte (in multi-writer mode) and then an exclusive
+"header lock", and holds both until the compaction is complete, so that no other process begins a
+transaction while pages move. An active transaction byte that is held at that point is a transaction
+in progress, and the compaction is refused.
+
 ## Savepoints
 
 In single writer mode, an ephemeral savepoint pins a transaction exactly as a read transaction does.

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,7 @@
 use crate::io;
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
+#[cfg(feature = "experimental-multiprocess")]
+use crate::tree_store::HeaderGuard;
 use crate::tree_store::LocklessBackend;
 #[cfg(not(redb_no_std))]
 use crate::tree_store::ReadOnlyBackend;
@@ -970,10 +972,33 @@ impl Database {
         if self.transaction_tracker.any_user_read_reference_exists() {
             return Err(CompactionError::TransactionInProgress);
         }
+        // Where the file is shared, held until the compaction is over and lent to the
+        // transactions it runs: no other process begins a transaction under them, and one that
+        // already has is a transaction in progress. Taken once a write transaction begun before
+        // this call has ended: its commit would wait on the holds, and in multi-writer mode its
+        // end would release the writer byte from under a hold taken meanwhile
+        #[cfg(feature = "experimental-multiprocess")]
+        let (writer_lock, header_lock) = if self.mem.concurrency_mode().is_multi_process_writable()
+        {
+            self.begin_write()
+                .map_err(|e| e.into_storage_error())?
+                .abort()?;
+            (
+                Some(self.mem.lock_writer()?),
+                Some(self.mem.lock_header_exclusive()?),
+            )
+        } else {
+            (None, None)
+        };
         // Use 2-phase commit to avoid any possible security issues. Plus this compaction is going to be so slow that it doesn't matter.
         // Once https://github.com/cberner/redb/issues/829 is fixed, we should upgrade this to use quick-repair -- that way the user
         // can cancel the compaction without requiring a full repair afterwards
-        let txn = self.begin_write().map_err(|e| e.into_storage_error())?;
+        let txn = self
+            .begin_write_with(
+                #[cfg(feature = "experimental-multiprocess")]
+                writer_lock.as_ref(),
+            )
+            .map_err(|e| e.into_storage_error())?;
         // Re-check inside the write transaction: a concurrent writer may have created a
         // savepoint between the checks above and the start of this transaction.
         if txn.list_persistent_savepoints()?.next().is_some() {
@@ -985,26 +1010,57 @@ impl Database {
         if self.transaction_tracker.any_user_read_reference_exists() {
             return Err(CompactionError::TransactionInProgress);
         }
+        // No local read is left to bound the scan, so a pin it finds is a peer's
+        #[cfg(feature = "experimental-multiprocess")]
+        if let Some(header_lock) = &header_lock
+            && self
+                .mem
+                .oldest_active_transaction(None, header_lock)?
+                .is_some()
+        {
+            return Err(CompactionError::TransactionInProgress);
+        }
         txn.abort()?;
         // Commit to free up any pending free pages
-        self.drain_pending_free_pages(ShrinkPolicy::Maximum)?;
+        self.drain_pending_free_pages(
+            ShrinkPolicy::Maximum,
+            #[cfg(feature = "experimental-multiprocess")]
+            writer_lock.as_ref(),
+            #[cfg(feature = "experimental-multiprocess")]
+            header_lock.as_ref(),
+        )?;
 
         let mut compacted = false;
         // Iteratively compact until no progress is made
         loop {
             let mut progress = false;
 
-            let mut txn = self.begin_write().map_err(|e| e.into_storage_error())?;
+            let mut txn = self
+                .begin_write_with(
+                    #[cfg(feature = "experimental-multiprocess")]
+                    writer_lock.as_ref(),
+                )
+                .map_err(|e| e.into_storage_error())?;
             if txn.compact_pages()? {
                 progress = true;
-                txn.commit().map_err(|e| e.into_storage_error())?;
+                txn.commit_with(
+                    #[cfg(feature = "experimental-multiprocess")]
+                    header_lock.as_ref(),
+                )
+                .map_err(|e| e.into_storage_error())?;
             } else {
                 txn.abort()?;
             }
 
             // Drain pages freed by compact_pages(), including system pages queued by any
             // post-commit cleanup root updates.
-            self.drain_pending_free_pages(ShrinkPolicy::Maximum)?;
+            self.drain_pending_free_pages(
+                ShrinkPolicy::Maximum,
+                #[cfg(feature = "experimental-multiprocess")]
+                writer_lock.as_ref(),
+                #[cfg(feature = "experimental-multiprocess")]
+                header_lock.as_ref(),
+            )?;
 
             if !progress {
                 break;
@@ -1016,12 +1072,22 @@ impl Database {
         Ok(compacted)
     }
 
-    fn drain_pending_free_pages(&self, shrink_policy: ShrinkPolicy) -> Result {
+    fn drain_pending_free_pages(
+        &self,
+        shrink_policy: ShrinkPolicy,
+        #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
+        #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
+    ) -> Result {
         // Preserve compact()'s empty durable commit, which also publishes pending
         // non-durable roots before checking for pending frees.
         let mut force_commit = true;
         loop {
-            let mut txn = self.begin_write().map_err(|e| e.into_storage_error())?;
+            let mut txn = self
+                .begin_write_with(
+                    #[cfg(feature = "experimental-multiprocess")]
+                    writer_lock,
+                )
+                .map_err(|e| e.into_storage_error())?;
             if !force_commit && !txn.pending_free_pages()? {
                 txn.abort()?;
                 return Ok(());
@@ -1029,7 +1095,11 @@ impl Database {
             force_commit = false;
             txn.set_two_phase_commit(true);
             txn.set_shrink_policy(shrink_policy);
-            txn.commit().map_err(|e| e.into_storage_error())?;
+            txn.commit_with(
+                #[cfg(feature = "experimental-multiprocess")]
+                header_lock,
+            )
+            .map_err(|e| e.into_storage_error())?;
         }
     }
 

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -376,3 +376,112 @@ mod reclamation {
         assert_eq!(t.get(&0).unwrap().unwrap().value(), [0u8; 4].as_slice());
     }
 }
+
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+mod compaction {
+    use super::*;
+    use redb::{
+        CompactionError, ReadOnlyDatabase, ReadableDatabase, ReadableTable, TableDefinition,
+    };
+    use std::path::Path;
+
+    const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("x");
+
+    fn create(path: &Path, mode: ConcurrencyMode) -> Database {
+        Database::builder()
+            .set_concurrency_mode(mode)
+            .create(path)
+            .unwrap()
+    }
+
+    fn open_read_only(path: &Path, mode: ConcurrencyMode) -> ReadOnlyDatabase {
+        Database::builder()
+            .set_concurrency_mode(mode)
+            .open_read_only(path)
+            .unwrap()
+    }
+
+    fn insert(db: &Database, keys: std::ops::Range<u64>, value: &[u8]) {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut t = txn.open_table(TABLE).unwrap();
+            for key in keys {
+                t.insert(&key, value).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    /// A read transaction in another process is a transaction in progress, as a local one is
+    #[test]
+    fn compaction_refuses_a_peers_read_transaction() {
+        for mode in [
+            ConcurrencyMode::SingleWriterProcess,
+            ConcurrencyMode::MultiWriterProcess,
+        ] {
+            let tmpfile = tempfile::NamedTempFile::new().unwrap();
+            let mut writer = create(tmpfile.path(), mode);
+            insert(&writer, 0..1, &[1u8; 512]);
+
+            let reader = open_read_only(tmpfile.path(), mode);
+            let pinned = reader.begin_read().unwrap();
+            assert!(
+                matches!(
+                    writer.compact(),
+                    Err(CompactionError::TransactionInProgress)
+                ),
+                "{mode:?}"
+            );
+
+            drop(pinned);
+            writer.compact().unwrap();
+            let read = reader.begin_read().unwrap();
+            let t = read.open_table(TABLE).unwrap();
+            assert_eq!(t.get(&0).unwrap().unwrap().value(), [1u8; 512].as_slice());
+        }
+    }
+
+    /// The file shrinks under a peer that has it open, and the peer's next read follows the pages
+    /// that moved
+    #[test]
+    fn compaction_shrinks_a_file_a_peer_has_open() {
+        for mode in [
+            ConcurrencyMode::SingleWriterProcess,
+            ConcurrencyMode::MultiWriterProcess,
+        ] {
+            let tmpfile = tempfile::NamedTempFile::new().unwrap();
+            let mut writer = create(tmpfile.path(), mode);
+            let value = vec![7u8; 1024];
+            insert(&writer, 0..512, &value);
+
+            // Caches the pages the compaction is about to move
+            let reader = open_read_only(tmpfile.path(), mode);
+            {
+                let read = reader.begin_read().unwrap();
+                let t = read.open_table(TABLE).unwrap();
+                assert_eq!(t.get(&511).unwrap().unwrap().value(), value.as_slice());
+            }
+
+            let txn = writer.begin_write().unwrap();
+            {
+                let mut t = txn.open_table(TABLE).unwrap();
+                for key in 8..512u64 {
+                    t.remove(&key).unwrap();
+                }
+            }
+            txn.commit().unwrap();
+
+            let before = std::fs::metadata(tmpfile.path()).unwrap().len();
+            assert!(writer.compact().unwrap(), "{mode:?}");
+            let after = std::fs::metadata(tmpfile.path()).unwrap().len();
+            assert!(after < before, "{mode:?}: {before} -> {after}");
+
+            let read = reader.begin_read().unwrap();
+            let t = read.open_table(TABLE).unwrap();
+            for key in 0..8u64 {
+                assert_eq!(t.get(&key).unwrap().unwrap().value(), value.as_slice());
+            }
+            assert!(t.get(&8).unwrap().is_none());
+        }
+    }
+}


### PR DESCRIPTION
Replaces #1442, which refused compaction in the shared modes. Compaction now works in both of them, and treats a read transaction in another process exactly as it treats a local one. The lending it relies on landed in #1446.

## What it does

`compact()` takes the writer byte, in multi-writer mode, and then the exclusive header lock, and holds both until it returns. No other process begins a transaction under them: a reader waits at the header lock, a multi-writer peer at the writer byte. A pin already held when the hold is taken is a transaction in progress, and `compact()` returns `CompactionError::TransactionInProgress` for it, as it does for a local read. That check is the scan #1441 added, run once under the hold with no local read to bound it, so any held byte is a peer's.

The holds are the `Arc<WriterLock>` from `lock_writer()` and an ordinary `HeaderGuard`, taken once where the file is shared and lent to every transaction the compaction runs through `begin_write_with()` and `commit_with()`, so none takes a lock of its own and none releases the byte at its end. A single-process database takes neither, since its header guard is only the in-process mutex, which the post-commit free pass that runs in that mode alone takes for itself. Before taking them, `compact()` begins and aborts one ordinary transaction, which waits out a write transaction begun before the call: its commit would otherwise wait on the holds, and in multi-writer mode it holds the writer byte, whose release at its end would drop a hold this handle took meanwhile, since a description's locks on one range are one lock.

The design doc gains a paragraph on this under the active transaction set, and the changelog bullet a clause on the error a peer's read produces.

## The decisions this isolates

1. **Refuse a peer's read as a transaction in progress, rather than waiting for it.** A local read is refused the same way, and a peer's could hold indefinitely; the caller decides whether to retry.
2. **Hold the writer byte across the whole compaction in multi-writer mode.** Compaction runs several write transactions. Between two of them a peer could take the writer byte, and its commit would then wait on the header lock this compaction holds while this compaction waited on the byte. Holding the byte throughout removes that cycle. A single-writer handle already holds it for its lifetime.
3. **Run the re-checks under the holds.** The savepoint and read checks run in a transaction begun after the holds are taken, so a peer's commit between the ordinary first transaction ending and the holds being taken is seen by them, where a persistent savepoint a peer created and closed on would otherwise be compacted over.

## Testing

`compaction_refuses_a_peers_read_transaction`: in each shared mode, a read-only handle on a second file description holds a read while `compact()` is called, which returns `TransactionInProgress`; once the read ends, compaction succeeds and the peer's next read sees the data. Without the peer check the test hangs in the drain, the spin Codex found on #1441. `compaction_shrinks_a_file_a_peer_has_open`: with a peer that has read the pages about to move, compaction shrinks the file and the peer's next read follows them. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9