### PR TITLE
Preserve read snapshots for untyped tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@
   with such keys use slightly less space, and lookups are faster.
 * Fix a crash shortly after a commit being able to silently roll that commit back during
   recovery, if `check_integrity()` had previously repaired the database.
+* Fix `ReadOnlyUntypedTable` and `ReadOnlyUntypedMultimapTable` losing their read snapshot when
+  the originating transaction is dropped. Their pages now remain protected from reclamation
+  and compaction until the tables are dropped.
 * Fix iterators silently omitting data when iteration continues after an error. An iterator
   that yielded `Err(Corrupted)` could yield the rest of the table on later calls, skipping the
   unreadable entries with no further error. Iterators and read-only cursors now keep returning

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -1100,6 +1100,8 @@ pub trait ReadableMultimapTable<K: Key + 'static, V: Key + 'static>: ReadableTab
 }
 
 /// A read-only untyped multimap table
+///
+/// Keeps its read transaction alive until the table is dropped.
 pub struct ReadOnlyUntypedMultimapTable {
     name: String,
     num_values: u64,
@@ -1108,6 +1110,7 @@ pub struct ReadOnlyUntypedMultimapTable {
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
     mem: PageResolver,
+    _transaction_guard: Arc<TransactionGuard>,
 }
 
 impl Sealed for ReadOnlyUntypedMultimapTable {}
@@ -1149,9 +1152,9 @@ impl ReadOnlyUntypedMultimapTable {
         name: &str,
         root: Option<BtreeHeader>,
         num_values: u64,
-        hint: PageHint,
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
+        guard: Arc<TransactionGuard>,
         mem: PageResolver,
     ) -> Self {
         Self {
@@ -1162,12 +1165,13 @@ impl ReadOnlyUntypedMultimapTable {
                 fixed_key_size,
                 DynamicCollection::<()>::fixed_width_with(fixed_value_size),
                 mem.clone(),
-                hint,
+                PageHint::Clean,
             ),
-            hint,
+            hint: PageHint::Clean,
             fixed_key_size,
             fixed_value_size,
             mem,
+            _transaction_guard: guard,
         }
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -804,9 +804,12 @@ pub trait ReadableTable<K: Key + 'static, V: Value + 'static>: ReadableTableMeta
 }
 
 /// A read-only untyped table
+///
+/// Keeps its read transaction alive until the table is dropped.
 pub struct ReadOnlyUntypedTable {
     name: String,
     tree: RawBtree,
+    _transaction_guard: Arc<TransactionGuard>,
 }
 
 impl Sealed for ReadOnlyUntypedTable {}
@@ -841,14 +844,21 @@ impl ReadOnlyUntypedTable {
     pub(crate) fn new(
         name: &str,
         root_page: Option<BtreeHeader>,
-        hint: PageHint,
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
+        guard: Arc<TransactionGuard>,
         mem: PageResolver,
     ) -> Self {
         Self {
             name: name.to_string(),
-            tree: RawBtree::new(root_page, fixed_key_size, fixed_value_size, mem, hint),
+            tree: RawBtree::new(
+                root_page,
+                fixed_key_size,
+                fixed_value_size,
+                mem,
+                PageHint::Clean,
+            ),
+            _transaction_guard: guard,
         }
     }
 }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2810,9 +2810,9 @@ impl ReadTransaction {
             } => Ok(ReadOnlyUntypedTable::new(
                 name,
                 table_root,
-                PageHint::Clean,
                 fixed_key_size,
                 fixed_value_size,
+                self.tree.transaction_guard().clone(),
                 PageResolver::new(self.mem.clone()),
             )),
             InternalTableDefinition::Multimap { .. } => unreachable!(),
@@ -2869,9 +2869,9 @@ impl ReadTransaction {
                 name,
                 table_root,
                 table_length,
-                PageHint::Clean,
                 fixed_key_size,
                 fixed_value_size,
+                self.tree.transaction_guard().clone(),
                 PageResolver::new(self.mem.clone()),
             )),
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1567,6 +1567,32 @@ fn explicit_close() {
 }
 
 #[test]
