### PR TITLE
Fix file locking on 32-bit GNU/Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,16 @@ jobs:
       - name: Clippy (default features)
         run: cargo clippy --all --all-targets -- -Dwarnings
 
+      - name: Run 32-bit locking tests
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes gcc-multilib
+          rustup target add i686-unknown-linux-gnu
+          cargo test -p $(cargo pkgid) --target i686-unknown-linux-gnu --lib range_lock_tests
+          cargo test -p $(cargo pkgid) --target i686-unknown-linux-gnu --all-features --lib range_lock_tests
+          cargo test -p $(cargo pkgid) --target i686-unknown-linux-gnu --all-features --test multiprocess_tests
+
       - name: Fuzzer
         if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
         run: just fuzz_ci

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -580,6 +580,78 @@ mod range_lock_tests {
         assert!(!asking.query_lock(byte).unwrap());
     }
 
+    #[test]
+    fn large_lock_offsets_do_not_alias_lower_bytes() {
+        let tmpfile = crate::create_tempfile();
+        let holder = reopen(tmpfile.path());
+        let observer = reopen(tmpfile.path());
+
+        for offset in PROTOCOL_OFFSETS
+            .into_iter()
+            .filter(|offset| *offset >= BASE)
+        {
+            let byte = offset..offset + 1;
+            let low_offset = offset & u64::from(u32::MAX);
+            let low_byte = low_offset..low_offset + 1;
+            for exclusive in [false, true] {
+                let acquired = if exclusive {
+                    holder.try_lock_range(byte.clone())
+                } else {
+                    holder.try_lock_shared_range(byte.clone())
+                };
+                assert!(acquired.unwrap());
+                assert!(observer.query_lock(byte.clone()).unwrap());
+                assert!(!observer.try_lock_range(byte.clone()).unwrap());
+                assert!(!observer.query_lock(low_byte.clone()).unwrap());
+                assert!(observer.try_lock_range(low_byte.clone()).unwrap());
+                observer.unlock_range(low_byte.clone()).unwrap();
+
+                holder.unlock_range(byte.clone()).unwrap();
+                assert!(!observer.query_lock(byte.clone()).unwrap());
+            }
+        }
+    }
+
+    #[test]
+    fn large_lock_lengths_preserve_range_boundaries() {
+        let tmpfile = crate::create_tempfile();
+        let holder = reopen(tmpfile.path());
+        let observer = reopen(tmpfile.path());
+
+        for range in [0..BASE, BASE..(1 << 63) - 1] {
+            let last_byte = range.end - 1..range.end;
+            assert!(holder.try_lock_shared_range(range.clone()).unwrap());
+            assert!(observer.query_lock(last_byte.clone()).unwrap());
+            assert!(!observer.try_lock_range(last_byte.clone()).unwrap());
+            assert!(observer.try_lock_shared_range(last_byte.clone()).unwrap());
+            observer.unlock_range(last_byte.clone()).unwrap();
+            assert!(!observer.query_lock(range.end..range.end + 1).unwrap());
+
+            holder.unlock_range(range).unwrap();
+            assert!(!observer.query_lock(last_byte).unwrap());
+        }
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    #[test]
+    fn blocking_locks_use_large_offsets() {
+        let tmpfile = crate::create_tempfile();
+        let holder = reopen(tmpfile.path());
+        let observer = reopen(tmpfile.path());
+        let byte = BASE + 4..BASE + 5;
+
+        holder.lock_shared_range(byte.clone()).unwrap();
+        assert!(observer.query_lock(byte.clone()).unwrap());
+        assert!(!observer.try_lock_range(byte.clone()).unwrap());
+        holder.unlock_range(byte.clone()).unwrap();
+
+        holder.lock_range(byte.clone()).unwrap();
+        assert!(observer.query_lock(byte.clone()).unwrap());
+        assert!(!observer.try_lock_shared_range(byte.clone()).unwrap());
+        holder.unlock_range(byte.clone()).unwrap();
+        assert!(!observer.query_lock(byte).unwrap());
+    }
+
     /// An ordinary Linux filesystem keeps the whole-file lock out of the range locks' table,
     /// so an open holds both: only the whole-file lock itself can refuse the observer's
     #[cfg(all(target_os = "linux", not(feature = "experimental-api-5")))]

--- a/src/tree_store/page_store/file_backend/range_lock.rs
+++ b/src/tree_store/page_store/file_backend/range_lock.rs
@@ -4,6 +4,14 @@ use std::ops::Range;
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 use std::os::unix::io::AsRawFd;
 
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "gnu")),
+    target_vendor = "apple"
+))]
+use libc::flock as Flock;
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+use libc::flock64 as Flock;
+
 pub(crate) trait RangeLock {
     /// Whether these locks and [`File::lock`]'s conflict.
     /// `None` indicates that it can only be determined at runtime, e.g. because it is filesystem
@@ -296,7 +304,7 @@ fn lock_type(kind: libc::c_short) -> libc::c_short {
 }
 
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
-fn flock_struct(kind: libc::c_short, range: Range<u64>) -> libc::flock {
+fn flock_struct(kind: libc::c_short, range: Range<u64>) -> Flock {
     debug_assert!(!range.is_empty());
     let len = if range.end == u64::MAX {
         0
@@ -305,12 +313,41 @@ fn flock_struct(kind: libc::c_short, range: Range<u64>) -> libc::flock {
     };
     // Zeroed rather than written field by field: struct flock's layout differs between Linux
     // and the Apple platforms
-    let mut lock: libc::flock = unsafe { std::mem::zeroed() };
+    let mut lock: Flock = unsafe { std::mem::zeroed() };
     lock.l_type = kind;
     lock.l_whence = libc::SEEK_SET.try_into().unwrap();
-    lock.l_start = libc::off_t::try_from(range.start).unwrap();
-    lock.l_len = libc::off_t::try_from(len).unwrap();
+    lock.l_start = range.start.try_into().unwrap();
+    lock.l_len = len.try_into().unwrap();
     lock
+}
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+fn fcntl_lock(file: &File, command: libc::c_int, lock: &mut Flock) -> libc::c_long {
+    // GNU's off_t can be 32 bits. Use the kernel's large-file ABI directly: glibc's fcntl
+    // translates through off_t, and its fcntl64 symbol requires glibc 2.28 or later.
+    // x32 and RISC-V already use 64-bit offsets with SYS_fcntl.
+    #[cfg(any(
+        target_pointer_width = "64",
+        target_arch = "x86_64",
+        target_arch = "riscv32"
+    ))]
+    use libc::SYS_fcntl as SYSCALL;
+    #[cfg(not(any(
+        target_pointer_width = "64",
+        target_arch = "x86_64",
+        target_arch = "riscv32"
+    )))]
+    use libc::SYS_fcntl64 as SYSCALL;
+
+    unsafe { libc::syscall(SYSCALL, file.as_raw_fd(), command, &raw mut *lock) }
+}
+
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "gnu")),
+    target_vendor = "apple"
+))]
+fn fcntl_lock(file: &File, command: libc::c_int, lock: &mut Flock) -> libc::c_int {
+    unsafe { libc::fcntl(file.as_raw_fd(), command, &raw mut *lock) }
 }
 
 /// The last lock failure, as `Unsupported` where the filesystem has no byte-range locks.
