### PR TITLE
Synchronize cross-process persistent savepoint changes

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use crate::{ReadTransaction, Result, WriteTransaction};
 use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
 use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
@@ -901,6 +902,15 @@ impl Database {
         Ok(was_clean)
     }
 
+    // Synchronizes the tracker state for the file's persistent savepoints
+    fn sync_persistent_savepoints(&self) -> Result<(), DatabaseError> {
+        let txn = self.begin_write().map_err(|e| e.into_storage_error())?;
+        sync_persistent_savepoints(&self.transaction_tracker, &self.mem, &txn)?;
+        txn.abort()?;
+
+        Ok(())
+    }
+
     // Verifies, and repairs in memory, the live (possibly non-durable) state. Returns:
     // - `None` if the live tree is corrupt and the commit must be rolled back;
     // - `Some(true)` if the live state is fully clean;
@@ -1456,27 +1466,7 @@ impl Database {
         };
 
         // Restore the tracker state for any persistent savepoints
-        let txn = db.begin_write().map_err(|e| e.into_storage_error())?;
-        if let Some(next_id) = txn.next_persistent_savepoint_id()? {
-            db.transaction_tracker
-                .restore_savepoint_counter_state(next_id);
-        }
-        for id in txn.list_persistent_savepoints()? {
-            let savepoint = match txn.get_persistent_savepoint(id) {
-                Ok(savepoint) => savepoint,
-                Err(err) => match err {
-                    SavepointError::InvalidSavepoint
-                    | SavepointError::ImmediateDurabilityRequired
-                    | SavepointError::EphemeralSavepointUnsupported => unreachable!(),
-                    SavepointError::Storage(storage) => {
-                        return Err(storage.into());
-                    }
-                },
-            };
-            db.transaction_tracker
-                .register_persistent_savepoint(&db.mem, &savepoint)?;
-        }
-        txn.abort()?;
+        db.sync_persistent_savepoints()?;
 
         Ok(db)
     }
@@ -1556,6 +1546,41 @@ impl Database {
             AllocationPolicy::Default,
         )
     }
+}
+
+// Syncs the file's persistent savepoints, which another process may have created or
+// deleted since the tracker last saw the file, and continues savepoint ids past the file's.
+fn sync_persistent_savepoints(
+    transaction_tracker: &TransactionTracker,
+    mem: &TransactionalMemory,
+    txn: &WriteTransaction,
+) -> Result {
+    if let Some(next_id) = txn.next_persistent_savepoint_id()? {
+        transaction_tracker.restore_savepoint_counter_state(next_id);
+    }
+    let mut current = BTreeMap::new();
+    for id in txn.list_persistent_savepoints()? {
+        let savepoint = match txn.get_persistent_savepoint(id) {
+            Ok(savepoint) => savepoint,
+            Err(err) => match err {
+                SavepointError::InvalidSavepoint
+                | SavepointError::ImmediateDurabilityRequired
+                | SavepointError::EphemeralSavepointUnsupported => unreachable!(),
+                SavepointError::Storage(storage) => {
+                    return Err(storage);
+                }
+            },
+        };
+        current.insert(savepoint.get_id(), savepoint.get_transaction_id());
+    }
+    #[cfg(feature = "experimental-multiprocess")]
+    let hold = mem.header_hold(None)?;
+    transaction_tracker.sync_persistent_savepoints(
+        mem,
+        &current,
+        #[cfg(feature = "experimental-multiprocess")]
+        &hold,
+    )
 }
 
 // Takes the write slot and the writer lock, and builds the transaction on them. A caller that

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -4,7 +4,7 @@ use crate::tree_store::HeaderGuard;
 use crate::tree_store::TransactionalMemory;
 #[cfg(feature = "experimental-multiprocess")]
 use crate::tree_store::WriterLock;
-use crate::{Key, Result, Savepoint, TypeName, Value};
+use crate::{Key, Result, TypeName, Value};
 use alloc::collections::BTreeSet;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::sync::Arc;
@@ -302,31 +302,45 @@ impl TransactionTracker {
         state.next_transaction_id = state.next_transaction_id.max(id);
     }
 
