### PR TITLE
Stop locking a persistent savepoint's transaction

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -981,10 +981,9 @@ impl Database {
             .map_err(|e| e.into_storage_error())?;
         sync_persistent_savepoints(
             &self.transaction_tracker,
+            #[cfg(feature = "experimental-multiprocess")]
             &self.mem,
             &txn,
-            #[cfg(feature = "experimental-multiprocess")]
-            None,
         )?;
         txn.abort()?;
 
@@ -1708,12 +1707,10 @@ impl Database {
 
 // Syncs the file's persistent savepoints, which another process may have created or
 // deleted since the tracker last saw the file, and continues savepoint ids past the file's.
-// `header_lock` is the header lock the caller already holds, if any.
 fn sync_persistent_savepoints(
     transaction_tracker: &TransactionTracker,
-    mem: &TransactionalMemory,
+    #[cfg(feature = "experimental-multiprocess")] mem: &TransactionalMemory,
     txn: &WriteTransaction,
-    #[cfg(feature = "experimental-multiprocess")] header_lock: Option<&HeaderGuard<'_>>,
 ) -> Result {
     if let Some(next_id) = txn.next_persistent_savepoint_id()? {
         transaction_tracker.restore_savepoint_counter_state(next_id);
@@ -1731,16 +1728,13 @@ fn sync_persistent_savepoints(
                 }
             },
         };
+        // The file names its persistent savepoints, so the transaction each points at is
+        // untrusted: one outside the lock range would be tracked as a read this process holds
+        #[cfg(feature = "experimental-multiprocess")]
+        mem.check_active_transaction_id(savepoint.get_transaction_id())?;
         current.insert(savepoint.get_id(), savepoint.get_transaction_id());
     }
-    #[cfg(feature = "experimental-multiprocess")]
-    let hold = mem.header_hold(header_lock)?;
-    transaction_tracker.sync_persistent_savepoints(
-        mem,
-        &current,
-        #[cfg(feature = "experimental-multiprocess")]
-        &hold,
-    )
+    transaction_tracker.sync_persistent_savepoints(&current)
 }
 
 /// Brings this handle up to the file's latest commit, in multi-writer mode, when it is not
