### PR TITLE
Hold the writer byte across the close's commit and header

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1677,14 +1677,27 @@ fn ensure_allocator_state_table_and_trim(
 // write-transaction slot.
 fn close_database(transaction_tracker: &Arc<TransactionTracker>, mem: &Arc<TransactionalMemory>) {
     // No saved allocator state when it needs repair: the next open must rebuild it instead
-    // of trusting the saved one
-    if !crate::panicking()
-        && !mem.needs_repair()
+    // of trusting the saved one. Nor after a latched I/O failure, decided ahead of the lock,
+    // which waits on a peer holding the writer byte
+    let writing = !crate::panicking() && !mem.needs_repair() && mem.check_io_errors().is_ok();
+    // One hold across the allocator state's commit and the shutdown header: a commit another
+    // process made between them would be overwritten by the header. Without the hold, neither
+    // is written: the commit would take one of its own and release it, and the header would
+    // then overwrite a commit made between them
+    #[cfg(feature = "experimental-multiprocess")]
+    let writer_lock = if writing {
+        mem.lock_writer().ok()
+    } else {
+        None
+    };
+    #[cfg(feature = "experimental-multiprocess")]
+    let writing = writing && writer_lock.is_some();
+    if writing
         && ensure_allocator_state_table_and_trim(
             transaction_tracker,
             mem,
             #[cfg(feature = "experimental-multiprocess")]
-            None,
+            writer_lock.as_ref(),
             #[cfg(feature = "experimental-multiprocess")]
             None,
         )
@@ -1694,7 +1707,13 @@ fn close_database(transaction_tracker: &Arc<TransactionTracker>, mem: &Arc<Trans
         warn!("Failed to write allocator state table. Repair may be required at restart.");
     }
 
-    if mem.close().is_err() {
+    if mem
+        .close(
+            #[cfg(feature = "experimental-multiprocess")]
+            writer_lock.as_ref(),
+        )
+        .is_err()
+    {
         #[cfg(feature = "logging")]
         warn!("Failed to flush database file. Repair may be required at restart.");
     }
@@ -2436,6 +2455,64 @@ mod writer_byte_test {
             table.insert(0, 0).unwrap();
         }
         write.commit().unwrap();
+    }
+
+    /// Whether the file is unclean, as a shared reader sees it: it is refused an unclean file
+    /// no live writer holds
+    fn left_unclean(path: &Path) -> bool {
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        match builder.open_read_only(path) {
+            Err(super::DatabaseError::RepairAborted) => true,
+            Err(err) => panic!("{err}"),
+            Ok(_) => false,
+        }
+    }
+
+    /// The shutdown header is written under the writer byte, or not at all: written without it,
+    /// it would overwrite a commit another process makes meanwhile
+    #[test]
+    fn the_shutdown_header_is_written_under_the_writer_byte_or_not_at_all() {
+        // The memory's close alone, without the database's, which would write the header itself
+        fn close(path: &Path, under_the_byte: bool) {
+            let db = create(path, ConcurrencyMode::MultiWriterProcess);
+            commit_one(&db);
+            let mem = db.mem.clone();
+            std::mem::forget(db);
+            if under_the_byte {
+                let writer_lock = mem.lock_writer().unwrap();
+                mem.close(Some(&writer_lock)).unwrap();
+            } else {
+                mem.close(None).unwrap();
+            }
+        }
+
+        let tmpfile = crate::create_tempfile();
+        close(tmpfile.path(), false);
+        assert!(
+            left_unclean(tmpfile.path()),
+            "a header was written without the byte"
+        );
+
+        let tmpfile = crate::create_tempfile();
+        close(tmpfile.path(), true);
+        assert!(
+            !left_unclean(tmpfile.path()),
+            "no header was written under the byte"
+        );
+    }
+
+    /// The close takes the byte once, for its commit and for the header after it
+    #[test]
+    fn a_close_leaves_a_clean_file() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        commit_one(&db);
+        drop(db);
+        assert!(
+            !left_unclean(tmpfile.path()),
+            "the close left the file unclean"
+        );
     }
 
     /// A multi-writer compaction ends with a commit recording the allocator state, for the next

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -2271,7 +2271,19 @@ impl TransactionalMemory {
         Ok(())
     }
 
-    pub(crate) fn close(&self) -> Result {
+    // Writes the shutdown header, under `writer_lock` where the database is shared, and closes
+    // the storage. Without the lock the header is not written: it would overwrite a commit
+    // another process makes meanwhile
+    pub(crate) fn close(
+        &self,
+        #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
+    ) -> Result {
+        #[cfg(feature = "experimental-multiprocess")]
+        let shutdown_result = match writer_lock {
+            Some(_held) => self.flush_shutdown_header(),
+            None => Ok(()),
+        };
+        #[cfg(not(feature = "experimental-multiprocess"))]
         let shutdown_result = self.flush_shutdown_header();
         // The backend's close() contract guarantees it is called exactly once, so it must be
         // called even if the shutdown writes above failed


### PR DESCRIPTION
The second of two more preps split out of the writer-side reload (#1449), on master now that #1457 is merged. The close's commit took the writer byte through its transaction and released it at the commit's end, and the shutdown header was then written under the header lock alone, so a commit another process made between the two was overwritten by the header: half of the thread on #1445, the other half being the close's commit itself beginning from a stale header, which #1449 fixes.

## What it does

`close_database()` takes the writer byte once, ahead of its commit, lends it to the transaction as compaction lends its own, and keeps it for `TransactionalMemory::close()`, which writes the shutdown header under the lock it is lent, or writes none. Whether there is anything to write is decided ahead of the byte, from the panic, repair and I/O checks the two writes made separately, so a close with nothing to write does not wait on a peer's write transaction, as it did not before; and where the byte cannot be taken, neither is written, since the header would overwrite whatever a peer commits meanwhile.

## The decisions this isolates

1. **One hold, taken by the close.** Locks on the byte from one file description are one lock, so the transaction cannot take its own inside the close's; the close takes it and lends it, as compaction does for its transactions.
2. **No byte, no header.** The header claims a clean shutdown of the file as this handle has it; written outside the byte it could land over another process's commit, so the close without the byte leaves the flag set for the next open to recover.

## Testing

`the_shutdown_header_is_written_under_the_writer_byte_or_not_at_all`: the memory's close writes the header only when lent the byte, seen through a shared reader, which is refused an unclean file no live writer holds. `a_close_leaves_a_clean_file`: the database's close lends it. The window between the commit and the header cannot be hit deterministically without a hook in the backend, which multi-writer mode refuses, so the tests cover the contract's two halves and the code holds the byte across both by construction. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9