### PR TITLE
Restore a persistent savepoint handle only while the file's record matches it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@
   `Database::compact()` treats a read transaction in another process as a transaction in progress.
   In `MultiWriterProcess`, every commit records the allocator state, for the next writer to load;
   compaction's own commits are the exception, and `Database::compact()` ends with one that does.
-  Ephemeral savepoints are refused there, with `SavepointError::EphemeralSavepointUnsupported`.
+  Ephemeral savepoints are refused there, with `SavepointError::EphemeralSavepointUnsupported`,
+  and a write transaction begins from the file as another process last committed it, as does the
+  close.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@
   compaction's own commits are the exception, and `Database::compact()` ends with one that does.
   Ephemeral savepoints are refused there, with `SavepointError::EphemeralSavepointUnsupported`,
   and a write transaction begins from the file as another process last committed it, as does the
-  close.
+  close. `WriteTransaction::restore_savepoint()` refuses a persistent savepoint's handle the
+  file's record no longer matches, with `SavepointError::InvalidSavepoint`.
 
 ### redb-derive (unreleased)
 * Fix `#[derive(Value)]` and `#[derive(Key)]` failing to compile on structs whose lifetimes are

--- a/src/db.rs
+++ b/src/db.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use crate::{ReadTransaction, Result, WriteTransaction};
 use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
 use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
@@ -901,6 +902,15 @@ impl Database {
         Ok(was_clean)
     }
 
+    // Restores the tracker state for the file's persistent savepoints
+    fn restore_persistent_savepoints(&self) -> Result<(), DatabaseError> {
+        let txn = self.begin_write().map_err(|e| e.into_storage_error())?;
+        register_persistent_savepoints(&self.transaction_tracker, &self.mem, &txn)?;
+        txn.abort()?;
+
+        Ok(())
+    }
+
     // Verifies, and repairs in memory, the live (possibly non-durable) state. Returns:
     // - `None` if the live tree is corrupt and the commit must be rolled back;
     // - `Some(true)` if the live state is fully clean;
@@ -1456,27 +1466,7 @@ impl Database {
         };
 
         // Restore the tracker state for any persistent savepoints
-        let txn = db.begin_write().map_err(|e| e.into_storage_error())?;
-        if let Some(next_id) = txn.next_persistent_savepoint_id()? {
-            db.transaction_tracker
-                .restore_savepoint_counter_state(next_id);
-        }
-        for id in txn.list_persistent_savepoints()? {
-            let savepoint = match txn.get_persistent_savepoint(id) {
-                Ok(savepoint) => savepoint,
-                Err(err) => match err {
-                    SavepointError::InvalidSavepoint
-                    | SavepointError::ImmediateDurabilityRequired
-                    | SavepointError::EphemeralSavepointUnsupported => unreachable!(),
-                    SavepointError::Storage(storage) => {
-                        return Err(storage.into());
-                    }
-                },
-            };
-            db.transaction_tracker
-                .register_persistent_savepoint(&db.mem, &savepoint)?;
-        }
-        txn.abort()?;
+        db.restore_persistent_savepoints()?;
 
         Ok(db)
     }
@@ -1556,6 +1546,42 @@ impl Database {
             AllocationPolicy::Default,
         )
     }
+}
+
+// Holds the file's persistent savepoints, which another process may have created, replaced or
+// deleted since the tracker last saw the file, and continues savepoint ids past the file's.
+// Under the header lock
+fn register_persistent_savepoints(
+    transaction_tracker: &TransactionTracker,
+    mem: &TransactionalMemory,
+    txn: &WriteTransaction,
+) -> Result {
+    if let Some(next_id) = txn.next_persistent_savepoint_id()? {
+        transaction_tracker.restore_savepoint_counter_state(next_id);
+    }
+    let mut held = BTreeMap::new();
+    for id in txn.list_persistent_savepoints()? {
+        let savepoint = match txn.get_persistent_savepoint(id) {
+            Ok(savepoint) => savepoint,
+            Err(err) => match err {
+                SavepointError::InvalidSavepoint
+                | SavepointError::ImmediateDurabilityRequired
+                | SavepointError::EphemeralSavepointUnsupported => unreachable!(),
+                SavepointError::Storage(storage) => {
+                    return Err(storage);
+                }
+            },
+        };
+        held.insert(savepoint.get_id(), savepoint.get_transaction_id());
+    }
+    #[cfg(feature = "experimental-multiprocess")]
+    let hold = mem.header_hold(None)?;
+    transaction_tracker.hold_persistent_savepoints(
+        mem,
+        &held,
+        #[cfg(feature = "experimental-multiprocess")]
+        &hold,
+    )
 }
 
 // Takes the write slot and the writer lock, and builds the transaction on them. A caller that

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,8 @@
 use crate::io;
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
 #[cfg(feature = "experimental-multiprocess")]
+use crate::transactions::AllocatorStateLatch;
+#[cfg(feature = "experimental-multiprocess")]
 use crate::tree_store::HeaderGuard;
 use crate::tree_store::LocklessBackend;
 #[cfg(not(redb_no_std))]
