### PR TITLE
Give the writer lock an owner every transaction shares

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,10 +1,10 @@
 use crate::io;
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
 use crate::tree_store::LocklessBackend;
-#[cfg(feature = "experimental-multiprocess")]
-use crate::tree_store::MultiProcessWriterGuard;
 #[cfg(not(redb_no_std))]
 use crate::tree_store::ReadOnlyBackend;
+#[cfg(feature = "experimental-multiprocess")]
+use crate::tree_store::WriterLock;
 use crate::tree_store::{
     AllocationPolicy, BtreeHeader, InternalTableDefinition, PAGE_SIZE, PageHint, PageNumber,
     PageResolver, ShrinkPolicy, TableTree, TableType, TransactionalMemory,
@@ -367,12 +367,10 @@ pub(crate) enum TransactionGuard {
     Write {
         tracker: Arc<TransactionTracker>,
         transaction_id: TransactionId,
-        // Owned alongside the write slot so the two can be ordered against each other: a
-        // thread waiting on that slot takes the byte on this same file description the moment
-        // it is free, so the byte must be released first and taken after.
-        // None indicates that the writer lock is held at the database level -- i.e. in a single writer mode
+        // The writer lock, held as long as the transaction is. `Option` only so that `Drop`
+        // can move it out
         #[cfg(feature = "experimental-multiprocess")]
-        multi_process_writer: Option<MultiProcessWriterGuard>,
+        writer_lock: Option<Arc<WriterLock>>,
     },
     // Used for internal accesses that happen outside of any tracked transaction,
     // such as opening the database, repairing it, and running integrity checks.
@@ -434,30 +432,18 @@ impl TransactionGuard {
         Ok(Self::new_read(id, tracker, mem))
     }
 
+    /// The caller must already hold the write slot and the lock the transaction writes under.
     pub(crate) fn new_write(
         transaction_id: TransactionId,
         tracker: Arc<TransactionTracker>,
-        #[cfg(feature = "experimental-multiprocess")] mem: &Arc<TransactionalMemory>,
-    ) -> Result<Self> {
-        #[allow(unused_mut)]
-        let mut guard = Self::Write {
+        #[cfg(feature = "experimental-multiprocess")] writer_lock: Arc<WriterLock>,
+    ) -> Self {
+        Self::Write {
             tracker,
             transaction_id,
             #[cfg(feature = "experimental-multiprocess")]
-            multi_process_writer: None,
-        };
-        // After the guard owns the slot, so that a failure here releases it rather than
-        // leaving the tracker with a live write transaction nothing will ever end
-        #[cfg(feature = "experimental-multiprocess")]
-        if let Self::Write {
-            multi_process_writer,
-            ..
-        } = &mut guard
-        {
-            *multi_process_writer = TransactionalMemory::lock_multi_process_writer(mem)?;
+            writer_lock: Some(writer_lock),
         }
-
-        Ok(guard)
     }
 
     pub(crate) fn untracked() -> Self {
@@ -492,15 +478,16 @@ impl Drop for TransactionGuard {
                 tracker,
                 transaction_id,
                 #[cfg(feature = "experimental-multiprocess")]
-                    multi_process_writer: writer,
+                writer_lock,
             } => {
-                // Drop the "writer byte" multi-process file lock, before our in-process lock.
-                // Otherwise, another transaction in our process could re-enter the file lock
-                #[cfg(feature = "experimental-multiprocess")]
-                drop(writer.take());
-                if let Some(mem) = tracker.end_write_transaction(*transaction_id) {
-                    // The Database was dropped while this transaction was live, deferring
-                    // the database close to the end of this transaction
+                let deferred = tracker.end_write_transaction(
+                    *transaction_id,
+                    #[cfg(feature = "experimental-multiprocess")]
+                    writer_lock.take(),
+                );
+                // The Database was dropped while this transaction was live, deferring
+                // the database close to the end of this transaction
+                if let Some(mem) = deferred {
                     close_database(tracker, &mem);
                 }
             }
@@ -1459,28 +1446,48 @@ impl Database {
     /// transaction remains usable and the database closes when the transaction completes.
     pub fn begin_write(&self) -> Result<WriteTransaction, TransactionError> {
         begin_write_with_allocation_policy(
+            self.write_guard()?,
             &self.transaction_tracker,
             &self.mem,
             AllocationPolicy::Default,
         )
+    }
+
+    /// The write slot, and the lock the transaction will write under.
+    fn write_guard(&self) -> Result<TransactionGuard, TransactionError> {
+        // Fail early if there has been an I/O error -- nothing can be committed in that case
+        self.mem.check_io_errors()?;
+        let transaction_id = self.transaction_tracker.start_write_transaction();
+        #[cfg(feature = "experimental-multiprocess")]
+        let writer_lock = match self.mem.lock_writer() {
+            Ok(lock) => lock,
+            Err(err) => {
+                // Nothing owns the slot yet, and this database is live, so no close is deferred
+                let deferred = self
+                    .transaction_tracker
+                    .end_write_transaction(transaction_id, None);
+                assert!(deferred.is_none());
+                return Err(err.into());
+            }
+        };
+
+        Ok(TransactionGuard::new_write(
+            transaction_id,
+            self.transaction_tracker.clone(),
+            #[cfg(feature = "experimental-multiprocess")]
+            writer_lock,
+        ))
     }
 }
 
 // The allocation policy is fixed for the lifetime of the transaction; every page allocation
 // this transaction makes goes through it.
 fn begin_write_with_allocation_policy(
+    guard: TransactionGuard,
     transaction_tracker: &Arc<TransactionTracker>,
     mem: &Arc<TransactionalMemory>,
     allocation_policy: AllocationPolicy,
 ) -> Result<WriteTransaction, TransactionError> {
-    // Fail early if there has been an I/O error -- nothing can be committed in that case
-    mem.check_io_errors()?;
-    let guard = TransactionGuard::new_write(
-        transaction_tracker.start_write_transaction(),
-        transaction_tracker.clone(),
-        #[cfg(feature = "experimental-multiprocess")]
-        mem,
-    )?;
     // Re-checked after acquiring the write slot: the writer this call blocked on can fail its
     // commit, latching an I/O error and discarding the allocator state. The I/O check comes
     // first so a backend failure is not misreported as corruption. Returning drops the guard,
@@ -1512,8 +1519,24 @@ fn ensure_allocator_state_table_and_trim(
     // commit's writes at high page indices (see AllocationPolicy::Lowest)
     // and try_shrink can't reclaim the growth. See
     // https://github.com/cberner/redb/issues/1165
-    let mut tx =
-        begin_write_with_allocation_policy(transaction_tracker, mem, AllocationPolicy::Lowest)?;
+    // Before the lock, which waits on a peer holding the writer byte: a latched I/O failure
+    // means there is nothing to write here anyway
+    mem.check_io_errors()?;
+    // The database is being closed, so nothing can be waiting on the write slot
+    #[cfg(feature = "experimental-multiprocess")]
+    let writer_lock = mem.lock_writer()?;
+    let guard = TransactionGuard::new_write(
+        transaction_tracker.start_write_transaction(),
+        transaction_tracker.clone(),
+        #[cfg(feature = "experimental-multiprocess")]
+        writer_lock,
+    );
+    let mut tx = begin_write_with_allocation_policy(
+        guard,
+        transaction_tracker,
+        mem,
+        AllocationPolicy::Lowest,
+    )?;
     tx.set_quick_repair(true);
     tx.disable_post_commit_free();
     tx.set_shrink_policy(ShrinkPolicy::Maximum);
@@ -2306,7 +2329,7 @@ mod writer_byte_test {
 
     /// This mode settles who writes at open instead, so the byte is held from then until the
     /// database closes. A transaction taking it again would convert that hold and drop what
-    /// remained on release, so it takes nothing.
+    /// remained on release, so it holds the open's instead.
     #[test]
     fn a_single_writer_open_holds_the_byte_for_its_lifetime() {
         let tmpfile = crate::create_tempfile();
@@ -2327,6 +2350,29 @@ mod writer_byte_test {
         assert!(
             probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap(),
             "the byte was still held after the database closed"
+        );
+        probe.unlock_range(byte_range(WRITER_BYTE)).unwrap();
+    }
+
+    /// A transaction that outlives the database keeps the lock, and the deferred close writes
+    /// the allocator state under it
+    #[test]
+    fn a_transaction_outliving_the_database_keeps_the_writer_lock() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::SingleWriterProcess);
+        let probe = probe(tmpfile.path());
+
+        let write = db.begin_write().unwrap();
+        drop(db);
+        assert!(
+            !probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap(),
+            "dropping the database released the byte from under a live transaction"
+        );
+
+        write.commit().unwrap();
+        assert!(
+            probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap(),
+            "the byte was still held after the deferred close"
         );
         probe.unlock_range(byte_range(WRITER_BYTE)).unwrap();
     }

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -2,6 +2,8 @@ use crate::sync::{Condvar, Mutex};
 #[cfg(feature = "experimental-multiprocess")]
 use crate::tree_store::HeaderGuard;
 use crate::tree_store::TransactionalMemory;
+#[cfg(feature = "experimental-multiprocess")]
+use crate::tree_store::WriterLock;
 use crate::{Key, Result, Savepoint, TypeName, Value};
 use alloc::collections::BTreeSet;
 use alloc::collections::btree_map::BTreeMap;
@@ -184,11 +186,17 @@ impl TransactionTracker {
     pub(crate) fn end_write_transaction(
         &self,
         id: TransactionId,
+        #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<Arc<WriterLock>>,
     ) -> Option<Arc<TransactionalMemory>> {
         let mut state = self.state.lock().unwrap();
         assert_eq!(state.live_write_transaction.unwrap(), id);
+        // Released before the slot is cleared, under the lock the slot uses: a thread waiting on
+        // it would take the same byte on this description, and this release would free theirs
+        #[cfg(feature = "experimental-multiprocess")]
+        drop(writer_lock);
         state.live_write_transaction = None;
         self.live_write_transaction_available.notify_one();
+
         state.deferred_close.take()
     }
 

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -25,10 +25,10 @@ pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multim
 #[cfg(feature = "experimental-multiprocess")]
 pub(crate) use page_store::HeaderGuard;
 pub(crate) use page_store::LocklessBackend;
-#[cfg(feature = "experimental-multiprocess")]
-pub(crate) use page_store::MultiProcessWriterGuard;
 #[cfg(not(redb_no_std))]
 pub(crate) use page_store::ReadOnlyBackend;
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) use page_store::WriterLock;
 #[cfg(not(redb_no_std))]
 pub use page_store::file_backend;
 pub(crate) use page_store::{

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use header::PAGE_SIZE;
 #[cfg(feature = "experimental-multiprocess")]
 pub(crate) use page_manager::HeaderGuard;
 #[cfg(feature = "experimental-multiprocess")]
-pub(crate) use page_manager::MultiProcessWriterGuard;
+pub(crate) use page_manager::WriterLock;
 pub(crate) use page_manager::{
     AllocationPolicy, FILE_FORMAT_VERSION3, PageAllocator, PageResolver, ShrinkPolicy,
     TransactionalMemory, xxh3_checksum,

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -533,23 +533,51 @@ impl Drop for HeaderGuard<'_> {
     }
 }
 
-/// A hold on the writer byte, released when it drops. Owns its handle, unlike `HeaderGuard`,
-/// since a write transaction outlives the call that takes it.
+/// The lock admitting this process to write, released when the last holder drops it. Holds the
+/// storage rather than the `TransactionalMemory`, which an integrity check takes by
+/// `Arc::get_mut()` and would find shared
 #[cfg(feature = "experimental-multiprocess")]
-pub(crate) struct MultiProcessWriterGuard {
-    mem: Arc<TransactionalMemory>,
+pub(crate) struct WriterLock {
+    storage: Arc<PagedCachedFile>,
+    range: Range<u64>,
 }
 
 #[cfg(feature = "experimental-multiprocess")]
-impl Drop for MultiProcessWriterGuard {
+impl Drop for WriterLock {
     fn drop(&mut self) {
-        let _ = self.mem.storage.unlock_range(byte_range(WRITER_BYTE));
+        // Errors where the backend has no locks, which the open found the same way
+        let _ = self.storage.unlock_range(self.range.clone());
     }
+}
+
+/// The writer lock a handle holds for the life of the database: the whole file where the
+/// database is not shared, and the writer byte where one process writes. Nothing in multi-writer
+/// mode, where a write transaction takes that byte itself, or for a read-only handle
+#[cfg(feature = "experimental-multiprocess")]
+fn database_writer_lock_for_mode(
+    storage: &Arc<PagedCachedFile>,
+    read_only: bool,
+    concurrency_mode: ConcurrencyMode,
+) -> Option<Arc<WriterLock>> {
+    if read_only {
+        return None;
+    }
+    let range = match concurrency_mode {
+        ConcurrencyMode::SingleProcess => FULL_RANGE,
+        ConcurrencyMode::SingleWriterProcess => byte_range(WRITER_BYTE),
+        ConcurrencyMode::MultiWriterProcess => return None,
+    };
+
+    Some(Arc::new(WriterLock {
+        storage: storage.clone(),
+        range,
+    }))
 }
 
 pub(crate) struct TransactionalMemory {
     unpersisted: Mutex<UnpersistedState>,
-    storage: PagedCachedFile,
+    // Shared, so that a `WriterLock` can outlive this and still release its range
+    storage: Arc<PagedCachedFile>,
     state: Mutex<InMemoryState>,
     // The number of PageMut which are outstanding
     #[cfg(debug_assertions)]
@@ -577,6 +605,11 @@ pub(crate) struct TransactionalMemory {
     // the ceiling of the scan before it, since every handle reads the id it pins from the file
     #[cfg(feature = "experimental-multiprocess")]
     scan_from: Mutex<u64>,
+    // The lock the open took, which every write transaction holds while it runs. `None` in
+    // multi-writer mode, where a write transaction takes the writer byte itself, and for a
+    // read-only handle
+    #[cfg(feature = "experimental-multiprocess")]
+    writer_lock: Option<Arc<WriterLock>>,
     page_size: u32,
     // We store these separately from the layout because they're static, and accessed on the get_page()
     // code path where there is no locking
@@ -782,19 +815,20 @@ impl TransactionalMemory {
         Ok(unrepaired.finalize_transaction_slots()?)
     }
 
-    /// Acquire the multi-process writer lock
+    /// The one the open took, or the writer byte a write transaction takes in multi-writer
+    /// mode, waiting on the peer that holds it. Taken after the in-process write slot: locks on
+    /// that byte from this file description are one lock, so the slot is what orders them
     #[cfg(feature = "experimental-multiprocess")]
-    pub(crate) fn lock_multi_process_writer(
-        mem: &Arc<Self>,
-    ) -> Result<Option<MultiProcessWriterGuard>> {
-        // The other modes settle who writes when the database is opened: a single-writer holds this byte
-        // for its lifetime, and taking it again here would convert that hold and then drop it.
-        if !matches!(mem.concurrency_mode, ConcurrencyMode::MultiWriterProcess) {
-            return Ok(None);
+    pub(crate) fn lock_writer(&self) -> Result<Arc<WriterLock>> {
+        if let Some(from_open) = &self.writer_lock {
+            return Ok(from_open.clone());
         }
-        mem.storage.lock_range(byte_range(WRITER_BYTE))?;
+        self.storage.lock_range(byte_range(WRITER_BYTE))?;
 
-        Ok(Some(MultiProcessWriterGuard { mem: mem.clone() }))
+        Ok(Arc::new(WriterLock {
+            storage: self.storage.clone(),
+            range: byte_range(WRITER_BYTE),
+        }))
     }
 
     #[cfg(feature = "experimental-multiprocess")]
@@ -931,7 +965,7 @@ impl TransactionalMemory {
         );
         assert!(region_size.is_power_of_two());
 
-        let storage = PagedCachedFile::new(file, page_size as u64, cache_size);
+        let storage = Arc::new(PagedCachedFile::new(file, page_size as u64, cache_size));
         // Dropping the storage releases whatever this took, so an open that fails below does too
         Self::lock_for_open(&storage, read_only, concurrency_mode)?;
         #[cfg(feature = "experimental-multiprocess")]
@@ -1047,6 +1081,9 @@ impl TransactionalMemory {
 
         assert!(page_size >= DB_HEADER_SIZE);
 
+        #[cfg(feature = "experimental-multiprocess")]
+        let writer_lock = database_writer_lock_for_mode(&storage, read_only, concurrency_mode);
+
         Ok(Self {
             unpersisted: Mutex::new(UnpersistedState::default()),
             storage,
@@ -1066,6 +1103,8 @@ impl TransactionalMemory {
             in_process_header_lock,
             #[cfg(feature = "experimental-multiprocess")]
             scan_from: Mutex::new(0),
+            #[cfg(feature = "experimental-multiprocess")]
+            writer_lock,
             page_size: page_size.try_into().unwrap(),
             region_size,
             region_header_with_padding_size: region_header_size,


### PR DESCRIPTION
Prep for #1444, which needs a compaction to hold the writer lock across the several write transactions it runs. Nothing here is user-visible.

## What it does

Which lock admits a process to write depends on the concurrency mode: the whole file where the database is not shared, `WRITER_BYTE` where one process writes, and `WRITER_BYTE` taken per transaction where several do. `TransactionGuard::new_write()` re-derived that on every begin, through `lock_multi_process_writer()` returning `None` in the first two modes, so a transaction in them held nothing and ran under whatever the open had left locked.

`TransactionalMemory` now holds the lock the open took, and `share_writer_lock()` is the one way to get a share of it: it clones that lock, or takes the writer byte where a transaction is what takes it. A write transaction holds a share for its whole life. Two things follow from the refcount that were previously true only by construction — a transaction that outlives its `Database` keeps the lock, and no range is ever locked twice on one file description — and one thing that was not true before: `close()` writes the shutdown header while the lock is still held, because the memory that owns it is the thing being closed.

`WriterLock` holds the storage rather than the `TransactionalMemory` around it, because `check_integrity()` takes the latter by `Arc::get_mut()`, which refuses while any other `Arc` or `Weak` to it exists. A read-only handle gets no writer lock, which it never had a use for.

## The decisions this isolates

1. **The memory owns the open's lock.** It was on the `Database` first, which meant threading it into `close_database()`, `ensure_allocator_state_table_and_trim()` and the deferred close, and getting the shutdown ordering right by hand. On the memory, none of that is threaded and the ordering is structural. The alternative to owning the real range at all was a guard that guards nothing in the two modes that settle the writer at open; holding the range makes the lifetime the truth rather than a convention.
2. **The write slot is taken before the share.** This description's locks on the writer byte are one lock, so a thread that took the byte while another held the slot would have it released from under it when that one ended. `Database::write_guard()` is where both are taken, in that order, and `begin_write_with_allocation_policy()` receives the guard already built.
3. **The release is handed to `end_write_transaction()`.** It drops the share before clearing the slot, under the lock the slot uses, so a waiting thread cannot take the byte while the outgoing transaction still holds it. This is why `TransactionGuard::Write` holds an `Option`: a field cannot be moved out of a type that implements `Drop`, so `take()` is the only way to hand it over. It is `Some` for the transaction's whole life.

## Testing

`a_single_writer_open_holds_the_byte_for_its_lifetime` covers the mode where this changes most, and `a_transaction_outliving_the_database_keeps_the_writer_lock` is new: the byte is still held after the `Database` is dropped under a live transaction, and free once the deferred close has run. Both fail if `share_writer_lock()` takes a lock instead of cloning the open's. The ordering in decision 3 and the shutdown window in decision 1 are not observable from a test — the shared modes reject a caller-supplied backend, and a single-process one has no locks to watch — so they rest on the structure rather than on coverage. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9