### PR TITLE
Read shared read-only snapshots directly from the file

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -3548,7 +3548,7 @@ mod active_transaction_test {
     }
 
     #[test]
-    fn read_only_snapshot_survives_reload_before_construction() {
+    fn read_only_snapshot_survives_new_read_before_construction() {
         use super::{ReadTransaction, TransactionGuard};
         use crate::ReadableTable;
 
@@ -3571,7 +3571,7 @@ mod active_transaction_test {
                 write.open_table(TABLE).unwrap().insert(0, value).unwrap();
                 write.commit().unwrap();
             }
-            // Another read reloads the shared header before the first read is constructed.
+            // Another read observes the peer's commit before the first read is constructed.
             let latest = db.begin_read().unwrap();
             assert_eq!(
                 latest
@@ -3585,6 +3585,85 @@ mod active_transaction_test {
             );
 
             let read = ReadTransaction::new(db.mem.clone(), guard, root).unwrap();
+            assert_eq!(
+                read.open_table(TABLE)
+                    .unwrap()
+                    .get(0)
+                    .unwrap()
+                    .unwrap()
+                    .value(),
+                0
+            );
+        }
+    }
+
+    #[cfg(feature = "cache_metrics")]
+    #[test]
+    fn read_only_file_snapshots_preserve_memory_state_and_reuse_cache() {
+        use super::TransactionGuard;
+        use crate::ReadableTable;
+
+        for mode in [
+            ConcurrencyMode::SingleWriterProcess,
+            ConcurrencyMode::MultiWriterProcess,
+        ] {
+            let tmpfile = crate::create_tempfile();
+            let writer = create(tmpfile.path(), mode);
+            let db = Database::builder()
+                .set_concurrency_mode(mode)
+                .open_read_only(tmpfile.path())
+                .unwrap();
+            let original_id = db.mem.get_last_committed_transaction_id().unwrap();
+            let original_root = db.mem.get_data_root();
+            let read = db.begin_read().unwrap();
+            assert_eq!(
+                read.open_table(TABLE)
+                    .unwrap()
+                    .get(0)
+                    .unwrap()
+                    .unwrap()
+                    .value(),
+                0
+            );
+            let cached_bytes = db.cache_stats().used_bytes();
+            assert!(cached_bytes > 0);
+
+            let (same, _) =
+                TransactionGuard::allocate_read(db.transaction_tracker.clone(), &db.mem).unwrap();
+            assert_eq!(same.id(), original_id);
+            assert_eq!(db.cache_stats().used_bytes(), cached_bytes);
+
+            let write = writer.begin_write().unwrap();
+            write.open_table(TABLE).unwrap().insert(0, 1).unwrap();
+            write.commit().unwrap();
+
+            let (latest, _) =
+                TransactionGuard::allocate_read(db.transaction_tracker.clone(), &db.mem).unwrap();
+            assert!(latest.id() > original_id);
+            assert_eq!(db.cache_stats().used_bytes(), 0);
+            assert_eq!(
+                db.mem.get_last_committed_transaction_id().unwrap(),
+                original_id
+            );
+            assert_eq!(db.mem.get_data_root(), original_root);
+
+            let current = db.begin_read().unwrap();
+            assert_eq!(
+                current
+                    .open_table(TABLE)
+                    .unwrap()
+                    .get(0)
+                    .unwrap()
+                    .unwrap()
+                    .value(),
+                1
+            );
+            let cached_bytes = db.cache_stats().used_bytes();
+            assert!(cached_bytes > 0);
+            let (repeated, _) =
+                TransactionGuard::allocate_read(db.transaction_tracker.clone(), &db.mem).unwrap();
+            assert_eq!(repeated.id(), latest.id());
+            assert_eq!(db.cache_stats().used_bytes(), cached_bytes);
             assert_eq!(
                 read.open_table(TABLE)
                     .unwrap()

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -1,6 +1,8 @@
 use crate::db::InternalStorageBackend;
 use crate::io;
 use crate::sync::{Mutex, MutexGuard, RwLock};
+#[cfg(feature = "experimental-multiprocess")]
+use crate::transaction_tracker::TransactionId;
 use crate::tree_store::page_store::base::PageHint;
 use crate::tree_store::page_store::lru_cache::LRUCache;
 use crate::{CacheStats, Result, StorageError};
@@ -289,6 +291,8 @@ pub(super) struct PagedCachedFile {
     // A third "total" counter would add contention on every insert/remove for
     // negligible accuracy gain.
     read_cache_bytes: AtomicUsize,
+    #[cfg(feature = "experimental-multiprocess")]
+    read_cache_transaction_id: Mutex<Option<TransactionId>>,
     write_buffer_bytes: AtomicUsize,
     // True when the write buffer holds committed, reader-visible pages, left there by a
     // non-durable commit (see write_barrier()) instead of being written to the file. While set,
@@ -337,6 +341,8 @@ impl PagedCachedFile {
             file: CheckedBackend::new(file),
             page_size,
             read_cache_bytes: AtomicUsize::new(0),
+            #[cfg(feature = "experimental-multiprocess")]
+            read_cache_transaction_id: Mutex::new(None),
             write_buffer_bytes: AtomicUsize::new(0),
             committed_pages_buffered: AtomicBool::new(false),
             max_cache_size,
@@ -755,6 +761,16 @@ impl PagedCachedFile {
             assert_eq!(len, removed.len());
             self.read_cache_bytes
                 .fetch_sub(removed.len(), Ordering::AcqRel);
+        }
+    }
+
+    // The caller holds the header lock across observing this id and updating the cache.
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(super) fn update_transaction_id(&self, transaction_id: TransactionId) {
+        let mut current = self.read_cache_transaction_id.lock().unwrap();
+        if *current != Some(transaction_id) {
+            self.invalidate_cache_all();
+            *current = Some(transaction_id);
         }
     }
 

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1348,7 +1348,7 @@ impl TransactionalMemory {
         Ok((was_clean, changed))
     }
 
-    /// Captures the committed id and data root together, reloading for a shared read-only handle.
+    /// Captures the committed id and data root together, reading the file for a shared read-only handle.
     /// The caller's `header` hold must also cover registering the returned id as active.
     pub(crate) fn latest_committed_snapshot(
         &self,
@@ -1356,7 +1356,7 @@ impl TransactionalMemory {
     ) -> Result<(TransactionId, Option<BtreeHeader>)> {
         #[cfg(feature = "experimental-multiprocess")]
         if self.read_only && self.concurrency_mode.is_multi_process_writable() {
-            self.reload_header(header)?;
+            return self.read_snapshot_from_file(header);
         }
         // Local commits can publish their in-memory state without holding the header lock.
         let state = self.state.lock()?;
@@ -1364,24 +1364,19 @@ impl TransactionalMemory {
         Ok((slot.transaction_id, slot.user_root))
     }
 
-    /// Adopts the header another process has written.
+    /// Reads a snapshot without changing the in-memory header or allocator state.
     #[cfg(feature = "experimental-multiprocess")]
-    fn reload_header(&self, header: &HeaderGuard<'_>) -> Result {
+    fn read_snapshot_from_file(
+        &self,
+        header: &HeaderGuard<'_>,
+    ) -> Result<(TransactionId, Option<BtreeHeader>)> {
         let unrepaired = Self::read_file_header(&self.storage, self.page_size, header)
             .map_err(DatabaseError::into_storage_error_or_corrupted)?;
-        let header = unrepaired.finalize_transaction_slots()?;
-        let (previous, current) = {
-            let mut state = self.state.lock()?;
-            let previous = state.header.primary_slot().transaction_id;
-            state.header = header;
-            (previous, state.header.primary_slot().transaction_id)
-        };
-        // The peer's commits may have freed and rewritten pages this handle cached
-        if current != previous {
-            self.clear_read_cache();
-        }
+        let file_header = unrepaired.finalize_transaction_slots()?;
+        let slot = file_header.primary_slot();
+        self.storage.update_transaction_id(slot.transaction_id);
 
-        Ok(())
+        Ok((slot.transaction_id, slot.user_root))
     }
 
     /// Brings this handle up to the file's latest commit, when it is not already on it, so that


### PR DESCRIPTION
Shared read-only transactions currently refresh their snapshots by replacing `TransactionalMemory`'s cached header. Read the validated primary ID/root directly from the file instead, leaving the in-memory header and allocators untouched.

`PagedCachedFile` stores the read cache's last observed transaction ID and handles comparison and invalidation in `update_transaction_id()`. `TransactionalMemory` calls it after reading the file snapshot, while still holding the header lock. Observing a different commit invalidates cached pages; repeated reads of the same commit retain them. `HeaderGuard` remains a plain lock guard. This changes only the existing shared read-only path; writable handles continue to use their in-memory snapshots.

Tests cover both multiprocess modes, including cache reuse, invalidation after a peer commit, unchanged in-memory ID/root, and retention of older snapshots.

Validation: `just test`, `cargo check --no-default-features`, and a bounded `just fuzz` smoke run without a sanitizer.
