### PR TITLE
Record the allocator state on every multi-writer commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@
   `Durability::None` is refused, and the database may be opened read-only while another process has
   it open for writing; each new read transaction then sees that process's durable commits, and
   `Database::compact()` treats a read transaction in another process as a transaction in progress.
-  In `MultiWriterProcess`, `Database::compact()` ends with a commit recording the allocator state,
-  for the next writer to load.
+  In `MultiWriterProcess`, every commit records the allocator state, for the next writer to load;
+  compaction's own commits are the exception, and `Database::compact()` ends with one that does.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/db.rs
+++ b/src/db.rs
@@ -1041,6 +1041,7 @@ impl Database {
                     writer_lock.as_ref(),
                 )
                 .map_err(|e| e.into_storage_error())?;
+            txn.skip_allocator_state_record();
             if txn.compact_pages()? {
                 progress = true;
                 txn.commit_with(
@@ -1108,6 +1109,7 @@ impl Database {
                 return Ok(());
             }
             force_commit = false;
+            txn.skip_allocator_state_record();
             txn.set_two_phase_commit(true);
             txn.set_shrink_policy(shrink_policy);
             txn.commit_with(
@@ -2887,6 +2889,24 @@ mod active_transaction_test {
             write.set_durability(Durability::None),
             Err(SetDurabilityError::NonDurableCommitUnsupported)
         ));
+    }
+
+    /// Every multi-writer commit records the allocator state, for the next writer, in any
+    /// process, to load rather than rebuild: turning quick-repair off has no effect there
+    #[test]
+    fn a_multi_writer_commit_records_the_allocator_state_regardless() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+
+        let mut write = db.begin_write().unwrap();
+        write.set_quick_repair(false);
+        write.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+        write.commit().unwrap();
+        assert!(
+            Database::get_allocator_state_table(&db.mem)
+                .unwrap()
+                .is_some()
+        );
     }
 
     /// A read-only participant sees what another process committed, not the header it read at open

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "experimental-multiprocess")]
+use crate::db::ConcurrencyMode;
 use crate::db::TransactionGuard;
 use crate::error::CommitError;
 use crate::multimap_table::ReadOnlyUntypedMultimapTable;
@@ -975,6 +977,11 @@ impl WriteTransaction {
             poisoned: AtomicBool::new(false),
             durability: InternalDurability::Immediate,
             two_phase_commit: false,
+            // A multi-writer commit records the allocator state, which `set_quick_repair()`
+            // keeps on there
+            #[cfg(feature = "experimental-multiprocess")]
+            quick_repair: mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess,
+            #[cfg(not(feature = "experimental-multiprocess"))]
             quick_repair: false,
             post_commit_free: PostCommitFree::Enabled,
             restored_transaction: None,
@@ -1546,8 +1553,25 @@ impl WriteTransaction {
     /// as part of each commit (so it doesn't need to be reconstructed), and enables 2-phase commit
     /// (which guarantees that the primary commit slot is valid without needing to look at the
     /// checksums). This means commits are slower, but recovery after a crash is almost instant.
+    #[cfg_attr(
+        feature = "experimental-multiprocess",
+        doc = "",
+        doc = "Disabling it has no effect in [`ConcurrencyMode::MultiWriterProcess`](crate::ConcurrencyMode::MultiWriterProcess), where every commit saves the allocator state, for the next write transaction, in any process, to load rather than reconstruct. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
+    )]
     pub fn set_quick_repair(&mut self, enabled: bool) {
+        // A multi-writer commit records the allocator state, for the next writer, in any
+        // process, to load rather than rebuild from the trees
+        #[cfg(feature = "experimental-multiprocess")]
+        if !enabled && self.mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess {
+            return;
+        }
         self.quick_repair = enabled;
+    }
+
+    // Compaction's commits record no allocator state, whatever the mode: the record is a table
+    // each commit frees and writes anew, which the next round would move again and find pending
+    pub(crate) fn skip_allocator_state_record(&mut self) {
+        self.quick_repair = false;
     }
 
     pub(crate) fn disable_post_commit_free(&mut self) {


### PR DESCRIPTION
The first of the writer-side reload's pieces, on master; #1453, #1449, #1454 and #1443 follow it, each on the one before. The design has every multi-writer commit record the allocator state, for the next write transaction, in any process, to load rather than rebuild from the trees; a commit recorded it only where `set_quick_repair(true)` had been called, as in the other modes.

## What it does

A `MultiWriterProcess` transaction's quick-repair is on, and `set_quick_repair(false)` has no effect there, as `set_two_phase_commit(false)` has none in the shared modes; its doc says so. Compaction's own commits opt out through a crate-private `skip_allocator_state_record()`, since the record is a table each commit frees and writes anew, which the next round would move again and find pending, so neither its drain nor its page moves would end. Compaction still ends with the close's commit, which records (#1450).

## The decisions this isolates

1. **Enforce in the setter rather than at commit.** The field's value is then always what the commit does, and the compaction opt-out is one crate-private call rather than a second flag.
2. **Every commit, not a default.** A default an application can turn off is not the design's requirement, and the changelog's "every commit" would not be true.

## Testing

`a_multi_writer_commit_records_the_allocator_state_regardless`: a commit told to skip quick-repair records the allocator state; with the setter honouring the call, the record is missing. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9