@@ -451,6 +453,16 @@ impl TransactionGuard {
 
     pub(crate) fn untracked() -> Self {
         Self::Untracked
+    }
+
+    // Renumbers the write transaction this guard holds, which the tracker has moved past a
+    // commit another process made
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn follow(&mut self, id: TransactionId) {
+        let Self::Write { transaction_id, .. } = self else {
+            unreachable!("only a write transaction is renumbered")
+        };
+        *transaction_id = id;
     }
 
     pub(crate) fn id(&self) -> TransactionId {
@@ -905,7 +917,13 @@ impl Database {
     // Restores the tracker state for the file's persistent savepoints
     fn restore_persistent_savepoints(&self) -> Result<(), DatabaseError> {
         let txn = self.begin_write().map_err(|e| e.into_storage_error())?;
-        register_persistent_savepoints(&self.transaction_tracker, &self.mem, &txn)?;
+        register_persistent_savepoints(
+            &self.transaction_tracker,
+            &self.mem,
+            &txn,
+            #[cfg(feature = "experimental-multiprocess")]
+            None,
+        )?;
         txn.abort()?;
 
         Ok(())
@@ -1007,6 +1025,8 @@ impl Database {
             .begin_write_with(
                 #[cfg(feature = "experimental-multiprocess")]
                 writer_lock.as_ref(),
+                #[cfg(feature = "experimental-multiprocess")]
+                header_lock.as_ref(),
             )
             .map_err(|e| e.into_storage_error())?;
         // Re-check inside the write transaction: a concurrent writer may have created a
@@ -1049,6 +1069,8 @@ impl Database {
                 .begin_write_with(
                     #[cfg(feature = "experimental-multiprocess")]
                     writer_lock.as_ref(),
+                    #[cfg(feature = "experimental-multiprocess")]
+                    header_lock.as_ref(),
                 )
                 .map_err(|e| e.into_storage_error())?;
             txn.skip_allocator_state_record();
@@ -1112,6 +1134,8 @@ impl Database {
                 .begin_write_with(
                     #[cfg(feature = "experimental-multiprocess")]
                     writer_lock,
+                    #[cfg(feature = "experimental-multiprocess")]
+                    header_lock,
                 )
                 .map_err(|e| e.into_storage_error())?;
             if !force_commit && !txn.pending_free_pages()? {
@@ -1402,6 +1426,28 @@ impl Database {
         root.map(|header| BtreeHeader::new(header.root, header.checksum, length))
     }
 
+    /// Loads the allocator state the file's latest commit recorded, or rebuilds it from the
+    /// trees where that commit recorded none: a repair's, or one made while the state needed
+    /// repair
+    #[cfg(feature = "experimental-multiprocess")]
+    fn load_or_rebuild_allocator_state(mem: &Arc<TransactionalMemory>) -> Result {
+        if let Some(tree) = Self::get_allocator_state_table(mem)? {
+            mem.load_allocator_state(&tree)?;
+            #[cfg(debug_assertions)]
+            Self::mark_allocated_page_for_debug(mem)?;
+        } else {
+            Self::rebuild_allocator_state(mem, &|_| {}).map_err(|err| match err {
+                DatabaseError::Storage(err) => err,
+                _ => unreachable!(),
+            })?;
+        }
+        // Loaded or rebuilt, the allocator state is the file's, without the leak a skipped abort
+        // had latched in the one it replaces
+        mem.clear_needs_repair();
+
+        Ok(())
+    }
+
     fn new(
         file: Box<dyn InternalStorageBackend>,
         allow_initialize: bool,
@@ -1531,18 +1577,23 @@ impl Database {
         self.begin_write_with(
             #[cfg(feature = "experimental-multiprocess")]
             None,
+            #[cfg(feature = "experimental-multiprocess")]
+            None,
         )
     }
 
     fn begin_write_with(
         &self,
         #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
+        #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
     ) -> Result<WriteTransaction, TransactionError> {
         begin_write_with_allocation_policy(
             &self.transaction_tracker,
             &self.mem,
             #[cfg(feature = "experimental-multiprocess")]
             writer_lock,
+            #[cfg(feature = "experimental-multiprocess")]
+            header_lock,
             AllocationPolicy::Default,
         )
     }
@@ -1550,11 +1601,12 @@ impl Database {
 
 // Holds the file's persistent savepoints, which another process may have created, replaced or
 // deleted since the tracker last saw the file, and continues savepoint ids past the file's.
-// Under the header lock
+// Under the header lock, `header_lock` where the caller holds it
 fn register_persistent_savepoints(
     transaction_tracker: &TransactionTracker,
     mem: &TransactionalMemory,
     txn: &WriteTransaction,
+    #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
 ) -> Result {
     if let Some(next_id) = txn.next_persistent_savepoint_id()? {
         transaction_tracker.restore_savepoint_counter_state(next_id);
@@ -1575,7 +1627,7 @@ fn register_persistent_savepoints(
         held.insert(savepoint.get_id(), savepoint.get_transaction_id());
     }
     #[cfg(feature = "experimental-multiprocess")]
-    let hold = mem.header_hold(None)?;
+    let hold = mem.header_hold(header_lock)?;
     transaction_tracker.hold_persistent_savepoints(
         mem,
         &held,
@@ -1584,15 +1636,56 @@ fn register_persistent_savepoints(
     )
 }
 
+/// Adopts the commit another process made since this handle last loaded the file, if there is
+/// one, and numbers the live write transaction `guard` holds past it. In multi-writer mode,
+/// where there can be one; under the writer byte, so nothing commits meanwhile, and the header
+/// lock, `header_lock` where the caller holds it
+#[cfg(feature = "experimental-multiprocess")]
+fn adopt_peer_commit(
+    transaction_tracker: &TransactionTracker,
+    mem: &Arc<TransactionalMemory>,
+    guard: &mut TransactionGuard,
+    header_lock: Option<&HeaderGuard<'_>>,
+) -> Result<bool> {
+    if mem.concurrency_mode() != ConcurrencyMode::MultiWriterProcess {
+        return Ok(false);
+    }
+    let adopted = {
+        let hold = mem.header_hold(header_lock)?;
+        mem.reload_for_write(&hold)?
+    };
+    if !adopted {
+        return Ok(false);
+    }
+    // Rebuilt part way, on an error or a panic the caller catches, the allocator state describes
+    // neither the file nor anything else, and holding one must continue to mean it describes
+    // the file
+    let latch = AllocatorStateLatch::arm(mem.clone());
+    Database::load_or_rebuild_allocator_state(mem)?;
+    latch.disarm();
+    // The recovery flag is this handle's rather than the commit's: a peer's close clears it in
+    // the file while this handle is still writing, and the load above clears it in memory, so
+    // the next commit writes it back, as it would have without the adoption, for a crash of
+    // this handle to be recovered from
+    mem.mark_recovery_required();
+    let last_committed = mem.get_last_committed_transaction_id()?;
+    guard.follow(transaction_tracker.follow_committed_transaction(guard.id(), last_committed));
+
+    Ok(true)
+}
+
 // Takes the write slot and the writer lock, and builds the transaction on them. A caller that
 // already holds the writer lock lends it as `writer_lock`: locking the byte again from this file
 // description would return the same lock, and this transaction's end would then release the
-// caller's. The allocation policy is fixed for the lifetime of the transaction; every page
-// allocation this transaction makes goes through it.
+// caller's. A caller holding the header lock lends it as `header_lock` for the same reason: its
+// in-process half is a mutex, which its holder cannot take twice. The allocation policy is
+// fixed for the lifetime of the transaction; every page allocation this transaction makes goes
+// through it.
 fn begin_write_with_allocation_policy(
     transaction_tracker: &Arc<TransactionTracker>,
     mem: &Arc<TransactionalMemory>,
     #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
+    #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
     allocation_policy: AllocationPolicy,
 ) -> Result<WriteTransaction, TransactionError> {
     // Fail early if there has been an I/O error -- nothing can be committed in that case
@@ -1614,6 +1707,13 @@ fn begin_write_with_allocation_policy(
         #[cfg(feature = "experimental-multiprocess")]
         writer_lock,
     );
+    // In multi-writer mode, another process may have committed since this handle last loaded
+    // the file: its commit is the one this transaction follows. Under the guard, so that a
+    // failure or a panic in the adoption releases the slot
+    #[cfg(feature = "experimental-multiprocess")]
+    let mut guard = guard;
+    #[cfg(feature = "experimental-multiprocess")]
+    let adopted = adopt_peer_commit(transaction_tracker, mem, &mut guard, header_lock)?;
     // Re-checked after acquiring the write slot: the writer this call blocked on can fail its
     // commit, latching an I/O error and discarding the allocator state. The I/O check comes
     // first so a backend failure is not misreported as corruption. Returning drops the guard,
@@ -1625,13 +1725,31 @@ fn begin_write_with_allocation_policy(
         )
         .into());
     }
-    WriteTransaction::new(
+    let transaction = WriteTransaction::new(
         guard,
         transaction_tracker.clone(),
         mem.clone(),
         allocation_policy,
-    )
-    .map_err(|e| e.into())
+    )?;
+    // The savepoints the adopted commit's tables hold pin their transactions from here, ahead
+    // of anything this transaction frees
+    #[cfg(feature = "experimental-multiprocess")]
+    if adopted {
+        // Held part way, on an error or a panic the caller catches, the rest would be freed from
+        // under by the next transaction: the allocator state is discarded, as after a rebuild
+        // that stops part way, so that none begins until a reopen holds them all
+        let latch = AllocatorStateLatch::arm(mem.clone());
+        if let Err(err) =
+            register_persistent_savepoints(transaction_tracker, mem, &transaction, header_lock)
+        {
+            // The abort frees nothing, and an I/O failure in it stays latched
+            let _ = transaction.abort();
+            return Err(err.into());
+        }
+        latch.disarm();
+    }
+
+    Ok(transaction)
 }
 
 // Records the allocator state in a commit that also trims the file: the close's last commit,
@@ -1655,6 +1773,8 @@ fn ensure_allocator_state_table_and_trim(
         mem,
         #[cfg(feature = "experimental-multiprocess")]
         writer_lock,
+        #[cfg(feature = "experimental-multiprocess")]
+        header_lock,
         AllocationPolicy::Lowest,
     )
     .map_err(|e| e.into_storage_error())?;
@@ -1678,24 +1798,48 @@ fn ensure_allocator_state_table_and_trim(
 // write-transaction slot.
 fn close_database(transaction_tracker: &Arc<TransactionTracker>, mem: &Arc<TransactionalMemory>) {
     // No saved allocator state when it needs repair: the next open must rebuild it instead
-    // of trusting the saved one
-    if !crate::panicking()
-        && !mem.needs_repair()
+    // of trusting the saved one. Nor after a latched I/O failure, decided ahead of the lock,
+    // which waits on a peer holding the writer byte
+    let writing = !crate::panicking() && !mem.needs_repair() && mem.check_io_errors().is_ok();
+    // One hold across the allocator state's commit and the shutdown header: a commit another
+    // process made between them would be overwritten by the header. Without the hold, neither
+    // is written: the commit would take one of its own and release it, and the header would
+    // then overwrite a commit made between them
+    #[cfg(feature = "experimental-multiprocess")]
+    let writer_lock = if writing {
+        mem.lock_writer().ok()
+    } else {
+        None
+    };
+    #[cfg(feature = "experimental-multiprocess")]
+    let writing = writing && writer_lock.is_some();
+    let recorded = writing
         && ensure_allocator_state_table_and_trim(
             transaction_tracker,
             mem,
             #[cfg(feature = "experimental-multiprocess")]
-            None,
+            writer_lock.as_ref(),
             #[cfg(feature = "experimental-multiprocess")]
             None,
         )
-        .is_err()
-    {
+        .is_ok();
+    if writing && !recorded {
         #[cfg(feature = "logging")]
         warn!("Failed to write allocator state table. Repair may be required at restart.");
     }
+    // The shutdown header is this handle's, which describes the file only once the commit above
+    // has adopted it: without the commit, no header, and the next open recovers from the file
+    // as the last commit left it
+    #[cfg(feature = "experimental-multiprocess")]
+    let writer_lock = if recorded { writer_lock } else { None };
 
-    if mem.close().is_err() {
+    if mem
+        .close(
+            #[cfg(feature = "experimental-multiprocess")]
+            writer_lock.as_ref(),
+        )
+        .is_err()
+    {
         #[cfg(feature = "logging")]
         warn!("Failed to flush database file. Repair may be required at restart.");
     }
@@ -2439,6 +2583,34 @@ mod writer_byte_test {
         write.commit().unwrap();
     }
 
+    /// A transaction dropped while a panic unwinds leaks its pages in the allocator state, which
+    /// latches a repair; adopting a peer's commit replaces that state with the file's, which has
+    /// no such leak, so the latch is released and the next commit records again
+    #[test]
+    fn adopting_a_peers_commit_releases_the_repair_a_panic_latched() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        let peer = builder.open(tmpfile.path()).unwrap();
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let write = db.begin_write().unwrap();
+            write.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+            panic!("unwinding through the transaction");
+        }));
+        assert!(unwound.is_err());
+        assert!(db.mem.needs_repair());
+
+        commit_one(&peer);
+        commit_one(&db);
+        assert!(!db.mem.needs_repair());
+        assert!(
+            Database::get_allocator_state_table(&db.mem)
+                .unwrap()
+                .is_some()
+        );
+    }
+
     /// A multi-writer compaction ends with a commit recording the allocator state, for the next
     /// writer, in any process, to load rather than rebuild
     #[test]
@@ -3143,7 +3315,62 @@ mod active_transaction_test {
         }
     }
 
-    /// A transaction lent the exclusive header hold commits under it and leaves it held
+    /// A transaction lent the exclusive header hold adopts a peer's commit under it, the
+    /// savepoints it carries included, rather than taking the header lock again
+    #[test]
+    fn a_lent_header_hold_covers_adopting_a_peers_commit() {
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        fn open(path: &Path) -> Database {
+            let mut builder = Database::builder();
+            builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+            builder.open(path).unwrap()
+        }
+
+        let tmpfile = crate::create_tempfile();
+        create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let peer = open(tmpfile.path());
+        // The handle opens before the peer commits, then adopts the commit under holds it took
+        // itself, as compaction does: in a thread, so that taking the header lock again is a
+        // failure rather than a hang
+        let path = tmpfile.path().to_path_buf();
+        let (opened, wait_for_open) = mpsc::channel();
+        let (committed, wait_for_commit) = mpsc::channel();
+        let (adopted, wait_for_adoption) = mpsc::channel();
+        let adopting = thread::spawn(move || {
+            let db = open(&path);
+            opened.send(()).unwrap();
+            wait_for_commit.recv().unwrap();
+            let writer_lock = db.mem.lock_writer().unwrap();
+            let header_lock = db.mem.lock_header_exclusive().unwrap();
+            let txn = db
+                .begin_write_with(Some(&writer_lock), Some(&header_lock))
+                .unwrap();
+            let savepoints: Vec<u64> = txn.list_persistent_savepoints().unwrap().collect();
+            txn.abort().unwrap();
+            drop(header_lock);
+            drop(writer_lock);
+            adopted.send(savepoints).unwrap();
+        });
+        wait_for_open.recv().unwrap();
+        let txn = peer.begin_write().unwrap();
+        let peers_savepoint = txn.persistent_savepoint().unwrap();
+        txn.commit().unwrap();
+        // Closed first: its close would otherwise wait on the byte a hung transaction holds
+        drop(peer);
+        committed.send(()).unwrap();
+
+        let savepoints = wait_for_adoption
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the transaction took the header lock its caller holds");
+        assert_eq!(savepoints, vec![peers_savepoint]);
+        adopting.join().unwrap();
+    }
+
+    /// A transaction lent the exclusive header hold begins and commits under it and leaves it
+    /// held
     #[test]
     fn a_lent_header_hold_outlives_the_commit() {
         let tmpfile = crate::create_tempfile();
@@ -3151,7 +3378,7 @@ mod active_transaction_test {
         let probe = probe(tmpfile.path());
 
         let header_lock = db.mem.lock_header_exclusive().unwrap();
-        let txn = db.begin_write().unwrap();
+        let txn = db.begin_write_with(None, Some(&header_lock)).unwrap();
         txn.open_table(TABLE).unwrap().insert(1, 1).unwrap();
         txn.commit_with(Some(&header_lock)).unwrap();
         assert!(!probe.try_lock_shared_range(HEADER_LOCK).unwrap());
@@ -3169,7 +3396,7 @@ mod active_transaction_test {
         let probe = probe(tmpfile.path());
 
         let writer_lock = db.mem.lock_writer().unwrap();
-        let txn = db.begin_write_with(Some(&writer_lock)).unwrap();
+        let txn = db.begin_write_with(Some(&writer_lock), None).unwrap();
         txn.abort().unwrap();
         assert!(!probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap());
 

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -294,6 +294,25 @@ impl TransactionTracker {
         state.next_transaction_id = id;
     }
 
+    // Numbers the live write transaction `id` past `last_committed`, the file's latest commit,
+    // which another process made after the id was issued
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn follow_committed_transaction(
+        &self,
+        id: TransactionId,
+        last_committed: TransactionId,
+    ) -> TransactionId {
+        let mut state = self.state.lock().unwrap();
+        assert_eq!(state.live_write_transaction, Some(id));
+        if last_committed < id {
+            return id;
+        }
+        state.next_transaction_id = last_committed;
+        let id = state.next_transaction_id.increment();
+        state.live_write_transaction = Some(id);
+        id
+    }
+
     // Reserves a repair commit's id so it is never issued again: crash recovery orders the
     // commit slots by transaction id, so an id must never be committed twice
     pub(crate) fn reserve_repair_transaction_id(&self, id: TransactionId) {

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -4,7 +4,7 @@ use crate::tree_store::HeaderGuard;
 use crate::tree_store::TransactionalMemory;
 #[cfg(feature = "experimental-multiprocess")]
 use crate::tree_store::WriterLock;
-use crate::{Key, Result, Savepoint, TypeName, Value};
+use crate::{Key, Result, TypeName, Value};
 use alloc::collections::BTreeSet;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::sync::Arc;
@@ -302,31 +302,50 @@ impl TransactionTracker {
         state.next_transaction_id = state.next_transaction_id.max(id);
     }
 
+    // Continues savepoint ids from `next_savepoint` where that is past the ones issued here:
+    // another process may have created the file's persistent savepoints
     pub(crate) fn restore_savepoint_counter_state(&self, next_savepoint: SavepointId) {
         let mut state = self.state.lock().unwrap();
-        assert!(state.valid_savepoints.is_empty());
-        assert!(state.persistent_savepoints.is_empty());
-        state.next_savepoint_id = next_savepoint;
+        state.next_savepoint_id = state.next_savepoint_id.max(next_savepoint);
     }
 
-    pub(crate) fn register_persistent_savepoint(
+    // Holds the file's persistent savepoints, `held`, and no other persistent ones, each pinning
+    // its transaction: registers those it lacked, moves those whose transaction changed, and
+    // forgets those gone, which another process created, replaced or deleted. Under the header
+    // lock, which `header` proves held
+    pub(crate) fn hold_persistent_savepoints(
         &self,
         mem: &TransactionalMemory,
-        savepoint: &Savepoint,
+        held: &BTreeMap<SavepointId, TransactionId>,
+        #[cfg(feature = "experimental-multiprocess")] header: &HeaderGuard<'_>,
     ) -> Result {
-        #[cfg(feature = "experimental-multiprocess")]
-        let header = mem.lock_header_shared()?;
         let mut state = self.state.lock().unwrap();
-        state.reference_transaction(
-            mem,
-            savepoint.get_transaction_id(),
-            #[cfg(feature = "experimental-multiprocess")]
-            &header,
-        )?;
-        state
-            .valid_savepoints
-            .insert(savepoint.get_id(), savepoint.get_transaction_id());
-        state.persistent_savepoints.insert(savepoint.get_id());
+        let gone: Vec<SavepointId> = state
+            .persistent_savepoints
+            .iter()
+            .filter(|id| !held.contains_key(id))
+            .copied()
+            .collect();
+        for id in gone {
+            state.persistent_savepoints.remove(&id);
+            let transaction = state.valid_savepoints.remove(&id).unwrap();
+            state.dereference_transaction(mem, transaction);
+        }
+        for (&id, &transaction) in held {
+            if state.valid_savepoints.get(&id) == Some(&transaction) {
+                continue;
+            }
+            state.reference_transaction(
+                mem,
+                transaction,
+                #[cfg(feature = "experimental-multiprocess")]
+                header,
+            )?;
+            if let Some(replaced) = state.valid_savepoints.insert(id, transaction) {
+                state.dereference_transaction(mem, replaced);
+            }
+            state.persistent_savepoints.insert(id);
+        }
 
         Ok(())
     }

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -463,6 +463,15 @@ impl TransactionTracker {
         self.deallocate_read_transaction(mem, transaction);
     }
 
+    // Whether `id` is a persistent savepoint the tracker holds, as against an ephemeral one
+    pub(crate) fn is_persistent_savepoint(&self, id: SavepointId) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .persistent_savepoints
+            .contains(&id)
+    }
+
     pub(crate) fn is_valid_savepoint(&self, id: SavepointId) -> bool {
         self.state
             .lock()

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -828,7 +828,8 @@ impl TableNamespace {
 #[derive(Default)]
 struct SavepointTransactionState {
     created_persistent: BTreeSet<(SavepointId, TransactionId)>,
-    deleted_persistent: Vec<(SavepointId, TransactionId)>,
+    // Each with the transaction and root its record named, for a handle to be checked against
+    deleted_persistent: Vec<(SavepointId, TransactionId, Option<BtreeHeader>)>,
     invalidated: BTreeSet<SavepointId>,
 }
 
@@ -837,8 +838,22 @@ impl SavepointTransactionState {
         self.created_persistent.insert((id, transaction_id));
     }
 
-    fn record_deleted(&mut self, id: SavepointId, transaction_id: TransactionId) {
-        self.deleted_persistent.push((id, transaction_id));
+    fn record_deleted(
+        &mut self,
+        id: SavepointId,
+        transaction_id: TransactionId,
+        user_root: Option<BtreeHeader>,
+    ) {
+        self.deleted_persistent
+            .push((id, transaction_id, user_root));
+    }
+
+    // The transaction and root of the record this transaction deleted under `id`, if any
+    fn deleted_record(&self, id: SavepointId) -> Option<(TransactionId, Option<BtreeHeader>)> {
+        self.deleted_persistent
+            .iter()
+            .find(|(deleted, _, _)| *deleted == id)
+            .map(|(_, transaction_id, user_root)| (*transaction_id, *user_root))
     }
 
     fn record_invalidated(&mut self, ids: impl IntoIterator<Item = SavepointId>) {
@@ -852,7 +867,10 @@ impl SavepointTransactionState {
     // Persistent savepoints whose deletion is staged in this transaction. They are still
     // present in the shared tracker until apply_on_commit() runs.
     fn pending_deleted_ids(&self) -> BTreeSet<SavepointId> {
-        self.deleted_persistent.iter().map(|(id, _)| *id).collect()
+        self.deleted_persistent
+            .iter()
+            .map(|(id, _, _)| *id)
+            .collect()
     }
 
     fn has_created_or_deleted(&self) -> bool {
@@ -862,7 +880,7 @@ impl SavepointTransactionState {
     fn apply_on_commit(&mut self, mem: &TransactionalMemory, tracker: &TransactionTracker) {
         // Persistent savepoints whose on-disk entry was deleted: release their
         // tracker refcount now that the deletion is durable.
-        for (savepoint, transaction) in self.deleted_persistent.drain(..) {
+        for (savepoint, transaction, _) in self.deleted_persistent.drain(..) {
             tracker.deallocate_savepoint(mem, savepoint, transaction);
         }
         // Savepoints that restore_savepoint() invalidated: remove them from the
@@ -1249,10 +1267,11 @@ impl WriteTransaction {
             return Ok(false);
         };
         table.remove(SavepointId(id))?;
-        self.savepoint_state
-            .lock()
-            .unwrap()
-            .record_deleted(savepoint.get_id(), savepoint.get_transaction_id());
+        self.savepoint_state.lock().unwrap().record_deleted(
+            savepoint.get_id(),
+            savepoint.get_transaction_id(),
+            savepoint.get_user_root(),
+        );
         Ok(true)
     }
 
@@ -1332,6 +1351,11 @@ impl WriteTransaction {
     ///
     /// Calling this method invalidates all [`Savepoint`]s created after savepoint
     ///
+    /// A persistent savepoint's handle outlives the transaction that read it. If the savepoint
+    /// has been replaced under its id, or removed, since, by another process or by a file
+    /// replaced from a copy, the handle is invalid, and [`SavepointError::InvalidSavepoint`] is
+    /// returned.
+    ///
     /// A failure partway through restoring poisons the transaction, so a half-restored state
     /// can never be committed: [`Self::commit`] rolls the transaction back and returns
     /// [`CommitError::TransactionPoisoned`]. After an I/O error the storage layer is latched
@@ -1350,6 +1374,37 @@ impl WriteTransaction {
                 .lock()
                 .unwrap()
                 .is_invalidated(savepoint.get_id())
+        {
+            return Err(SavepointError::InvalidSavepoint);
+        }
+        // A handle is known by its id alone, and the file can have replaced the record under it
+        // since the handle was read, by another process or from a copy: the handle restores the
+        // record the file has, or the one this transaction deleted, which the tracker still pins
+        let stored = match self.get_persistent_savepoint(savepoint.get_id().0) {
+            Ok(stored) => Some((stored.get_transaction_id(), stored.get_user_root())),
+            // No record on file: one this transaction deleted, or an ephemeral savepoint's. A
+            // persistent savepoint's gone otherwise was removed from under the handle, by a file
+            // replaced from a copy
+            Err(SavepointError::InvalidSavepoint) => {
+                let deleted = self
+                    .savepoint_state
+                    .lock()
+                    .unwrap()
+                    .deleted_record(savepoint.get_id());
+                if deleted.is_none()
+                    && self
+                        .transaction_tracker
+                        .is_persistent_savepoint(savepoint.get_id())
+                {
+                    return Err(SavepointError::InvalidSavepoint);
+                }
+                deleted
+            }
+            Err(err) => return Err(err),
+        };
+        if let Some((transaction_id, user_root)) = stored
+            && (transaction_id != savepoint.get_transaction_id()
+                || user_root != savepoint.get_user_root())
         {
             return Err(SavepointError::InvalidSavepoint);
         }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -895,17 +895,19 @@ impl SavepointTransactionState {
 // Discards the in-memory allocator state on drop, unless disarmed. An incomplete commit may
 // have returned pages to the allocator that the durable roots still reference through the
 // freed tables; such an allocator state must never be used, or persisted by a clean
-// shutdown, again.
-struct AllocatorStateLatch {
+// shutdown, again. A load or a rebuild of the state, or a registration of the savepoints it
+// must not free from under, that stops part way leaves one that describes nothing, whether it
+// returned an error or a panic unwound through it.
+pub(crate) struct AllocatorStateLatch {
     mem: Option<Arc<TransactionalMemory>>,
 }
 
 impl AllocatorStateLatch {
-    fn arm(mem: Arc<TransactionalMemory>) -> Self {
+    pub(crate) fn arm(mem: Arc<TransactionalMemory>) -> Self {
         Self { mem: Some(mem) }
     }
 
-    fn disarm(mut self) {
+    pub(crate) fn disarm(mut self) {
         self.mem = None;
     }
 }

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -474,7 +474,7 @@ impl DatabaseHeader {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub(super) struct TransactionHeader {
     pub(super) version: u8,
     pub(super) user_root: Option<BtreeHeader>,

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1299,6 +1299,43 @@ impl TransactionalMemory {
         Ok(current)
     }
 
+    /// Adopts the commit another process made since this handle last loaded the file, ahead of
+    /// a write transaction: the header, with the cached pages dropped, since that process may
+    /// have reused any of them, and the allocator state dropped for the caller to load or
+    /// rebuild. Under the header lock, which `_header_lock` proves held, and the writer byte,
+    /// which the caller holds too, so the commit adopted is the one the transaction follows.
+    /// Returns whether there was one
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn reload_for_write(&self, _header_lock: &HeaderGuard<'_>) -> Result<bool> {
+        let header_bytes = self.storage.read_direct(0, DB_HEADER_SIZE)?;
+        let unrepaired = UnrepairedDatabaseHeader::from_bytes(&header_bytes, self.page_size)
+            .map_err(|err| match err {
+                DatabaseError::Storage(err) => err,
+                other => StorageError::Corrupted(other.to_string()),
+            })?;
+        let (header, _) = unrepaired.finalize(self.storage.raw_file_len()?)?;
+        if *header.primary_slot() == *self.state.lock().unwrap().header.primary_slot() {
+            return Ok(false);
+        }
+
+        // Buffered writes can only belong to the state being discarded: a commit flushes its
+        // own, and a transaction dropped while a panic unwinds leaves its pages behind, which
+        // that process may have allocated since
+        self.storage.discard_write_buffer();
+        self.storage.invalidate_cache_all();
+        {
+            let mut state = self.state.lock().unwrap();
+            state.header = header;
+            state.read_from_secondary = false;
+            state.allocators = None;
+        }
+        // Mirrors the allocator state that was just dropped, so it is repopulated with it
+        #[cfg(debug_assertions)]
+        self.allocated_pages.lock().unwrap().clear();
+
+        Ok(true)
+    }
+
     pub(crate) fn begin_writable(&self) -> Result {
         #[cfg(feature = "experimental-multiprocess")]
         let header_lock = self.lock_header_exclusive()?;
@@ -1441,6 +1478,13 @@ impl TransactionalMemory {
             .copy_from_slice(&header.to_bytes(true));
 
         Ok(())
+    }
+
+    // Marks the header this process holds as a live writer's, for its next commit to write: the
+    // allocator state's load clears the flag, as it does for the open ahead of `begin_writable()`
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn mark_recovery_required(&self) {
+        self.state.lock().unwrap().header.recovery_required = true;
     }
 
     // Durably clears the recovery flag, marking the repair as complete.
@@ -2267,7 +2311,19 @@ impl TransactionalMemory {
         Ok(())
     }
 
-    pub(crate) fn close(&self) -> Result {
+    // Writes the shutdown header, under `writer_lock` where the database is shared, and closes
+    // the storage. Without the lock the header is not written: it would overwrite a commit
+    // another process makes meanwhile
+    pub(crate) fn close(
+        &self,
+        #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
+    ) -> Result {
+        #[cfg(feature = "experimental-multiprocess")]
+        let shutdown_result = match writer_lock {
+            Some(_held) => self.flush_shutdown_header(),
+            None => Ok(()),
+        };
+        #[cfg(not(feature = "experimental-multiprocess"))]
         let shutdown_result = self.flush_shutdown_header();
         // The backend's close() contract guarantees it is called exactly once, so it must be
         // called even if the shutdown writes above failed
@@ -2624,6 +2680,46 @@ mod header_lock_test {
         let peer = open_read_only(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
         drop(hold(&peer, false).unwrap());
         drop(held);
+    }
+
+    /// The recovery flag is this handle's rather than the commit's: a peer's close clears it in
+    /// the file while this handle is still writing, and the commit that adopts the peer's close
+    /// writes it back, so that a crash of this handle is recovered from
+    #[test]
+    fn adopting_a_peers_close_keeps_the_recovery_flag() {
+        use super::DB_HEADER_SIZE;
+        use crate::tree_store::page_store::header::UnrepairedDatabaseHeader;
+        use crate::{Database, TableDefinition};
+        const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+        fn unclean(path: &Path) -> bool {
+            let bytes = std::fs::read(path).unwrap();
+            UnrepairedDatabaseHeader::from_bytes(
+                &bytes[..DB_HEADER_SIZE],
+                PAGE_SIZE.try_into().unwrap(),
+            )
+            .unwrap()
+            .unclean()
+        }
+
+        let tmpfile = crate::create_tempfile();
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.create(tmpfile.path()).unwrap();
+        let db = builder.open(tmpfile.path()).unwrap();
+        let peer = builder.open(tmpfile.path()).unwrap();
+        drop(peer);
+        assert!(!unclean(tmpfile.path()), "the peer's close left the flag");
+
+        let txn = db.begin_write().unwrap();
+        txn.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+        txn.commit().unwrap();
+        assert!(
+            unclean(tmpfile.path()),
+            "the commit did not write the flag back"
+        );
+        drop(db);
+        assert!(!unclean(tmpfile.path()), "the close left the flag");
     }
 
     /// The other half of the hold covering the write: the bytes are on the file when

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -290,6 +290,124 @@ fn the_concurrency_mode_excludes_incompatible_opens() {
     Database::open(tmpfile.path()).unwrap();
 }
 
+/// Writes `with`'s contents over `path`'s, in place, so that a handle open on `path` finds
+/// them: a file replaced from a copy, out from under the database
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+fn overwrite(path: &std::path::Path, with: &std::path::Path) {
+    use std::io::Write;
+
+    let contents = std::fs::read(with).unwrap();
+    let mut file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+    file.write_all(&contents).unwrap();
+    file.set_len(contents.len() as u64).unwrap();
+    file.sync_all().unwrap();
+}
+
+/// A handle to a persistent savepoint outlives the transaction that read it, and a file copied
+/// in can replace the savepoint under its id with one of the same transaction and another root,
+/// whose pages the allocator state the handle adopts allocates without: the handle is invalid,
+/// and one read from the file restores
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+#[test]
+fn a_savepoint_handle_a_peer_replaced_under_its_id_is_invalid() {
+    use redb::{ReadableDatabase, ReadableTable, SavepointError, TableDefinition};
+    const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+    let tmpfile = tempfile::NamedTempFile::new().unwrap();
+    Database::builder()
+        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .create(tmpfile.path())
+        .unwrap();
+    let copy = tempfile::NamedTempFile::new().unwrap();
+    std::fs::copy(tmpfile.path(), copy.path()).unwrap();
+    let db = Database::builder()
+        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .open(tmpfile.path())
+        .unwrap();
+    // The handle and the copy each commit a row of their own, then a savepoint of that commit:
+    // the same savepoint and transaction ids, counted from the same header, naming different
+    // roots
+    let txn = db.begin_write().unwrap();
+    txn.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+    txn.commit().unwrap();
+    let txn = db.begin_write().unwrap();
+    let savepoint = txn.persistent_savepoint().unwrap();
+    txn.commit().unwrap();
+    let txn = db.begin_write().unwrap();
+    let handle = txn.get_persistent_savepoint(savepoint).unwrap();
+    txn.abort().unwrap();
+    let other = Database::builder()
+        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .open(copy.path())
+        .unwrap();
+    let txn = other.begin_write().unwrap();
+    txn.open_table(TABLE).unwrap().insert(2, 2).unwrap();
+    txn.commit().unwrap();
+    let txn = other.begin_write().unwrap();
+    assert_eq!(txn.persistent_savepoint().unwrap(), savepoint);
+    txn.commit().unwrap();
+    drop(other);
+    overwrite(tmpfile.path(), copy.path());
+
+    // The transaction adopts the copy's commit, and its savepoint under the id
+    let mut txn = db.begin_write().unwrap();
+    assert!(matches!(
+        txn.restore_savepoint(&handle),
+        Err(SavepointError::InvalidSavepoint)
+    ));
+    let current = txn.get_persistent_savepoint(savepoint).unwrap();
+    // Deleting the record leaves the stale handle invalid: it is compared against the record
+    // deleted, which the handle read from the file matches, so that one restores still
+    assert!(txn.delete_persistent_savepoint(savepoint).unwrap());
+    assert!(matches!(
+        txn.restore_savepoint(&handle),
+        Err(SavepointError::InvalidSavepoint)
+    ));
+    txn.restore_savepoint(&current).unwrap();
+    txn.commit().unwrap();
+    let read = db.begin_read().unwrap();
+    let table = read.open_table(TABLE).unwrap();
+    assert!(table.get(1).unwrap().is_none());
+    assert_eq!(table.get(2).unwrap().unwrap().value(), 2);
+}
+
+/// A handle to a persistent savepoint outlives the transaction that read it, and a check can
+/// reload a file copied in that lacks the savepoint while the tracker still holds its id: the
+/// handle is invalid, rather than restoring a root the rebuilt allocator state allocates without
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+#[test]
+fn a_savepoint_handle_a_reloaded_file_lacks_is_invalid() {
+    use redb::SavepointError;
+
+    let tmpfile = tempfile::NamedTempFile::new().unwrap();
+    Database::builder()
+        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .create(tmpfile.path())
+        .unwrap();
+    let copy = tempfile::NamedTempFile::new().unwrap();
+    std::fs::copy(tmpfile.path(), copy.path()).unwrap();
+    let mut db = Database::builder()
+        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .open(tmpfile.path())
+        .unwrap();
+    let txn = db.begin_write().unwrap();
+    let savepoint = txn.persistent_savepoint().unwrap();
+    txn.commit().unwrap();
+    let txn = db.begin_write().unwrap();
+    let handle = txn.get_persistent_savepoint(savepoint).unwrap();
+    txn.abort().unwrap();
+    // The copy, from before the savepoint, written over the file and reloaded by a check
+    overwrite(tmpfile.path(), copy.path());
+    db.check_integrity().unwrap();
+
+    let mut txn = db.begin_write().unwrap();
+    assert!(matches!(
+        txn.restore_savepoint(&handle),
+        Err(SavepointError::InvalidSavepoint)
+    ));
+    txn.abort().unwrap();
+}
+
 /// A multi-writer handle's write transaction begins from the file as another process last
 /// committed it, and so does its close
 #[cfg(any(target_os = "linux", target_vendor = "apple", windows))]

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -290,6 +290,218 @@ fn the_concurrency_mode_excludes_incompatible_opens() {
     Database::open(tmpfile.path()).unwrap();
 }
 
+/// A multi-writer handle's write transaction begins from the file as another process last
+/// committed it, and so does its close
+#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
+mod peer_commits {
+    use super::*;
+    use redb::{CompactionError, ReadableDatabase, ReadableTable, TableDefinition};
+    use std::path::Path;
+
+    const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
+
+    fn open(path: &Path) -> Database {
+        Database::builder()
+            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .open(path)
+            .unwrap()
+    }
+
+    /// Two handles on a file a clean close left, so that neither open commits
+    fn two_handles(path: &Path) -> (Database, Database) {
+        Database::builder()
+            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .create(path)
+            .unwrap();
+        (open(path), open(path))
+    }
+
+    fn insert(db: &Database, key: u64) {
+        let txn = db.begin_write().unwrap();
+        txn.open_table(TABLE).unwrap().insert(key, key).unwrap();
+        txn.commit().unwrap();
+    }
+
+    fn value(db: &Database, key: u64) -> u64 {
+        let read = db.begin_read().unwrap();
+        let table = read.open_table(TABLE).unwrap();
+        table.get(key).unwrap().unwrap().value()
+    }
+
+    /// The transaction sees the peer's commit, and its own commit follows it, so neither is lost
+    #[test]
+    fn a_write_transaction_adopts_a_peers_commit() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let (db, peer) = two_handles(tmpfile.path());
+        insert(&peer, 1);
+
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            assert_eq!(table.get(1).unwrap().unwrap().value(), 1);
+            table.insert(2, 2).unwrap();
+        }
+        txn.commit().unwrap();
+        let txn = peer.begin_write().unwrap();
+        {
+            let table = txn.open_table(TABLE).unwrap();
+            assert_eq!(table.get(1).unwrap().unwrap().value(), 1);
+            assert_eq!(table.get(2).unwrap().unwrap().value(), 2);
+        }
+        txn.abort().unwrap();
+        drop(peer);
+        drop(db);
+
+        let db = open(tmpfile.path());
+        assert_eq!(value(&db, 1), 1);
+        assert_eq!(value(&db, 2), 2);
+    }
+
+    /// The persistent savepoint the peer created is held from the transaction on, and the
+    /// transaction's own takes a fresh id; the savepoint the peer deleted is forgotten from the
+    /// transaction on, with the pin it held
+    #[test]
+    fn a_write_transaction_adopts_a_peers_savepoint() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let (mut db, peer) = two_handles(tmpfile.path());
+        let txn = peer.begin_write().unwrap();
+        let peers_savepoint = txn.persistent_savepoint().unwrap();
+        txn.commit().unwrap();
+
+        db.begin_write().unwrap().abort().unwrap();
+        assert!(matches!(
+            db.compact(),
+            Err(CompactionError::PersistentSavepointExists)
+        ));
+        let txn = db.begin_write().unwrap();
+        let own_savepoint = txn.persistent_savepoint().unwrap();
+        assert_ne!(own_savepoint, peers_savepoint);
+        txn.commit().unwrap();
+        {
+            let txn = db.begin_write().unwrap();
+            let mut savepoints: Vec<u64> = txn.list_persistent_savepoints().unwrap().collect();
+            savepoints.sort_unstable();
+            assert_eq!(savepoints, vec![peers_savepoint, own_savepoint]);
+            txn.abort().unwrap();
+        }
+
+        let txn = peer.begin_write().unwrap();
+        assert!(txn.delete_persistent_savepoint(peers_savepoint).unwrap());
+        assert!(txn.delete_persistent_savepoint(own_savepoint).unwrap());
+        txn.commit().unwrap();
+        db.begin_write().unwrap().abort().unwrap();
+        db.compact().unwrap();
+    }
+
+    /// The close's commit adopts the file's latest commit, and where it cannot, the shutdown
+    /// header is not written: it would put this handle's stale header, marked clean, over the
+    /// commit another process made
+    #[test]
+    fn a_close_writes_no_header_over_a_commit_it_could_not_adopt() {
+        use std::io::{Read, Seek, SeekFrom, Write};
+
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let (db, peer) = two_handles(tmpfile.path());
+        insert(&peer, 1);
+        drop(peer);
+        // The peer's commit with its primary slot's checksum flipped on disk: a commit the close
+        // cannot adopt, since a shared commit is 2-phase, under which a corrupt primary is
+        // corruption rather than a torn write to fall back from. The god byte at 9 names the
+        // primary of the two 128-byte commit slots at 64 and 192, each ending in a 16-byte
+        // checksum
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(tmpfile.path())
+            .unwrap();
+        let mut god_byte = [0u8];
+        file.seek(SeekFrom::Start(9)).unwrap();
+        file.read_exact(&mut god_byte).unwrap();
+        let checksum = 64 + 128 * u64::from(god_byte[0] & 1) + 112;
+        let mut flipped = [0u8; 16];
+        file.seek(SeekFrom::Start(checksum)).unwrap();
+        file.read_exact(&mut flipped).unwrap();
+        for byte in &mut flipped {
+            *byte ^= 0xFF;
+        }
+        file.seek(SeekFrom::Start(checksum)).unwrap();
+        file.write_all(&flipped).unwrap();
+        file.sync_all().unwrap();
+
+        drop(db);
+        let mut after = [0u8; 16];
+        file.seek(SeekFrom::Start(checksum)).unwrap();
+        file.read_exact(&mut after).unwrap();
+        assert_eq!(
+            after, flipped,
+            "the close wrote its header over the peer's commit"
+        );
+    }
+
+    /// The close commits from the file as the peer last committed it
+    #[test]
+    fn a_close_records_a_peers_commit() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let (db, peer) = two_handles(tmpfile.path());
+        insert(&peer, 1);
+        drop(peer);
+        drop(db);
+
+        let db = open(tmpfile.path());
+        assert_eq!(value(&db, 1), 1);
+    }
+
+    /// A repair's commit records no allocator state, so the transaction that adopts one rebuilds
+    /// it from the trees
+    #[test]
+    fn a_write_transaction_rebuilds_the_allocator_a_peers_repair_left_unsaved() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        // The create's commit is a repair's, so the peer's open repairs and commits too
+        let db = Database::builder()
+            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .create(tmpfile.path())
+            .unwrap();
+        let peer = open(tmpfile.path());
+        insert(&db, 1);
+        insert(&peer, 2);
+        drop(peer);
+        drop(db);
+
+        let db = open(tmpfile.path());
+        assert_eq!(value(&db, 1), 1);
+        assert_eq!(value(&db, 2), 2);
+    }
+
+    /// A transaction dropped while a panic unwinds leaves its pages in the write buffer, and the
+    /// peer can allocate and commit the same pages: the adoption discards the buffer with the
+    /// rest of the state it replaces, so the peer's page reads as committed
+    #[test]
+    fn a_write_transaction_reads_a_peers_page_over_a_page_a_panic_left_buffered() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let (db, peer) = two_handles(tmpfile.path());
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let txn = db.begin_write().unwrap();
+            txn.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+            panic!("unwinding through the transaction");
+        }));
+        assert!(unwound.is_err());
+        let txn = peer.begin_write().unwrap();
+        txn.open_table(TABLE).unwrap().insert(1, 2).unwrap();
+        txn.commit().unwrap();
+
+        let txn = db.begin_write().unwrap();
+        assert_eq!(
+            txn.open_table(TABLE)
+                .unwrap()
+                .get(1)
+                .unwrap()
+                .unwrap()
+                .value(),
+            2
+        );
+    }
+}
+
 /// A caller-supplied backend has no locks to negotiate with, which is reported like a platform
 /// without them
 #[test]


### PR DESCRIPTION
The fourth of the writer-side reload's pieces, on `claude/writer-side-reload` (#1449); #1443 follows it. A handle to a persistent savepoint outlives the transaction that read it, and with write transactions adopting the file's latest commit, the file can have replaced the savepoint under its id since: by another process, or by a file replaced from a copy, with a savepoint of the same transaction id and another root, whose pages the allocator state the handle adopted allocates without. `restore_savepoint()` installed that root.

## What it does

`restore_savepoint()` checks a persistent savepoint's handle against the file's record, its transaction id and its user root, and refuses one the file no longer matches with `SavepointError::InvalidSavepoint`; a handle read from the file restores as before. Where the record is gone because this transaction deleted it, the handle is checked against the record deleted, which the deletion now keeps with its root, since the tracker holds that snapshot until the commit and a handle that matches it may restore as it always could. Where the record is gone otherwise, a file replaced from a copy that a check reloaded having removed it, a handle the tracker holds as a persistent savepoint's is refused too, through `TransactionTracker::is_persistent_savepoint()`; only an ephemeral savepoint's handle, which never had a record, goes through the checks it always did. The doc comment and the changelog's multi-process entry say so.

## The decisions this isolates

1. **Compare the handle with the record at restore, rather than track record identity in the tracker.** The tracker's pin follows the file by transaction, but a handle is identified by its id alone and can name a root the file has replaced under it; the comparison at restore covers every way the record can change under a handle, and costs a system table read on a restore.
2. **Transaction id and user root, not the whole record.** They are what the restore installs; the system root and the freed pages are the restore's own to recompute.
3. **A deleted record stays comparable.** Deleting the record under a handle's id in the same transaction would otherwise leave nothing to compare and let the stale handle through, the Codex finding here; keeping the deleted record's transaction and root is one field on the deletion the transaction already stages.
4. **A missing record is refused for a persistent handle, not for an ephemeral one.** The tracker knows which of its savepoints are persistent, so a persistent handle with no record and no deletion in this transaction can only be one the file lost from under it; ephemeral savepoints never have a record and keep restoring as before.

## Testing

`a_savepoint_handle_a_peer_replaced_under_its_id_is_invalid`: the handle and a copy of the file each commit a row of their own and then a savepoint of it, so the copy's savepoint carries the handle's savepoint and transaction ids with another root; after the copy is written over the file, the handle read before the replacement is refused as invalid, and stays refused once the transaction deletes the record, while the one read from the file restores, to the copy's row. Without the record check the stale handle is accepted, and without the deleted record kept it is accepted after the deletion. `a_savepoint_handle_a_reloaded_file_lacks_is_invalid`: a copy from before the savepoint is written over the file and a check reloads it; the handle, whose id the tracker still holds, is refused, where before the fix it was accepted. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9