### PR TITLE
Lend a write transaction the locks its caller holds

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -882,6 +882,8 @@ impl Database {
                 next_transaction_id,
                 true,
                 ShrinkPolicy::Never,
+                #[cfg(feature = "experimental-multiprocess")]
+                None,
             )?;
             // Reserve the id, or the next write transaction would commit with the same one,
             // which crash recovery could then resolve to the wrong slot
@@ -1349,6 +1351,8 @@ impl Database {
                 next_transaction_id,
                 true,
                 ShrinkPolicy::Never,
+                #[cfg(feature = "experimental-multiprocess")]
+                None,
             )?;
         }
 
@@ -1445,31 +1449,50 @@ impl Database {
     /// database open: if the [`Database`] is dropped while the transaction is live, the
     /// transaction remains usable and the database closes when the transaction completes.
     pub fn begin_write(&self) -> Result<WriteTransaction, TransactionError> {
+        self.begin_write_with(
+            #[cfg(feature = "experimental-multiprocess")]
+            None,
+        )
+    }
+
+    fn begin_write_with(
+        &self,
+        #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
+    ) -> Result<WriteTransaction, TransactionError> {
         begin_write_with_allocation_policy(
-            self.write_guard()?,
+            self.write_guard(
+                #[cfg(feature = "experimental-multiprocess")]
+                writer_lock,
+            )?,
             &self.transaction_tracker,
             &self.mem,
             AllocationPolicy::Default,
         )
     }
 
-    /// The write slot, and the lock the transaction will write under.
-    fn write_guard(&self) -> Result<TransactionGuard, TransactionError> {
+    /// The write slot, and the lock the transaction will write under: `writer_lock` where the
+    /// caller lends the one it holds, since a second lock on that byte from this file
+    /// description is the same lock, and this transaction's end would release the caller's.
+    fn write_guard(
+        &self,
+        #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
+    ) -> Result<TransactionGuard, TransactionError> {
         // Fail early if there has been an I/O error -- nothing can be committed in that case
         self.mem.check_io_errors()?;
         let transaction_id = self.transaction_tracker.start_write_transaction();
         #[cfg(feature = "experimental-multiprocess")]
-        let writer_lock = match self.mem.lock_writer() {
-            Ok(lock) => lock,
-            Err(err) => {
-                // Nothing owns the slot yet, and this database is live, so no close is deferred
-                let deferred = self
-                    .transaction_tracker
-                    .end_write_transaction(transaction_id, None);
-                assert!(deferred.is_none());
-                return Err(err.into());
-            }
-        };
+        let writer_lock =
+            match writer_lock.map_or_else(|| self.mem.lock_writer(), |lent| Ok(lent.clone())) {
+                Ok(lock) => lock,
+                Err(err) => {
+                    // Nothing owns the slot yet, and this database is live, so no close is deferred
+                    let deferred = self
+                        .transaction_tracker
+                        .end_write_transaction(transaction_id, None);
+                    assert!(deferred.is_none());
+                    return Err(err.into());
+                }
+            };
 
         Ok(TransactionGuard::new_write(
             transaction_id,
@@ -2541,7 +2564,8 @@ mod consistent_byte_test {
     any(target_os = "linux", target_vendor = "apple", windows)
 ))]
 mod active_transaction_test {
-    use super::{ConcurrencyMode, Database, ReadableDatabase, TXN_BASE, byte_range};
+    use super::{ConcurrencyMode, Database, ReadableDatabase, TXN_BASE, WRITER_BYTE, byte_range};
+    use crate::tree_store::HEADER_LOCK;
     use crate::tree_store::file_backend::range_lock::RangeLock;
     use crate::{Durability, SetDurabilityError, TableDefinition};
     use std::fs::{File, OpenOptions};
@@ -2927,19 +2951,21 @@ mod active_transaction_test {
         ] {
             let tmpfile = crate::create_tempfile();
             let db = create(tmpfile.path(), mode);
+            let scan = |local| {
+                let header_lock = db.mem.lock_header_exclusive().unwrap();
+                db.mem
+                    .oldest_active_transaction(local, &header_lock)
+                    .unwrap()
+            };
             let first = db.mem.get_last_committed_transaction_id().unwrap();
-            assert_eq!(db.mem.oldest_active_transaction(None).unwrap(), None);
+            assert_eq!(scan(None), None);
 
             // A peer pins the last committed transaction, as its read of the header would
             let probe = probe(tmpfile.path());
             probe
                 .lock_shared_range(byte_range(TXN_BASE + first.raw_id()))
                 .unwrap();
-            assert_eq!(
-                db.mem.oldest_active_transaction(None).unwrap(),
-                Some(first),
-                "{mode:?}"
-            );
+            assert_eq!(scan(None), Some(first), "{mode:?}");
 
             let write = db.begin_write().unwrap();
             {
@@ -2949,19 +2975,46 @@ mod active_transaction_test {
             write.commit().unwrap();
             let second = db.mem.get_last_committed_transaction_id().unwrap();
             assert!(first < second);
-            assert_eq!(
-                db.mem.oldest_active_transaction(Some(second)).unwrap(),
-                Some(first),
-                "{mode:?}"
-            );
+            assert_eq!(scan(Some(second)), Some(first), "{mode:?}");
             probe
                 .unlock_range(byte_range(TXN_BASE + first.raw_id()))
                 .unwrap();
-            assert_eq!(
-                db.mem.oldest_active_transaction(Some(second)).unwrap(),
-                Some(second),
-                "{mode:?}"
-            );
+            assert_eq!(scan(Some(second)), Some(second), "{mode:?}");
         }
+    }
+
+    /// A transaction lent the exclusive header hold commits under it and leaves it held
+    #[test]
+    fn a_lent_header_hold_outlives_the_commit() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let probe = probe(tmpfile.path());
+
+        let header_lock = db.mem.lock_header_exclusive().unwrap();
+        let txn = db.begin_write().unwrap();
+        txn.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+        txn.commit_with(Some(&header_lock)).unwrap();
+        assert!(!probe.try_lock_shared_range(HEADER_LOCK).unwrap());
+
+        drop(header_lock);
+        assert!(probe.try_lock_shared_range(HEADER_LOCK).unwrap());
+        probe.unlock_range(HEADER_LOCK).unwrap();
+    }
+
+    /// A transaction lent the writer byte leaves it held when it ends
+    #[test]
+    fn a_lent_writer_byte_outlives_the_transaction() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let probe = probe(tmpfile.path());
+
+        let writer_lock = db.mem.lock_writer().unwrap();
+        let txn = db.begin_write_with(Some(&writer_lock)).unwrap();
+        txn.abort().unwrap();
+        assert!(!probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap());
+
+        drop(writer_lock);
+        assert!(probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap());
+        probe.unlock_range(byte_range(WRITER_BYTE)).unwrap();
     }
 }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -5,6 +5,8 @@ use crate::sealed::Sealed;
 use crate::sync::Mutex;
 use crate::table::ReadOnlyUntypedTable;
 use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker};
+#[cfg(feature = "experimental-multiprocess")]
+use crate::tree_store::HeaderGuard;
 #[cfg(all(debug_assertions, not(redb_no_std)))]
 use crate::tree_store::PageNumberHashSet;
 use crate::tree_store::{
@@ -1695,28 +1697,51 @@ impl WriteTransaction {
     /// applied atomically -- fully or not at all -- but may already have become durable, so they
     /// must not be assumed rolled back. The database refuses further write transactions; closing
     /// and reopening it repairs any internal state left by the failed commit.
-    pub fn commit(mut self) -> Result<(), CommitError> {
+    pub fn commit(self) -> Result<(), CommitError> {
+        self.commit_with(
+            #[cfg(feature = "experimental-multiprocess")]
+            None,
+        )
+    }
+
+    /// `commit()`, under `header_lock` where the caller already holds the header lock
+    pub(crate) fn commit_with(
+        mut self,
+        #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
+    ) -> Result<(), CommitError> {
         // Set completed flag first, so that we don't go through the abort() path on drop, if this fails
         self.completed = true;
         if self.is_poisoned() {
             self.abort_inner()?;
             return Err(CommitError::TransactionPoisoned);
         }
-        self.commit_inner()
+        self.commit_inner(
+            #[cfg(feature = "experimental-multiprocess")]
+            header_lock,
+        )
     }
 
-    fn commit_inner(&mut self) -> Result<(), CommitError> {
+    fn commit_inner(
+        &mut self,
+        #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
+    ) -> Result<(), CommitError> {
         // Covers both the error and the panic-unwind path. Without an allocator state,
         // begin_write() refuses new write transactions and the next open repairs.
         let latch = AllocatorStateLatch::arm(self.mem.clone());
-        let result = self.commit_inner_helper();
+        let result = self.commit_inner_helper(
+            #[cfg(feature = "experimental-multiprocess")]
+            header_lock,
+        );
         if result.is_ok() {
             latch.disarm();
         }
         result
     }
 
-    fn commit_inner_helper(&mut self) -> Result<(), CommitError> {
+    fn commit_inner_helper(
+        &mut self,
+        #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
+    ) -> Result<(), CommitError> {
         // Quick-repair requires 2-phase commit
         if self.quick_repair {
             self.two_phase_commit = true;
@@ -1770,7 +1795,12 @@ impl WriteTransaction {
                 self.non_durable_commit(user_root, allocated_pages, stored_data_freed_pages)?;
                 self.apply_savepoint_state_on_commit();
             }
-            InternalDurability::Immediate => self.durable_commit(user_root, allocated_pages)?,
+            InternalDurability::Immediate => self.durable_commit(
+                user_root,
+                allocated_pages,
+                #[cfg(feature = "experimental-multiprocess")]
+                header_lock,
+            )?,
         }
 
         assert!(
@@ -1995,6 +2025,7 @@ impl WriteTransaction {
         &mut self,
         user_root: Option<BtreeHeader>,
         allocated_pages: Vec<PageNumber>,
+        #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
     ) -> Result {
         // Write out the freed-page records that earlier non-durable commits kept in memory, so
         // that they survive from here on like any other durable record.
@@ -2002,10 +2033,16 @@ impl WriteTransaction {
             self.store_data_freed_pages_for(transaction_id, pages)?;
         }
 
-        let free_until_transaction = self
-            .mem
-            .oldest_active_transaction(self.transaction_tracker.oldest_local_read_transaction())?
-            .map_or(self.transaction_id, |x| x.next());
+        let free_until_transaction = {
+            #[cfg(feature = "experimental-multiprocess")]
+            let hold = self.mem.header_hold(header_lock)?;
+            self.mem.oldest_active_transaction(
+                self.transaction_tracker.oldest_local_read_transaction(),
+                #[cfg(feature = "experimental-multiprocess")]
+                &hold,
+            )?
+        }
+        .map_or(self.transaction_id, |x| x.next());
         self.process_freed_pages(free_until_transaction)?;
         // Flush allocated pages (including previously unpersisted allocations that are now
         // becoming durable) AFTER process_freed_pages, so that any pages reclaimed here have
@@ -2069,6 +2106,8 @@ impl WriteTransaction {
             self.transaction_id,
             self.two_phase_commit,
             self.shrink_policy,
+            #[cfg(feature = "experimental-multiprocess")]
+            header_lock,
         )?;
         // All of this transaction's allocations are durable; discard the per-txn tracker.
         let _ = page_allocator.take_allocated_since_commit();

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -22,6 +22,8 @@ pub(crate) use btree_cursor_range::BtreeCursorRange;
 pub(crate) use btree_iters::{AllPageNumbersBtreeIter, encode_bounds};
 pub(crate) use extract_if::BtreeExtractIf;
 pub(crate) use multimap_btree::{DynamicCollection, DynamicCollectionType, multimap_btree_stats};
+#[cfg(all(test, feature = "experimental-multiprocess"))]
+pub(crate) use page_store::HEADER_LOCK;
 #[cfg(feature = "experimental-multiprocess")]
 pub(crate) use page_store::HeaderGuard;
 pub(crate) use page_store::LocklessBackend;

--- a/src/tree_store/page_store/mod.rs
+++ b/src/tree_store/page_store/mod.rs
@@ -24,6 +24,8 @@ pub(crate) use backends::ReadOnlyBackend;
 pub(crate) use base::{MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, Page, PageHint, PageNumber, PageTracker};
 pub(crate) use fast_hash::{PageNumberHashMap, PageNumberHashSet};
 pub(crate) use header::PAGE_SIZE;
+#[cfg(all(test, feature = "experimental-multiprocess"))]
+pub(crate) use page_manager::HEADER_LOCK;
 #[cfg(feature = "experimental-multiprocess")]
 pub(crate) use page_manager::HeaderGuard;
 #[cfg(feature = "experimental-multiprocess")]

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -36,7 +36,7 @@ use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem;
 #[cfg(feature = "experimental-multiprocess")]
-use core::ops::Range;
+use core::ops::{Deref, Range};
 use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg(feature = "logging")]
 use log::warn;
@@ -517,7 +517,10 @@ impl UnpersistedState {
 #[cfg(feature = "experimental-multiprocess")]
 pub(crate) const HEADER_LOCK: Range<u64> = 0..DB_HEADER_SIZE as u64;
 
-/// A hold on the header lock, released when it drops.
+/// A hold on the header lock, released when it drops. Taken ahead of the memory's and the
+/// tracker's state locks, which a reader's registration and the reclamation scan take under it.
+/// Lent to the work under it rather than taken again: the in-process half is a mutex, which its
+/// holder cannot take twice.
 #[cfg(feature = "experimental-multiprocess")]
 pub(crate) struct HeaderGuard<'a> {
     storage: Option<&'a PagedCachedFile>,
@@ -529,6 +532,25 @@ impl Drop for HeaderGuard<'_> {
     fn drop(&mut self) {
         if let Some(storage) = self.storage {
             let _ = storage.unlock_range(HEADER_LOCK);
+        }
+    }
+}
+
+/// One operation's exclusive header hold, released after it unless it was the caller's
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) enum HeaderHold<'a> {
+    Lent(&'a HeaderGuard<'a>),
+    Own(HeaderGuard<'a>),
+}
+
+#[cfg(feature = "experimental-multiprocess")]
+impl<'a> Deref for HeaderHold<'a> {
+    type Target = HeaderGuard<'a>;
+
+    fn deref(&self) -> &HeaderGuard<'a> {
+        match self {
+            Self::Lent(guard) => guard,
+            Self::Own(guard) => guard,
         }
     }
 }
@@ -853,7 +875,7 @@ impl TransactionalMemory {
     }
 
     #[cfg(feature = "experimental-multiprocess")]
-    fn lock_header_exclusive(&self) -> Result<HeaderGuard<'_>> {
+    pub(crate) fn lock_header_exclusive(&self) -> Result<HeaderGuard<'_>> {
         Self::lock_header(
             &self.storage,
             &self.in_process_header_lock,
@@ -862,16 +884,29 @@ impl TransactionalMemory {
         )
     }
 
+    /// The exclusive header hold for one operation: `lent` where the caller holds it already, and
+    /// a hold of its own otherwise
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn header_hold<'a>(
+        &'a self,
+        lent: Option<&'a HeaderGuard<'a>>,
+    ) -> Result<HeaderHold<'a>> {
+        Ok(match lent {
+            Some(guard) => HeaderHold::Lent(guard),
+            None => HeaderHold::Own(self.lock_header_exclusive()?),
+        })
+    }
+
     /// The oldest transaction still being read in any process, given `local`, the oldest this
-    /// process reads. Where the file is shared it is found under the exclusive header hold, which
-    /// every registration waits behind, so no pin lands below what this reports.
+    /// process reads. Where the file is shared it is found under the caller's exclusive header
+    /// hold, which every registration waits behind, so no pin lands below what this reports.
     #[cfg(feature = "experimental-multiprocess")]
     pub(crate) fn oldest_active_transaction(
         &self,
         local: Option<TransactionId>,
+        _header_lock: &HeaderGuard<'_>,
     ) -> Result<Option<TransactionId>> {
         if self.concurrency_mode.is_multi_process_writable() {
-            let _guard = self.lock_header_exclusive()?;
             let ceiling = self.get_last_committed_transaction_id()?;
             // Every id scanned is at most the ceiling, so this bounds the whole scan's offsets
             Self::active_transaction_byte(ceiling)?;
@@ -1201,7 +1236,13 @@ impl TransactionalMemory {
         let unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes, self.page_size)?;
         let (header, was_clean) = unrepaired.finalize(self.storage.raw_file_len()?)?;
         if !was_clean {
-            self.write_header(&header)?;
+            #[cfg(feature = "experimental-multiprocess")]
+            let header_lock = self.lock_header_exclusive()?;
+            self.write_header(
+                &header,
+                #[cfg(feature = "experimental-multiprocess")]
+                &header_lock,
+            )?;
             self.storage.flush()?;
         }
 
@@ -1259,10 +1300,16 @@ impl TransactionalMemory {
     }
 
     pub(crate) fn begin_writable(&self) -> Result {
+        #[cfg(feature = "experimental-multiprocess")]
+        let header_lock = self.lock_header_exclusive()?;
         let mut state = self.state.lock().unwrap();
         assert!(!state.header.recovery_required);
         state.header.recovery_required = true;
-        self.write_header(&state.header)?;
+        self.write_header(
+            &state.header,
+            #[cfg(feature = "experimental-multiprocess")]
+            &header_lock,
+        )?;
         self.storage.flush()
     }
 
@@ -1375,19 +1422,18 @@ impl TransactionalMemory {
         Ok(())
     }
 
-    fn write_header(&self, header: &DatabaseHeader) -> Result {
+    /// Writes the header under the caller's exclusive header hold, which is what keeps another
+    /// process from reading it torn where the file is shared.
+    fn write_header(
+        &self,
+        header: &DatabaseHeader,
+        #[cfg(feature = "experimental-multiprocess")] _header_lock: &HeaderGuard<'_>,
+    ) -> Result {
         #[cfg(feature = "experimental-multiprocess")]
         if self.concurrency_mode.is_multi_process_writable() {
-            // Write directly, while holding the header lock, so that other processes cannot observe
-            // a torn write.
-            let bytes = header.to_bytes(true);
-            let _guard = Self::lock_header(
-                &self.storage,
-                &self.in_process_header_lock,
-                self.concurrency_mode,
-                true,
-            )?;
-            return self.storage.write_direct(0, &bytes);
+            // Written directly rather than through the write buffer, so that the hold covers the
+            // bytes reaching the file
+            return self.storage.write_direct(0, &header.to_bytes(true));
         }
         self.storage
             .write(0, DB_HEADER_SIZE, true)?
@@ -1399,9 +1445,15 @@ impl TransactionalMemory {
 
     // Durably clears the recovery flag, marking the repair as complete.
     pub(crate) fn clear_recovery_required(&self) -> Result<()> {
+        #[cfg(feature = "experimental-multiprocess")]
+        let header_lock = self.lock_header_exclusive()?;
         let mut state = self.state.lock().unwrap();
         state.header.recovery_required = false;
-        self.write_header(&state.header)?;
+        self.write_header(
+            &state.header,
+            #[cfg(feature = "experimental-multiprocess")]
+            &header_lock,
+        )?;
         self.storage.flush()?;
         Ok(())
     }
@@ -1563,6 +1615,7 @@ impl TransactionalMemory {
         transaction_id: TransactionId,
         two_phase: bool,
         shrink_policy: ShrinkPolicy,
+        #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
     ) -> Result {
         // All mutable pages must be dropped, this ensures that when a transaction completes
         // no more writes can happen to the pages it allocated. Thus it is safe to make them visible
@@ -1591,7 +1644,17 @@ impl TransactionalMemory {
         let old_transaction_id = header.secondary_slot().transaction_id;
         header.write_secondary_slot(transaction_id, data_root, system_root);
 
-        self.write_header(&header)?;
+        // A hold of its own covers one write and not the flush between them, where the caller
+        // lends none
+        {
+            #[cfg(feature = "experimental-multiprocess")]
+            let hold = self.header_hold(header_lock)?;
+            self.write_header(
+                &header,
+                #[cfg(feature = "experimental-multiprocess")]
+                &hold,
+            )?;
+        }
 
         // Use 2-phase commit, if checksums are disabled
         if two_phase {
@@ -1604,7 +1667,15 @@ impl TransactionalMemory {
         header.two_phase_commit = two_phase;
 
         // Write the new header to disk
-        self.write_header(&header)?;
+        {
+            #[cfg(feature = "experimental-multiprocess")]
+            let hold = self.header_hold(header_lock)?;
+            self.write_header(
+                &header,
+                #[cfg(feature = "experimental-multiprocess")]
+                &hold,
+            )?;
+        }
         self.storage.flush()?;
 
         if shrunk {
@@ -2206,12 +2277,18 @@ impl TransactionalMemory {
 
     fn flush_shutdown_header(&self) -> Result {
         if self.storage.check_io_errors().is_ok() && !crate::panicking() {
+            #[cfg(feature = "experimental-multiprocess")]
+            let header_lock = self.lock_header_exclusive()?;
             let mut state = self.state.lock()?;
             // Clearing the flag asserts that this process left the file consistent, which requires
             // an allocator state describing what it wrote, and one not marked for repair.
             if state.allocators.is_some() && !self.needs_repair() && self.storage.flush().is_ok() {
                 state.header.recovery_required = false;
-                self.write_header(&state.header)?;
+                self.write_header(
+                    &state.header,
+                    #[cfg(feature = "experimental-multiprocess")]
+                    &header_lock,
+                )?;
                 self.storage.flush()?;
             }
         }
@@ -2561,7 +2638,9 @@ mod header_lock_test {
         let mut header = writer.state.lock().unwrap().header.clone();
         header.recovery_required = !header.recovery_required;
         let expected = header.to_bytes(true);
-        writer.write_header(&header).unwrap();
+        let header_lock = writer.lock_header_exclusive().unwrap();
+        writer.write_header(&header, &header_lock).unwrap();
+        drop(header_lock);
 
         // Read around redb entirely, and with no flush in between
         let on_disk = std::fs::read(tmpfile.path()).unwrap();
@@ -2582,7 +2661,8 @@ mod header_lock_test {
 
         let (tx, rx) = mpsc::channel();
         let writing = thread::spawn(move || {
-            writer.write_header(&header).unwrap();
+            let header_lock = writer.lock_header_exclusive().unwrap();
+            writer.write_header(&header, &header_lock).unwrap();
             tx.send(()).unwrap();
         });
 


### PR DESCRIPTION
Prep for #1444, which holds the writer byte and the exclusive header lock across the several write transactions a compaction runs. Split out so the plumbing can be checked on its own: every caller here lends nothing, and behaves as before.

## What it does

A write transaction takes the writer lock in `Database::write_guard()` when it begins, and the exclusive header lock when it commits: once for the reclamation scan, and once for each of the two header writes, with a flush between them. A caller that holds either lock across several transactions cannot let a transaction take its own: the header lock's in-process half is a mutex, which its holder cannot take twice, and a second lock on the writer byte from one file description is the same lock, which the transaction's end would release.

`Database::begin_write_with()` takes an `Option<&Arc<WriterLock>>`, and `write_guard()` clones a lent lock rather than calling `lock_writer()`, so the transaction's end drops one holder and leaves the byte held. `WriteTransaction::commit_with()` takes an `Option<&HeaderGuard>`, which `durable_commit()` and `TransactionalMemory::commit()` resolve at each of the three holds through `header_hold()`: the lent guard where there is one, and otherwise a `HeaderHold` of their own that ends with the operation. The leaves take the hold as proof: `write_header()` and `oldest_active_transaction()` take a `&HeaderGuard`, in the style `lock_mp_transaction()` already uses, and the four other header writers (the open's repair, `begin_writable()`, `clear_recovery_required()` and the shutdown header) take one first, ahead of the state lock. `begin_write()` and `commit()` pass `None`, as do the two repair-path commits, so nothing observable changes. `HeaderGuard`'s doc states the rule once, and `lock_header_exclusive()` becomes crate-visible so that a caller can take the hold it lends.

No changelog entry: nothing user-visible changes.

## The decisions this isolates

1. **Lend the locks rather than flag the `TransactionalMemory`.** The first cut of #1444 set a `compacting` flag under which every acquisition handed back a guard that locked nothing. Lending threads an `Option` through `commit_with()`, `durable_commit()` and `TransactionalMemory::commit()`, but each hold is a value with an owner and a lifetime, the locking code has no mode, and a transaction that should take a lock of its own cannot silently take none.
2. **Lend the writer lock by `Arc` and the header guard by reference.** The writer lock is already the `Arc<WriterLock>` #1445 gave every transaction, so a lent one is cloned and the byte is released when its last holder drops it. The header guard is the in-process mutex guard itself, which cannot be shared, so it is borrowed for the transaction's lifetime.
3. **Resolve the `Option` at the three holds, not at the entry point.** `commit_with()` could take one hold for the whole commit, but that hold would span the data flush and both header flushes, so every reader, in this process and in others, would wait on the writer's fsyncs to begin. Resolving at each hold keeps master's three short holds for a commit that lends nothing, and only a caller that lends a hold runs a whole commit under one. The leaves then need no `Option` at all.

## Testing

`a_lent_header_hold_outlives_the_commit`: a transaction commits under a lent exclusive hold, which a probe on another description finds still held until it is dropped. A `durable_commit()` that takes its own hold for the scan regardless, or a `TransactionalMemory::commit()` that takes its own for a header write, hangs it on the in-process mutex. `a_lent_writer_byte_outlives_the_transaction`: a transaction lent the writer byte ends without releasing it, which a probe confirms until the lock is dropped; a `write_guard()` that takes the byte instead of cloning the lent lock fails it, since that acquisition and the lent one are one lock, released by the transaction's end. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9