### PR TITLE
Avoid deadlock after a failed multi-writer open

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -945,7 +945,9 @@ impl Database {
 
         // The tracker holds the persistent savepoints the reloaded tables hold, as the open's does
         if peer_committed {
-            self.sync_persistent_savepoints(
+            Self::sync_persistent_savepoints(
+                &self.transaction_tracker,
+                &self.mem,
                 #[cfg(feature = "experimental-multiprocess")]
                 Some(writer_lock),
             )?;
@@ -968,21 +970,24 @@ impl Database {
     // Synchronizes the tracker state for the file's persistent savepoints. The transaction this
     // begins is lent `writer_lock`, when the caller holds one
     fn sync_persistent_savepoints(
-        &self,
+        transaction_tracker: &Arc<TransactionTracker>,
+        mem: &Arc<TransactionalMemory>,
         #[cfg(feature = "experimental-multiprocess")] writer_lock: Option<&Arc<WriterLock>>,
     ) -> Result<(), DatabaseError> {
-        let txn = self
-            .begin_write_with(
-                #[cfg(feature = "experimental-multiprocess")]
-                writer_lock,
-                #[cfg(feature = "experimental-multiprocess")]
-                None,
-            )
-            .map_err(|e| e.into_storage_error())?;
-        sync_persistent_savepoints(
-            &self.transaction_tracker,
+        let txn = begin_write_with_allocation_policy(
+            transaction_tracker,
+            mem,
             #[cfg(feature = "experimental-multiprocess")]
-            &self.mem,
+            writer_lock,
+            #[cfg(feature = "experimental-multiprocess")]
+            None,
+            AllocationPolicy::Default,
+        )
+        .map_err(|e| e.into_storage_error())?;
+        sync_persistent_savepoints(
+            transaction_tracker,
+            #[cfg(feature = "experimental-multiprocess")]
+            mem,
             &txn,
         )?;
         txn.abort()?;
@@ -1596,13 +1601,12 @@ impl Database {
         mem.mark_consistent()?;
         let next_transaction_id = mem.get_last_committed_transaction_id()?.next();
 
-        let db = Database {
-            mem,
-            transaction_tracker: Arc::new(TransactionTracker::new(next_transaction_id)),
-        };
+        let transaction_tracker = Arc::new(TransactionTracker::new(next_transaction_id));
 
         // Restore the tracker state for any persistent savepoints
-        db.sync_persistent_savepoints(
+        Self::sync_persistent_savepoints(
+            &transaction_tracker,
+            &mem,
             #[cfg(feature = "experimental-multiprocess")]
             writer_lock.as_ref(),
         )?;
@@ -1611,16 +1615,20 @@ impl Database {
         #[cfg(feature = "experimental-multiprocess")]
         if repaired && concurrency_mode == ConcurrencyMode::MultiWriterProcess {
             ensure_allocator_state_table_and_trim(
-                &db.transaction_tracker,
-                &db.mem,
+                &transaction_tracker,
+                &mem,
                 writer_lock.as_ref(),
                 None,
             )?;
         }
         #[cfg(not(feature = "experimental-multiprocess"))]
         let _ = (repaired, writer_lock);
-        // Dropped here: a write transaction takes the writer byte for itself from now on
-        Ok(db)
+        // Construct only after initialization succeeds: Database::drop takes the writer lock,
+        // which the open still holds, and assumes the savepoint tracker is complete.
+        Ok(Database {
+            mem,
+            transaction_tracker,
+        })
     }
 
     fn get_allocator_state_table(

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2970,6 +2970,90 @@ mod test {
         ));
     }
 
+    #[cfg(all(
+        feature = "experimental-multiprocess",
+        any(target_os = "linux", target_vendor = "apple", windows)
+    ))]
+    #[test]
+    fn failed_multi_writer_open_releases_locks_without_committing() {
+        use super::{SAVEPOINT_TABLE, SavepointId, SerializedSavepoint};
+        use crate::db::FULL_RANGE;
+        use crate::tree_store::file_backend::range_lock::RangeLock;
+        use crate::tree_store::{PAGE_SIZE, TransactionalMemory};
+        use crate::{ConcurrencyMode, DatabaseError, backends::FileBackend};
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        let tmpfile = crate::create_tempfile();
+        let db = Database::builder()
+            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .create(tmpfile.path())
+            .unwrap();
+        let txn = db.begin_write().unwrap();
+        txn.open_table(X).unwrap().insert("key", "value").unwrap();
+        txn.commit().unwrap();
+
+        // A valid tree and allocator snapshot, with a savepoint that fails to deserialize.
+        // The open reaches tracker initialization without latching an I/O error.
+        let txn = db.begin_write().unwrap();
+        let id = txn.persistent_savepoint().unwrap();
+        txn.system_tables
+            .lock()
+            .unwrap()
+            .open_system_table(SAVEPOINT_TABLE)
+            .unwrap()
+            .insert(SavepointId(id), SerializedSavepoint::Ref(&[]))
+            .unwrap();
+        txn.commit().unwrap();
+        let mem = db.get_memory();
+        drop(db);
+        let committed_id = mem.get_last_committed_transaction_id().unwrap();
+        drop(mem);
+
+        let file = tmpfile.reopen().unwrap();
+        let kept_by_caller = file.try_clone().unwrap();
+        let (completed, completion) = mpsc::channel();
+        let opening = thread::spawn(move || {
+            let result = Database::builder()
+                .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+                .set_repair_callback(|_| panic!("the allocator snapshot should be valid"))
+                .create_file(file);
+            completed.send(result).unwrap();
+        });
+        let result = completion
+            .recv_timeout(Duration::from_secs(10))
+            .expect("failed open deadlocked during cleanup");
+        opening.join().unwrap();
+        assert!(matches!(
+            result,
+            Err(DatabaseError::Storage(StorageError::Corrupted(message)))
+                if message == "Corrupted savepoint record"
+        ));
+
+        // A caller's duplicate keeps the file description alive, so dropping the backend's
+        // File alone would leave its locks held on platforms with open-file-description locks.
+        let observer = tmpfile.reopen().unwrap();
+        assert!(observer.try_lock_range(FULL_RANGE).unwrap());
+        observer.unlock_range(FULL_RANGE).unwrap();
+        drop(kept_by_caller);
+
+        let (mem, _writer) = TransactionalMemory::new(
+            Box::new(FileBackend::new(observer).unwrap()),
+            false,
+            PAGE_SIZE,
+            None,
+            0,
+            false,
+            ConcurrencyMode::MultiWriterProcess,
+        )
+        .unwrap();
+        assert_eq!(
+            mem.get_last_committed_transaction_id().unwrap(),
+            committed_id
+        );
+    }
+
     // A commit that stops part way may leave pages returned to the allocator while the durable
     // freed tables still reference them, so commit_inner() discards the allocator state unless
     // it completes. Verify the resulting contract: writes are refused, reads keep working, the


### PR DESCRIPTION
A malformed persistent savepoint can make a multi-writer open fail while it still holds the opening writer lock. The partially constructed `Database` then runs its normal close, which tries to take that lock again and hangs on Windows. On Linux, the same cleanup can publish shutdown commits with an incomplete savepoint tracker.

Construct `Database` after savepoint tracking and the final repair allocator commit succeed. Savepoint loading now operates directly on the memory and tracker, allowing failed initialization to release its resources through the existing backend cleanup.

The regression creates a valid allocator snapshot with a malformed savepoint, then checks that opening returns the original corruption error within a timeout, releases every lock while a duplicate file handle remains alive, and leaves the committed transaction ID unchanged. It runs on Windows, Linux, and macOS under `experimental-multiprocess`.

Validation:

- The regression failed before the fix on Linux: cleanup advanced the committed transaction ID from 7 to 10. It passes with the fix.
- `just test` passed, including formatting, Clippy, dependency checks, and all-feature tests.
- All 132 default-feature unit tests passed.
- A bounded `just fuzz` run completed over 60,000 executions without a failure before being stopped at its two-minute limit.
