### PR TITLE
Report a failed release of the active transaction byte

### DIFF
--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -14,6 +14,8 @@ use core::mem;
 use core::mem::size_of;
 #[cfg(feature = "logging")]
 use log::debug;
+#[cfg(all(feature = "logging", feature = "experimental-multiprocess"))]
+use log::error;
 
 #[derive(Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub(crate) struct TransactionId(u64);
@@ -166,13 +168,26 @@ impl State {
         id: TransactionId,
     ) {
         self.decrement_reference_count(id);
-        // Failing to release only leaves a peer reclaiming less than it could
         #[cfg(feature = "experimental-multiprocess")]
         if self.active_transaction_lock_references(id) == 0 {
-            let _ = mem.unlock_mp_transaction(id);
+            Self::release_active_transaction_lock(mem, id);
         }
         #[cfg(not(feature = "experimental-multiprocess"))]
         let _ = mem;
+    }
+
+    #[cfg(feature = "experimental-multiprocess")]
+    fn release_active_transaction_lock(mem: &TransactionalMemory, id: TransactionId) {
+        if let Err(failure) = mem.unlock_mp_transaction(id) {
+            #[cfg(feature = "logging")]
+            error!(
+                "Failed to release a finished read transaction: {failure}. Until this database is \
+                 closed, no process sharing it can reclaim space from data overwritten or deleted \
+                 after this point, so the file may grow"
+            );
+            #[cfg(not(feature = "logging"))]
+            let _ = failure;
+        }
     }
 
     // A persistent savepoint's reference, which takes no byte. See `persistent_savepoint_references`
@@ -200,7 +215,7 @@ impl State {
         *self.persistent_savepoint_references.entry(id).or_insert(0) += 1;
         #[cfg(feature = "experimental-multiprocess")]
         if self.active_transaction_lock_references(id) == 0 {
-            let _ = mem.unlock_mp_transaction(id);
+            Self::release_active_transaction_lock(mem, id);
         }
         #[cfg(not(feature = "experimental-multiprocess"))]
         let _ = mem;


### PR DESCRIPTION
The byte a read transaction holds is released as its last reference goes away. A failure was dropped on the floor:

```rust
// Failing to release only leaves a peer reclaiming less than it could
if self.active_transaction_lock_references(id) == 0 {
    let _ = mem.unlock_mp_transaction(id);
}
```

That comment understates it. The byte stays held for the life of the handle, and it is how every other process learns how far back this one is still reading. So a failed release stops the **whole cohort** from reclaiming past that transaction, for as long as the handle is open -- not one peer, and not briefly.

The callers are drop paths (`TransactionGuard::drop`, savepoint teardown), with nothing to return an error to and no way to undo the failure. So it stays best-effort, but it is now reported instead of discarded:

> Failed to release a finished read transaction: {failure}. Until this database is closed, no process sharing it can reclaim space from data overwritten or deleted after this point, so the file may grow

`persistent_savepoint()` releases the byte on the same condition, so both releases go through one `release_active_transaction_lock()` rather than the message being mirrored in two places.

## Notes

- The `error` import is gated on `all(logging, experimental-multiprocess)`, and the binding is consumed by a `let _` when `logging` is off, so neither becomes an unused-item warning under `RUSTFLAGS=--deny warnings`.
- The binding is named `failure` rather than `error`, so it does not read like the `error!` macro beside it, and so it is not an underscore-prefixed binding used in a format string (`clippy::used_underscore_binding`, denied via `clippy::pedantic` in `lib.rs`).
- No `CHANGELOG.md` entry: no behaviour change, only a log line on a path that should never be taken.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all --all-targets --all-features` with `RUSTFLAGS=--deny warnings`
- `cargo clippy --tests` under `--all-features` and under `experimental-multiprocess` alone, since the `logging`-off build is the one that needs the `let _`
- `cargo test --all --all-features` -- 25 test binaries, 0 failures
- `cargo check` under default, `experimental-api-5`, `experimental-multiprocess`, `logging`, and `logging,experimental-multiprocess`, since the change is gated on two features independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qy3Dih4QKoKh59qcqxj5r