### PR TITLE
Read the file's length under the header lock at open

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2654,6 +2654,7 @@ mod test {
 mod writer_byte_test {
     use super::{ConcurrencyMode, Database, WRITER_BYTE, byte_range};
     use crate::TableDefinition;
+    use crate::tree_store::HEADER_LOCK;
     use crate::tree_store::file_backend::range_lock::RangeLock;
     use std::fs::{File, OpenOptions};
     use std::path::Path;
@@ -2976,6 +2977,66 @@ mod writer_byte_test {
             .expect("the peer syncs to a commit that recorded the allocator state")
             .abort()
             .unwrap();
+    }
+
+    /// An open reads the file's length under the header lock, so a create holding that lock is
+    /// waited for and its result read, rather than the file being sampled part way through it.
+    /// Before, the length was sampled outside any lock: an empty file was called empty and a
+    /// resized one not a redb database, however far the create had got by the time it was read
+    #[test]
+    fn an_open_waits_behind_a_creator_instead_of_calling_the_file_empty() {
+        use std::io::{Read, Seek, SeekFrom, Write};
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        // What the create will have produced by the time it releases the lock
+        let initialized = crate::create_tempfile();
+        drop(create(
+            initialized.path(),
+            ConcurrencyMode::MultiWriterProcess,
+        ));
+        let mut bytes = Vec::new();
+        File::open(initialized.path())
+            .unwrap()
+            .read_to_end(&mut bytes)
+            .unwrap();
+
+        let tmpfile = crate::create_tempfile();
+        let probe = probe(tmpfile.path());
+        // Stands in for a create holding the header lock across its initialization
+        assert!(probe.try_lock_range(HEADER_LOCK).unwrap());
+
+        let path = tmpfile.path().to_path_buf();
+        let (opened, opens) = mpsc::channel();
+        let opening = thread::spawn(move || {
+            let mut builder = Database::builder();
+            builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+            let result = builder.open(&path);
+            opened.send(()).unwrap();
+            result
+        });
+
+        assert!(
+            opens.recv_timeout(Duration::from_millis(500)).is_err(),
+            "the open read the file while the creator held the header lock"
+        );
+        // The create finishes: from here the file is a database, as it would be at the release.
+        // Written through the handle that holds the lock, as a create writes under its own: on
+        // Windows a byte-range lock is mandatory, and excludes writes from every other handle
+        (&probe).seek(SeekFrom::Start(0)).unwrap();
+        (&probe).write_all(&bytes).unwrap();
+        probe.sync_all().unwrap();
+        probe.unlock_range(HEADER_LOCK).unwrap();
+
+        opens
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the open never took the header lock");
+        // A length sampled before the lock would still be the zero it read at the start
+        opening
+            .join()
+            .unwrap()
+            .expect("the open used a length it read before the creator finished");
     }
 
     /// A multi-writer open runs under the writer byte, so that two processes do not repair the

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1071,13 +1071,19 @@ impl TransactionalMemory {
         #[cfg(feature = "experimental-multiprocess")]
         let in_process_header_lock = Mutex::new(());
 
+        // Ensure that we have a consistent view across reading the file length and metadata
+        #[cfg(feature = "experimental-multiprocess")]
+        let init_guard = Self::lock_header(
+            &storage,
+            &in_process_header_lock,
+            concurrency_mode,
+            allow_initialize,
+        )?;
+
         let initial_storage_len = storage.raw_file_len()?;
 
         let magic_number: [u8; MAGICNUMBER.len()] =
             if initial_storage_len >= MAGICNUMBER.len() as u64 {
-                #[cfg(feature = "experimental-multiprocess")]
-                let _guard =
-                    Self::lock_header(&storage, &in_process_header_lock, concurrency_mode, false)?;
                 storage
                     .read_direct(0, MAGICNUMBER.len())?
                     .try_into()
@@ -1141,29 +1147,22 @@ impl TransactionalMemory {
 
             header.recovery_required = false;
             header.two_phase_commit = true;
-            {
-                #[cfg(feature = "experimental-multiprocess")]
-                let _guard =
-                    Self::lock_header(&storage, &in_process_header_lock, concurrency_mode, true)?;
-                storage
-                    .write(0, DB_HEADER_SIZE, true)?
-                    .mem_mut()
-                    .copy_from_slice(&header.to_bytes(false));
-                storage.flush()?;
-            }
+            storage
+                .write(0, DB_HEADER_SIZE, true)?
+                .mem_mut()
+                .copy_from_slice(&header.to_bytes(false));
+            storage.flush()?;
             // Write the magic number only after the data structure is initialized and written to disk
             // to ensure that it's crash safe
-            {
-                #[cfg(feature = "experimental-multiprocess")]
-                let _guard =
-                    Self::lock_header(&storage, &in_process_header_lock, concurrency_mode, true)?;
-                storage
-                    .write(0, DB_HEADER_SIZE, true)?
-                    .mem_mut()
-                    .copy_from_slice(&header.to_bytes(true));
-                storage.flush()?;
-            }
+            storage
+                .write(0, DB_HEADER_SIZE, true)?
+                .mem_mut()
+                .copy_from_slice(&header.to_bytes(true));
+            storage.flush()?;
         }
+        // Given up before the read below takes it again: neither hold nests
+        #[cfg(feature = "experimental-multiprocess")]
+        drop(init_guard);
         let header = Self::read_header(
             &storage,
             #[cfg(feature = "experimental-multiprocess")]


### PR DESCRIPTION
Prep, split out of #1413's open items. Independent of #1463 and #1464; any order.

## The bug

An open sampled the file's length before taking any lock:

```rust
let initial_storage_len = storage.raw_file_len()?;
```

and a create resizes the file before it writes the magic number. So an open that read the length while a create was part way through drew a conclusion from a state that never lasts:

* length zero, before the resize -- reported as `"Database file is empty and creating a new database was not requested"`
* length nonzero, after the resize and before the magic number -- reported as `"Not a redb database: magic number mismatch"`

The second is the worse of the two: a corruption-shaped error for a file that is about to be perfectly good.

#1462 closed this between *writable* opens, which take the writer byte and so wait for a create holding it. A read-only open in a shared mode takes no writer byte, by design, so it was left racing.

## What it does

The open takes the header lock before it reads the length, and holds it across the initialization it may run -- the resize, the header write and the magic number, which each took a hold of their own. An open racing a create therefore sees the file as it was before that create, or as it left it, and never part way through it.

The hold is exclusive only for an open that may initialize, so ordinary opens and shared readers still run under it alongside each other; only a create excludes them. It is released before `read_header()`, which takes the lock itself -- neither hold nests, which is what the three inner holds were avoiding.

Removing those three is what makes one outer hold possible: nesting them under it would deadlock on Windows, where a range this handle already holds cannot be locked again.

## What it does not do

An open that genuinely arrives before a create has taken the lock still reports the file empty. That is a true statement about the file at the instant it looked, and closing it would mean a read-only open probing the writer byte and waiting -- which is a different decision about what a read-only handle may block on, not this change.

## Testing

`an_open_waits_behind_a_creator_instead_of_calling_the_file_empty`, in `writer_byte_test` where the byte constants are reachable: a probe holds the header lock over an empty file, standing in for a create, and the file becomes a database before the lock is released. The open waits, and then reads what the create left.

It fails two ways, both checked:

* without the lock at all, it reports the file empty at once -- `"the open read the file while the creator held the header lock"`
* with the length sampled ahead of the lock rather than under it, it waits and then reports the zero it had already read -- `"the open used a length it read before the creator finished: ... Database file is empty"`

The second is why the ordering and not just the hold is the point.

`cargo fmt --check`, `cargo clippy --all --all-targets --all-features` under `--deny warnings`, `cargo clippy --all --all-targets` with default features, and `cargo test --all --all-features` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9BSFJKvzsERy8jjeMxwjD

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9BSFJKvzsERy8jjeMxwjD)_