### PR TITLE
Record the allocator state after a multi-writer repair

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1432,12 +1432,13 @@ impl Database {
         let mut mem = Arc::new(mem);
         // If the last transaction used 2-phase commit and updated the allocator state table, then
         // we can just load the allocator state from there. Otherwise, we need a full repair
-        if let Some(tree) = Self::get_allocator_state_table(&mem)? {
+        let repaired = if let Some(tree) = Self::get_allocator_state_table(&mem)? {
             #[cfg(feature = "logging")]
             debug!("Found valid allocator state, full repair not needed");
             mem.load_allocator_state(&tree)?;
             #[cfg(debug_assertions)]
             Self::mark_allocated_page_for_debug(&mem)?;
+            false
         } else {
             #[cfg(feature = "logging")]
             warn!("Database {:?} not shutdown cleanly. Repairing", &file_path);
@@ -1457,7 +1458,8 @@ impl Database {
                 #[cfg(feature = "experimental-multiprocess")]
                 None,
             )?;
-        }
+            true
+        };
 
         mem.begin_writable()?;
         // Past recovery, so a reader finding this byte held knows the flag means a live writer
@@ -1472,6 +1474,14 @@ impl Database {
 
         // Restore the tracker state for any persistent savepoints
         db.sync_persistent_savepoints()?;
+        // In multi-writer mode a repair ends with a commit recording the allocator state, as
+        // compaction does, so that the next open, in any process, loads it
+        #[cfg(feature = "experimental-multiprocess")]
+        if repaired && concurrency_mode == ConcurrencyMode::MultiWriterProcess {
+            ensure_allocator_state_table_and_trim(&db.transaction_tracker, &db.mem, None, None)?;
+        }
+        #[cfg(not(feature = "experimental-multiprocess"))]
+        let _ = repaired;
 
         Ok(db)
     }
@@ -2510,6 +2520,19 @@ mod writer_byte_test {
         assert!(
             !left_unclean(tmpfile.path()),
             "the close left the file unclean"
+        );
+    }
+
+    /// A multi-writer repair, the create's included, ends with a commit recording the allocator
+    /// state it rebuilt, for the next open to load
+    #[test]
+    fn a_multi_writer_repair_records_the_allocator_state() {
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        assert!(
+            Database::get_allocator_state_table(&db.mem)
+                .unwrap()
+                .is_some()
         );
     }
 


### PR DESCRIPTION
A prep for #1449, split out of it at review, on #1460. In multi-writer mode every commit records the allocator state, since #1452, for the next write transaction in any process to load rather than rebuild; the open's repair ended without one.

## What it does

`Database::new()` ends a repair in `MultiWriterProcess` mode with `ensure_allocator_state_table_and_trim()`, the recording commit the close and compaction make, once the tracker holds the file's persistent savepoints. A create is a repair, a new file having no state to load, so a created database is recorded from its first commit too. Before this, a peer opening the file after a repair, or after a create, ahead of the handle's first commit, found no recorded state and repaired again; with #1449, a sync to that commit finds none where every other commit records one.

## The decisions this isolates

1. **A second commit, rather than a recording repair.** The repair's own commit is `TransactionalMemory::commit()`, made ahead of the tracker; the recording commit is a write transaction, as compaction's is, and begins once the tracker holds the file's savepoints, as every write transaction does.
2. **Multi-writer mode only.** In the other modes nothing reads the file between the repair and the close, which records, and a second record would leave the file one record larger, the pages of the one it replaces being freed only by the next commit.

## Testing

`a_multi_writer_repair_records_the_allocator_state`: a create in multi-writer mode, whose first commit is a repair's, leaves a recorded state behind it; it fails without the commit. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9)_