### PR TITLE
Discard a buffered write that a direct write supersedes

### DIFF
--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -600,6 +600,7 @@ impl PagedCachedFile {
     #[cfg(feature = "experimental-multiprocess")]
     pub(super) fn write_direct(&self, offset: u64, data: &[u8]) -> Result<()> {
         self.invalidate_cache(offset, data.len());
+        self.cancel_pending_write(offset, data.len());
         self.file.write(offset, data)
     }
 
@@ -1141,6 +1142,25 @@ mod test {
         );
         cached_file.flush().unwrap();
         assert_eq!(writes.load(Ordering::SeqCst), 0);
+    }
+
+    // A direct write is the file's content from the moment it returns, so a buffered write of the
+    // same range must not reach the file after it.
+    #[test]
+    #[cfg(feature = "experimental-multiprocess")]
+    fn write_direct_supersedes_a_buffered_write() {
+        let (backend, _writes) = CountingBackend::new(1024);
+        let cached_file = PagedCachedFile::new(LocklessBackend::boxed(backend), 128, 1024);
+
+        let mut page = cached_file.write(0, 128, true).unwrap();
+        page.mem_mut().fill(0xAA);
+        drop(page);
+        cached_file.write_barrier();
+
+        cached_file.write_direct(0, &[0xBB; 128]).unwrap();
+        cached_file.flush().unwrap();
+
+        assert_eq!(cached_file.read_direct(0, 128).unwrap(), vec![0xBB; 128]);
     }
 
     // Pages retained by a non-durable commit must not hold the read cache below its share: they


### PR DESCRIPTION
`write_direct()` puts its bytes on the file rather than in the write buffer, so that the header reaches the file while the header lock is held. It dropped the read cache's copy of the range but left the write buffer's, which the next flush would then write over the top of it.

```rust
self.invalidate_cache(offset, data.len());
self.cancel_pending_write(offset, data.len());   // added
self.file.write(offset, data)
```

That pairing is the one `free()` already uses for a page it releases (`page_manager.rs`).

## Reachability

Nothing reaches this today. The only `write_direct()` caller is the multi-process header write at offset 0, and the only buffered writes at that offset are the ones an open makes, each flushed before the open returns. But nothing enforces that, and the failure mode is a silently clobbered header.

## Testing

`write_direct_supersedes_a_buffered_write` buffers a write over the same range, does a direct write, then flushes. Verified in both directions:

- with the fix, the file holds the direct write (`0xBB`)
- with the `cancel_pending_write` line removed, it fails with the buffered page (`0xAA`) back on the file

Also run:

- `cargo fmt --all -- --check`
- `cargo clippy --all --all-targets --all-features` with `RUSTFLAGS=--deny warnings`
- `cargo test --all --all-features` -- 25 test binaries, 0 failures

## Not included

The original note on this code also mentioned `invalidate_cache()`'s `assert_eq!(len, removed.len())` firing on a length mismatch. That needs something to populate the read cache at offset 0, and nothing does -- the header is always read through `read_direct()`. Loosening the assert would weaken a real invariant check used on the page paths, so it is left alone.

No `CHANGELOG.md` entry: no reachable behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qy3Dih4QKoKh59qcqxj5r

---
_Generated by [Claude Code](https://claude.ai/code/session_015qy3Dih4QKoKh59qcqxj5r)_