### PR TITLE
Open a multi-writer database under the writer byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@
   `Durability::None` is refused, and the database may be opened read-only while another process has
   it open for writing; each new read transaction then sees that process's durable commits,
   `Database::compact()` treats a read transaction in another process as a transaction in progress,
-  and `Database::check_integrity()` waits for a write transaction in another process to end.
+  and a `MultiWriterProcess` open and `Database::check_integrity()` wait for a write transaction in
+  another process to end.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/db.rs
+++ b/src/db.rs
@@ -938,17 +938,31 @@ impl Database {
         // The tracker holds the persistent savepoints the tables adopted above hold, as the
         // open's does: another process may have created, replaced or deleted any of them
         if adopted_peer_commits {
-            let txn = self
-                .begin_write_with(
-                    #[cfg(feature = "experimental-multiprocess")]
-                    Some(writer_lock),
-                )
-                .map_err(|e| DatabaseError::Storage(e.into_storage_error()))?;
-            self.register_persistent_savepoints(&txn)?;
-            txn.abort()?;
+            self.restore_persistent_savepoints(
+                #[cfg(feature = "experimental-multiprocess")]
+                Some(writer_lock),
+            )?;
         }
 
         Ok(was_clean)
+    }
+
+    // Restores the tracker state for the file's persistent savepoints, in a transaction lent
+    // `writer_lock` where the caller holds it
+    fn restore_persistent_savepoints(
+        &self,
+        #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
+    ) -> Result<(), DatabaseError> {
+        let txn = self
+            .begin_write_with(
+                #[cfg(feature = "experimental-multiprocess")]
+                writer_lock,
+            )
+            .map_err(|e| e.into_storage_error())?;
+        self.register_persistent_savepoints(&txn)?;
+        txn.abort()?;
+
+        Ok(())
     }
 
     // Holds the file's persistent savepoints, which another process may have created, replaced
@@ -1464,7 +1478,8 @@ impl Database {
         let file_path = format!("{:?}", &file);
         #[cfg(feature = "logging")]
         debug!("Opening database {:?}", &file_path);
-        let mem = TransactionalMemory::new(
+        #[cfg_attr(not(feature = "experimental-multiprocess"), expect(unused_mut))]
+        let mut mem = TransactionalMemory::new(
             file,
             allow_initialize,
             page_size,
@@ -1473,6 +1488,10 @@ impl Database {
             false,
             concurrency_mode,
         )?;
+        // Held until the open is over, and lent to the transaction restoring the savepoints: a
+        // write transaction takes the byte itself once it is released
+        #[cfg(feature = "experimental-multiprocess")]
+        let open_writer_lock = mem.take_open_writer_lock();
         let mut mem = Arc::new(mem);
         // If the last transaction used 2-phase commit and updated the allocator state table, then
         // we can just load the allocator state from there. Otherwise, we need a full repair
@@ -1514,10 +1533,14 @@ impl Database {
             transaction_tracker: Arc::new(TransactionTracker::new(next_transaction_id)),
         };
 
-        // Restore the tracker state for any persistent savepoints
-        let txn = db.begin_write().map_err(|e| e.into_storage_error())?;
-        db.register_persistent_savepoints(&txn)?;
-        txn.abort()?;
+        let restored = db.restore_persistent_savepoints(
+            #[cfg(feature = "experimental-multiprocess")]
+            open_writer_lock.as_ref(),
+        );
+        // Released before an error drops `db`, whose close takes the byte itself
+        #[cfg(feature = "experimental-multiprocess")]
+        drop(open_writer_lock);
+        restored?;
 
         Ok(db)
     }
@@ -2505,6 +2528,77 @@ mod writer_byte_test {
             "the byte was still held after the database closed"
         );
         probe.unlock_range(byte_range(WRITER_BYTE)).unwrap();
+    }
+
+    /// The open waits on a write transaction in another process, as one would, and gives the
+    /// byte back once the handle is writable
+    #[test]
+    fn a_multi_writer_open_holds_the_byte_until_it_is_writable() {
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        let tmpfile = crate::create_tempfile();
+        create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let probe = probe(tmpfile.path());
+        assert!(probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap());
+
+        let path = tmpfile.path().to_path_buf();
+        let (tx, rx) = mpsc::channel();
+        let opening = thread::spawn(move || {
+            let mut builder = Database::builder();
+            builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+            let db = builder.open(&path).unwrap();
+            tx.send(()).unwrap();
+            db
+        });
+        assert!(
+            rx.recv_timeout(Duration::from_millis(200)).is_err(),
+            "the open ran under another process's hold on the writer byte"
+        );
+        probe.unlock_range(byte_range(WRITER_BYTE)).unwrap();
+        rx.recv_timeout(Duration::from_secs(10))
+            .expect("the open never ran");
+        let db = opening.join().unwrap();
+
+        assert!(
+            probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap(),
+            "the byte was still held after the open"
+        );
+        probe.unlock_range(byte_range(WRITER_BYTE)).unwrap();
+        drop(db);
+    }
+
+    /// Taken before the header is read: a peer's ordinary commit saves no allocator snapshot, so
+    /// the open rebuilds one and commits, which the byte keeps a peer's commit from interleaving
+    /// with
+    #[test]
+    fn a_multi_writer_open_repairs_under_the_byte() {
+        use std::sync::{Arc, Mutex};
+
+        let tmpfile = crate::create_tempfile();
+        let peer = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        commit_one(&peer);
+
+        let probe = probe(tmpfile.path());
+        let held_during_repair = Arc::new(Mutex::new(None));
+        let seen = held_during_repair.clone();
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.set_repair_callback(move |_| {
+            let free = probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap();
+            if free {
+                probe.unlock_range(byte_range(WRITER_BYTE)).unwrap();
+            }
+            *seen.lock().unwrap() = Some(!free);
+        });
+        let db = builder.open(tmpfile.path()).unwrap();
+        assert_eq!(
+            *held_during_repair.lock().unwrap(),
+            Some(true),
+            "the open repaired without the writer byte"
+        );
+        drop(db);
     }
 
     /// A transaction that outlives the database keeps the lock, and the deferred close writes

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -572,9 +572,10 @@ impl Drop for WriterLock {
     }
 }
 
