### PR TITLE
Open a multi-writer database under the writer byte

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -618,7 +618,7 @@ impl ReadOnlyDatabase {
         let file_path = format!("{:?}", &file);
         #[cfg(feature = "logging")]
         debug!("Opening database in read-only {:?}", &file_path);
-        let mem = TransactionalMemory::new(
+        let (mem, _writer_lock) = TransactionalMemory::new(
             Box::new(ReadOnlyBackend::new(file)),
             false,
             page_size,
@@ -909,9 +909,20 @@ impl Database {
         Ok(was_clean)
     }
 
-    // Synchronizes the tracker state for the file's persistent savepoints
-    fn sync_persistent_savepoints(&self) -> Result<(), DatabaseError> {
-        let txn = self.begin_write().map_err(|e| e.into_storage_error())?;
+    // Synchronizes the tracker state for the file's persistent savepoints. `writer_lock` is the
+    // lock the open holds, which the transaction this begins is lent
+    fn sync_persistent_savepoints(
+        &self,
+        #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
+    ) -> Result<(), DatabaseError> {
+        let txn = self
+            .begin_write_with(
+                #[cfg(feature = "experimental-multiprocess")]
+                writer_lock,
+                #[cfg(feature = "experimental-multiprocess")]
+                None,
+            )
+            .map_err(|e| e.into_storage_error())?;
         sync_persistent_savepoints(
             &self.transaction_tracker,
             &self.mem,
@@ -1467,7 +1478,9 @@ impl Database {
         let file_path = format!("{:?}", &file);
         #[cfg(feature = "logging")]
         debug!("Opening database {:?}", &file_path);
-        let mem = TransactionalMemory::new(
+        // The open runs under this lock, which the multi-writer open took for the header read
+        // below and the repair after it, and which the transactions it runs are lent
+        let (mem, writer_lock) = TransactionalMemory::new(
             file,
             allow_initialize,
             page_size,
@@ -1520,16 +1533,24 @@ impl Database {
         };
 
         // Restore the tracker state for any persistent savepoints
-        db.sync_persistent_savepoints()?;
+        db.sync_persistent_savepoints(
+            #[cfg(feature = "experimental-multiprocess")]
+            writer_lock.as_ref(),
+        )?;
         // In multi-writer mode a repair ends with a commit recording the allocator state, as
         // compaction does, so that the next open, in any process, loads it
         #[cfg(feature = "experimental-multiprocess")]
         if repaired && concurrency_mode == ConcurrencyMode::MultiWriterProcess {
-            ensure_allocator_state_table_and_trim(&db.transaction_tracker, &db.mem, None, None)?;
+            ensure_allocator_state_table_and_trim(
+                &db.transaction_tracker,
+                &db.mem,
+                writer_lock.as_ref(),
+                None,
+            )?;
         }
         #[cfg(not(feature = "experimental-multiprocess"))]
-        let _ = repaired;
-
+        let _ = (repaired, writer_lock);
+        // Dropped here: a write transaction takes the writer byte for itself from now on
         Ok(db)
     }
 
@@ -2738,6 +2759,104 @@ mod writer_byte_test {
             .unwrap();
     }
 
+    /// A multi-writer open runs under the writer byte, so that two processes do not repair the
+    /// same file at once and commit over each other
+    #[test]
+    fn a_multi_writer_open_waits_for_the_writer_byte() {
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        // A commit recording nothing leaves the file for the next open to repair. The handle
+        // stays open, since its close would record
+        let mut write = db.begin_write().unwrap();
+        write.skip_allocator_state_record();
+        write.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+        write.commit().unwrap();
+
+        let probe = probe(tmpfile.path());
+        assert!(probe.try_lock_range(byte_range(WRITER_BYTE)).unwrap());
+        let path = tmpfile.path().to_path_buf();
+        let (repairing, repairs) = mpsc::channel();
+        let opening = thread::spawn(move || {
+            let mut builder = Database::builder();
+            builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+            builder.set_repair_callback(move |_| {
+                let _ = repairing.send(());
+            });
+            builder.open(&path).unwrap()
+        });
+
+        assert!(
+            repairs.recv_timeout(Duration::from_millis(500)).is_err(),
+            "the open repaired while the writer byte was held"
+        );
+        probe.unlock_range(byte_range(WRITER_BYTE)).unwrap();
+        repairs
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the repair runs once the byte is free");
+        opening.join().unwrap();
+    }
+
+    /// A peer can commit while an open waits for the writer byte. The open reads the file only
+    /// once it holds the byte, so it sees that commit and repairs nothing it recorded.
+    #[test]
+    fn a_multi_writer_open_reads_the_file_a_peer_committed_while_it_waited() {
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let mut write = db.begin_write().unwrap();
+        write.skip_allocator_state_record();
+        write.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+        write.commit().unwrap();
+        // Holds the byte across the open, and records the allocator state when it commits
+        let held = db.begin_write().unwrap();
+        held.open_table(TABLE).unwrap().insert(2, 2).unwrap();
+
+        let path = tmpfile.path().to_path_buf();
+        let (repairing, repairs) = mpsc::channel();
+        let (opened, opens) = mpsc::channel();
+        let opening = thread::spawn(move || {
+            let mut builder = Database::builder();
+            builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+            builder.set_repair_callback(move |_| {
+                let _ = repairing.send(());
+            });
+            let db = builder.open(&path).unwrap();
+            opened.send(()).unwrap();
+            db
+        });
+
+        assert!(
+            opens.recv_timeout(Duration::from_millis(500)).is_err(),
+            "the open did not wait for the byte"
+        );
+        held.commit().unwrap();
+        opens
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the open takes the byte the commit released");
+        let peer = opening.join().unwrap();
+
+        assert!(
+            repairs.try_recv().is_err(),
+            "the open repaired a file the commit had recorded"
+        );
+        // A repair from the header read before that commit would have committed over it
+        let read = super::ReadableDatabase::begin_read(&peer).unwrap();
+        let table = read.open_table(TABLE).unwrap();
+        assert_eq!(
+            crate::ReadableTable::get(&table, 2)
+                .unwrap()
+                .unwrap()
+                .value(),
+            2
+        );
+    }
     /// A multi-writer compaction ends with a commit recording the allocator state, for the next
     /// writer, in any process, to load rather than rebuild
     #[test]

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -549,7 +549,7 @@ mod test {
     fn memory() -> TransactionalMemory {
         use crate::tree_store::{InMemoryBackend, LocklessBackend, PAGE_SIZE};
 
-        TransactionalMemory::new(
+        let (mem, _writer_lock) = TransactionalMemory::new(
             LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             PAGE_SIZE,
@@ -558,7 +558,9 @@ mod test {
             false,
             crate::db::ConcurrencyMode::SingleProcess,
         )
-        .unwrap()
+        .unwrap();
+
+        mem
     }
 
     #[test]

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -1433,7 +1433,7 @@ mod tests {
             AllocationPolicy, InMemoryBackend, LocklessBackend, PAGE_SIZE, TransactionalMemory,
         };
 
-        let mem = TransactionalMemory::new(
+        let (mem, _writer_lock) = TransactionalMemory::new(
             LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             PAGE_SIZE,

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -2292,7 +2292,7 @@ mod tests {
     }
 
     fn make_allocator_with_page_size(page_size: usize) -> PageAllocator {
-        let mem = TransactionalMemory::new(
+        let (mem, _writer_lock) = TransactionalMemory::new(
             LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             page_size,

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -2460,7 +2460,7 @@ mod tests {
     };
 
     fn test_page_allocator() -> PageAllocator {
-        let mem = TransactionalMemory::new(
+        let (mem, _writer_lock) = TransactionalMemory::new(
             LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             PAGE_SIZE,

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -1842,7 +1842,7 @@ mod tests {
     const HUGE_PAGE: usize = 4 * 1024 * 1024;
 
     fn make_allocator_with_page_size(page_size: usize) -> PageAllocator {
-        let mem = TransactionalMemory::new(
+        let (mem, _writer_lock) = TransactionalMemory::new(
             LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             page_size,

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -596,6 +596,39 @@ fn database_writer_lock_for_mode(
     }))
 }
 
+// Typename used here so that with the feature off it can be an empty type
+#[cfg(feature = "experimental-multiprocess")]
+pub(crate) type OpenWriterLock = Arc<WriterLock>;
+/// Without the feature there are no writer locks to hand an open
+#[cfg(not(feature = "experimental-multiprocess"))]
+pub(crate) type OpenWriterLock = ();
+
+// Acquire the writer byte lock that open() should use for repair
+#[cfg(feature = "experimental-multiprocess")]
+fn open_writer_lock_for_mode(
+    storage: &Arc<PagedCachedFile>,
+    read_only: bool,
+    concurrency_mode: ConcurrencyMode,
+    database_writer_lock: Option<Arc<WriterLock>>,
+) -> Result<Option<Arc<WriterLock>>> {
+    if read_only {
+        return Ok(None);
+    }
+    match concurrency_mode {
+        ConcurrencyMode::SingleProcess | ConcurrencyMode::SingleWriterProcess => {
+            Ok(database_writer_lock)
+        }
+        ConcurrencyMode::MultiWriterProcess => {
+            storage.lock_range(byte_range(WRITER_BYTE))?;
+
+            Ok(Some(Arc::new(WriterLock {
+                storage: storage.clone(),
+                range: byte_range(WRITER_BYTE),
+            })))
+        }
+    }
+}
+
 pub(crate) struct TransactionalMemory {
     unpersisted: Mutex<UnpersistedState>,
     // Shared, so that a `WriterLock` can outlive this and still release its range
@@ -991,6 +1024,8 @@ impl TransactionalMemory {
         Ok(())
     }
 
+    /// Returns the memory and if opened for writing, the writer lock, which should be held if
+    /// repair is needed to complete the opening process
     pub(crate) fn new(
         file: Box<dyn InternalStorageBackend>,
         // Allow initializing a new database in an empty file
@@ -1000,7 +1035,7 @@ impl TransactionalMemory {
         cache_size: usize,
         read_only: bool,
         concurrency_mode: ConcurrencyMode,
-    ) -> Result<Self, DatabaseError> {
+    ) -> Result<(Self, Option<OpenWriterLock>), DatabaseError> {
         assert!(page_size.is_power_of_two() && page_size >= DB_HEADER_SIZE);
 
         let region_size = requested_region_size.unwrap_or(MAX_USABLE_REGION_SPACE);
@@ -1013,6 +1048,16 @@ impl TransactionalMemory {
         let storage = Arc::new(PagedCachedFile::new(file, page_size as u64, cache_size));
         // Dropping the storage releases whatever this took, so an open that fails below does too
         Self::lock_for_open(&storage, read_only, concurrency_mode)?;
+        #[cfg(feature = "experimental-multiprocess")]
+        let writer_lock = database_writer_lock_for_mode(&storage, read_only, concurrency_mode);
+        // The lock the open() runs under: its own where it took one, and the handle's otherwise
+        // Taken before anything is read, so that the header the open reads is the header it
+        // repairs and commits over
+        #[cfg(feature = "experimental-multiprocess")]
+        let open_writer_lock =
+            open_writer_lock_for_mode(&storage, read_only, concurrency_mode, writer_lock.clone())?;
+        #[cfg(not(feature = "experimental-multiprocess"))]
+        let open_writer_lock = None;
         #[cfg(feature = "experimental-multiprocess")]
         let in_process_header_lock = Mutex::new(());
 
@@ -1126,10 +1171,7 @@ impl TransactionalMemory {
 
         assert!(page_size >= DB_HEADER_SIZE);
 
-        #[cfg(feature = "experimental-multiprocess")]
-        let writer_lock = database_writer_lock_for_mode(&storage, read_only, concurrency_mode);
-
-        Ok(Self {
+        let mem = Self {
             unpersisted: Mutex::new(UnpersistedState::default()),
             storage,
             state: Mutex::new(state),
@@ -1153,7 +1195,9 @@ impl TransactionalMemory {
             page_size: page_size.try_into().unwrap(),
             region_size,
             region_header_with_padding_size: region_header_size,
-        })
+        };
+
+        Ok((mem, open_writer_lock))
     }
 
     // An order read from a corrupted file would otherwise size a multi-terabyte read buffer, whose
@@ -2432,7 +2476,7 @@ mod test {
         use super::TransactionalMemory;
         use crate::tree_store::{InMemoryBackend, LocklessBackend};
 
-        let mem = TransactionalMemory::new(
+        let (mem, _writer_lock) = TransactionalMemory::new(
             LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             4096,
@@ -2475,7 +2519,7 @@ mod test {
         use crate::tree_store::{InMemoryBackend, LocklessBackend, PageNumber};
 
         let page_size = 4096;
-        let mem = TransactionalMemory::new(
+        let (mem, _writer_lock) = TransactionalMemory::new(
             LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             page_size,
@@ -2524,7 +2568,7 @@ mod test {
         use crate::tree_store::{InMemoryBackend, LocklessBackend, Page, PageNumber, PageTracker};
 
         let page_size = 4096;
-        let mem = TransactionalMemory::new(
+        let (mem, _writer_lock) = TransactionalMemory::new(
             LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             page_size,
@@ -2568,7 +2612,7 @@ mod test {
         // Small pages and regions keep the reproduction cheap to set up.
         let page_size = 128 * 1024;
         let region_size = 16 * page_size as u64;
-        let mem = TransactionalMemory::new(
+        let (mem, _writer_lock) = TransactionalMemory::new(
             LocklessBackend::boxed(InMemoryBackend::new()),
             true,
             page_size,
@@ -2654,7 +2698,9 @@ mod header_lock_test {
             .read(true)
             .write(true)
             .open(path)?;
-        Ok(Arc::new(TransactionalMemory::new(
+        // These stand in for separate processes' handles, so each gives the writer byte back as
+        // the end of an open does, by dropping the lock its open held
+        let (mem, _writer_lock) = TransactionalMemory::new(
             Box::new(FileBackend::new(file)?),
             true,
             PAGE_SIZE,
@@ -2662,7 +2708,9 @@ mod header_lock_test {
             0,
             false,
             mode,
-        )?))
+        )?;
+
+        Ok(Arc::new(mem))
     }
 
     fn open_read_only(
@@ -2670,7 +2718,7 @@ mod header_lock_test {
         mode: ConcurrencyMode,
     ) -> Result<Arc<TransactionalMemory>, DatabaseError> {
         let file = std::fs::OpenOptions::new().read(true).open(path)?;
-        Ok(Arc::new(TransactionalMemory::new(
+        let (mem, _writer_lock) = TransactionalMemory::new(
             Box::new(crate::tree_store::ReadOnlyBackend::new(Box::new(
                 FileBackend::new(file)?,
             ))),
@@ -2680,7 +2728,9 @@ mod header_lock_test {
             0,
             true,
             mode,
-        )?))
+        )?;
+
+        Ok(Arc::new(mem))
     }
 
     /// Through the read-only backend the open wraps its storage in


### PR DESCRIPTION
The multi-writer open protocol, on master after #1449. The open took the writer byte only for the transactions it ran, so everything before them ran under no lock at all: `database_writer_lock_for_mode()` returned nothing for the mode, and the header read in `TransactionalMemory::new()`, the repair decision and the repair's own `mem.commit()` were unprotected.

Two things came of that. Two processes opening a file that needed a repair both repaired it and committed over each other. And `read_header()` does not only read: when the recovery flag is set — which it is in the file for as long as any writable handle is open — it writes the finalized header back, god byte and both transaction slots, under the header lock alone. A peer committing between that read and that write had its commit rolled back.

## What it does

A multi-writer open takes the writer byte before it reads anything, and holds it until the open returns. The header read, the repair, the savepoint sync and the commit that records the allocator state all run under it, and no other process commits while they do. The open waits for a peer's write transaction to end, as a write transaction would — which it already did, for the transaction that syncs the savepoints, so this is not new waiting.

`open_writer_lock_for_mode()` takes that byte, before the header is read. `database_writer_lock_for_mode()` is untouched: it still describes the lock a handle holds for the life of the database, which multi-writer mode does not have.

`TransactionalMemory::new()` returns the lock its caller's open runs under alongside the memory: the byte it just took in multi-writer mode, and a clone of the lifetime lock in the other modes, which is the lock their opens have always run under. The open lends it to the transactions it begins, through `sync_persistent_savepoints()` and `ensure_allocator_state_table_and_trim()`, and releases it by dropping it when it returns, from where a write transaction takes the byte for itself. A read-only open holds no writer lock and is unaffected.

## The decisions this isolates

1. **One hold across the whole open, rather than one per phase.** The alternative was to take the byte only where a repair is needed and re-read the file under it, which leaves the header read and its write-back racing and needs the re-read to spot a peer that repaired first. Holding it from the start removes both: nothing can commit between the read and the decision, so there is nothing to re-check.
2. **The open's lock is its own, separate from the handle's.** They answer different questions — what this handle holds for its life, and what its open runs under — so they are two functions, and the open's is a value it owns rather than state on the memory. Dropping it is what gives the byte back, so an open that fails part way releases it on the way out.
3. **Given back at the end of the open, not held for the handle.** A multi-writer handle holds the byte only while it writes; keeping it would make one open exclude every peer's writes for as long as the handle lived.

## Testing

`a_multi_writer_open_waits_for_the_writer_byte`: with the byte held on another file description, an open that must repair does not reach its repair callback, and does once the byte is released; before this it repaired while the byte was held. `a_multi_writer_open_reads_the_file_a_peer_committed_while_it_waited`: a peer holds the byte in a write transaction that records the allocator state when it commits, an open that would otherwise repair waits for it, and once the commit lands the open loads rather than repairing, with the peer's row intact; without the byte the open repairs from the header it read first and its commit loses that row. Both fail with the acquisition removed. Not covered: the create/open race on an empty file, which is `TransactionalMemory::new()`'s initialization rather than this lock. The full local check set passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRkkxVfm21mACyTopBHS9