+    // Continues savepoint ids from `next_savepoint` where that is past the ones issued here:
+    // another process may have created the file's persistent savepoints
     pub(crate) fn restore_savepoint_counter_state(&self, next_savepoint: SavepointId) {
         let mut state = self.state.lock().unwrap();
-        assert!(state.valid_savepoints.is_empty());
-        assert!(state.persistent_savepoints.is_empty());
-        state.next_savepoint_id = next_savepoint;
+        state.next_savepoint_id = state.next_savepoint_id.max(next_savepoint);
     }
 
-    pub(crate) fn register_persistent_savepoint(
+    // Sync the file's persistent savepoints. `current` must be the current set of persistent savepoints.
+    pub(crate) fn sync_persistent_savepoints(
         &self,
         mem: &TransactionalMemory,
-        savepoint: &Savepoint,
+        current: &BTreeMap<SavepointId, TransactionId>,
+        #[cfg(feature = "experimental-multiprocess")] header: &HeaderGuard<'_>,
     ) -> Result {
-        #[cfg(feature = "experimental-multiprocess")]
-        let header = mem.lock_header_shared()?;
         let mut state = self.state.lock().unwrap();
-        state.reference_transaction(
-            mem,
-            savepoint.get_transaction_id(),
-            #[cfg(feature = "experimental-multiprocess")]
-            &header,
-        )?;
-        state
-            .valid_savepoints
-            .insert(savepoint.get_id(), savepoint.get_transaction_id());
-        state.persistent_savepoints.insert(savepoint.get_id());
+        let gone: Vec<SavepointId> = state
+            .persistent_savepoints
+            .iter()
+            .filter(|id| !current.contains_key(id))
+            .copied()
+            .collect();
+        for id in gone {
+            state.persistent_savepoints.remove(&id);
+            let transaction = state.valid_savepoints.remove(&id).unwrap();
+            state.dereference_transaction(mem, transaction);
+        }
+        for (&id, &transaction) in current {
+            if state.valid_savepoints.contains_key(&id) {
+                continue;
+            }
+            state.reference_transaction(
+                mem,
+                transaction,
+                #[cfg(feature = "experimental-multiprocess")]
+                header,
+            )?;
+            assert!(state.valid_savepoints.insert(id, transaction).is_none());
+            state.persistent_savepoints.insert(id);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
The second of two preps split out of the writer-side reload (#1449), on master now that #1455 is merged. The open registered the file's persistent savepoints one at a time into an empty tracker, each registration taking the header lock itself. A handle that adopts another process's commit, which the reload will have every write transaction do, has to hold what that commit's tables hold: the savepoints it lacked, registered; those the file no longer has, forgotten. The open is the same operation on an empty tracker.

## What it does

`TransactionTracker::sync_persistent_savepoints()` replaces `register_persistent_savepoint()`: given the set the file has, it registers the savepoints the tracker lacked and forgets those gone, each with the pin it held, under a header lock its caller proves held with a `&HeaderGuard`, as the header writes are. A savepoint the tracker already holds is left as it is: ids come from a counter the file persists and are never reused, so it is the same savepoint. `restore_savepoint_counter_state()` continues the savepoint counter past the file's rather than asserting an empty tracker. The free `sync_persistent_savepoints()` reads the file's set through a transaction and hands it to the tracker, and the open calls it through `Database::sync_persistent_savepoints()`, where the reload will call it too.

## The decisions this isolates

1. **A set, not a sequence of registrations.** The reload's cases are all differences between two sets, and one function that takes the file's set covers the open as its empty-tracker case.
2. **The header lock is the caller's.** Compaction lends the reload its exclusive hold, and the in-process half of the lock is a mutex its holder cannot take twice, so the tracker takes proof rather than the lock.
3. **No case for a known id with another transaction.** The API cannot produce one, since ids are never reused; a file modified from outside can, and gets whatever it gets.

## Testing

At the open the tracker is empty, so only the registration runs, which the existing persistent savepoint tests cover across a reopen. The forget branch runs only once a handle adopts a peer's commit; #1449 brings its test. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9