### PR TITLE
Subtract the savepoint references from the reads with a check

### DIFF
--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -127,12 +127,15 @@ impl State {
     // other processes. Persistent savepoints are excluded
     #[cfg(feature = "experimental-multiprocess")]
     fn active_transaction_lock_references(&self, id: TransactionId) -> u64 {
-        self.live_read_transactions.get(&id).copied().unwrap_or(0)
-            - self
-                .persistent_savepoint_references
-                .get(&id)
-                .copied()
-                .unwrap_or(0)
+        let references = self.live_read_transactions.get(&id).copied().unwrap_or(0);
+        let savepoints = self
+            .persistent_savepoint_references
+            .get(&id)
+            .copied()
+            .unwrap_or(0);
+        references
+            .checked_sub(savepoints)
+            .expect("persistent savepoint references exceed the reads they are a subset of")
     }
 
     // Takes the "active transaction byte" as the first read of `id` appears, and releases it


### PR DESCRIPTION
`active_transaction_lock_references()` is the count of references to a transaction that are *reads* -- the ones the "active transaction byte" announces to the other processes -- which is every reference minus the ones a persistent savepoint holds, since those take no byte.

The savepoint references are a subset of the reads, so the subtraction cannot go negative. But it is unsigned, and release builds compile with `overflow-checks = false`, so a broken invariant would wrap rather than stop.

That matters because both callers compare the result against a specific value:

- `add_active_transaction_lock_reference()` takes the byte when the count is `1`
- `remove_active_transaction_lock_reference()` releases it when the count is `0`

A wrapped count is neither, so the byte would be neither taken as the first read appears nor released as the last goes away -- a reader announcing nothing to its peers, or a transaction pinned for the life of the handle. Both are silent, and neither points back at the count.

`checked_sub` makes the invariant fail where it breaks.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all --all-targets --all-features` with `RUSTFLAGS=--deny warnings`
- `cargo test --all --all-features` -- 25 test binaries, 0 failures
- `cargo check` under default features and `experimental-multiprocess`

No `CHANGELOG.md` entry: no behaviour change unless an invariant is already broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qy3Dih4QKoKh59qcqxj5r

---
_Generated by [Claude Code](https://claude.ai/code/session_015qy3Dih4QKoKh59qcqxj5r)_