@@ -1841,7 +1835,7 @@ fn begin_write_with_allocation_policy(
     // aborted and the latch then discards the allocator state.
     #[cfg(feature = "experimental-multiprocess")]
     if latch.is_some() {
-        sync_persistent_savepoints(transaction_tracker, mem, &transaction, header_lock)?;
+        sync_persistent_savepoints(transaction_tracker, mem, &transaction)?;
     }
     #[cfg(feature = "experimental-multiprocess")]
     if let Some(latch) = latch {
@@ -3466,31 +3460,52 @@ mod active_transaction_test {
         );
     }
 
-    /// A persistent savepoint outlives its handle -- and the process -- so its lock goes to the
-    /// database with the reference rather than being released when the handle drops. Nothing
-    /// releases it yet: deletion and re-locking at open both belong with the scan
+    /// A persistent savepoint bounds this process's reclamation, but takes no byte: the file
+    /// names it, so every process protects it by syncing, and a byte would go on pinning the
+    /// transaction after another process deleted the savepoint, until this one next synced
     #[test]
-    fn a_persistent_savepoint_keeps_its_lock_after_its_handle_drops() {
+    fn a_persistent_savepoint_takes_no_active_transaction_byte() {
         let tmpfile = crate::create_tempfile();
         let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
         let probe = probe(tmpfile.path());
 
+        // Nothing else references the savepoint's transaction, so the byte is the savepoint's to
+        // take or leave
+        let pinned = db.mem.get_last_committed_transaction_id().unwrap();
         let write = db.begin_write().unwrap();
-        write.persistent_savepoint().unwrap();
+        let savepoint = write.persistent_savepoint().unwrap();
         write.commit().unwrap();
-
-        assert_eq!(
-            held_ids(&probe).len(),
-            1,
-            "a persistent savepoint left {:?} locked",
+        assert!(
+            held_ids(&probe).is_empty(),
+            "the savepoint locked {:?}",
             held_ids(&probe)
         );
+        assert_eq!(
+            db.transaction_tracker.oldest_local_referenced_transaction(),
+            Some(pinned),
+            "the savepoint stopped bounding this process's reclamation"
+        );
+        // The probe does see a byte where there is one to see
+        let read = db.begin_read().unwrap();
+        assert_eq!(held_ids(&probe).len(), 1);
+        drop(read);
+        assert!(held_ids(&probe).is_empty());
+
+        let write = db.begin_write().unwrap();
+        assert!(write.delete_persistent_savepoint(savepoint).unwrap());
+        write.commit().unwrap();
+        assert_eq!(
+            db.transaction_tracker.oldest_local_referenced_transaction(),
+            None,
+            "the deleted savepoint kept its reference"
+        );
+        assert!(held_ids(&probe).is_empty());
     }
 
-    /// A persistent savepoint survives the process that made it, so reopening has to take its
-    /// byte again: the snapshot its record names is still one a peer must not reclaim
+    /// The same for a savepoint this handle adopted rather than created: the open syncs the
+    /// file's persistent savepoints, and references them without locking them either
     #[test]
-    fn reopening_locks_a_persistent_savepoints_snapshot() {
+    fn a_synced_persistent_savepoint_takes_no_active_transaction_byte() {
         let tmpfile = crate::create_tempfile();
         let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
         let write = db.begin_write().unwrap();
@@ -3504,16 +3519,22 @@ mod active_transaction_test {
             "the closed database left a lock"
         );
 
-        let mut builder = Database::builder();
-        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
-        let db = builder.open(tmpfile.path()).unwrap();
-        assert_eq!(
-            held_ids(&probe).len(),
-            1,
-            "reopening locked {:?}",
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        assert!(
+            held_ids(&probe).is_empty(),
+            "the open locked {:?} for the file's savepoint",
             held_ids(&probe)
         );
-        drop(db);
+        assert!(
+            db.transaction_tracker
+                .oldest_local_referenced_transaction()
+                .is_some(),
+            "the open did not adopt the file's savepoint"
+        );
+        // The probe does see a byte where there is one to see
+        let read = db.begin_read().unwrap();
+        assert_eq!(held_ids(&probe).len(), 1);
+        drop(read);
     }
 
     /// A non-durable commit exists only in this process's memory, so a shared mode refuses it

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -93,6 +93,8 @@ struct State {
     next_savepoint_id: SavepointId,
     // reference count of read transactions per transaction id
     live_read_transactions: BTreeMap<TransactionId, u64>,
+    // Subset of live_read_transactions which are persistent savepoints
+    persistent_savepoint_references: BTreeMap<TransactionId, u64>,
     next_transaction_id: TransactionId,
     write_slot: WriteSlotState,
     valid_savepoints: BTreeMap<SavepointId, TransactionId>,
@@ -113,24 +115,35 @@ struct State {
 }
 
 impl State {
-    // Takes the "active transaction byte" as the first reference to `id` appears, and releases it
+    // The references to `id` that are reads, which the "active transaction byte" announces to the
+    // other processes. Persistent savepoints are excluded
+    #[cfg(feature = "experimental-multiprocess")]
+    fn active_transaction_lock_references(&self, id: TransactionId) -> u64 {
+        self.live_read_transactions.get(&id).copied().unwrap_or(0)
+            - self
+                .persistent_savepoint_references
+                .get(&id)
+                .copied()
+                .unwrap_or(0)
+    }
+
+    // Takes the "active transaction byte" as the first read of `id` appears, and releases it
     // as the last goes away, so a writer in another process sees exactly the transactions this one
     // is still reading. Done under the lock that holds the count, so the two cannot disagree: a
     // reference taken between the count reaching zero and the byte being released would otherwise
     // read a snapshot nothing protects
-    fn reference_transaction(
+    fn add_active_transaction_lock_reference(
         &mut self,
         mem: &TransactionalMemory,
         id: TransactionId,
         #[cfg(feature = "experimental-multiprocess")] header: &HeaderGuard<'_>,
     ) -> Result {
-        let count = self.live_read_transactions.entry(id).or_insert(0);
-        *count += 1;
+        *self.live_read_transactions.entry(id).or_insert(0) += 1;
         #[cfg(feature = "experimental-multiprocess")]
-        if *count == 1
+        if self.active_transaction_lock_references(id) == 1
             && let Err(err) = mem.lock_mp_transaction(id, header)
         {
-            self.live_read_transactions.remove(&id);
+            self.decrement_reference_count(id);
             return Err(err);
         }
         #[cfg(not(feature = "experimental-multiprocess"))]
@@ -139,17 +152,58 @@ impl State {
         Ok(())
     }
 
-    fn dereference_transaction(&mut self, mem: &TransactionalMemory, id: TransactionId) {
-        let count = self.live_read_transactions.get_mut(&id).unwrap();
-        *count -= 1;
-        if *count == 0 {
-            self.live_read_transactions.remove(&id);
-            // Failing to release only leaves a peer reclaiming less than it could
-            #[cfg(feature = "experimental-multiprocess")]
+    fn remove_active_transaction_lock_reference(
+        &mut self,
+        mem: &TransactionalMemory,
+        id: TransactionId,
+    ) {
+        self.decrement_reference_count(id);
+        // Failing to release only leaves a peer reclaiming less than it could
+        #[cfg(feature = "experimental-multiprocess")]
+        if self.active_transaction_lock_references(id) == 0 {
             let _ = mem.unlock_mp_transaction(id);
         }
         #[cfg(not(feature = "experimental-multiprocess"))]
         let _ = mem;
+    }
+
+    // A persistent savepoint's reference, which takes no byte. See `persistent_savepoint_references`
+    fn reference_persistent_savepoint(&mut self, id: TransactionId) {
+        *self.live_read_transactions.entry(id).or_insert(0) += 1;
+        *self.persistent_savepoint_references.entry(id).or_insert(0) += 1;
+    }
+
+    fn dereference_persistent_savepoint(&mut self, id: TransactionId) {
+        self.decrement_reference_count(id);
+        let count = self.persistent_savepoint_references.get_mut(&id).unwrap();
+        *count -= 1;
+        if *count == 0 {
+            self.persistent_savepoint_references.remove(&id);
+        }
+    }
+
+    // Hands the read transaction's reference over to the savepoint made from it, releasing the
+    // byte with it: from here on the savepoint is protected the way a synced one is
+    fn convert_reference_to_persistent_savepoint(
+        &mut self,
+        mem: &TransactionalMemory,
+        id: TransactionId,
+    ) {
+        *self.persistent_savepoint_references.entry(id).or_insert(0) += 1;
+        #[cfg(feature = "experimental-multiprocess")]
+        if self.active_transaction_lock_references(id) == 0 {
+            let _ = mem.unlock_mp_transaction(id);
+        }
+        #[cfg(not(feature = "experimental-multiprocess"))]
+        let _ = mem;
+    }
+
+    fn decrement_reference_count(&mut self, id: TransactionId) {
+        let count = self.live_read_transactions.get_mut(&id).unwrap();
+        *count -= 1;
+        if *count == 0 {
+            self.live_read_transactions.remove(&id);
+        }
     }
 }
 
@@ -164,6 +218,7 @@ impl TransactionTracker {
             state: Mutex::new(State {
                 next_savepoint_id: SavepointId(0),
                 live_read_transactions: BTreeMap::default(),
+                persistent_savepoint_references: BTreeMap::default(),
                 next_transaction_id,
                 write_slot: WriteSlotState::Free,
                 valid_savepoints: BTreeMap::default(),
@@ -244,7 +299,7 @@ impl TransactionTracker {
         let mut state = self.state.lock().unwrap();
         let ids = mem::take(&mut state.pending_non_durable_commits);
         for (_, durable_ancestor) in ids {
-            state.dereference_transaction(memory, durable_ancestor);
+            state.remove_active_transaction_lock_reference(memory, durable_ancestor);
         }
     }
 
@@ -285,7 +340,7 @@ impl TransactionTracker {
         #[cfg(feature = "experimental-multiprocess")]
         let header = mem.lock_header_shared()?;
         let mut state = self.state.lock().unwrap();
-        state.reference_transaction(
+        state.add_active_transaction_lock_reference(
             mem,
             durable_ancestor,
             #[cfg(feature = "experimental-multiprocess")]
@@ -338,9 +393,7 @@ impl TransactionTracker {
     // Sync the file's persistent savepoints. `current` must be the current set of persistent savepoints.
     pub(crate) fn sync_persistent_savepoints(
         &self,
-        mem: &TransactionalMemory,
         current: &BTreeMap<SavepointId, TransactionId>,
-        #[cfg(feature = "experimental-multiprocess")] header: &HeaderGuard<'_>,
     ) -> Result {
         let mut state = self.state.lock().unwrap();
         let gone: Vec<SavepointId> = state
@@ -352,18 +405,13 @@ impl TransactionTracker {
         for id in gone {
             state.persistent_savepoints.remove(&id);
             let transaction = state.valid_savepoints.remove(&id).unwrap();
-            state.dereference_transaction(mem, transaction);
+            state.dereference_persistent_savepoint(transaction);
         }
         for (&id, &transaction) in current {
             if state.valid_savepoints.contains_key(&id) {
                 continue;
             }
-            state.reference_transaction(
-                mem,
-                transaction,
-                #[cfg(feature = "experimental-multiprocess")]
-                header,
-            )?;
+            state.reference_persistent_savepoint(transaction);
             assert!(state.valid_savepoints.insert(id, transaction).is_none());
             state.persistent_savepoints.insert(id);
         }
@@ -371,11 +419,17 @@ impl TransactionTracker {
         Ok(())
     }
 
-    // Marks an already-registered savepoint as persistent
-    pub(crate) fn mark_savepoint_persistent(&self, id: SavepointId) {
+    // Marks an already-registered savepoint as persistent, which hands it the reference held by
+    // the read transaction it was created from
+    pub(crate) fn convert_savepoint_to_persistent(
+        &self,
+        mem: &TransactionalMemory,
+        id: SavepointId,
+    ) {
         let mut state = self.state.lock().unwrap();
-        assert!(state.valid_savepoints.contains_key(&id));
+        let transaction = *state.valid_savepoints.get(&id).unwrap();
         state.persistent_savepoints.insert(id);
+        state.convert_reference_to_persistent_savepoint(mem, transaction);
     }
 
     pub(crate) fn register_read_transaction(
@@ -389,7 +443,7 @@ impl TransactionTracker {
             &header,
         )?;
         let mut state = self.state.lock()?;
-        state.reference_transaction(
+        state.add_active_transaction_lock_reference(
             mem,
             id,
             #[cfg(feature = "experimental-multiprocess")]
@@ -401,7 +455,7 @@ impl TransactionTracker {
 
     pub(crate) fn deallocate_read_transaction(&self, mem: &TransactionalMemory, id: TransactionId) {
         let mut state = self.state.lock().unwrap();
-        state.dereference_transaction(mem, id);
+        state.remove_active_transaction_lock_reference(mem, id);
     }
 
     pub(crate) fn any_savepoint_exists(&self) -> bool {
@@ -448,21 +502,23 @@ impl TransactionTracker {
     }
 
     // Forgets the savepoint, leaving the transaction's reference to whoever owns it
-    pub(crate) fn remove_savepoint(&self, savepoint: SavepointId) {
+    pub(crate) fn remove_savepoint_registration(&self, savepoint: SavepointId) {
         let mut state = self.state.lock().unwrap();
         state.valid_savepoints.remove(&savepoint);
         state.persistent_savepoints.remove(&savepoint);
     }
 
-    // Deallocates the given savepoint and its matching reference count on the transcation
-    pub(crate) fn deallocate_savepoint(
+    // Deallocates the given persistent savepoint and its matching reference on the transaction
+    pub(crate) fn deallocate_persistent_savepoint(
         &self,
-        mem: &TransactionalMemory,
         savepoint: SavepointId,
         transaction: TransactionId,
     ) {
-        self.remove_savepoint(savepoint);
-        self.deallocate_read_transaction(mem, transaction);
+        self.remove_savepoint_registration(savepoint);
+        self.state
+            .lock()
+            .unwrap()
+            .dereference_persistent_savepoint(transaction);
     }
 
     pub(crate) fn is_valid_savepoint(&self, id: SavepointId) -> bool {
@@ -488,10 +544,10 @@ impl TransactionTracker {
 
     // Removes the given savepoints from the in-memory `valid_savepoints` map without touching
     // live_read_transactions refs. The caller is responsible for making sure those refs are
-    // released by some other means: ephemeral `Savepoint::drop` or `deallocate_savepoint`
+    // released by some other means: ephemeral `Savepoint::drop` or `deallocate_persistent_savepoint`
     // (called via `delete_persistent_savepoint`) do that for their respective savepoint kinds.
     //
-    // Savepoints that have already been removed (for example, by `deallocate_savepoint` earlier
+    // Savepoints that have already been removed (for example, by `deallocate_persistent_savepoint` earlier
     // in the same transaction) are silently skipped.
     pub(crate) fn invalidate_savepoints(&self, savepoints: impl IntoIterator<Item = SavepointId>) {
         let mut state = self.state.lock().unwrap();
@@ -517,7 +573,7 @@ impl TransactionTracker {
             .map(|(id, txn_id)| (*id, *txn_id))
     }
 
-    pub(crate) fn oldest_local_read_transaction(&self) -> Option<TransactionId> {
+    pub(crate) fn oldest_local_referenced_transaction(&self) -> Option<TransactionId> {
         self.state
             .lock()
             .unwrap()

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -859,15 +859,15 @@ impl SavepointTransactionState {
         !self.created_persistent.is_empty() || !self.deleted_persistent.is_empty()
     }
 
-    fn apply_on_commit(&mut self, mem: &TransactionalMemory, tracker: &TransactionTracker) {
+    fn apply_on_commit(&mut self, tracker: &TransactionTracker) {
         // Persistent savepoints whose on-disk entry was deleted: release their
         // tracker refcount now that the deletion is durable.
         for (savepoint, transaction) in self.deleted_persistent.drain(..) {
-            tracker.deallocate_savepoint(mem, savepoint, transaction);
+            tracker.deallocate_persistent_savepoint(savepoint, transaction);
         }
         // Savepoints that restore_savepoint() invalidated: remove them from the
         // shared valid_savepoints map. For persistent savepoints,
-        // deallocate_savepoint above has already removed them; for ephemeral,
+        // deallocate_persistent_savepoint above has already removed them; for ephemeral,
         // the user's Savepoint handle still owns the live_read_transactions
         // refcount and will release it on drop.
         tracker.invalidate_savepoints(core::mem::take(&mut self.invalidated));
@@ -876,12 +876,12 @@ impl SavepointTransactionState {
         self.created_persistent.clear();
     }
 
-    fn apply_on_abort(&mut self, mem: &TransactionalMemory, tracker: &TransactionTracker) {
+    fn apply_on_abort(&mut self, tracker: &TransactionTracker) {
         // Persistent savepoints created during this transaction: their
         // on-disk entries will be rolled back by rollback_uncommitted_writes(),
         // but the shared tracker registration must be released explicitly.
         for (savepoint, transaction) in mem::take(&mut self.created_persistent) {
-            tracker.deallocate_savepoint(mem, savepoint, transaction);
+            tracker.deallocate_persistent_savepoint(savepoint, transaction);
         }
         // Deleted-persistent entries will be rolled back on disk, so the
         // tracker state must NOT be released (it is still valid).
@@ -1182,7 +1182,7 @@ impl WriteTransaction {
 
         savepoint.set_persistent();
         self.transaction_tracker
-            .mark_savepoint_persistent(savepoint.get_id());
+            .convert_savepoint_to_persistent(&self.mem, savepoint.get_id());
 
         self.savepoint_state
             .lock()
@@ -1875,7 +1875,7 @@ impl WriteTransaction {
         self.savepoint_state
             .lock()
             .unwrap()
-            .apply_on_commit(&self.mem, &self.transaction_tracker);
+            .apply_on_commit(&self.transaction_tracker);
     }
 
     fn store_data_freed_pages(&self, freed_pages: Vec<PageNumber>) -> Result<bool> {
@@ -2053,7 +2053,7 @@ impl WriteTransaction {
         self.savepoint_state
             .lock()
             .unwrap()
-            .apply_on_abort(&self.mem, &self.transaction_tracker);
+            .apply_on_abort(&self.transaction_tracker);
         self.mem.check_io_errors()?;
         self.page_allocator().rollback_all();
         #[cfg(feature = "logging")]
@@ -2077,7 +2077,8 @@ impl WriteTransaction {
             #[cfg(feature = "experimental-multiprocess")]
             let hold = self.mem.header_hold(header_lock)?;
             self.mem.oldest_active_transaction(
-                self.transaction_tracker.oldest_local_read_transaction(),
+                self.transaction_tracker
+                    .oldest_local_referenced_transaction(),
                 #[cfg(feature = "experimental-multiprocess")]
                 &hold,
             )?
@@ -2193,10 +2194,10 @@ impl WriteTransaction {
         let epilogue_transaction = self.transaction_id.next();
         let mut free_until = self
             .transaction_tracker
-            .oldest_local_read_transaction()
+            .oldest_local_referenced_transaction()
             .map_or(epilogue_transaction, |x| x.next());
         // Clamp the free horizon to the savepoint horizon captured during the purge. A savepoint
-        // is also a live read, so absent concurrency `oldest_local_read_transaction()` never
+        // is also a live read, so absent concurrency `oldest_local_referenced_transaction()` never
         // exceeds it and this is a no-op. But an ephemeral `Savepoint::drop` racing this commit
         // (legal since `WriteTransaction: Sync`) can land between the purge and here, advancing
         // the oldest live read past the savepoint the purge kept entries for. Freeing those pages
@@ -2409,7 +2410,7 @@ impl WriteTransaction {
         let page_allocator = self.page_allocator();
         let mut free_page = |page| {
             // These pages cannot be unpersisted: free_until is bounded by
-            // oldest_local_read_transaction, which pins back to the durable_ancestor of every
+            // oldest_local_referenced_transaction, which pins back to the durable_ancestor of every
             // pending non-durable commit (see register_non_durable_commit). As a result, no entry
             // whose pages are still unpersisted is eligible for processing here.
             debug_assert!(!self.mem.unpersisted(page));
@@ -2920,6 +2921,54 @@ mod test {
 
     const X: TableDefinition<&str, &str> = TableDefinition::new("x");
     const BIG_VALUE: TableDefinition<u64, &[u8]> = TableDefinition::new("big_value");
+
+    // A persistent savepoint takes no "active transaction byte", so nothing on the way in checks
+    // that its transaction id is one the multi-process protocol can represent. The file names it,
+    // so it is untrusted: an id past the lock range must be reported as corruption rather than
+    // tracked as this process's oldest read, where the next commit's scan and `TransactionId::next`
+    // would run past the end of the range.
+    #[cfg(all(
+        feature = "experimental-multiprocess",
+        any(target_os = "linux", target_vendor = "apple", windows)
+    ))]
+    #[test]
+    fn a_savepoint_naming_an_unrepresentable_transaction_is_corruption() {
+        use super::{SAVEPOINT_TABLE, SavepointId, SerializedSavepoint};
+        use crate::tree_store::BtreeHeader;
+        use crate::{ConcurrencyMode, DatabaseError};
+
+        let tmpfile = crate::create_tempfile();
+        let mut builder = Database::builder();
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        let db = builder.create(tmpfile.path()).unwrap();
+        let txn = db.begin_write().unwrap();
+        let id = txn.persistent_savepoint().unwrap();
+        txn.commit().unwrap();
+
+        // The record as the format has it, naming a transaction no lock byte can address
+        let mut record = vec![3u8];
+        record.extend(id.to_le_bytes());
+        record.extend(u64::MAX.to_le_bytes());
+        record.push(0);
+        record.extend([0; BtreeHeader::serialized_size()]);
+
+        let txn = db.begin_write().unwrap();
+        txn.system_tables
+            .lock()
+            .unwrap()
+            .open_system_table(SAVEPOINT_TABLE)
+            .unwrap()
+            .insert(SavepointId(id), SerializedSavepoint::Ref(&record))
+            .unwrap();
+        txn.commit().unwrap();
+        drop(db);
+
+        // The open syncs the file's persistent savepoints, which is where the id arrives
+        assert!(matches!(
+            builder.open(tmpfile.path()),
+            Err(DatabaseError::Storage(StorageError::Corrupted(_)))
+        ));
+    }
 
     // A commit that stops part way may leave pages returned to the allocator while the durable
     // freed tables still reference them, so commit_inner() discards the allocator state unless

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -907,6 +907,16 @@ impl TransactionalMemory {
         }
     }
 
+    /// Checks that `id` is one this file's locks can announce. A persistent savepoint takes no
+    /// "active transaction byte", so nothing else checks the ids the file names.
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(crate) fn check_active_transaction_id(&self, id: TransactionId) -> Result {
+        if self.concurrency_mode.is_multi_process_writable() {
+            Self::active_transaction_byte(id)?;
+        }
+        Ok(())
+    }
+
     #[cfg(feature = "experimental-multiprocess")]
     pub(crate) fn lock_header_shared(&self) -> Result<HeaderGuard<'_>> {
         Self::lock_header(

--- a/src/tree_store/page_store/savepoint.rs
+++ b/src/tree_store/page_store/savepoint.rs
@@ -78,7 +78,9 @@ impl Drop for Savepoint {
         // A persistent savepoint outlives its handle: the database record owns both its entry
         // and the transaction's reference until the savepoint is deleted
         if self.transaction.owns_reference() {
-            self.transaction.tracker().remove_savepoint(self.id);
+            self.transaction
+                .tracker()
+                .remove_savepoint_registration(self.id);
         }
         // The guard releases the transaction as it drops
     }


### PR DESCRIPTION
Prep, split out of #1413. Independent of #1463 and of the read path still on that branch; any order.

## What it does

A persistent savepoint took the "active transaction byte" for the transaction it references, announcing to the other processes an interest none of them needs to hear about, and holding it longer than the interest lasts. `sync_persistent_savepoints()` reaches `reference_transaction()`, which takes the byte.

The file names its persistent savepoints, and every writer syncs them before it can free a page, so each process already protects them through its own tracker. The byte, meanwhile, goes on pinning the transaction after another process has deleted the savepoint, until the process that created it next syncs.

`docs/design.md` already describes it the other way round: the writer scans the active transaction range and "takes the minimum of this id and the lowest one referenced by a persistent savepoint", which it reads out of the database rather than off a byte.

So `savepoint_references` splits out of `live_read_transactions`, and the byte follows the difference -- the references that are reads. A savepoint still holds its reference, and so bounds its own process's reclamation exactly as before. `persistent_savepoint()` hands the savepoint the reference of the read it was created from, releasing the byte with it, and a savepoint the sync adopts never takes one.

Dropping the byte lets `sync_persistent_savepoints()` and `deallocate_savepoint()` shed the memory and header-lock arguments they only needed in order to take it.

## Testing

`a_persistent_savepoint_keeps_its_lock_after_its_handle_drops` and `reopening_locks_a_persistent_savepoints_snapshot` asserted the behaviour this removes, and two tests replace them.

`a_persistent_savepoint_takes_no_active_transaction_byte` probes the byte directly. Nothing else references the savepoint's transaction, so the byte is the savepoint's to take or leave, and none is held -- while the tracker still names that transaction as this process's oldest read, so reclamation is bounded as before. A read started afterwards is the positive control, showing the probe reports a byte where there is one. Deleting the savepoint then releases the reference.

`a_synced_persistent_savepoint_takes_no_active_transaction_byte` is the same for a savepoint the open adopts from the file rather than creating.

`an_ephemeral_savepoint_locks_the_snapshot_it_references` is untouched: an ephemeral savepoint is a read, and still takes the byte.

`cargo fmt --check`, `cargo clippy --all --all-targets --all-features` under `--deny warnings`, `cargo clippy --all --all-targets` with default features, and `cargo test --all --all-features` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9BSFJKvzsERy8jjeMxwjD

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9BSFJKvzsERy8jjeMxwjD)_