### PR TITLE
Begin a multi-writer transaction from the file's latest commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@
   `Database::compact()` treats a read transaction in another process as a transaction in progress.
   In `MultiWriterProcess`, every commit records the allocator state, for the next writer to load;
   compaction's own commits are the exception, and `Database::compact()` ends with one that does.
-  Ephemeral savepoints are refused there, with `SavepointError::EphemeralSavepointUnsupported`.
+  Ephemeral savepoints are refused there, with `SavepointError::EphemeralSavepointUnsupported`,
+  and a write transaction begins from the file as another process last committed it, as does the
+  close.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,8 @@
 use crate::io;
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
 #[cfg(feature = "experimental-multiprocess")]
+use crate::transactions::AllocatorStateLatch;
+#[cfg(feature = "experimental-multiprocess")]
 use crate::tree_store::HeaderGuard;
 use crate::tree_store::LocklessBackend;
 #[cfg(not(redb_no_std))]
@@ -910,7 +912,13 @@ impl Database {
     // Synchronizes the tracker state for the file's persistent savepoints
     fn sync_persistent_savepoints(&self) -> Result<(), DatabaseError> {
         let txn = self.begin_write().map_err(|e| e.into_storage_error())?;
-        sync_persistent_savepoints(&self.transaction_tracker, &self.mem, &txn)?;
+        sync_persistent_savepoints(
+            &self.transaction_tracker,
+            &self.mem,
+            &txn,
+            #[cfg(feature = "experimental-multiprocess")]
+            None,
+        )?;
         txn.abort()?;
 
         Ok(())
@@ -978,6 +986,19 @@ impl Database {
         // be diagnosed before read references, because every live savepoint also holds a read
         // reference. The tracker covers persistent savepoints created by previous Database
         // instances, because they are re-registered when the database is opened.
+        // In multi-writer mode the tracker's savepoints go stale: a peer may have deleted one
+        // since this handle last synced, and only a write transaction of this handle's own syncs
+        // them again. Refresh before reporting one as a blocker, unless this process already has
+        // a write transaction live, since beginning another would block on it.
+        #[cfg(feature = "experimental-multiprocess")]
+        if self.mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess
+            && self.transaction_tracker.any_persistent_savepoint_exists()
+            && !self.transaction_tracker.write_transaction_live()
+        {
+            self.begin_write()
+                .map_err(|e| e.into_storage_error())?
+                .abort()?;
+        }
         if self.transaction_tracker.any_persistent_savepoint_exists() {
             return Err(CompactionError::PersistentSavepointExists);
         }
@@ -1012,6 +1033,8 @@ impl Database {
             .begin_write_with(
                 #[cfg(feature = "experimental-multiprocess")]
                 writer_lock.as_ref(),
+                #[cfg(feature = "experimental-multiprocess")]
+                header_lock.as_ref(),
             )
             .map_err(|e| e.into_storage_error())?;
         // Re-check inside the write transaction: a concurrent writer may have created a
@@ -1054,6 +1077,8 @@ impl Database {
                 .begin_write_with(
                     #[cfg(feature = "experimental-multiprocess")]
                     writer_lock.as_ref(),
+                    #[cfg(feature = "experimental-multiprocess")]
+                    header_lock.as_ref(),
                 )
                 .map_err(|e| e.into_storage_error())?;
             txn.skip_allocator_state_record();
@@ -1117,6 +1142,8 @@ impl Database {
                 .begin_write_with(
                     #[cfg(feature = "experimental-multiprocess")]
                     writer_lock,
+                    #[cfg(feature = "experimental-multiprocess")]
+                    header_lock,
                 )
                 .map_err(|e| e.into_storage_error())?;
             if !force_commit && !txn.pending_free_pages()? {
@@ -1407,6 +1434,26 @@ impl Database {
         root.map(|header| BtreeHeader::new(header.root, header.checksum, length))
     }
 
+    /// Loads the allocator state that the file's latest commit recorded. In multi-writer mode
+    /// every commit records one, including the repair an open performs, so a commit that
+    /// recorded none has broken the protocol and is refused as corruption.
+    #[cfg(feature = "experimental-multiprocess")]
+    fn load_synced_allocator_state(mem: &Arc<TransactionalMemory>) -> Result {
+        let Some(tree) = Self::get_allocator_state_table(mem)? else {
+            return Err(StorageError::Corrupted(
+                "The latest commit recorded no allocator state, which every commit in multi-writer mode does".to_string(),
+            ));
+        };
+        mem.load_allocator_state(&tree)?;
+        #[cfg(debug_assertions)]
+        Self::mark_allocated_page_for_debug(mem)?;
+        // This allocator state came from the file, so it holds none of the pages leaked by a
+        // transaction that was dropped while a panic unwound. Commits may record again.
+        mem.clear_needs_repair();
+
+        Ok(())
+    }
+
     fn new(
         file: Box<dyn InternalStorageBackend>,
         allow_initialize: bool,
@@ -1546,18 +1593,23 @@ impl Database {
         self.begin_write_with(
             #[cfg(feature = "experimental-multiprocess")]
             None,
+            #[cfg(feature = "experimental-multiprocess")]
+            None,
         )
     }
 
     fn begin_write_with(
         &self,
         #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
+        #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
     ) -> Result<WriteTransaction, TransactionError> {
         begin_write_with_allocation_policy(
             &self.transaction_tracker,
             &self.mem,
             #[cfg(feature = "experimental-multiprocess")]
             writer_lock,
+            #[cfg(feature = "experimental-multiprocess")]
+            header_lock,
             AllocationPolicy::Default,
         )
     }
@@ -1565,10 +1617,12 @@ impl Database {
 
 // Syncs the file's persistent savepoints, which another process may have created or
 // deleted since the tracker last saw the file, and continues savepoint ids past the file's.
+// `header_lock` is the header lock the caller already holds, if any.
 fn sync_persistent_savepoints(
     transaction_tracker: &TransactionTracker,
     mem: &TransactionalMemory,
     txn: &WriteTransaction,
+    #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
 ) -> Result {
     if let Some(next_id) = txn.next_persistent_savepoint_id()? {
         transaction_tracker.restore_savepoint_counter_state(next_id);
@@ -1589,7 +1643,7 @@ fn sync_persistent_savepoints(
         current.insert(savepoint.get_id(), savepoint.get_transaction_id());
     }
     #[cfg(feature = "experimental-multiprocess")]
-    let hold = mem.header_hold(None)?;
+    let hold = mem.header_hold(header_lock)?;
     transaction_tracker.sync_persistent_savepoints(
         mem,
         &current,
@@ -1598,15 +1652,60 @@ fn sync_persistent_savepoints(
     )
 }
 
-// Takes the write slot and the writer lock, and builds the transaction on them. A caller that
-// already holds the writer lock lends it as `writer_lock`: locking the byte again from this file
-// description would return the same lock, and this transaction's end would then release the
-// caller's. The allocation policy is fixed for the lifetime of the transaction; every page
-// allocation this transaction makes goes through it.
+/// Brings this handle up to the file's latest commit, in multi-writer mode, when it is not
+/// already on it. That is the case when another process has committed since this handle last
+/// read the file, and when a panic latched a repair, which leaves this handle's allocator state
+/// holding pages that the file's latest commit does not.
+///
+/// `writer_lock` proves that the caller holds the writer byte, so that no other process commits
+/// while the header is read and the allocator state loaded from it; `header_lock` is the header
+/// lock the caller already holds, if any.
+///
+/// Returns `None` when the handle was already on the file's latest commit. Otherwise returns a
+/// latch that discards the allocator state unless the caller finishes the sync.
+#[cfg(feature = "experimental-multiprocess")]
+fn sync_to_latest_commit(
+    mem: &Arc<TransactionalMemory>,
+    writer_lock: &WriterLock,
+    header_lock: Option<&HeaderGuard<'_>>,
+) -> Result<Option<AllocatorStateLatch>> {
+    if mem.concurrency_mode() != ConcurrencyMode::MultiWriterProcess {
+        return Ok(None);
+    }
+    let synced = {
+        let hold = mem.header_hold(header_lock)?;
+        mem.reload_for_write(writer_lock, &hold)?
+    };
+    if !synced {
+        return Ok(None);
+    }
+    // Armed before the load, because a load that stops part way leaves an allocator state that
+    // describes neither the commit it came from nor the one it was going to
+    let latch = AllocatorStateLatch::arm(mem.clone());
+    Database::load_synced_allocator_state(mem)?;
+    // Loading the allocator state cleared the recovery flag that a live writer keeps set, and a
+    // peer's close may have cleared it in the file as well. Set it again, so that the next
+    // commit writes it back and a crash of this handle is still recovered from.
+    mem.mark_recovery_required();
+
+    Ok(Some(latch))
+}
+
+// Takes the write slot and the writer byte, syncs to the file's latest commit, and builds the
+// transaction on them.
+//
+// A caller that already holds the writer byte lends its lock as `writer_lock`. Taking the writer
+// byte again from this file description would return that same lock, and the end of this
+// transaction would then release the caller's. A caller that holds the header lock lends it as
+// `header_lock`, because the in-process half of that lock cannot be taken twice.
+//
+// The allocation policy is fixed for the lifetime of the transaction; every page allocation the
+// transaction makes goes through it.
 fn begin_write_with_allocation_policy(
     transaction_tracker: &Arc<TransactionTracker>,
     mem: &Arc<TransactionalMemory>,
     #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
+    #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
     allocation_policy: AllocationPolicy,
 ) -> Result<WriteTransaction, TransactionError> {
     // Fail early if there has been an I/O error -- nothing can be committed in that case
@@ -1616,6 +1715,8 @@ fn begin_write_with_allocation_policy(
     let slot = WriteSlot::take(transaction_tracker.clone());
     #[cfg(feature = "experimental-multiprocess")]
     let writer_lock = writer_lock.map_or_else(|| mem.lock_writer(), |lent| Ok(lent.clone()))?;
+    #[cfg(feature = "experimental-multiprocess")]
+    let latch = sync_to_latest_commit(mem, &writer_lock, header_lock)?;
     // Re-checked after acquiring the write slot: the writer this call blocked on can fail its
     // commit, latching an I/O error and discarding the allocator state. The I/O check comes
     // first so a backend failure is not misreported as corruption
@@ -1626,19 +1727,37 @@ fn begin_write_with_allocation_policy(
         )
         .into());
     }
+    // Issued once the sync is done, so that the id follows the file's latest commit
+    let transaction_id = transaction_tracker.issue_write_transaction_id(
+        mem.get_last_committed_transaction_id()?,
+        #[cfg(feature = "experimental-multiprocess")]
+        &writer_lock,
+    );
     let guard = TransactionGuard::new_write(
-        transaction_tracker.issue_write_transaction_id(),
+        transaction_id,
         slot,
         #[cfg(feature = "experimental-multiprocess")]
         writer_lock,
     );
-    WriteTransaction::new(
+    let transaction = WriteTransaction::new(
         guard,
         transaction_tracker.clone(),
         mem.clone(),
         allocation_policy,
-    )
-    .map_err(|e| e.into())
+    )?;
+    // The file's persistent savepoints are synced here, before this transaction frees anything,
+    // so that the transactions they point at stay pinned. If the sync fails, the transaction is
+    // aborted and the latch then discards the allocator state.
+    #[cfg(feature = "experimental-multiprocess")]
+    if latch.is_some() {
+        sync_persistent_savepoints(transaction_tracker, mem, &transaction, header_lock)?;
+    }
+    #[cfg(feature = "experimental-multiprocess")]
+    if let Some(latch) = latch {
+        latch.disarm();
+    }
+
+    Ok(transaction)
 }
 
 // Records the allocator state in a commit that also trims the file: the close's last commit,
@@ -1662,6 +1781,8 @@ fn ensure_allocator_state_table_and_trim(
         mem,
         #[cfg(feature = "experimental-multiprocess")]
         writer_lock,
+        #[cfg(feature = "experimental-multiprocess")]
+        header_lock,
         AllocationPolicy::Lowest,
     )
     .map_err(|e| e.into_storage_error())?;
@@ -1700,7 +1821,7 @@ fn close_database(transaction_tracker: &Arc<TransactionTracker>, mem: &Arc<Trans
     };
     #[cfg(feature = "experimental-multiprocess")]
     let writing = writing && writer_lock.is_some();
-    if writing
+    let recorded = writing
         && ensure_allocator_state_table_and_trim(
             transaction_tracker,
             mem,
@@ -1709,11 +1830,16 @@ fn close_database(transaction_tracker: &Arc<TransactionTracker>, mem: &Arc<Trans
             #[cfg(feature = "experimental-multiprocess")]
             None,
         )
-        .is_err()
-    {
+        .is_ok();
+    if writing && !recorded {
         #[cfg(feature = "logging")]
         warn!("Failed to write allocator state table. Repair may be required at restart.");
     }
+    // The shutdown header describes this handle, which matches the file only once the commit
+    // above has synced to the file's latest commit. Without that commit, write no header, and
+    // leave the file for the next open to recover.
+    #[cfg(feature = "experimental-multiprocess")]
+    let writer_lock = writer_lock.filter(|_| recorded);
 
     if mem
         .close(
@@ -2536,6 +2662,82 @@ mod writer_byte_test {
         );
     }
 
+    /// Every commit in multi-writer mode records the allocator state. A sync that finds a
+    /// commit without one refuses it as corruption.
+    #[test]
+    fn a_sync_refuses_a_commit_without_an_allocator_state() {
+        use crate::{StorageError, TransactionError};
+
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        let peer = builder.open(tmpfile.path()).unwrap();
+        let mut write = peer.begin_write().unwrap();
+        write.skip_allocator_state_record();
+        write.open_table(TABLE).unwrap().insert(0, 0).unwrap();
+        write.commit().unwrap();
+
+        assert!(matches!(
+            db.begin_write(),
+            Err(TransactionError::Storage(StorageError::Corrupted(_)))
+        ));
+    }
+
+    /// A transaction dropped while a panic unwinds leaks its pages, which latches a repair.
+    /// Syncing to a peer's commit replaces the allocator state with the file's, which does not
+    /// hold those pages, so the next commit records the state again.
+    #[test]
+    fn syncing_to_a_peers_commit_releases_the_repair_a_panic_latched() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        let peer = builder.open(tmpfile.path()).unwrap();
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let write = db.begin_write().unwrap();
+            write.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+            panic!("unwinding through the transaction");
+        }));
+        assert!(unwound.is_err());
+        assert!(db.mem.needs_repair());
+
+        commit_one(&peer);
+        commit_one(&db);
+        assert!(!db.mem.needs_repair());
+        assert!(
+            Database::get_allocator_state_table(&db.mem)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    /// A commit made while a repair is latched records no allocator state, and a peer that
+    /// syncs to such a commit refuses it. So the first transaction after the panic releases the
+    /// latch itself, without waiting for a peer to commit.
+    #[test]
+    fn a_transaction_releases_the_repair_a_panic_latched_without_a_peers_commit() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        let peer = builder.open(tmpfile.path()).unwrap();
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let write = db.begin_write().unwrap();
+            write.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+            panic!("unwinding through the transaction");
+        }));
+        assert!(unwound.is_err());
+        assert!(db.mem.needs_repair());
+
+        commit_one(&db);
+        assert!(!db.mem.needs_repair());
+        peer.begin_write()
+            .expect("the peer syncs to a commit that recorded the allocator state")
+            .abort()
+            .unwrap();
+    }
+
     /// A multi-writer compaction ends with a commit recording the allocator state, for the next
     /// writer, in any process, to load rather than rebuild
     #[test]
@@ -3240,7 +3442,62 @@ mod active_transaction_test {
         }
     }
 
-    /// A transaction lent the exclusive header hold commits under it and leaves it held
+    /// A transaction that is lent the exclusive header lock syncs to a peer's commit under that
+    /// lock, savepoints included, rather than trying to take the lock a second time.
+    #[test]
+    fn a_lent_header_lock_covers_syncing_to_a_peers_commit() {
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        fn open(path: &Path) -> Database {
+            let mut builder = Database::builder();
+            builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+            builder.open(path).unwrap()
+        }
+
+        let tmpfile = crate::create_tempfile();
+        create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let peer = open(tmpfile.path());
+        // The handle syncs to the commit under holds it took itself, as compaction does, in a
+        // thread, so that taking the header lock again fails rather than hangs
+        let path = tmpfile.path().to_path_buf();
+        let (opened, wait_for_open) = mpsc::channel();
+        let (committed, wait_for_commit) = mpsc::channel();
+        let (synced, wait_for_sync) = mpsc::channel();
+        let syncing = thread::spawn(move || {
+            let db = open(&path);
+            opened.send(()).unwrap();
+            wait_for_commit.recv().unwrap();
+            let writer_lock = db.mem.lock_writer().unwrap();
+            let header_lock = db.mem.lock_header_exclusive().unwrap();
+            let txn = db
+                .begin_write_with(Some(&writer_lock), Some(&header_lock))
+                .unwrap();
+            let savepoints: Vec<u64> = txn.list_persistent_savepoints().unwrap().collect();
+            txn.abort().unwrap();
+            drop(header_lock);
+            drop(writer_lock);
+            synced.send(savepoints).unwrap();
+        });
+        wait_for_open.recv().unwrap();
+        let txn = peer.begin_write().unwrap();
+        let peers_savepoint = txn.persistent_savepoint().unwrap();
+        txn.commit().unwrap();
+        // Closed first: otherwise its close would wait on the writer byte that a hung
+        // transaction still holds
+        drop(peer);
+        committed.send(()).unwrap();
+
+        let savepoints = wait_for_sync
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the transaction took the header lock its caller holds");
+        assert_eq!(savepoints, vec![peers_savepoint]);
+        syncing.join().unwrap();
+    }
+
+    /// A transaction that is lent the exclusive header lock begins and commits under it, and
+    /// leaves the lock held afterwards.
     #[test]
     fn a_lent_header_hold_outlives_the_commit() {
         let tmpfile = crate::create_tempfile();
@@ -3248,7 +3505,7 @@ mod active_transaction_test {
         let probe = probe(tmpfile.path());
 
         let header_lock = db.mem.lock_header_exclusive().unwrap();
-        let txn = db.begin_write().unwrap();
+        let txn = db.begin_write_with(None, Some(&header_lock)).unwrap();
         txn.open_table(TABLE).unwrap().insert(1, 1).unwrap();
         txn.commit_with(Some(&header_lock)).unwrap();
         assert!(!probe.try_lock_shared_range(HEADER_LOCK).unwrap());
@@ -3266,7 +3523,7 @@ mod active_transaction_test {
         let probe = probe(tmpfile.path());
 
         let writer_lock = db.mem.lock_writer().unwrap();
-        let txn = db.begin_write_with(Some(&writer_lock)).unwrap();
+        let txn = db.begin_write_with(Some(&writer_lock), None).unwrap();
         txn.abort().unwrap();
         assert!(!probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap());
 

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -2,6 +2,8 @@ use crate::sync::{Condvar, Mutex};
 #[cfg(feature = "experimental-multiprocess")]
 use crate::tree_store::HeaderGuard;
 use crate::tree_store::TransactionalMemory;
+#[cfg(feature = "experimental-multiprocess")]
+use crate::tree_store::WriterLock;
 use crate::{Key, Result, TypeName, Value};
 use alloc::collections::BTreeSet;
 use alloc::collections::btree_map::BTreeMap;
@@ -78,8 +80,8 @@ impl Key for SavepointId {
     }
 }
 
-// The write slot's state: taken ahead of the writer byte, and given its transaction's id once
-// the locks are held
+// The write slot's state. It is taken ahead of the writer byte, and given its transaction's id
+// once the writer byte is held and the file's latest commit is known.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum WriteSlotState {
     Free,
@@ -174,8 +176,9 @@ impl TransactionTracker {
         }
     }
 
-    // Takes the write slot, waiting for the write transaction holding it to end. The
-    // transaction's id is issued by `issue_write_transaction_id()`, once the locks are held
+    // Takes the write slot, waiting for the write transaction that holds it to end. The
+    // transaction's id is issued separately, by `issue_write_transaction_id()`, once the file's
+    // latest commit is known.
     pub(crate) fn take_write_slot(&self) {
         let mut state = self.state.lock().unwrap();
         while state.write_slot != WriteSlotState::Free {
@@ -184,16 +187,29 @@ impl TransactionTracker {
         state.write_slot = WriteSlotState::Taken;
     }
 
-    // Issues the slot's transaction its id
-    pub(crate) fn issue_write_transaction_id(&self) -> TransactionId {
+    // Issues the slot's transaction an id that follows `last_committed`, the id of the file's
+    // latest commit. `writer_lock` proves that the caller holds the writer byte, so that no
+    // other process commits between reading that id and issuing this one.
+    pub(crate) fn issue_write_transaction_id(
+        &self,
+        last_committed: TransactionId,
+        #[cfg(feature = "experimental-multiprocess")] _writer_lock: &WriterLock,
+    ) -> TransactionId {
         let mut state = self.state.lock().unwrap();
         assert_eq!(state.write_slot, WriteSlotState::Taken);
+        state.next_transaction_id = state.next_transaction_id.max(last_committed);
         let transaction_id = state.next_transaction_id.increment();
         #[cfg(feature = "logging")]
         debug!("Beginning write transaction id={transaction_id:?}");
         state.write_slot = WriteSlotState::Live(transaction_id);
 
         transaction_id
+    }
+
+    // Whether a write transaction holds the write slot in this process
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn write_transaction_live(&self) -> bool {
+        self.state.lock().unwrap().write_slot != WriteSlotState::Free
     }
 
     // Returns the deferred close, if the Database was dropped while this transaction was live.

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -892,20 +892,22 @@ impl SavepointTransactionState {
     }
 }
 
-// Discards the in-memory allocator state on drop, unless disarmed. An incomplete commit may
-// have returned pages to the allocator that the durable roots still reference through the
-// freed tables; such an allocator state must never be used, or persisted by a clean
-// shutdown, again.
-struct AllocatorStateLatch {
+// Armed around work that would leave the in-memory allocator state unusable if it stopped part
+// way, and disarmed once that work is complete. Three things need it: a commit, which may have
+// freed pages that the durable roots still reference; a load of the allocator state; and a sync
+// of the file's persistent savepoints, before which the state could free pages a savepoint
+// still holds. Dropping it while armed discards the allocator state, so that nothing goes on to
+// use it, and a clean shutdown does not persist it.
+pub(crate) struct AllocatorStateLatch {
     mem: Option<Arc<TransactionalMemory>>,
 }
 
 impl AllocatorStateLatch {
-    fn arm(mem: Arc<TransactionalMemory>) -> Self {
+    pub(crate) fn arm(mem: Arc<TransactionalMemory>) -> Self {
         Self { mem: Some(mem) }
     }
 
-    fn disarm(mut self) {
+    pub(crate) fn disarm(mut self) {
         self.mem = None;
     }
 }

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -581,6 +581,14 @@ impl PagedCachedFile {
         }
     }
 
+    // Whether a commit has left pages in the write buffer instead of writing them to the file.
+    // Only a non-durable commit does that, so this is always false in the multi-process modes,
+    // which refuse `Durability::None`.
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(super) fn has_committed_pages_buffered(&self) -> bool {
+        self.committed_pages_buffered.load(Ordering::Acquire)
+    }
+
     // Write directly to the file, bypassing the write buffer, so the bytes are on the file when
     // this returns rather than whenever the buffer is next flushed
     #[cfg(feature = "experimental-multiprocess")]

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1304,6 +1304,54 @@ impl TransactionalMemory {
         Ok(current)
     }
 
+    /// Brings this handle up to the file's latest commit, when it is not already on it, so that
+    /// a write transaction starts from whatever another process committed last. The cached
+    /// pages, the buffered writes and the allocator state all describe the commit being left
+    /// behind, so they are dropped here; the caller then loads the allocator state that the new
+    /// commit recorded. Returns whether anything was synced.
+    ///
+    /// `writer_lock` and `header_lock` prove that the caller holds the writer byte and the
+    /// header lock, so that no other process commits while this reads the file.
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn reload_for_write(
+        &self,
+        _writer_lock: &WriterLock,
+        header_lock: &HeaderGuard<'_>,
+    ) -> Result<bool> {
+        let unrepaired = Self::read_file_header(&self.storage, self.page_size, header_lock)
+            .map_err(DatabaseError::into_storage_error_or_corrupted)?;
+        let (header, _) = unrepaired.finalize(self.storage.raw_file_len()?)?;
+        // Every writer holds the writer byte while it reloads, so transaction ids only move
+        // forward, and comparing them says whether the file has moved on. A latched repair
+        // syncs whatever the ids say: the pages it leaked are this handle's alone, and the
+        // allocator state the file's latest commit recorded does not include them.
+        if header.primary_slot().transaction_id == self.get_last_durable_transaction_id()?
+            && !self.needs_repair()
+        {
+            return Ok(false);
+        }
+
+        // Discarding the write buffer cannot lose a commit: only a non-durable commit leaves
+        // its pages buffered, and the multi-process modes refuse `Durability::None`. What can
+        // be buffered here are the writes of a transaction that was dropped while a panic
+        // unwound, which never committed, over pages the other process may have reused since.
+        assert!(!self.storage.has_committed_pages_buffered());
+        self.storage.discard_write_buffer();
+        // The other process may have rewritten any page this handle has cached
+        self.storage.invalidate_cache_all();
+        {
+            let mut state = self.state.lock().unwrap();
+            state.header = header;
+            state.read_from_secondary = false;
+            state.allocators = None;
+        }
+        // Mirrors the allocator state, which was just dropped, so it is rebuilt along with it
+        #[cfg(debug_assertions)]
+        self.allocated_pages.lock().unwrap().clear();
+
+        Ok(true)
+    }
+
     pub(crate) fn begin_writable(&self) -> Result {
         #[cfg(feature = "experimental-multiprocess")]
         let header_lock = self.lock_header_exclusive()?;
@@ -1446,6 +1494,13 @@ impl TransactionalMemory {
             .copy_from_slice(&header.to_bytes(true));
 
         Ok(())
+    }
+
+    // Sets the recovery flag that a live writer keeps in its header. Loading the allocator
+    // state clears that flag, so a handle that has just synced must set it again.
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn mark_recovery_required(&self) {
+        self.state.lock().unwrap().header.recovery_required = true;
     }
 
     // Durably clears the recovery flag, marking the repair as complete.
@@ -2640,6 +2695,46 @@ mod header_lock_test {
         let peer = open_read_only(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
         drop(hold(&peer, false).unwrap());
         drop(held);
+    }
+
+    /// A peer's close clears the recovery flag in the file while this handle is still writing.
+    /// The commit that syncs to that close sets the flag again, so that a crash of this handle
+    /// is still recovered from.
+    #[test]
+    fn syncing_to_a_peers_close_keeps_the_recovery_flag() {
+        use super::DB_HEADER_SIZE;
+        use crate::tree_store::page_store::header::UnrepairedDatabaseHeader;
+        use crate::{Database, TableDefinition};
+        const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+        fn unclean(path: &Path) -> bool {
+            let bytes = std::fs::read(path).unwrap();
+            UnrepairedDatabaseHeader::from_bytes(
+                &bytes[..DB_HEADER_SIZE],
+                PAGE_SIZE.try_into().unwrap(),
+            )
+            .unwrap()
+            .unclean()
+        }
+
+        let tmpfile = crate::create_tempfile();
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.create(tmpfile.path()).unwrap();
+        let db = builder.open(tmpfile.path()).unwrap();
+        let peer = builder.open(tmpfile.path()).unwrap();
+        drop(peer);
+        assert!(!unclean(tmpfile.path()), "the peer's close left the flag");
+
+        let txn = db.begin_write().unwrap();
+        txn.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+        txn.commit().unwrap();
+        assert!(
+            unclean(tmpfile.path()),
+            "the commit did not write the flag back"
+        );
+        drop(db);
+        assert!(!unclean(tmpfile.path()), "the close left the flag");
     }
 
     /// The other half of the hold covering the write: the bytes are on the file when

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -290,6 +290,198 @@ fn the_concurrency_mode_excludes_incompatible_opens() {
     Database::open(tmpfile.path()).unwrap();
 }
 
+/// A multi-writer handle's write transaction begins from the file as another process last
+/// committed it, and so does the commit its close makes.
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+mod peer_commits {
+    use super::*;
+    use redb::{CompactionError, ReadableDatabase, ReadableTable, TableDefinition};
+    use std::path::Path;
+
+    const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+    fn open(path: &Path) -> Database {
+        Database::builder()
+            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .open(path)
+            .unwrap()
+    }
+
+    /// Two handles on a file that a clean close left behind, so that neither open has to
+    /// repair it and commit.
+    fn two_handles(path: &Path) -> (Database, Database) {
+        Database::builder()
+            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .create(path)
+            .unwrap();
+        (open(path), open(path))
+    }
+
+    fn insert(db: &Database, key: u64) {
+        let txn = db.begin_write().unwrap();
+        txn.open_table(TABLE).unwrap().insert(key, key).unwrap();
+        txn.commit().unwrap();
+    }
+
+    fn value(db: &Database, key: u64) -> u64 {
+        let read = db.begin_read().unwrap();
+        let table = read.open_table(TABLE).unwrap();
+        table.get(key).unwrap().unwrap().value()
+    }
+
+    /// The transaction sees the peer's commit, and its own commit lands after it, so that
+    /// neither one is lost.
+    #[test]
+    fn a_write_transaction_syncs_to_a_peers_commit() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let (db, peer) = two_handles(tmpfile.path());
+        insert(&peer, 1);
+
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            assert_eq!(table.get(1).unwrap().unwrap().value(), 1);
+            table.insert(2, 2).unwrap();
+        }
+        txn.commit().unwrap();
+        let txn = peer.begin_write().unwrap();
+        {
+            let table = txn.open_table(TABLE).unwrap();
+            assert_eq!(table.get(1).unwrap().unwrap().value(), 1);
+            assert_eq!(table.get(2).unwrap().unwrap().value(), 2);
+        }
+        txn.abort().unwrap();
+        drop(peer);
+        drop(db);
+
+        let db = open(tmpfile.path());
+        assert_eq!(value(&db, 1), 1);
+        assert_eq!(value(&db, 2), 2);
+    }
+
+    /// The peer's persistent savepoint is held from that transaction onwards, and a savepoint
+    /// the transaction creates itself takes a fresh id. A savepoint the peer has deleted is
+    /// forgotten, releasing the pin it held.
+    #[test]
+    fn a_write_transaction_syncs_to_a_peers_savepoint() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let (mut db, peer) = two_handles(tmpfile.path());
+        let txn = peer.begin_write().unwrap();
+        let peers_savepoint = txn.persistent_savepoint().unwrap();
+        txn.commit().unwrap();
+
+        db.begin_write().unwrap().abort().unwrap();
+        assert!(matches!(
+            db.compact(),
+            Err(CompactionError::PersistentSavepointExists)
+        ));
+        let txn = db.begin_write().unwrap();
+        let own_savepoint = txn.persistent_savepoint().unwrap();
+        assert_ne!(own_savepoint, peers_savepoint);
+        txn.commit().unwrap();
+        {
+            let txn = db.begin_write().unwrap();
+            let mut savepoints: Vec<u64> = txn.list_persistent_savepoints().unwrap().collect();
+            savepoints.sort_unstable();
+            assert_eq!(savepoints, vec![peers_savepoint, own_savepoint]);
+            txn.abort().unwrap();
+        }
+
+        let txn = peer.begin_write().unwrap();
+        assert!(txn.delete_persistent_savepoint(peers_savepoint).unwrap());
+        assert!(txn.delete_persistent_savepoint(own_savepoint).unwrap());
+        txn.commit().unwrap();
+        // Straight to the compaction: it refreshes the savepoints the peer deleted itself
+        db.compact().unwrap();
+    }
+
+    /// When the close's commit cannot sync to the file's latest commit, the close writes no
+    /// shutdown header. Writing one would put this handle's stale header, marked clean, over
+    /// that commit.
+    #[test]
+    fn a_close_writes_no_header_over_a_commit_it_could_not_sync_to() {
+        use std::io::{Read, Seek, SeekFrom, Write};
+
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let (db, peer) = two_handles(tmpfile.path());
+        insert(&peer, 1);
+        drop(peer);
+        // The peer's commit with its primary slot's checksum flipped: corruption, not a torn
+        // write to fall back from, since a shared commit is 2-phase. The god byte at 9 names the
+        // primary of the two 128-byte slots at 64 and 192, each ending in a 16-byte checksum
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(tmpfile.path())
+            .unwrap();
+        let mut god_byte = [0u8];
+        file.seek(SeekFrom::Start(9)).unwrap();
+        file.read_exact(&mut god_byte).unwrap();
+        let checksum = 64 + 128 * u64::from(god_byte[0] & 1) + 112;
+        let mut flipped = [0u8; 16];
+        file.seek(SeekFrom::Start(checksum)).unwrap();
+        file.read_exact(&mut flipped).unwrap();
+        for byte in &mut flipped {
+            *byte ^= 0xFF;
+        }
+        file.seek(SeekFrom::Start(checksum)).unwrap();
+        file.write_all(&flipped).unwrap();
+        file.sync_all().unwrap();
+
+        drop(db);
+        let mut after = [0u8; 16];
+        file.seek(SeekFrom::Start(checksum)).unwrap();
+        file.read_exact(&mut after).unwrap();
+        assert_eq!(
+            after, flipped,
+            "the close wrote its header over the peer's commit"
+        );
+    }
+
+    /// The close commits from the file as the peer last committed it, rather than from the
+    /// state this handle had.
+    #[test]
+    fn a_close_records_a_peers_commit() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let (db, peer) = two_handles(tmpfile.path());
+        insert(&peer, 1);
+        drop(peer);
+        drop(db);
+
+        let db = open(tmpfile.path());
+        assert_eq!(value(&db, 1), 1);
+    }
+
+    /// A transaction dropped while a panic unwinds leaves its pages in the write buffer, and
+    /// the peer can then commit those same pages. The sync discards the buffer, so the page
+    /// reads back as the peer committed it.
+    #[test]
+    fn a_write_transaction_reads_a_peers_page_over_a_page_a_panic_left_buffered() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let (db, peer) = two_handles(tmpfile.path());
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let txn = db.begin_write().unwrap();
+            txn.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+            panic!("unwinding through the transaction");
+        }));
+        assert!(unwound.is_err());
+        let txn = peer.begin_write().unwrap();
+        txn.open_table(TABLE).unwrap().insert(1, 2).unwrap();
+        txn.commit().unwrap();
+
+        let txn = db.begin_write().unwrap();
+        assert_eq!(
+            txn.open_table(TABLE)
+                .unwrap()
+                .get(1)
+                .unwrap()
+                .unwrap()
+                .value(),
+            2
+        );
+    }
+}
+
 /// A caller-supplied backend has no locks to negotiate with, which is reported like a platform
 /// without them
 #[test]


### PR DESCRIPTION
The writer-side reload itself, on master now that every prep split out of it is merged: #1455, #1456, #1457, #1458, #1460 and #1461. #1443 comes after it. A `MultiWriterProcess` handle never picked up another process's commits: `begin_write()` began from the header the handle had, so two live handles overwrote each other's commits, the compaction scan's ceiling was stale (the Codex thread on #1444), and a close's commit and shutdown header overwrote whatever a peer had committed since (the thread on #1445). The design has every write transaction reload the allocator state from the latest record; #1452 made every commit record one.

## What it does

On the one path #1455 gave every write transaction, `begin_write_with_allocation_policy()` takes the write slot and the writer byte, as #1460 has it, syncs to the file's latest commit in multi-writer mode through `sync_to_latest_commit()`, and then builds the transaction's guard and the transaction. The slot and the byte release themselves on drop, so a start that fails or panics in the sync leaves neither held rather than leaving every later `begin_write()` waiting on the slot; the id is issued past the file's latest commit once the sync is done, through `issue_write_transaction_id()`, and the guard is built from the two with it. `TransactionalMemory::reload_for_write()` reads the header under the header lock, `&HeaderGuard` being the proof, through the read #1457 shares, and where the handle is not on the file's latest commit, by its id, or a panic has latched a repair over the state it holds, syncs to it: the cached pages and the buffered writes are dropped, since that process may have reused any of the pages, and a transaction dropped while a panic unwinds leaves its writes buffered, and the allocator state is dropped for `load_synced_allocator_state()` to load from what the commit recorded. Every commit in multi-writer mode records one, the open's repair's since #1461, so a commit without one is refused as corruption rather than rebuilt from. The file's persistent savepoints are synced through `sync_persistent_savepoints()` from #1456, ahead of anything the transaction frees; it takes the caller's header lock as proof from here, lent by compaction and its own otherwise, as the reload does. A load, or a savepoint sync, that stops part way, on an error or a panic the caller catches, discards the allocator state through the commit path's `AllocatorStateLatch`, which `sync_to_latest_commit()` returns armed and the builder disarms once the savepoints are synced, so the next transaction is refused rather than allocating from a partial state, or freeing from under a savepoint the tracker does not hold yet. A load that succeeds releases the repair latch a transaction dropped in a panic left, since the leak it latched is in the state replaced. That release is why a latched repair syncs where no peer has committed too: a commit made under one records no allocator state, which the next writer to sync to it would refuse, so one panic in one process would otherwise refuse every peer until it reopened.

The close's transaction goes through the same path, so the close commits from the file as a peer last committed it, under the writer byte #1458 has it hold across that commit and the shutdown header. And without the commit, no header: the header the close would write is this handle's, which describes the file only once the commit has synced to it, so a commit that fails, at the sync or after, leaves the file for the next open to recover.

The reload and the compaction hold have to agree on the header lock: compaction lends its exclusive hold to the transactions it begins, as it lends it to their commits, and `header_hold()` gives the reload a hold of its own otherwise. The same lent hold reaches the savepoint sync, which would deadlock under compaction's taking the lock again.

The recovery flag stays this handle's across a sync: a peer's close clears it in the file while this handle is still writing, and the allocator state's load clears it in memory, as it does for the open ahead of `begin_writable()`, so `sync_to_latest_commit()` marks it again for the next commit to write back, for a crash of this handle to be recovered from.

## The decisions this isolates

1. **Take the locks, sync, then build the transaction.** The slot and the byte, taken as #1460 has them, release themselves on drop, the sync runs under them, and the guard is built from them with the id once the sync is done, so no id is ever issued unsynced and nothing is left held by a start that fails.
2. **A commit is known by its id.** With every writer reloading under the writer byte, ids only advance, so the file's latest commit is another than the handle's exactly when its id is. The roots need no comparing, and `TransactionHeader` no `PartialEq`. A latched repair syncs whatever the id says, the leak being this handle's own and the recorded state free of it.
3. **No rebuild at the sync.** Every multi-writer commit records the allocator state, the open's repair's with #1461, so a commit without one broke the protocol and is refused rather than repaired from.
4. **The reload runs in multi-writer mode only.** A handle in the other modes is the only writer, so the file's commit is its own; the header read and parse per transaction would be wasted there.
5. **Read transactions on a writable handle still do not reload.** They see the handle's commits and the peer commits its write transactions synced to. Making them reload, as a read-only handle's do, needs the header to be synced ahead of the allocator, and the `begin_read` race a read-only handle guards against; it is a later slice.

## Testing

`a_write_transaction_syncs_to_a_peers_commit`: a peer's row is visible in the transaction, and both handles' commits survive to a reopen; never syncing fails the first assertion, and issuing the id ahead of the sync trips the commit's ordering assertion. `a_write_transaction_syncs_to_a_peers_savepoint`: the peer's persistent savepoint refuses compaction on the handle once a transaction has synced to it, the handle's own savepoint takes a fresh id and both are listed, and once the peer deletes both, compaction proceeds; skipping the sync hands the peer's id out again, and without the forgetting compaction is still refused. `a_close_records_a_peers_commit`: the peer's row survives the handle's close, which used to commit over it. `a_close_writes_no_header_over_a_commit_it_could_not_sync_to`: with the peer's primary slot checksum flipped on disk, the close's commit cannot sync to it, and the slot's bytes read back unchanged after the close; before the fix the close wrote its stale header over them. `a_write_transaction_reads_a_peers_page_over_a_page_a_panic_left_buffered`: a transaction dropped while a panic unwinds leaves its pages buffered, the peer allocates and commits the same pages, and the handle's next transaction reads the peer's value; without the discard it reads its own. `a_sync_refuses_a_commit_without_an_allocator_state`: a peer's commit made with the record skipped is refused by the next `begin_write()` as corruption. `syncing_to_a_peers_commit_releases_the_repair_a_panic_latched`: after a panic-dropped transaction latched a repair, syncing to a peer's commit releases it and the next commit records again. `a_transaction_releases_the_repair_a_panic_latched_without_a_peers_commit`: with no peer commit to sync to, the handle's own next transaction releases it, and a peer syncs to the commit that follows; without the release that commit records nothing and the peer is refused (the Codex thread here). `a_lent_header_lock_covers_syncing_to_a_peers_commit`: a transaction lent compaction's exclusive header lock syncs to a peer's commit, savepoints included, in a thread so that taking the lock again fails rather than hangs. `syncing_to_a_peers_close_keeps_the_recovery_flag`: a peer's close clears the flag in the file, the handle's next commit writes it back, and the handle's close clears it; without the mark the commit leaves it cleared. Not covered: a load or a sync that fails part way, which needs corruption the tree walk reports rather than panics on, or a lock that fails, neither of which the suite can inject under a live handle; nor the writer byte failing at the close, for the same reason; nor a panic in the sync, verified by hand with panics injected into the loader, after which the next `begin_write()` returns, refused until a reopen, where it hung or went ahead on an empty allocator before. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9