### PR TITLE
Refuse ephemeral savepoints in multi-writer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
   `Database::compact()` treats a read transaction in another process as a transaction in progress.
   In `MultiWriterProcess`, every commit records the allocator state, for the next writer to load;
   compaction's own commits are the exception, and `Database::compact()` ends with one that does.
+  Ephemeral savepoints are refused there, with `SavepointError::EphemeralSavepointUnsupported`.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/db.rs
+++ b/src/db.rs
@@ -1465,7 +1465,8 @@ impl Database {
                 Ok(savepoint) => savepoint,
                 Err(err) => match err {
                     SavepointError::InvalidSavepoint
-                    | SavepointError::ImmediateDurabilityRequired => unreachable!(),
+                    | SavepointError::ImmediateDurabilityRequired
+                    | SavepointError::EphemeralSavepointUnsupported => unreachable!(),
                     SavepointError::Storage(storage) => {
                         return Err(storage.into());
                     }
@@ -2690,7 +2691,7 @@ mod active_transaction_test {
     use super::{ConcurrencyMode, Database, ReadableDatabase, TXN_BASE, WRITER_BYTE, byte_range};
     use crate::tree_store::HEADER_LOCK;
     use crate::tree_store::file_backend::range_lock::RangeLock;
-    use crate::{Durability, SetDurabilityError, TableDefinition};
+    use crate::{Durability, SavepointError, SetDurabilityError, TableDefinition};
     use std::fs::{File, OpenOptions};
     use std::path::Path;
 
@@ -2803,11 +2804,11 @@ mod active_transaction_test {
     }
 
     /// A savepoint holds a read transaction live, so its snapshot stays active for as long as
-    /// the savepoint does
+    /// the savepoint does. In the shared mode that supports an ephemeral one
     #[test]
     fn an_ephemeral_savepoint_locks_the_snapshot_it_references() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::SingleWriterProcess);
         let probe = probe(tmpfile.path());
         assert!(held_ids(&probe).is_empty());
 
@@ -2907,6 +2908,22 @@ mod active_transaction_test {
                 .unwrap()
                 .is_some()
         );
+    }
+
+    /// An ephemeral savepoint would be known to this process alone, and a persistent savepoint
+    /// a peer creates could take its id, so multi-writer mode refuses it
+    #[test]
+    fn a_multi_writer_mode_refuses_an_ephemeral_savepoint() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+
+        let write = db.begin_write().unwrap();
+        assert!(matches!(
+            write.ephemeral_savepoint(),
+            Err(SavepointError::EphemeralSavepointUnsupported)
+        ));
+        write.persistent_savepoint().unwrap();
+        write.commit().unwrap();
     }
 
     /// A read-only participant sees what another process committed, not the header it read at open

--- a/src/error.rs
+++ b/src/error.rs
@@ -300,6 +300,9 @@ pub enum SavepointError {
     /// creating or deleting a persistent savepoint, or restoring an older savepoint while
     /// newer persistent savepoints exist that would need to be deleted.
     ImmediateDurabilityRequired,
+    /// An ephemeral savepoint would be known to this process alone, and a persistent savepoint
+    /// another process creates could take its id
+    EphemeralSavepointUnsupported,
     /// Error from underlying storage
     Storage(StorageError),
 }
@@ -309,6 +312,7 @@ impl From<SavepointError> for Error {
         match err {
             SavepointError::InvalidSavepoint => Error::InvalidSavepoint,
             SavepointError::ImmediateDurabilityRequired => Error::ImmediateDurabilityRequired,
+            SavepointError::EphemeralSavepointUnsupported => Error::EphemeralSavepointUnsupported,
             SavepointError::Storage(storage) => storage.into(),
         }
     }
@@ -330,6 +334,12 @@ impl Display for SavepointError {
                 write!(
                     f,
                     "Operation requires Durability::Immediate for the current transaction."
+                )
+            }
+            SavepointError::EphemeralSavepointUnsupported => {
+                write!(
+                    f,
+                    "Ephemeral savepoints are not supported when the database is shared with other writer processes"
                 )
             }
             SavepointError::Storage(storage) => storage.fmt(f),
