### PR TITLE
Take the write slot ahead of the transaction's id

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -358,6 +358,27 @@ impl CacheStats {
     }
 }
 
+// The write slot, taken ahead of the writer byte and held until the transaction ends. Releases
+// it on drop, and performs the close a `Database::drop()` deferred to that end
+pub(crate) struct WriteSlot {
+    tracker: Arc<TransactionTracker>,
+}
+
+impl WriteSlot {
+    fn take(tracker: Arc<TransactionTracker>) -> Self {
+        tracker.take_write_slot();
+        Self { tracker }
+    }
+}
+
+impl Drop for WriteSlot {
+    fn drop(&mut self) {
+        if let Some(mem) = self.tracker.end_write_transaction() {
+            close_database(&self.tracker, &mem);
+        }
+    }
+}
+
 pub(crate) enum TransactionGuard {
     Read {
         tracker: Arc<TransactionTracker>,
@@ -368,12 +389,13 @@ pub(crate) enum TransactionGuard {
         reference: Option<Arc<TransactionalMemory>>,
     },
     Write {
-        tracker: Arc<TransactionTracker>,
         transaction_id: TransactionId,
-        // The writer lock, held as long as the transaction is. `Option` only so that `Drop`
-        // can move it out
+        // Held for the transaction's span, and dropped ahead of the slot, in this order: a
+        // thread waiting on the slot would take the same byte on this file description, and
+        // this release would free theirs
         #[cfg(feature = "experimental-multiprocess")]
-        writer_lock: Option<Arc<WriterLock>>,
+        _writer_lock: Arc<WriterLock>,
+        slot: WriteSlot,
     },
     // Used for internal accesses that happen outside of any tracked transaction,
     // such as opening the database, repairing it, and running integrity checks.
@@ -421,7 +443,8 @@ impl TransactionGuard {
 
     pub(crate) fn tracker(&self) -> &Arc<TransactionTracker> {
         match self {
-            Self::Read { tracker, .. } | Self::Write { tracker, .. } => tracker,
+            Self::Read { tracker, .. } => tracker,
+            Self::Write { slot, .. } => &slot.tracker,
             Self::Untracked => unreachable!("an untracked guard has no tracker"),
         }
     }
@@ -435,17 +458,16 @@ impl TransactionGuard {
         Ok(Self::new_read(id, tracker, mem))
     }
 
-    /// The caller must already hold the write slot and the lock the transaction writes under.
     pub(crate) fn new_write(
         transaction_id: TransactionId,
-        tracker: Arc<TransactionTracker>,
+        slot: WriteSlot,
         #[cfg(feature = "experimental-multiprocess")] writer_lock: Arc<WriterLock>,
     ) -> Self {
         Self::Write {
-            tracker,
             transaction_id,
             #[cfg(feature = "experimental-multiprocess")]
-            writer_lock: Some(writer_lock),
+            _writer_lock: writer_lock,
+            slot,
         }
     }
 
@@ -477,24 +499,7 @@ impl Drop for TransactionGuard {
                     tracker.deallocate_read_transaction(mem, *transaction_id);
                 }
             }
-            Self::Write {
-                tracker,
-                transaction_id,
-                #[cfg(feature = "experimental-multiprocess")]
-                writer_lock,
-            } => {
-                let deferred = tracker.end_write_transaction(
-                    *transaction_id,
-                    #[cfg(feature = "experimental-multiprocess")]
-                    writer_lock.take(),
-                );
-                // The Database was dropped while this transaction was live, deferring
-                // the database close to the end of this transaction
-                if let Some(mem) = deferred {
-                    close_database(tracker, &mem);
-                }
-            }
-            Self::Untracked => {}
+            Self::Write { .. } | Self::Untracked => {}
         }
     }
 }
