### PR TITLE
Capture read snapshots under the header lock

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -450,13 +450,14 @@ impl TransactionGuard {
         }
     }
 
+    // Returns a read guard and the data root its registration protects.
     pub(crate) fn allocate_read(
         tracker: Arc<TransactionTracker>,
         mem: &Arc<TransactionalMemory>,
-    ) -> Result<Self> {
-        let id = tracker.register_read_transaction(mem)?;
+    ) -> Result<(Self, Option<BtreeHeader>)> {
+        let (id, root) = tracker.register_read_transaction(mem)?;
 
-        Ok(Self::new_read(id, tracker, mem))
+        Ok((Self::new_read(id, tracker, mem), root))
     }
 
     pub(crate) fn new_write(
@@ -581,10 +582,6 @@ pub trait ReadableDatabase: SealedInApi5 {
 pub struct ReadOnlyDatabase {
     mem: Arc<TransactionalMemory>,
     transaction_tracker: Arc<TransactionTracker>,
-    // Serializes beginning a read, so that the id a transaction locks and the root it then
-    // reads come from the same state
-    #[cfg(feature = "experimental-multiprocess")]
-    begin_read: crate::sync::Mutex<()>,
 }
 
 #[cfg(not(redb_no_std))]
@@ -593,13 +590,12 @@ impl Sealed for ReadOnlyDatabase {}
 #[cfg(not(redb_no_std))]
 impl ReadableDatabase for ReadOnlyDatabase {
     fn begin_read(&self) -> Result<ReadTransaction, TransactionError> {
-        #[cfg(feature = "experimental-multiprocess")]
-        let _begin = self.begin_read.lock().unwrap();
-        let guard = TransactionGuard::allocate_read(self.transaction_tracker.clone(), &self.mem)?;
+        let (guard, root) =
+            TransactionGuard::allocate_read(self.transaction_tracker.clone(), &self.mem)?;
         #[cfg(feature = "logging")]
         debug!("Beginning read transaction id={:?}", guard.id());
 
-        ReadTransaction::new(self.mem.clone(), guard)
+        ReadTransaction::new(self.mem.clone(), guard, root)
     }
 
     fn cache_stats(&self) -> CacheStats {
@@ -660,8 +656,6 @@ impl ReadOnlyDatabase {
         let db = Self {
             mem,
             transaction_tracker: Arc::new(TransactionTracker::new(next_transaction_id)),
-            #[cfg(feature = "experimental-multiprocess")]
-            begin_read: crate::sync::Mutex::new(()),
         };
 
         Ok(db)
@@ -721,10 +715,11 @@ impl Sealed for Database {}
 
 impl ReadableDatabase for Database {
     fn begin_read(&self) -> Result<ReadTransaction, TransactionError> {
-        let guard = TransactionGuard::allocate_read(self.transaction_tracker.clone(), &self.mem)?;
+        let (guard, root) =
+            TransactionGuard::allocate_read(self.transaction_tracker.clone(), &self.mem)?;
         #[cfg(feature = "logging")]
         debug!("Beginning read transaction id={:?}", guard.id());
-        ReadTransaction::new(self.get_memory(), guard)
+        ReadTransaction::new(self.get_memory(), guard, root)
     }
 
     fn cache_stats(&self) -> CacheStats {
@@ -2293,6 +2288,47 @@ mod test {
     }
 
     #[test]
+    fn read_snapshot_survives_commits_before_construction() {
+        use super::{ReadTransaction, TransactionGuard};
+
+        const TABLE: TableDefinition<u64, u64> = TableDefinition::new("snapshot");
+        for durability in [Durability::Immediate, Durability::None] {
+            let tmpfile = crate::create_tempfile();
+            let db = Database::create(tmpfile.path()).unwrap();
+            let mut write = db.begin_write().unwrap();
+            write.set_durability(durability).unwrap();
+            write.open_table(TABLE).unwrap().insert(0, 0).unwrap();
+            write.commit().unwrap();
+
+            let (guard, root) =
+                TransactionGuard::allocate_read(db.transaction_tracker.clone(), &db.mem).unwrap();
+            assert_eq!(
+                guard.id(),
+                db.mem.get_last_committed_transaction_id().unwrap()
+            );
+
+            // Commits between registration and construction must not change this read's root.
+            for value in 1..4 {
+                let mut write = db.begin_write().unwrap();
+                write.set_durability(durability).unwrap();
+                write.open_table(TABLE).unwrap().insert(0, value).unwrap();
+                write.commit().unwrap();
+            }
+
+            let read = ReadTransaction::new(db.mem.clone(), guard, root).unwrap();
+            assert_eq!(
+                read.open_table(TABLE)
+                    .unwrap()
+                    .get(0)
+                    .unwrap()
+                    .unwrap()
+                    .value(),
+                0
+            );
+        }
+    }
+
+    #[test]
     fn crash_regression4() {
         let tmpfile = crate::create_tempfile();
         let (file, path) = tmpfile.into_parts();
@@ -3509,6 +3545,56 @@ mod active_transaction_test {
 
         drop(read);
         assert!(held_ids(&probe).is_empty(), "the lock outlived the reader");
+    }
+
+    #[test]
+    fn read_only_snapshot_survives_reload_before_construction() {
+        use super::{ReadTransaction, TransactionGuard};
+        use crate::ReadableTable;
+
+        for mode in [
+            ConcurrencyMode::SingleWriterProcess,
+            ConcurrencyMode::MultiWriterProcess,
+        ] {
+            let tmpfile = crate::create_tempfile();
+            let writer = create(tmpfile.path(), mode);
+            let db = Database::builder()
+                .set_concurrency_mode(mode)
+                .set_cache_size(0)
+                .open_read_only(tmpfile.path())
+                .unwrap();
+            let (guard, root) =
+                TransactionGuard::allocate_read(db.transaction_tracker.clone(), &db.mem).unwrap();
+
+            for value in 1..4 {
+                let write = writer.begin_write().unwrap();
+                write.open_table(TABLE).unwrap().insert(0, value).unwrap();
+                write.commit().unwrap();
+            }
+            // Another read reloads the shared header before the first read is constructed.
+            let latest = db.begin_read().unwrap();
+            assert_eq!(
+                latest
+                    .open_table(TABLE)
+                    .unwrap()
+                    .get(0)
+                    .unwrap()
+                    .unwrap()
+                    .value(),
+                3
+            );
+
+            let read = ReadTransaction::new(db.mem.clone(), guard, root).unwrap();
+            assert_eq!(
+                read.open_table(TABLE)
+                    .unwrap()
+                    .get(0)
+                    .unwrap()
+                    .unwrap()
+                    .value(),
+                0
+            );
+        }
     }
 
     /// A savepoint holds a read transaction live, so its snapshot stays active for as long as

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -1,9 +1,9 @@
 use crate::sync::{Condvar, Mutex};
 #[cfg(feature = "experimental-multiprocess")]
 use crate::tree_store::HeaderGuard;
-use crate::tree_store::TransactionalMemory;
 #[cfg(feature = "experimental-multiprocess")]
 use crate::tree_store::WriterLock;
+use crate::tree_store::{BtreeHeader, TransactionalMemory};
 use crate::{Key, Result, TypeName, Value};
 use alloc::collections::BTreeSet;
 use alloc::collections::btree_map::BTreeMap;
@@ -467,14 +467,16 @@ impl TransactionTracker {
     pub(crate) fn register_read_transaction(
         &self,
         mem: &TransactionalMemory,
-    ) -> Result<TransactionId> {
+    ) -> Result<(TransactionId, Option<BtreeHeader>)> {
         #[cfg(feature = "experimental-multiprocess")]
         let header = mem.lock_header_shared()?;
-        let id = mem.latest_committed_transaction_id(
+        // Hold the tracker across snapshot capture and registration so reclamation cannot
+        // miss this reader. The header lock also excludes peer commits and local reloads.
+        let mut state = self.state.lock()?;
+        let (id, root) = mem.latest_committed_snapshot(
             #[cfg(feature = "experimental-multiprocess")]
             &header,
         )?;
-        let mut state = self.state.lock()?;
         state.add_active_transaction_lock_reference(
             mem,
             id,
@@ -482,7 +484,7 @@ impl TransactionTracker {
             &header,
         )?;
 
-        Ok(id)
+        Ok((id, root))
     }
 
     pub(crate) fn deallocate_read_transaction(&self, mem: &TransactionalMemory, id: TransactionId) {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1273,7 +1273,7 @@ impl WriteTransaction {
 
     fn allocate_savepoint(&self) -> Result<(SavepointId, TransactionGuard)> {
         // Through the guard, so the savepoint's snapshot is held active like any other reader's
-        let transaction =
+        let (transaction, _) =
             TransactionGuard::allocate_read(self.transaction_tracker.clone(), &self.mem)?;
         let id = self
             .transaction_tracker
@@ -2757,8 +2757,8 @@ impl ReadTransaction {
     pub(crate) fn new(
         mem: Arc<TransactionalMemory>,
         guard: TransactionGuard,
+        root_page: Option<BtreeHeader>,
     ) -> Result<Self, TransactionError> {
-        let root_page = mem.get_data_root();
         let guard = Arc::new(guard);
         let resolver = PageResolver::new(mem.clone());
         Ok(Self {

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1348,22 +1348,25 @@ impl TransactionalMemory {
         Ok((was_clean, changed))
     }
 
-    /// The latest committed transaction id, read from the file by a shared reader since a peer
-    /// may have committed. The caller's `header` hold must also cover locking the id returned.
-    pub(crate) fn latest_committed_transaction_id(
+    /// Captures the committed id and data root together, reloading for a shared read-only handle.
+    /// The caller's `header` hold must also cover registering the returned id as active.
+    pub(crate) fn latest_committed_snapshot(
         &self,
         #[cfg(feature = "experimental-multiprocess")] header: &HeaderGuard<'_>,
-    ) -> Result<TransactionId> {
+    ) -> Result<(TransactionId, Option<BtreeHeader>)> {
         #[cfg(feature = "experimental-multiprocess")]
         if self.read_only && self.concurrency_mode.is_multi_process_writable() {
-            return self.reload_header(header);
+            self.reload_header(header)?;
         }
-        self.get_last_committed_transaction_id()
+        // Local commits can publish their in-memory state without holding the header lock.
+        let state = self.state.lock()?;
+        let slot = state.latest_slot();
+        Ok((slot.transaction_id, slot.user_root))
     }
 
-    /// Adopts the header another process has written. Returns the transaction id now visible.
+    /// Adopts the header another process has written.
     #[cfg(feature = "experimental-multiprocess")]
-    fn reload_header(&self, header: &HeaderGuard<'_>) -> Result<TransactionId> {
+    fn reload_header(&self, header: &HeaderGuard<'_>) -> Result {
         let unrepaired = Self::read_file_header(&self.storage, self.page_size, header)
             .map_err(DatabaseError::into_storage_error_or_corrupted)?;
         let header = unrepaired.finalize_transaction_slots()?;
@@ -1378,7 +1381,7 @@ impl TransactionalMemory {
             self.clear_read_cache();
         }
 
-        Ok(current)
+        Ok(())
     }
 
     /// Brings this handle up to the file's latest commit, when it is not already on it, so that


### PR DESCRIPTION
Read registration pins a transaction ID before `ReadTransaction::new()` reads the data root. `ReadOnlyDatabase` uses a separate `begin_read` mutex to prevent another read from reloading the header between those steps.

Capture the ID and root together under the memory-state mutex, with the header lock held through capture and registration. Return the root with its transaction guard and use it to construct reads in both `Database` and `ReadOnlyDatabase`. This removes the extra `ReadOnlyDatabase` mutex and releases the header lock before constructing the table tree. Savepoint registration continues to use the same guard allocation path.

Regression tests cover commits between registration and construction, including non-durable commits, and a read-only header reload before an earlier read is constructed in both multiprocess modes.

Validation: `just test`; the local snapshot regression with default features; `cargo check --no-default-features`; a bounded `just fuzz` smoke run without a sanitizer.