@@ -557,6 +567,9 @@ pub enum Error {
     PersistentSavepointModified,
     /// A non-durable commit would be invisible to the other processes sharing the database
     NonDurableCommitUnsupported,
+    /// An ephemeral savepoint would be known to this process alone, and a persistent savepoint
+    /// another process creates could take its id
+    EphemeralSavepointUnsupported,
     /// A persistent savepoint exists
     PersistentSavepointExists,
     /// An Ephemeral savepoint exists
@@ -628,6 +641,12 @@ impl Display for Error {
                 write!(
                     f,
                     "Non-durable commits are not supported when the database is shared with other processes"
+                )
+            }
+            Error::EphemeralSavepointUnsupported => {
+                write!(
+                    f,
+                    "Ephemeral savepoints are not supported when the database is shared with other writer processes"
                 )
             }
             Error::UpgradeRequired(actual) => {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1157,7 +1157,7 @@ impl WriteTransaction {
             return Err(SavepointError::ImmediateDurabilityRequired);
         }
 
-        let mut savepoint = self.ephemeral_savepoint()?;
+        let mut savepoint = self.create_savepoint()?;
 
         let mut system_tables = self.system_tables.lock().unwrap();
 
@@ -1285,7 +1285,21 @@ impl WriteTransaction {
     ///
     /// Returns [`SavepointError::InvalidSavepoint`] if the transaction is "dirty" (a data
     /// table has been opened, renamed, or deleted, or a savepoint has been restored)
+    #[cfg_attr(
+        feature = "experimental-multiprocess",
+        doc = "",
+        doc = "Refused, with [`SavepointError::EphemeralSavepointUnsupported`], in [`ConcurrencyMode::MultiWriterProcess`](crate::ConcurrencyMode::MultiWriterProcess): the savepoint would be known to this process alone, and a persistent savepoint another process creates could take its id. Persistent savepoints are supported. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
+    )]
     pub fn ephemeral_savepoint(&self) -> Result<Savepoint, SavepointError> {
+        #[cfg(feature = "experimental-multiprocess")]
+        if self.mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess {
+            return Err(SavepointError::EphemeralSavepointUnsupported);
+        }
+        self.create_savepoint()
+    }
+
+    // The savepoint, ephemeral until `persistent_savepoint()` records it
+    fn create_savepoint(&self) -> Result<Savepoint, SavepointError> {
         // Serialize the dirty check and savepoint registration against
         // `TableNamespace::set_dirty()`, which runs under the same tables lock. Without this,
         // a concurrent first table-open (legal since `WriteTransaction: Sync`) can read the


### PR DESCRIPTION
The second of the writer-side reload's pieces, on master now that #1452 is merged; #1449, #1454 and #1443 follow it. The design lists ephemeral savepoints as unsupported in multi-writer mode, and the API did not refuse them. An ephemeral savepoint's id is known to this process alone: a persistent savepoint another process creates can take it, and a handle that adopts that process's commit, as the reload will have every write transaction do, then holds the persistent savepoint under the id of its own ephemeral one, unpinning that snapshot and panicking when the ephemeral savepoint is dropped.

## What it does

`ephemeral_savepoint()` refuses in `MultiWriterProcess`, with a new `SavepointError::EphemeralSavepointUnsupported`, beside `SetDurabilityError::NonDurableCommitUnsupported`; its doc says so. `persistent_savepoint()` creates its savepoint through the same path as before, now `create_savepoint()`.

## The decisions this isolates

1. **Refuse, rather than keep ephemeral ids apart from the peers'.** The design withholds the support an id space of their own would be, and the refusal is the smaller change.
2. **A new error variant.** No existing `SavepointError` says "unsupported in this mode"; the durability refusal got a variant of its own for the same reason.

## Testing

`a_multi_writer_mode_refuses_an_ephemeral_savepoint`: refused, while a persistent savepoint is still created. `an_ephemeral_savepoint_locks_the_snapshot_it_references` runs in `SingleWriterProcess` now, the shared mode that supports one. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9