+fn untyped_tables_keep_read_transaction_alive() {
+    const MULTIMAP: MultimapTableDefinition<u64, u64> = MultimapTableDefinition::new("multi");
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+    let write = db.begin_write().unwrap();
+    write.open_table(U64_TABLE).unwrap();
+    write.open_multimap_table(MULTIMAP).unwrap();
+    write.commit().unwrap();
+
+    for multimap in [false, true] {
+        let read = db.begin_read().unwrap();
+        let table: Box<dyn ReadableTableMetadata> = if multimap {
+            Box::new(read.open_untyped_multimap_table(MULTIMAP).unwrap())
+        } else {
+            Box::new(read.open_untyped_table(U64_TABLE).unwrap())
+        };
+        let read = match read.close() {
+            Err(TransactionError::ReadTransactionStillInUse(read)) => read,
+            result => panic!("close with an untyped table alive: {result:?}"),
+        };
+        drop(table);
+        read.close().unwrap();
+    }
+}
+
+#[test]
 fn read_only_get_guard_keeps_transaction_alive() {
     let tmpfile = create_tempfile();
     let db = Database::create(tmpfile.path()).unwrap();

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -715,7 +715,8 @@ mod reclamation {
 mod compaction {
     use super::*;
     use redb::{
-        CompactionError, ReadOnlyDatabase, ReadableDatabase, ReadableTable, TableDefinition,
+        CompactionError, MultimapTableDefinition, ReadOnlyDatabase, ReadableDatabase,
+        ReadableTable, ReadableTableMetadata, TableDefinition,
     };
     use std::path::Path;
 
@@ -772,6 +773,72 @@ mod compaction {
             let read = reader.begin_read().unwrap();
             let t = read.open_table(TABLE).unwrap();
             assert_eq!(t.get(&0).unwrap().unwrap().value(), [1u8; 512].as_slice());
+        }
+    }
+
+    #[test]
+    fn untyped_tables_pin_a_peers_snapshot_until_dropped() {
+        const MULTIMAP: MultimapTableDefinition<u64, &[u8]> = MultimapTableDefinition::new("multi");
+        for mode in [
+            ConcurrencyMode::SingleWriterProcess,
+            ConcurrencyMode::MultiWriterProcess,
+        ] {
+            for multimap in [false, true] {
+                let tmpfile = tempfile::NamedTempFile::new().unwrap();
+                let mut writer = create(tmpfile.path(), mode);
+                let value = [7u8; 512];
+                let write = writer.begin_write().unwrap();
+                {
+                    let mut table = write.open_table(TABLE).unwrap();
+                    let mut multi = write.open_multimap_table(MULTIMAP).unwrap();
+                    for key in 0..128u64 {
+                        table.insert(key, value.as_slice()).unwrap();
+                        multi.insert(key, value.as_slice()).unwrap();
+                    }
+                }
+                write.commit().unwrap();
+
+                let reader = Database::builder()
+                    .set_concurrency_mode(mode)
+                    .set_cache_size(0)
+                    .open_read_only(tmpfile.path())
+                    .unwrap();
+                let read = reader.begin_read().unwrap();
+                let table: Box<dyn ReadableTableMetadata> = if multimap {
+                    Box::new(read.open_untyped_multimap_table(MULTIMAP).unwrap())
+                } else {
+                    Box::new(read.open_untyped_table(TABLE).unwrap())
+                };
+                let before = table.stats().unwrap();
+                assert!(before.branch_pages() > 0);
+                drop(read);
+
+                let write = writer.begin_write().unwrap();
+                write.delete_table(TABLE).unwrap();
+                write.delete_multimap_table(MULTIMAP).unwrap();
+                write.commit().unwrap();
+                for _ in 0..3 {
+                    writer.begin_write().unwrap().commit().unwrap();
+                }
+                assert!(
+                    matches!(
+                        writer.compact(),
+                        Err(CompactionError::TransactionInProgress)
+                    ),
+                    "{mode:?}, multimap={multimap}"
+                );
+
+                // The table alone pins the snapshot, and an empty cache forces stats to read it.
+                let after = table.stats().unwrap();
+                assert_eq!(table.len().unwrap(), 128);
+                assert_eq!(after.stored_bytes(), before.stored_bytes());
+                assert_eq!(after.tree_height(), before.tree_height());
+                assert_eq!(after.leaf_pages(), before.leaf_pages());
+                assert_eq!(after.branch_pages(), before.branch_pages());
+
+                drop(table);
+                writer.compact().unwrap();
+            }
         }
     }
 


### PR DESCRIPTION
Untyped table handles could outlive their read transaction without retaining its snapshot. Later commits or compaction could reclaim the pages they still needed, making `stats()` fail with `UnexpectedEof`. `ReadTransaction::close()` also incorrectly succeeded while an untyped table remained alive.

Both untyped table types now retain the transaction guard used by typed tables. Their snapshots stay protected until the table objects are dropped, and explicit transaction close reports `ReadTransactionStillInUse` while either type is alive. This also fixes existing single-process behavior; the changelog records the fix for released versions.

Regression coverage checks each table type independently:

- Explicit close is refused while the table is alive and succeeds after it drops, including with default features.
- In both shared writer modes, a table alone retains its snapshot after a peer deletes the tables and makes further commits. With the reader cache disabled, its statistics still match the original snapshot, compaction is refused until it drops, and compaction succeeds afterward.

Validation:

- Both regressions failed before the fix and pass afterward.
- The default-feature close regression passed.
- `just test` passed, including formatting, Clippy, dependency checks, and the full all-feature test suite.
- A bounded run of the existing `just fuzz` harness completed over 40,000 executions without a failure before its two-minute limit.