@@ -335,7 +372,7 @@ fn set_lock(file: &File, exclusive: bool, range: Range<u64>) -> io::Result<bool>
         libc::F_RDLCK
     });
     let mut lock = flock_struct(kind, range);
-    let rc = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_OFD_SETLK, &raw mut lock) };
+    let rc = fcntl_lock(file, libc::F_OFD_SETLK, &mut lock);
     if rc == 0 {
         return Ok(true);
     }
@@ -359,7 +396,7 @@ fn set_lock_blocking(file: &File, exclusive: bool, range: Range<u64>) -> io::Res
     });
     loop {
         let mut lock = flock_struct(kind, range.clone());
-        let rc = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_OFD_SETLKW, &raw mut lock) };
+        let rc = fcntl_lock(file, libc::F_OFD_SETLKW, &mut lock);
         if rc == 0 {
             return Ok(());
         }
@@ -400,13 +437,13 @@ impl RangeLock for File {
 
     fn unlock_range(&self, range: Range<u64>) -> io::Result<()> {
         let mut lock = flock_struct(lock_type(libc::F_UNLCK), range);
-        let rc = unsafe { libc::fcntl(self.as_raw_fd(), libc::F_OFD_SETLK, &raw mut lock) };
+        let rc = fcntl_lock(self, libc::F_OFD_SETLK, &mut lock);
         if rc == 0 { Ok(()) } else { Err(lock_error()) }
     }
 
     fn query_lock(&self, range: Range<u64>) -> io::Result<bool> {
         let mut lock = flock_struct(lock_type(libc::F_WRLCK), range);
-        let rc = unsafe { libc::fcntl(self.as_raw_fd(), libc::F_OFD_GETLK, &raw mut lock) };
+        let rc = fcntl_lock(self, libc::F_OFD_GETLK, &mut lock);
         if rc != 0 {
             return Err(lock_error());
         }


### PR DESCRIPTION
Opening even an empty database can panic on 32-bit GNU/Linux because the locking protocol uses offsets near `2^62`, while `libc::off_t` is only 32 bits on targets such as i686. Both lock offsets and lengths can fail the checked conversion.

Use `flock64` and the appropriate large-file `fcntl` syscall for GNU/Linux acquisitions, queries, and unlocks, including blocking locks. Calling through `libc::syscall` avoids glibc's narrow `flock` conversion without requiring the `fcntl64` symbol introduced in glibc 2.28.

Add regressions for high offsets remaining distinct from low offsets, exact boundaries of large ranges, and blocking locks. CI now runs the locking tests with default and all features, plus the multi-process integration suite, on i686.

Validation:

- Before the fix, all 12 existing default-feature locking tests panicked on `i686-unknown-linux-gnu` with `TryFromIntError`.
- `just test` passed, including formatting, Clippy, dependency checks, and all-feature tests.
- i686 GNU/Linux: 14 default-feature locking tests, 12 all-feature locking tests, and all 19 multi-process integration tests passed. Clippy passed for all targets and features.
- i686 musl: all 12 all-feature locking tests passed.
- All-feature builds checked successfully for `armv7-unknown-linux-gnueabihf` and `x86_64-unknown-linux-gnux32`.
