### PR TITLE
Record the allocator state at the end of a multi-writer compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
   `Durability::None` is refused, and the database may be opened read-only while another process has
   it open for writing; each new read transaction then sees that process's durable commits, and
   `Database::compact()` treats a read transaction in another process as a transaction in progress.
+  In `MultiWriterProcess`, `Database::compact()` ends with a commit recording the allocator state,
+  for the next writer to load.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/db.rs
+++ b/src/db.rs
@@ -13,8 +13,8 @@ use crate::tree_store::{
 };
 use crate::types::{Key, Value};
 use crate::{
-    CompactionError, DatabaseError, Error, ReadOnlyTable, ReadableTable, SavepointError,
-    StorageError, TableError,
+    CompactionError, DatabaseError, ReadOnlyTable, ReadableTable, SavepointError, StorageError,
+    TableError,
 };
 use crate::{ReadTransaction, Result, WriteTransaction};
 use alloc::boxed::Box;
@@ -1069,6 +1069,21 @@ impl Database {
             compacted = true;
         }
 
+        // In multi-writer mode the file's latest commit records the allocator state, for the
+        // next writer, in any process, to load rather than rebuild: the commit the close makes.
+        // Not in the other modes, where the close records and a second record would leave the
+        // file one record larger, the pages of the one it replaces being freed only by the next
+        // commit
+        #[cfg(feature = "experimental-multiprocess")]
+        if self.mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess {
+            ensure_allocator_state_table_and_trim(
+                &self.transaction_tracker,
+                &self.mem,
+                writer_lock.as_ref(),
+                header_lock.as_ref(),
+            )?;
+        }
+
         Ok(compacted)
     }
 
@@ -1601,10 +1616,15 @@ fn begin_write_with_allocation_policy(
     .map_err(|e| e.into())
 }
 
+// Records the allocator state in a commit that also trims the file: the close's last commit,
+// and compaction's. `writer_lock` and `header_lock` where the caller lends the ones it holds, as
+// compaction does; nothing is waiting on the write slot in either case
 fn ensure_allocator_state_table_and_trim(
     transaction_tracker: &Arc<TransactionTracker>,
     mem: &Arc<TransactionalMemory>,
-) -> Result<(), Error> {
+    #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
+    #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
+) -> Result {
     // Make a new quick-repair commit to update the allocator state table
     #[cfg(feature = "logging")]
     debug!("Writing allocator state table");
@@ -1615,9 +1635,11 @@ fn ensure_allocator_state_table_and_trim(
     // Before the lock, which waits on a peer holding the writer byte: a latched I/O failure
     // means there is nothing to write here anyway
     mem.check_io_errors()?;
-    // The database is being closed, so nothing can be waiting on the write slot
     #[cfg(feature = "experimental-multiprocess")]
-    let writer_lock = mem.lock_writer()?;
+    let writer_lock = match writer_lock {
+        Some(lent) => lent.clone(),
+        None => mem.lock_writer()?,
+    };
     let guard = TransactionGuard::new_write(
         transaction_tracker.start_write_transaction(),
         transaction_tracker.clone(),
@@ -1629,11 +1651,16 @@ fn ensure_allocator_state_table_and_trim(
         transaction_tracker,
         mem,
         AllocationPolicy::Lowest,
-    )?;
+    )
+    .map_err(|e| e.into_storage_error())?;
     tx.set_quick_repair(true);
     tx.disable_post_commit_free();
     tx.set_shrink_policy(ShrinkPolicy::Maximum);
-    tx.commit()?;
+    tx.commit_with(
+        #[cfg(feature = "experimental-multiprocess")]
+        header_lock,
+    )
+    .map_err(|e| e.into_storage_error())?;
 
     Ok(())
 }
@@ -1649,7 +1676,15 @@ fn close_database(transaction_tracker: &Arc<TransactionTracker>, mem: &Arc<Trans
     // of trusting the saved one
     if !crate::panicking()
         && !mem.needs_repair()
-        && ensure_allocator_state_table_and_trim(transaction_tracker, mem).is_err()
+        && ensure_allocator_state_table_and_trim(
+            transaction_tracker,
+            mem,
+            #[cfg(feature = "experimental-multiprocess")]
+            None,
+            #[cfg(feature = "experimental-multiprocess")]
+            None,
+        )
+        .is_err()
     {
         #[cfg(feature = "logging")]
         warn!("Failed to write allocator state table. Repair may be required at restart.");
@@ -2397,6 +2432,22 @@ mod writer_byte_test {
             table.insert(0, 0).unwrap();
         }
         write.commit().unwrap();
+    }
+
+    /// A multi-writer compaction ends with a commit recording the allocator state, for the next
+    /// writer, in any process, to load rather than rebuild
+    #[test]
+    fn a_multi_writer_compaction_records_the_allocator_state() {
+        let tmpfile = crate::create_tempfile();
+        let mut db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        commit_one(&db);
+
+        db.compact().unwrap();
+        assert!(
+            Database::get_allocator_state_table(&db.mem)
+                .unwrap()
+                .is_some()
+        );
     }
 
     /// Held for the transaction and no longer, which is what lets the next writer in


### PR DESCRIPTION
In multi-writer mode the design requires every commit to record the allocator state, for the next writer, in any process, to load rather than rebuild. Compaction's own commits cannot: the record is a table each commit frees and writes anew, which the next round would move again and find pending, so neither its drain nor its page moves would end. So compaction has to end with one. Prep for #1449, which makes the multi-writer commits record and needs compaction to end recorded.

## What it does

A `MultiWriterProcess` compaction ends with the commit the close makes: `ensure_allocator_state_table_and_trim()`, which records the allocator state with the lowest-address allocation policy and trims the file, and now takes the writer and header locks its caller lends, as a transaction does, since compaction holds both across its work: a second lock on the byte from the same file description would release compaction's when it ended, and the header lock's in-process half cannot be taken twice. The close lends nothing and the helper takes the writer byte itself, as before; its transaction commits through `commit_with()` so that a lent header hold covers the commit too.

## The decisions this isolates

1. **The close's commit, not the drain's last.** The drain ends every compaction round, and a record made at the end of each would be moved by the next round's page relocation and re-recorded, so compaction would not converge; one record after the loop cannot be moved by anything. Reusing the close's helper also gets the lowest-address policy and the trim, so the record does not grow the file compaction just shrank.
2. **Multi-writer mode only.** The other modes are left as they were: the close records there, and a second record would leave the file one record larger, since the pages of the one it replaces are freed only by the next commit, which `small_db_is_small_file` measures. In multi-writer mode the next writer's commit reclaims them.

## Testing

`a_multi_writer_compaction_records_the_allocator_state`: after `compact()`, the file's latest commit has a valid allocator state table; without the final commit it has none, since the drain's last commit deleted it. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_