@@ -1596,27 +1601,14 @@ fn begin_write_with_allocation_policy(
 ) -> Result<WriteTransaction, TransactionError> {
     // Fail early if there has been an I/O error -- nothing can be committed in that case
     mem.check_io_errors()?;
-    let transaction_id = transaction_tracker.start_write_transaction();
+    // The slot ahead of the byte: locks on the byte from one file description are one lock, so
+    // the slot is what orders this process's writers. An error return drops both
+    let slot = WriteSlot::take(transaction_tracker.clone());
     #[cfg(feature = "experimental-multiprocess")]
-    let writer_lock = match writer_lock.map_or_else(|| mem.lock_writer(), |lent| Ok(lent.clone())) {
-        Ok(lock) => lock,
-        Err(err) => {
-            // Nothing owns the slot yet, and this database is live, so no close is deferred
-            let deferred = transaction_tracker.end_write_transaction(transaction_id, None);
-            assert!(deferred.is_none());
-            return Err(err.into());
-        }
-    };
-    let guard = TransactionGuard::new_write(
-        transaction_id,
-        transaction_tracker.clone(),
-        #[cfg(feature = "experimental-multiprocess")]
-        writer_lock,
-    );
+    let writer_lock = writer_lock.map_or_else(|| mem.lock_writer(), |lent| Ok(lent.clone()))?;
     // Re-checked after acquiring the write slot: the writer this call blocked on can fail its
     // commit, latching an I/O error and discarding the allocator state. The I/O check comes
-    // first so a backend failure is not misreported as corruption. Returning drops the guard,
-    // releasing the slot.
+    // first so a backend failure is not misreported as corruption
     mem.check_io_errors()?;
     if !mem.allocator_state_loaded() {
         return Err(StorageError::Corrupted(
@@ -1624,6 +1616,12 @@ fn begin_write_with_allocation_policy(
         )
         .into());
     }
+    let guard = TransactionGuard::new_write(
+        transaction_tracker.issue_write_transaction_id(),
+        slot,
+        #[cfg(feature = "experimental-multiprocess")]
+        writer_lock,
+    );
     WriteTransaction::new(
         guard,
         transaction_tracker.clone(),

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -2,8 +2,6 @@ use crate::sync::{Condvar, Mutex};
 #[cfg(feature = "experimental-multiprocess")]
 use crate::tree_store::HeaderGuard;
 use crate::tree_store::TransactionalMemory;
-#[cfg(feature = "experimental-multiprocess")]
-use crate::tree_store::WriterLock;
 use crate::{Key, Result, TypeName, Value};
 use alloc::collections::BTreeSet;
 use alloc::collections::btree_map::BTreeMap;
@@ -80,12 +78,21 @@ impl Key for SavepointId {
     }
 }
 
+// The write slot's state: taken ahead of the writer byte, and given its transaction's id once
+// the locks are held
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum WriteSlotState {
+    Free,
+    Taken,
+    Live(TransactionId),
+}
+
 struct State {
     next_savepoint_id: SavepointId,
     // reference count of read transactions per transaction id
     live_read_transactions: BTreeMap<TransactionId, u64>,
     next_transaction_id: TransactionId,
-    live_write_transaction: Option<TransactionId>,
+    write_slot: WriteSlotState,
     valid_savepoints: BTreeMap<SavepointId, TransactionId>,
     // Subset of valid_savepoints that are persistent
     persistent_savepoints: BTreeSet<SavepointId>,
@@ -156,7 +163,7 @@ impl TransactionTracker {
                 next_savepoint_id: SavepointId(0),
                 live_read_transactions: BTreeMap::default(),
                 next_transaction_id,
-                live_write_transaction: None,
+                write_slot: WriteSlotState::Free,
                 valid_savepoints: BTreeMap::default(),
                 persistent_savepoints: BTreeSet::default(),
                 pending_non_durable_commits: BTreeMap::default(),
@@ -167,34 +174,34 @@ impl TransactionTracker {
         }
     }
 
-    pub(crate) fn start_write_transaction(&self) -> TransactionId {
+    // Takes the write slot, waiting for the write transaction holding it to end. The
+    // transaction's id is issued by `issue_write_transaction_id()`, once the locks are held
+    pub(crate) fn take_write_slot(&self) {
         let mut state = self.state.lock().unwrap();
-        while state.live_write_transaction.is_some() {
+        while state.write_slot != WriteSlotState::Free {
             state = self.live_write_transaction_available.wait(state).unwrap();
         }
-        assert!(state.live_write_transaction.is_none());
+        state.write_slot = WriteSlotState::Taken;
+    }
+
+    // Issues the slot's transaction its id
+    pub(crate) fn issue_write_transaction_id(&self) -> TransactionId {
+        let mut state = self.state.lock().unwrap();
+        assert_eq!(state.write_slot, WriteSlotState::Taken);
         let transaction_id = state.next_transaction_id.increment();
         #[cfg(feature = "logging")]
         debug!("Beginning write transaction id={transaction_id:?}");
-        state.live_write_transaction = Some(transaction_id);
+        state.write_slot = WriteSlotState::Live(transaction_id);
 
         transaction_id
     }
 
     // Returns the deferred close, if the Database was dropped while this transaction was live.
     // The caller must close the database, now that the write transaction has ended
-    pub(crate) fn end_write_transaction(
-        &self,
-        id: TransactionId,
-        #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<Arc<WriterLock>>,
-    ) -> Option<Arc<TransactionalMemory>> {
+    pub(crate) fn end_write_transaction(&self) -> Option<Arc<TransactionalMemory>> {
         let mut state = self.state.lock().unwrap();
-        assert_eq!(state.live_write_transaction.unwrap(), id);
-        // Released before the slot is cleared, under the lock the slot uses: a thread waiting on
-        // it would take the same byte on this description, and this release would free theirs
-        #[cfg(feature = "experimental-multiprocess")]
-        drop(writer_lock);
-        state.live_write_transaction = None;
+        assert_ne!(state.write_slot, WriteSlotState::Free);
+        state.write_slot = WriteSlotState::Free;
         self.live_write_transaction_available.notify_one();
 
         state.deferred_close.take()
@@ -209,7 +216,7 @@ impl TransactionTracker {
         mem: &Arc<TransactionalMemory>,
     ) -> bool {
         let mut state = self.state.lock().unwrap();
-        if state.live_write_transaction.is_some() {
+        if state.write_slot != WriteSlotState::Free {
             state.deferred_close = Some(mem.clone());
             true
         } else {
@@ -289,7 +296,10 @@ impl TransactionTracker {
         live_write_transaction: TransactionId,
     ) {
         let mut state = self.state.lock().unwrap();
-        assert_eq!(state.live_write_transaction, Some(live_write_transaction));
+        assert_eq!(
+            state.write_slot,
+            WriteSlotState::Live(live_write_transaction)
+        );
         assert_eq!(id, state.next_transaction_id.next());
         state.next_transaction_id = id;
     }
@@ -298,7 +308,7 @@ impl TransactionTracker {
     // commit slots by transaction id, so an id must never be committed twice
     pub(crate) fn reserve_repair_transaction_id(&self, id: TransactionId) {
         let mut state = self.state.lock().unwrap();
-        assert!(state.live_write_transaction.is_none());
+        assert_eq!(state.write_slot, WriteSlotState::Free);
         state.next_transaction_id = state.next_transaction_id.max(id);
     }
 


### PR DESCRIPTION
A prep for #1449, split out of it at review. The write slot becomes a value the transaction's guard is built on, and the transaction's id is issued once the locks are held.

## What it does

`WriteSlot` is the write slot as a value: `WriteSlot::take()` takes it, waiting on the transaction holding it, and its drop releases it and performs the close a `Database::drop()` deferred to that transaction's end. The tracker records the slot's state as `WriteSlotState`, free, taken, or live with its transaction's id, which `issue_write_transaction_id()` issues to a taken slot. `begin_write_with_allocation_policy()` takes the slot, then the writer byte, runs its checks, and builds `TransactionGuard::Write` from the id, the slot and the byte; the guard holds the byte ahead of the slot, so its drop releases the byte first. An error return drops the slot and the byte the same way, so the byte's failure path, which cleared the slot by hand, is gone, as is the `Option` the guard held the byte in for its `Drop` arm, and `end_write_transaction()` takes no arguments.

## The decisions this isolates

1. **The slot is a value.** Released on drop rather than by the guard's `Drop` arm, so a start that fails past taking it, and #1449's sync between the locks and the guard, release it the way the guard does.
2. **The id is issued once the locks are held.** Nothing between the checks and the guard needs it, and #1449 issues it past the file's latest commit, which is known only under the locks. The ids issued are the same as before: the slot orders this process's writers, and the id goes to the slot's holder.
3. **The byte is released ahead of the slot by the guard's field order**, rather than under the tracker's lock as before. The order is what matters: a thread waiting on the slot takes the same byte on this file description, so the byte has to be free by the time the slot is.

## Testing

No new tests; the existing ones cover the slot's ordering, `a_multi_writer_transaction_holds_the_byte_and_gives_it_back`, and the close deferred to a transaction's end, `a_transaction_outliving_the_database_keeps_the_writer_lock` and `deferred_close_invalidates_read_transactions`. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_