### PR TITLE
Lend the integrity check's writer lock to every transaction it runs

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -865,7 +865,12 @@ impl Database {
                 // clean only if neither the allocator nor the durable state below needed repair.
                 let durable_clean = self.durable_state_clean()?;
                 let mut txn = self
-                    .begin_write()
+                    .begin_write_with(
+                        #[cfg(feature = "experimental-multiprocess")]
+                        Some(writer_lock),
+                        #[cfg(feature = "experimental-multiprocess")]
+                        None,
+                    )
                     .map_err(|e| DatabaseError::Storage(e.into_storage_error()))?;
                 txn.disable_post_commit_free();
                 txn.commit()


### PR DESCRIPTION
`check_integrity()` takes the writer byte and holds it for the duration of the check, so that the file it reloads is the file it repairs. Its doc comment promises that "no other process writes to the file until it returns".

Every transaction the check runs is lent that lock -- `sync_persistent_savepoints()` and `ensure_allocator_state_table_and_trim()` both take it as an argument -- except one: the commit that promotes a pending `Durability::None` transaction called `begin_write()`, which takes the writer byte for itself.

Locks on the writer byte from one file description are one lock, so that transaction's end would release the check's, and the check would carry on believing it still held it. `TransactionGuard::Write` already orders its fields to avoid exactly this hazard between two threads of one process; the same hazard applies to a transaction nested inside an operation that already holds the byte.

Only `MultiWriterProcess` is affected. In the other modes the memory hands out one shared `Arc<WriterLock>` taken at open, so the nested transaction gets a clone and its end releases nothing.

## Reachability

The branch is unreachable today, so this is hardening rather than a bug fix, and there is no behaviour change to test:

- `pending_non_durable_commit()` is `read_from_secondary`, set only by `non_durable_commit()`.
- That runs only on the `InternalDurability::None` path.
- `set_durability(Durability::None)` returns `NonDurableCommitUnsupported` whenever `concurrency_mode().is_multi_process_writable()`.

So a `MultiWriterProcess` handle never has a pending non-durable commit, and the one mode where the release would happen never enters the branch. This removes the dependency on that coincidence.

It does not make the branch *correct* for `MultiWriterProcess`, only free of this particular hazard. If `Durability::None` were ever supported there, the branch would need more: `sync_to_latest_commit()` would reach `reload_for_write()`, whose `assert!(!has_committed_pages_buffered())` is precisely what a pending non-durable commit violates.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all --all-targets --all-features` with `RUSTFLAGS=--deny warnings`
- `cargo test --all --all-features` -- 570 tests across 25 binaries, 0 failures
- `cargo check` under default features, `experimental-api-5`, and `experimental-multiprocess`, since the lent argument sits behind the feature cfg

No `CHANGELOG.md` entry, as there is no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qy3Dih4QKoKh59qcqxj5r

---
_Generated by [Claude Code](https://claude.ai/code/session_015qy3Dih4QKoKh59qcqxj5r)_