-/// The writer lock a handle holds for the life of the database: the whole file where the
-/// database is not shared, and the writer byte where one process writes. Nothing in multi-writer
-/// mode, where a write transaction takes that byte itself, or for a read-only handle
+/// The writer lock a handle holds from the open: for the life of the database, the whole file
+/// where the database is not shared and the writer byte where one process writes; in
+/// multi-writer mode, the writer byte until the handle is writable, which a write transaction
+/// takes itself from then on. Nothing for a read-only handle
 #[cfg(feature = "experimental-multiprocess")]
 fn database_writer_lock_for_mode(
     storage: &Arc<PagedCachedFile>,
@@ -586,8 +587,9 @@ fn database_writer_lock_for_mode(
     }
     let range = match concurrency_mode {
         ConcurrencyMode::SingleProcess => FULL_RANGE,
-        ConcurrencyMode::SingleWriterProcess => byte_range(WRITER_BYTE),
-        ConcurrencyMode::MultiWriterProcess => return None,
+        ConcurrencyMode::SingleWriterProcess | ConcurrencyMode::MultiWriterProcess => {
+            byte_range(WRITER_BYTE)
+        }
     };
 
     Some(Arc::new(WriterLock {
@@ -627,9 +629,9 @@ pub(crate) struct TransactionalMemory {
     // the ceiling of the scan before it, since every handle reads the id it pins from the file
     #[cfg(feature = "experimental-multiprocess")]
     scan_from: Mutex<u64>,
-    // The lock the open took, which every write transaction holds while it runs. `None` in
-    // multi-writer mode, where a write transaction takes the writer byte itself, and for a
-    // read-only handle
+    // The lock the open took, which every write transaction holds while it runs: for the life
+    // of the database, or in multi-writer mode until the handle is writable, when
+    // `take_open_writer_lock()` hands it to the database. `None` for a read-only handle
     #[cfg(feature = "experimental-multiprocess")]
     writer_lock: Option<Arc<WriterLock>>,
     page_size: u32,
@@ -853,6 +855,18 @@ impl TransactionalMemory {
         }))
     }
 
+    /// The writer byte a multi-writer open holds, for the database to hold until the handle is
+    /// writable and lend to the write transactions it begins meanwhile: a write transaction
+    /// takes the byte itself once it is released. `None` in every other mode, where the open's
+    /// lock is the handle's for the life of the database
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn take_open_writer_lock(&mut self) -> Option<Arc<WriterLock>> {
+        match self.concurrency_mode {
+            ConcurrencyMode::MultiWriterProcess => self.writer_lock.take(),
+            _ => None,
+        }
+    }
+
     #[cfg(feature = "experimental-multiprocess")]
     fn active_transaction_byte(id: TransactionId) -> Result<u64> {
         match TXN_BASE.checked_add(id.raw_id()) {
@@ -1003,6 +1017,12 @@ impl TransactionalMemory {
         let storage = Arc::new(PagedCachedFile::new(file, page_size as u64, cache_size));
         // Dropping the storage releases whatever this took, so an open that fails below does too
         Self::lock_for_open(&storage, read_only, concurrency_mode)?;
+        // A multi-writer open repairs and commits under the writer byte, as a write transaction
+        // does, so it waits on the peer holding it before it reads the header
+        #[cfg(feature = "experimental-multiprocess")]
+        if !read_only && concurrency_mode == ConcurrencyMode::MultiWriterProcess {
+            storage.lock_range(byte_range(WRITER_BYTE))?;
+        }
         #[cfg(feature = "experimental-multiprocess")]
         let in_process_header_lock = Mutex::new(());
 
@@ -2583,7 +2603,7 @@ mod header_lock_test {
             .read(true)
             .write(true)
             .open(path)?;
-        Ok(Arc::new(TransactionalMemory::new(
+        let mut mem = TransactionalMemory::new(
             Box::new(FileBackend::new(file)?),
             true,
             PAGE_SIZE,
@@ -2591,7 +2611,10 @@ mod header_lock_test {
             0,
             false,
             mode,
-        )?))
+        )?;
+        // Which a `Database` holds until the handle is writable, as this one is at once
+        drop(mem.take_open_writer_lock());
+        Ok(Arc::new(mem))
     }
 
     fn open_read_only(


### PR DESCRIPTION
Prep for the writer-side reload, on #1443. A `MultiWriterProcess` open that finds no allocator snapshot, which is whenever a live peer's last commit was an ordinary one, rebuilds the allocator and commits holding only the shared writer byte, so a peer's write transaction could commit between the header the open read and the commit it made, and either header then overwrote the other's. Codex raised it on #1443, where the integrity check holds the writer byte and this open was the one writer left that takes none.

## What it does

`TransactionalMemory::new()` takes `WRITER_BYTE` right after the mode bytes, before it reads the header, as the lock the open took: the one `writer_lock` field, which holds the single modes' lock for the life of the database, holds it in multi-writer mode until the handle is writable, when `Database::new()` takes it through `take_open_writer_lock()`. The open holds it until it is over: through the repair and its commit, `begin_writable()`, and the restoration of the file's persistent savepoints, whose transaction is lent the hold as a transaction is lent the open's lock in the other modes; it is released before an error could drop the database, whose close takes the byte itself. A write transaction takes the byte itself once it is released, as before. The single modes are untouched: their lock is held for the life of the database, as it was, and `take_open_writer_lock()` gives `None` for them and for a read-only handle.

The open already waited on a peer's write transaction, at the registration transaction that ends it; it now waits at its start, and the changelog says so, as it does for the check.

## The decisions this isolates

1. **The memory takes the byte, the database holds it.** The header read and its write-back are inside `TransactionalMemory::new()`, so the byte has to be taken there; when the open is over is the database's to know, so the hold is a value it takes and drops, rather than state the memory releases on a call, and it is the same field as the other modes' lock rather than a second one, since a handle has one writer lock, whose span depends on the mode. A memory built without a database, as the header lock tests build one, drops the hold at once.
2. **Hold through the whole open, not only the repair.** One hold from before the header read to the end of `Database::new()` is simpler to state than a release and a re-take around the registration transaction, and nothing in between needs the byte free.
3. **Not the reload.** A handle that holds the byte reads a header current as of its open; that it goes stale as peers commit, and that a peer's next commit overwrites this open's repair, is the writer-side reload at `begin_write()` and at the close, which is the next prep.

## Testing

`a_multi_writer_open_holds_the_byte_until_it_is_writable`: with the byte held from another file description, the open does not complete until it is released, and the byte is free once the open returns; never releasing fails the second assertion. `a_multi_writer_open_repairs_under_the_byte`: a live peer's ordinary commit leaves no snapshot, so the open repairs, and the repair callback finds the byte held; not taking it, or dropping the hold before the repair, reports it free. The header lock tests, which open two multi-writer memories directly, release the hold themselves. `restore_persistent_savepoints()` is the transaction the open and the check each ran inline, so that the open can release the hold before it propagates an error. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9