### PR TITLE
Rename the concurrency modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,17 +33,17 @@
   alone, rather than also with the whole-file lock earlier versions take.
 * Add the `experimental-multiprocess` feature flag, under which `Builder::set_concurrency_mode()`
   takes a `ConcurrencyMode` configuring how processes may share the database.
-  When `SingleWriterProcess` or `MultiWriterProcess` is configured, commits are always 2-phase,
+  When `SingleWriter` or `MultiWriter` is configured, commits are always 2-phase,
   `Durability::None` is refused, and the database may be opened read-only while another process has
   it open for writing; each new read transaction then sees that process's durable commits, and
   `Database::compact()` treats a read transaction in another process as a transaction in progress.
-  In `MultiWriterProcess`, every commit records the allocator state, for the next writer to load;
+  In `MultiWriter`, every commit records the allocator state, for the next writer to load;
   compaction's own commits are the exception, and `Database::compact()` ends with one that does.
   Ephemeral savepoints are refused there, with `SavepointError::EphemeralSavepointUnsupported`,
   and a write transaction begins from the file as another process last committed it, as do the
   close and `Database::check_integrity()`, which waits for a write transaction in another process
   to end.
-* In `MultiWriterProcess`, existing handles recover automatically after another process exits
+* In `MultiWriter`, existing handles recover automatically after another process exits
   during compaction or repair. They can resume writing without reopening the database.
 
 ### redb-derive (unreleased)

--- a/docs/design.md
+++ b/docs/design.md
@@ -478,25 +478,26 @@ b) it is not referenced, in which case it is in the pending free state and is co
 # Multi-process concurrency
 
 The following concurrency modes are supported, and their locking protocol is described below:
-* Immutable
-* Single process
-* Multi-process with a single writer process
-* Multi-process with multiple writer processes
+* Exclusive writer
+* Single writer
+* Multi-writer
 
-Platforms that do not have file range locks only support Immutable and Single process modes, via
-shared and exclusive whole file locks, respectively.
+The mode names the regime a writer operates under; whether a given handle writes is chosen when it
+is opened, not by the mode. Platforms that do not have file range locks only support the exclusive
+writer mode, via a whole file lock: exclusive for a writer, shared for read-only handles.
 
-## Immutable
+## Exclusive writer
 
-In this mode, multiple processes may open the database. Each takes a shared lock on the "immutable byte"
-and the rest of the database file, except for the "shared writer byte" and the backend-reserved bytes.
+A writer takes an exclusive lock on the entire database file except for the backend-reserved bytes,
+so no other process may open the database while it is open.
 
-## Single process
+A read-only handle takes a shared lock on the same range, except for the "shared writer byte", which
+is left free so that the check described below can find a multi-writer process holding it. Any number
+of read-only handles may share the file, and each excludes a writer in any mode. Since nothing may
+write the file while they hold it, they perform none of the header synchronization, cache
+invalidation or active transaction bookkeeping the other modes require.
 
-In this mode, only a single process may open the database. The process takes an exclusive lock on
-the entire database file except for the backend-reserved bytes.
-
-## Multi-process with a single writer process
+## Single writer
 
 A single process may open the database for writing, and multiple other processes may open the database
 read-only.
@@ -508,7 +509,7 @@ and synchronization protocols described below.
 Reading processes must participate in the cache invalidation and synchronization protocols described below,
 and must hold a shared lock on the "shared reader byte" while the database is open.
 
-## Multi-process with multiple writer processes
+## Multi-writer
 
 Multiple processes may open the database read-write.
 
@@ -540,7 +541,7 @@ The multi-process concurrency modes rely on file range locks and define the foll
 | `BASE`                    | writer byte                       |
 | `BASE + 1`                | shared writer byte                |
 | `BASE + 2`                | shared reader byte                |
-| `BASE + 3`                | immutable byte                    |
+| `BASE + 3`                | whole-file reader byte            |
 | `BASE + 4`                | consistent byte                   |
 | `BASE + 5..BASE + 896`     | reserved for the core             |
 | `BASE + 896..BASE + 1024`  | reserved for backend locking      |
@@ -559,18 +560,20 @@ multi-writer mode -- holds an exclusive lock on this byte until it is done writi
 
 The lock status of this byte is used to determine whether the database is open for a single writer
 or multiple writers.
-After locking this byte, the "immutable byte" must be checked, since that mode is incompatible.
+After locking this byte shared, a multi-writer open must check the "whole-file reader byte", since
+read-only exclusive-writer handles leave this byte free. A single-writer open needs no such check:
+its exclusive lock on the "writer byte" already fails under such a handle.
 
 ### "shared reader byte"
 
 Read-only multi-process databases must hold a shared lock on this byte while they are open. This
 prevents a non-multi-process writer from opening the database.
 
-### "immutable byte"
+### "whole-file reader byte"
 
-Processes hold a shared lock on this byte when the database is open in Immutable mode.
-After locking this byte, they must check if the "shared writer byte" is locked -- which would
-indicate an idle writer (if the "writer byte" is unlocked).
+Read-only handles in exclusive-writer mode hold a shared lock on this byte, as part of their
+whole-file lock. After taking it, they must check whether the "shared writer byte" is locked --
+which would indicate a multi-writer process, idle if the "writer byte" is unlocked.
 
 ### "consistent byte"
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -67,10 +67,10 @@ use log::{debug, warn};
 /// Backends that support locking must support one of the following levels:
 /// 1) All representable ranges requested by redb are supported. All concurrency modes will work.
 /// 2) Only whole-storage locks (`Unbounded, Unbounded` or `Included(0), Unbounded`) are
-///    supported. Other ranges return [`BackendError::Unsupported`]. Only single-process
-///    concurrency modes will work.
-/// 3) All inputs return [`BackendError::Unsupported`]. Only single-process concurrency modes
-///    will work, and redb will log a warning on open if logging is enabled.
+///    supported. Other ranges return [`BackendError::Unsupported`]. Only the `ExclusiveWriter`
+///    concurrency mode will work.
+/// 3) All inputs return [`BackendError::Unsupported`]. Only the `ExclusiveWriter` concurrency
+///    mode will work, and redb will log a warning on open if logging is enabled.
 pub trait StorageBackend: 'static + Debug + Send + Sync {
     /// Gets the current length of the storage.
     fn len(&self) -> core::result::Result<u64, io::Error>;
@@ -190,11 +190,14 @@ pub(crate) const WRITER_BYTE: u64 = LOCK_BASE;
 #[cfg_attr(not(any(windows, unix, target_os = "wasi")), allow(dead_code))]
 pub(crate) const SHARED_WRITER_BYTE: u64 = LOCK_BASE + 1;
 /// Held shared by every read-only multi-process handle while the database is open, so that a
-/// single-process open conflicts with a live reader no matter what the reader is doing.
+/// exclusive-writer open conflicts with a live reader no matter what the reader is doing.
 #[cfg(feature = "experimental-multiprocess")]
 pub(crate) const SHARED_READER_BYTE: u64 = LOCK_BASE + 2;
+/// Held shared by a read-only exclusive-writer handle as part of its whole-file lock. Such a
+/// handle leaves `SHARED_WRITER_BYTE` free, so a multi-writer open, which takes only that byte,
+/// must probe this one to find it.
 #[cfg(feature = "experimental-multiprocess")]
-pub(crate) const IMMUTABLE_READER_BYTE: u64 = LOCK_BASE + 3;
+pub(crate) const WHOLE_FILE_READER_BYTE: u64 = LOCK_BASE + 3;
 /// Held shared by a writing process from the moment its open is complete -- past recovery and
 /// the allocator load -- until it closes: the file is consistent, and the recovery flag, set from
 /// here on, means only that a writer is live. `SHARED_WRITER_BYTE` is taken before recovery, so
@@ -605,7 +608,7 @@ pub trait ReadableDatabase: SealedInApi5 {
 #[cfg_attr(
     feature = "experimental-multiprocess",
     doc = "",
-    doc = "The multi-process concurrency modes are the exception: a reader shares the file with the writer and follows its commits. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
+    doc = "`SingleWriter` and `MultiWriter` are the exception: a reader shares the file with the writer and follows its commits. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
 )]
 ///
 /// # Examples
@@ -972,7 +975,7 @@ impl Database {
         #[cfg(feature = "experimental-multiprocess")]
         if peer_committed
             && allocator_hash.is_none()
-            && self.mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess
+            && self.mem.concurrency_mode() == ConcurrencyMode::MultiWriter
         {
             was_clean = false;
         }
@@ -1026,7 +1029,7 @@ impl Database {
         // In multi-writer mode a repair ends with a commit recording the allocator state, as the
         // open's does; after the savepoints are held, since a commit frees what nothing pins
         #[cfg(feature = "experimental-multiprocess")]
-        if !was_clean && self.mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess {
+        if !was_clean && self.mem.concurrency_mode() == ConcurrencyMode::MultiWriter {
             ensure_allocator_state_table_and_trim(
                 &self.transaction_tracker,
                 &self.mem,
@@ -1133,7 +1136,7 @@ impl Database {
         // them again. Refresh before reporting one as a blocker, unless this process already has
         // a write transaction live, since beginning another would block on it.
         #[cfg(feature = "experimental-multiprocess")]
-        if self.mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess
+        if self.mem.concurrency_mode() == ConcurrencyMode::MultiWriter
             && self.transaction_tracker.any_persistent_savepoint_exists()
             && !self.transaction_tracker.write_transaction_live()
         {
@@ -1258,7 +1261,7 @@ impl Database {
         // file one record larger, the pages of the one it replaces being freed only by the next
         // commit
         #[cfg(feature = "experimental-multiprocess")]
-        if self.mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess {
+        if self.mem.concurrency_mode() == ConcurrencyMode::MultiWriter {
             ensure_allocator_state_table_and_trim(
                 &self.transaction_tracker,
                 &self.mem,
@@ -1684,7 +1687,7 @@ impl Database {
         // In multi-writer mode a repair ends with a commit recording the allocator state, as
         // compaction and the integrity check do, so that the next open, in any process, loads it
         #[cfg(feature = "experimental-multiprocess")]
-        if repaired && concurrency_mode == ConcurrencyMode::MultiWriterProcess {
+        if repaired && concurrency_mode == ConcurrencyMode::MultiWriter {
             ensure_allocator_state_table_and_trim(
                 &transaction_tracker,
                 &mem,
@@ -1821,7 +1824,7 @@ fn sync_to_latest_commit(
     writer_lock: &WriterLock,
     header_lock: Option<&HeaderGuard<'_>>,
 ) -> Result<Option<AllocatorStateLatch>> {
-    if mem.concurrency_mode() != ConcurrencyMode::MultiWriterProcess {
+    if mem.concurrency_mode() != ConcurrencyMode::MultiWriter {
         return Ok(None);
     }
     let synced = {
@@ -2053,28 +2056,30 @@ impl RepairSession {
     }
 }
 
-/// The sharing mode between processes accessing the database
+/// How processes share a database: the regime a writer operates under. Whether a given handle
+/// writes is chosen by `open()` against `open_read_only()`, not by the mode.
 ///
 /// Every process opening one database concurrently must use a compatible mode: one
-/// `SingleWriterProcess` writer or any number of `MultiWriterProcess` writers, plus read-only
-/// handles in either case. The multi-process modes need byte-range file locks, so they are
-/// supported on Linux, the Apple platforms and Windows; elsewhere, opening a database in one of
-/// them fails.
+/// `SingleWriter` writer or any number of `MultiWriter` writers, plus read-only handles in either
+/// case. Those two modes need byte-range file locks, so they are supported on Linux, the Apple
+/// platforms and Windows; elsewhere, opening a database in one of them fails. `ExclusiveWriter`
+/// locks the whole file and works everywhere.
 #[cfg_attr(
     not(feature = "experimental-multiprocess"),
     allow(dead_code, unreachable_pub, clippy::enum_variant_names)
 )]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
 pub enum ConcurrencyMode {
-    /// The database is not shared: one process may open it for writing, or several read-only.
-    /// Enforced by locking the whole file. The default.
+    /// A writer excludes every other process; read-only handles share the file with each other
+    /// and exclude any writer. Enforced by locking the whole file. The default.
     #[default]
-    SingleProcess,
-    /// One process writes; any number of processes may, concurrently, open the database read-only.
-    SingleWriterProcess,
-    /// Any number of processes may, concurrently open the database for reading and writing.
+    ExclusiveWriter,
+    /// One process writes; any number of processes may, concurrently, open the database read-only
+    /// and follow its commits.
+    SingleWriter,
+    /// Any number of processes may, concurrently, open the database for reading and writing.
     /// Only one write transaction may be open at a time.
-    MultiWriterProcess,
+    MultiWriter,
 }
 
 #[cfg(feature = "experimental-multiprocess")]
@@ -2082,7 +2087,7 @@ impl ConcurrencyMode {
     /// Whether another process may have the database open, concurrently, and one process
     /// (possibly this one) is a writer
     pub(crate) fn is_multi_process_writable(self) -> bool {
-        !matches!(self, ConcurrencyMode::SingleProcess)
+        !matches!(self, ConcurrencyMode::ExclusiveWriter)
     }
 }
 
@@ -2109,7 +2114,7 @@ impl Builder {
             // It is part of the file format, so can be enabled in the future.
             page_size: PAGE_SIZE,
             region_size: None,
-            concurrency_mode: ConcurrencyMode::SingleProcess,
+            concurrency_mode: ConcurrencyMode::ExclusiveWriter,
             cache_size: 1024 * 1024 * 1024,
             repair_callback: Box::new(|_| {}),
         }
@@ -2150,7 +2155,7 @@ impl Builder {
         self
     }
 
-    /// Set how processes may share this database. Defaults to [`ConcurrencyMode::SingleProcess`].
+    /// Set how processes may share this database. Defaults to [`ConcurrencyMode::ExclusiveWriter`].
     #[cfg(feature = "experimental-multiprocess")]
     pub fn set_concurrency_mode(&mut self, mode: ConcurrencyMode) -> &mut Self {
         self.concurrency_mode = mode;
@@ -2212,7 +2217,7 @@ impl Builder {
     #[cfg_attr(
         feature = "experimental-multiprocess",
         doc = "",
-        doc = "Only a single-process writer is refused: in the multi-process concurrency modes a reader opened in the same mode as the writer shares the file with it and picks up its commits. See [`Self::set_concurrency_mode`]."
+        doc = "Only an `ExclusiveWriter` writer is refused: in `SingleWriter` and `MultiWriter` a reader opened in the same mode as the writer shares the file with it and picks up its commits. See [`Self::set_concurrency_mode`]."
     )]
     #[cfg(not(redb_no_std))]
     pub fn open_read_only(
@@ -2790,7 +2795,7 @@ mod writer_byte_test {
     /// no live writer holds
     fn left_unclean(path: &Path) -> bool {
         let mut builder = Database::builder();
-        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
         match builder.open_read_only(path) {
             Err(super::DatabaseError::RepairAborted) => true,
             Err(err) => panic!("{err}"),
@@ -2804,7 +2809,7 @@ mod writer_byte_test {
     fn the_shutdown_header_is_written_under_the_writer_byte_or_not_at_all() {
         // The memory's close alone, without the database's, which would write the header itself
         fn close(path: &Path, under_the_byte: bool) {
-            let db = create(path, ConcurrencyMode::MultiWriterProcess);
+            let db = create(path, ConcurrencyMode::MultiWriter);
             commit_one(&db);
             let mem = db.mem.clone();
             std::mem::forget(db);
@@ -2835,7 +2840,7 @@ mod writer_byte_test {
     #[test]
     fn a_close_leaves_a_clean_file() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         commit_one(&db);
         drop(db);
         assert!(
@@ -2849,7 +2854,7 @@ mod writer_byte_test {
     #[test]
     fn a_multi_writer_repair_records_the_allocator_state() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         assert!(
             Database::get_allocator_state_table(&db.mem)
                 .unwrap()
@@ -2866,7 +2871,7 @@ mod writer_byte_test {
         let tmpfile = crate::create_tempfile();
         let mut builder = Database::builder();
         builder
-            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .set_concurrency_mode(ConcurrencyMode::MultiWriter)
             .set_cache_size(0);
         let db = builder.create(tmpfile.path()).unwrap();
         commit_one(&db);
@@ -2922,7 +2927,7 @@ mod writer_byte_test {
         const CHILD_PATH: &str = "REDB_TEST_INTERRUPTED_COMPACTION_PATH";
         let mut builder = Database::builder();
         builder
-            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .set_concurrency_mode(ConcurrencyMode::MultiWriter)
             .set_cache_size(0);
         if let Some(path) = std::env::var_os(CHILD_PATH) {
             let db = builder.open(path).unwrap();
@@ -2991,8 +2996,8 @@ mod writer_byte_test {
 
         for corrupt_checksum in [true, false] {
             let tmpfile = crate::create_tempfile();
-            let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
-            let peer = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+            let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
+            let peer = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
             commit_one(&peer);
             let writer = peer.mem.lock_writer().unwrap();
             let mut root = peer.mem.get_data_root().unwrap();
@@ -3032,9 +3037,9 @@ mod writer_byte_test {
     #[test]
     fn syncing_to_a_peers_commit_releases_the_repair_a_panic_latched() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let mut builder = Database::builder();
-        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
         let peer = builder.open(tmpfile.path()).unwrap();
         let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let write = db.begin_write().unwrap();
@@ -3059,9 +3064,9 @@ mod writer_byte_test {
     #[test]
     fn a_transaction_releases_the_repair_a_panic_latched_without_a_peers_commit() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let mut builder = Database::builder();
-        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
         let peer = builder.open(tmpfile.path()).unwrap();
         let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let write = db.begin_write().unwrap();
@@ -3092,10 +3097,7 @@ mod writer_byte_test {
 
         // What the create will have produced by the time it releases the lock
         let initialized = crate::create_tempfile();
-        drop(create(
-            initialized.path(),
-            ConcurrencyMode::MultiWriterProcess,
-        ));
+        drop(create(initialized.path(), ConcurrencyMode::MultiWriter));
         let mut bytes = Vec::new();
         File::open(initialized.path())
             .unwrap()
@@ -3111,7 +3113,7 @@ mod writer_byte_test {
         let (opened, opens) = mpsc::channel();
         let opening = thread::spawn(move || {
             let mut builder = Database::builder();
-            builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+            builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
             let result = builder.open(&path);
             opened.send(()).unwrap();
             result
@@ -3148,7 +3150,7 @@ mod writer_byte_test {
         use std::time::Duration;
 
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         // A commit recording nothing leaves the file for the next open to repair. The handle
         // stays open, since its close would record
         let mut write = db.begin_write().unwrap();
@@ -3162,7 +3164,7 @@ mod writer_byte_test {
         let (repairing, repairs) = mpsc::channel();
         let opening = thread::spawn(move || {
             let mut builder = Database::builder();
-            builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+            builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
             builder.set_repair_callback(move |_| {
                 let _ = repairing.send(());
             });
@@ -3189,7 +3191,7 @@ mod writer_byte_test {
         use std::time::Duration;
 
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let mut write = db.begin_write().unwrap();
         write.skip_allocator_state_record();
         write.open_table(TABLE).unwrap().insert(1, 1).unwrap();
@@ -3203,7 +3205,7 @@ mod writer_byte_test {
         let (opened, opens) = mpsc::channel();
         let opening = thread::spawn(move || {
             let mut builder = Database::builder();
-            builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+            builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
             builder.set_repair_callback(move |_| {
                 let _ = repairing.send(());
             });
@@ -3242,7 +3244,7 @@ mod writer_byte_test {
     #[test]
     fn a_multi_writer_compaction_records_the_allocator_state() {
         let tmpfile = crate::create_tempfile();
-        let mut db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let mut db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         commit_one(&db);
 
         db.compact().unwrap();
@@ -3257,7 +3259,7 @@ mod writer_byte_test {
     #[test]
     fn a_multi_writer_transaction_holds_the_byte_and_gives_it_back() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let probe = probe(tmpfile.path());
 
         let write = db.begin_write().unwrap();
@@ -3280,7 +3282,7 @@ mod writer_byte_test {
     #[test]
     fn a_single_writer_open_holds_the_byte_for_its_lifetime() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::SingleWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::SingleWriter);
         let probe = probe(tmpfile.path());
 
         assert!(
@@ -3306,7 +3308,7 @@ mod writer_byte_test {
     #[test]
     fn a_transaction_outliving_the_database_keeps_the_writer_lock() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::SingleWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::SingleWriter);
         let probe = probe(tmpfile.path());
 
         let write = db.begin_write().unwrap();
@@ -3432,10 +3434,7 @@ mod consistent_byte_test {
 
     #[test]
     fn a_shared_writable_open_asserts_consistency_until_it_closes() {
-        for mode in [
-            ConcurrencyMode::SingleWriterProcess,
-            ConcurrencyMode::MultiWriterProcess,
-        ] {
+        for mode in [ConcurrencyMode::SingleWriter, ConcurrencyMode::MultiWriter] {
             let tmpfile = crate::create_tempfile();
             let db = builder(mode).create(tmpfile.path()).unwrap();
             let probe = probe(tmpfile.path());
@@ -3460,7 +3459,7 @@ mod consistent_byte_test {
         let db = {
             let probe = probe.clone();
             let during = during.clone();
-            let mut builder = builder(ConcurrencyMode::MultiWriterProcess);
+            let mut builder = builder(ConcurrencyMode::MultiWriter);
             builder.set_repair_callback(move |_| {
                 let mut during = during.lock().unwrap();
                 if during.is_none() {
@@ -3523,8 +3522,8 @@ mod active_transaction_test {
     }
 
     /// Probed exclusively, since the byte is held shared and another process may hold the same
-    /// one. Reports the whole-file lock a single-process open holds as well, which is what
-    /// `a_single_process_read_does_not_puncture_the_whole_file_lock` relies on
+    /// one. Reports the whole-file lock a exclusive-writer open holds as well, which is what
+    /// `an_exclusive_writer_read_does_not_puncture_the_whole_file_lock` relies on
     fn is_held(probe: &File, id: u64) -> bool {
         let free = probe.try_lock_range(byte_range(TXN_BASE + id)).unwrap();
         if free {
@@ -3540,7 +3539,7 @@ mod active_transaction_test {
     #[test]
     fn a_read_transaction_locks_the_id_it_reads_until_it_ends() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let probe = probe(tmpfile.path());
         assert!(held_ids(&probe).is_empty());
 
@@ -3564,7 +3563,7 @@ mod active_transaction_test {
     #[test]
     fn concurrent_readers_of_one_snapshot_share_the_lock() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let probe = probe(tmpfile.path());
 
         let first = db.begin_read().unwrap();
@@ -3585,11 +3584,11 @@ mod active_transaction_test {
         let tmpfile = crate::create_tempfile();
         // Dropped, so the read-only open is the only handle: it takes SHARED_READER_BYTE, and
         // the writer that created the file would otherwise hold the whole storage
-        drop(create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess));
+        drop(create(tmpfile.path(), ConcurrencyMode::MultiWriter));
         let probe = probe(tmpfile.path());
 
         let mut builder = Database::builder();
-        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
         let db = builder.open_read_only(tmpfile.path()).unwrap();
         let read = db.begin_read().unwrap();
         assert_eq!(
@@ -3608,10 +3607,7 @@ mod active_transaction_test {
         use super::{ReadTransaction, TransactionGuard};
         use crate::ReadableTable;
 
-        for mode in [
-            ConcurrencyMode::SingleWriterProcess,
-            ConcurrencyMode::MultiWriterProcess,
-        ] {
+        for mode in [ConcurrencyMode::SingleWriter, ConcurrencyMode::MultiWriter] {
             let tmpfile = crate::create_tempfile();
             let writer = create(tmpfile.path(), mode);
             let db = Database::builder()
@@ -3659,10 +3655,7 @@ mod active_transaction_test {
         use super::TransactionGuard;
         use crate::ReadableTable;
 
-        for mode in [
-            ConcurrencyMode::SingleWriterProcess,
-            ConcurrencyMode::MultiWriterProcess,
-        ] {
+        for mode in [ConcurrencyMode::SingleWriter, ConcurrencyMode::MultiWriter] {
             let tmpfile = crate::create_tempfile();
             let writer = create(tmpfile.path(), mode);
             let db = Database::builder()
@@ -3737,7 +3730,7 @@ mod active_transaction_test {
     #[test]
     fn an_ephemeral_savepoint_locks_the_snapshot_it_references() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::SingleWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::SingleWriter);
         let probe = probe(tmpfile.path());
         assert!(held_ids(&probe).is_empty());
 
@@ -3764,7 +3757,7 @@ mod active_transaction_test {
     #[test]
     fn a_persistent_savepoint_takes_no_active_transaction_byte() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let probe = probe(tmpfile.path());
 
         // Nothing else references the savepoint's transaction, so the byte is the savepoint's to
@@ -3805,7 +3798,7 @@ mod active_transaction_test {
     #[test]
     fn a_synced_persistent_savepoint_takes_no_active_transaction_byte() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let write = db.begin_write().unwrap();
         write.persistent_savepoint().unwrap();
         write.commit().unwrap();
@@ -3817,7 +3810,7 @@ mod active_transaction_test {
             "the closed database left a lock"
         );
 
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         assert!(
             held_ids(&probe).is_empty(),
             "the open locked {:?} for the file's savepoint",
@@ -3839,7 +3832,7 @@ mod active_transaction_test {
     #[test]
     fn a_shared_mode_refuses_durability_none() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::SingleWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::SingleWriter);
 
         let mut write = db.begin_write().unwrap();
         assert!(matches!(
@@ -3853,7 +3846,7 @@ mod active_transaction_test {
     #[test]
     fn a_multi_writer_commit_records_the_allocator_state_regardless() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
 
         let mut write = db.begin_write().unwrap();
         write.set_quick_repair(false);
@@ -3871,7 +3864,7 @@ mod active_transaction_test {
     #[test]
     fn a_multi_writer_mode_refuses_an_ephemeral_savepoint() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
 
         let write = db.begin_write().unwrap();
         assert!(matches!(
@@ -3887,9 +3880,9 @@ mod active_transaction_test {
     #[test]
     fn an_integrity_check_records_a_peers_unrecorded_commit() {
         let tmpfile = crate::create_tempfile();
-        let mut db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let mut db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let peer = Database::builder()
-            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .set_concurrency_mode(ConcurrencyMode::MultiWriter)
             .open(tmpfile.path())
             .unwrap();
         // A commit recording no allocator state, as a repair's does. The peer stays open, since
@@ -3911,7 +3904,7 @@ mod active_transaction_test {
     #[test]
     fn a_write_transaction_releases_the_writer_byte_and_slot() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let probe = probe(tmpfile.path());
 
         let txn = db.begin_write().unwrap();
@@ -3933,9 +3926,9 @@ mod active_transaction_test {
         use crate::tree_store::{AllocationPolicy, PageAllocator, PageTracker};
 
         let tmpfile = crate::create_tempfile();
-        let mut db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let mut db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let peer = Database::builder()
-            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .set_concurrency_mode(ConcurrencyMode::MultiWriter)
             .open(tmpfile.path())
             .unwrap();
         // A page the peer allocates and neither frees nor references: a leak its close's snapshot
@@ -3959,10 +3952,10 @@ mod active_transaction_test {
     #[test]
     fn a_read_only_participant_picks_up_a_peers_commit() {
         let tmpfile = crate::create_tempfile();
-        let writer = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let writer = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
 
         let mut builder = Database::builder();
-        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
         let reader = builder.open_read_only(tmpfile.path()).unwrap();
         let probe = probe(tmpfile.path());
 
@@ -4003,10 +3996,10 @@ mod active_transaction_test {
         use std::io::{Read, Write};
 
         let tmpfile = crate::create_tempfile();
-        drop(create(tmpfile.path(), ConcurrencyMode::SingleProcess));
+        drop(create(tmpfile.path(), ConcurrencyMode::ExclusiveWriter));
 
         let mut builder = Database::builder();
-        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
         let reader = builder.open_read_only(tmpfile.path()).unwrap();
 
         // A newer commit whose pages this file never received: made in a copy, then its slot
@@ -4064,7 +4057,7 @@ mod active_transaction_test {
     #[test]
     fn a_shared_commit_is_two_phase() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
 
         let mut write = db.begin_write().unwrap();
         write.set_two_phase_commit(false);
@@ -4086,7 +4079,7 @@ mod active_transaction_test {
         use std::io::{Read, Seek, SeekFrom, Write};
 
         let tmpfile = crate::create_tempfile();
-        drop(create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess));
+        drop(create(tmpfile.path(), ConcurrencyMode::MultiWriter));
 
         // The god byte's recovery-required bit, which a clean shutdown clears
         {
@@ -4104,19 +4097,19 @@ mod active_transaction_test {
         }
 
         let mut builder = Database::builder();
-        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
         assert!(matches!(
             builder.open_read_only(tmpfile.path()),
             Err(crate::DatabaseError::RepairAborted)
         ));
     }
 
-    /// A single-process open holds the whole file, which covers these bytes. Locking one and
+    /// A exclusive-writer open holds the whole file, which covers these bytes. Locking one and
     /// releasing it would punch a hole in that lock, so this mode locks nothing
     #[test]
-    fn a_single_process_read_does_not_puncture_the_whole_file_lock() {
+    fn an_exclusive_writer_read_does_not_puncture_the_whole_file_lock() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::SingleProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::ExclusiveWriter);
         let probe = probe(tmpfile.path());
 
         drop(db.begin_read().unwrap());
@@ -4132,10 +4125,7 @@ mod active_transaction_test {
     /// only matters below the former, which is where the scan looks
     #[test]
     fn the_oldest_active_transaction_is_the_lower_of_ours_and_a_peers() {
-        for mode in [
-            ConcurrencyMode::SingleWriterProcess,
-            ConcurrencyMode::MultiWriterProcess,
-        ] {
+        for mode in [ConcurrencyMode::SingleWriter, ConcurrencyMode::MultiWriter] {
             let tmpfile = crate::create_tempfile();
             let db = create(tmpfile.path(), mode);
             let scan = |local| {
@@ -4180,12 +4170,12 @@ mod active_transaction_test {
 
         fn open(path: &Path) -> Database {
             let mut builder = Database::builder();
-            builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+            builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
             builder.open(path).unwrap()
         }
 
         let tmpfile = crate::create_tempfile();
-        create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let peer = open(tmpfile.path());
         // The handle syncs to the commit under holds it took itself, as compaction does, in a
         // thread, so that taking the header lock again fails rather than hangs
@@ -4229,7 +4219,7 @@ mod active_transaction_test {
     #[test]
     fn a_lent_header_hold_outlives_the_commit() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let probe = probe(tmpfile.path());
 
         let header_lock = db.mem.lock_header_exclusive().unwrap();
@@ -4247,7 +4237,7 @@ mod active_transaction_test {
     #[test]
     fn a_lent_writer_byte_outlives_the_transaction() {
         let tmpfile = crate::create_tempfile();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess);
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
         let probe = probe(tmpfile.path());
 
         let writer_lock = db.mem.lock_writer().unwrap();

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -688,7 +688,7 @@ mod test {
     use super::*;
 
     // The tracker takes the "active transaction byte" through this, so it needs somewhere to
-    // take it. Opened SingleProcess, where that is a no-op
+    // take it. Opened ExclusiveWriter, where that is a no-op
     fn memory() -> TransactionalMemory {
         use crate::tree_store::{InMemoryBackend, PAGE_SIZE};
 
@@ -699,7 +699,7 @@ mod test {
             None,
             0,
             false,
-            crate::db::ConcurrencyMode::SingleProcess,
+            crate::db::ConcurrencyMode::ExclusiveWriter,
         )
         .unwrap();
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -984,7 +984,7 @@ impl WriteTransaction {
             // A multi-writer commit records the allocator state, which `set_quick_repair()`
             // keeps on there
             #[cfg(feature = "experimental-multiprocess")]
-            quick_repair: mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess,
+            quick_repair: mem.concurrency_mode() == ConcurrencyMode::MultiWriter,
             #[cfg(not(feature = "experimental-multiprocess"))]
             quick_repair: false,
             post_commit_free: PostCommitFree::Enabled,
@@ -1309,11 +1309,11 @@ impl WriteTransaction {
     #[cfg_attr(
         feature = "experimental-multiprocess",
         doc = "",
-        doc = "Refused, with [`SavepointError::EphemeralSavepointUnsupported`], in [`ConcurrencyMode::MultiWriterProcess`](crate::ConcurrencyMode::MultiWriterProcess): the savepoint would be known to this process alone, and a persistent savepoint another process creates could take its id. Persistent savepoints are supported. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
+        doc = "Refused, with [`SavepointError::EphemeralSavepointUnsupported`], in [`ConcurrencyMode::MultiWriter`](crate::ConcurrencyMode::MultiWriter): the savepoint would be known to this process alone, and a persistent savepoint another process creates could take its id. Persistent savepoints are supported. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
     )]
     pub fn ephemeral_savepoint(&self) -> Result<Savepoint, SavepointError> {
         #[cfg(feature = "experimental-multiprocess")]
-        if self.mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess {
+        if self.mem.concurrency_mode() == ConcurrencyMode::MultiWriter {
             return Err(SavepointError::EphemeralSavepointUnsupported);
         }
         self.create_savepoint()
@@ -1591,13 +1591,13 @@ impl WriteTransaction {
     #[cfg_attr(
         feature = "experimental-multiprocess",
         doc = "",
-        doc = "Disabling it has no effect in [`ConcurrencyMode::MultiWriterProcess`](crate::ConcurrencyMode::MultiWriterProcess), where every commit saves the allocator state, for the next write transaction, in any process, to load rather than reconstruct. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
+        doc = "Disabling it has no effect in [`ConcurrencyMode::MultiWriter`](crate::ConcurrencyMode::MultiWriter), where every commit saves the allocator state, for the next write transaction, in any process, to load rather than reconstruct. See [`Builder::set_concurrency_mode`](crate::Builder::set_concurrency_mode)."
     )]
     pub fn set_quick_repair(&mut self, enabled: bool) {
         // A multi-writer commit records the allocator state, for the next writer, in any
         // process, to load rather than rebuild from the trees
         #[cfg(feature = "experimental-multiprocess")]
-        if !enabled && self.mem.concurrency_mode() == ConcurrencyMode::MultiWriterProcess {
+        if !enabled && self.mem.concurrency_mode() == ConcurrencyMode::MultiWriter {
             return;
         }
         self.quick_repair = enabled;
@@ -2964,7 +2964,7 @@ mod test {
 
         let tmpfile = crate::create_tempfile();
         let mut builder = Database::builder();
-        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
         let db = builder.create(tmpfile.path()).unwrap();
         let txn = db.begin_write().unwrap();
         let id = txn.persistent_savepoint().unwrap();
@@ -3012,7 +3012,7 @@ mod test {
 
         let tmpfile = crate::create_tempfile();
         let db = Database::builder()
-            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .set_concurrency_mode(ConcurrencyMode::MultiWriter)
             .create(tmpfile.path())
             .unwrap();
         let txn = db.begin_write().unwrap();
@@ -3041,7 +3041,7 @@ mod test {
         let (completed, completion) = mpsc::channel();
         let opening = thread::spawn(move || {
             let result = Database::builder()
-                .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+                .set_concurrency_mode(ConcurrencyMode::MultiWriter)
                 .set_repair_callback(|_| panic!("the allocator snapshot should be valid"))
                 .create_file(file);
             completed.send(result).unwrap();
@@ -3070,7 +3070,7 @@ mod test {
             None,
             0,
             false,
-            ConcurrencyMode::MultiWriterProcess,
+            ConcurrencyMode::MultiWriter,
         )
         .unwrap();
         assert_eq!(

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -1440,7 +1440,7 @@ mod tests {
             None,
             0,
             false,
-            crate::db::ConcurrencyMode::SingleProcess,
+            crate::db::ConcurrencyMode::ExclusiveWriter,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -2297,7 +2297,7 @@ mod tests {
             None,
             0,
             false,
-            crate::db::ConcurrencyMode::SingleProcess,
+            crate::db::ConcurrencyMode::ExclusiveWriter,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/src/tree_store/btree_cursor.rs
+++ b/src/tree_store/btree_cursor.rs
@@ -2465,7 +2465,7 @@ mod tests {
             None,
             0,
             false,
-            crate::db::ConcurrencyMode::SingleProcess,
+            crate::db::ConcurrencyMode::ExclusiveWriter,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -1847,7 +1847,7 @@ mod tests {
             None,
             0,
             false,
-            crate::db::ConcurrencyMode::SingleProcess,
+            crate::db::ConcurrencyMode::ExclusiveWriter,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -84,7 +84,7 @@ impl FileBackend {
         })
     }
 
-    // Best-effort 4.x compatibility: when a single-process open takes its suffix range,
+    // Best-effort 4.x compatibility: when a exclusive-writer open takes its suffix range,
     // also take the flock used by older redb, unless it shares the range-lock namespace.
     #[cfg(all(target_os = "linux", not(feature = "experimental-api-5")))]
     fn lock_legacy_file(&self, shared: bool) -> io::Result<bool> {

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -2,7 +2,7 @@ use crate::CacheStats;
 use crate::db::{BACKEND_LOCK_RANGE, ConcurrencyMode, FULL_RANGE, SHARED_WRITER_BYTE, byte_range};
 #[cfg(feature = "experimental-multiprocess")]
 use crate::db::{
-    CONSISTENT_BYTE, IMMUTABLE_READER_BYTE, SHARED_READER_BYTE, TXN_BASE, WRITER_BYTE,
+    CONSISTENT_BYTE, SHARED_READER_BYTE, TXN_BASE, WHOLE_FILE_READER_BYTE, WRITER_BYTE,
 };
 use crate::io;
 use crate::sync::Mutex;
@@ -576,7 +576,7 @@ impl<'a> Deref for HeaderHold<'a> {
 }
 
 /// The lock admitting this process to write. Writer-byte locks are released when the last
-/// holder drops; single-process locks are released by `close()`. Holds the storage rather than
+/// holder drops; exclusive-writer locks are released by `close()`. Holds the storage rather than
 /// `TransactionalMemory`, so integrity checks can borrow the memory through `Arc::get_mut()`.
 #[cfg(feature = "experimental-multiprocess")]
 pub(crate) struct WriterLock {
@@ -606,11 +606,11 @@ fn database_writer_lock_for_mode(
         return None;
     }
     let range = match concurrency_mode {
-        // Single-process locks belong to the backend until close(), including when locking
+        // Exclusive-writer locks belong to the backend until close(), including when locking
         // fell back to a whole-storage lock or was unsupported altogether.
-        ConcurrencyMode::SingleProcess => None,
-        ConcurrencyMode::SingleWriterProcess => Some(byte_range(WRITER_BYTE)),
-        ConcurrencyMode::MultiWriterProcess => return None,
+        ConcurrencyMode::ExclusiveWriter => None,
+        ConcurrencyMode::SingleWriter => Some(byte_range(WRITER_BYTE)),
+        ConcurrencyMode::MultiWriter => return None,
     };
 
     Some(Arc::new(WriterLock {
@@ -638,10 +638,10 @@ fn open_writer_lock_for_mode(
         return Ok(None);
     }
     match concurrency_mode {
-        ConcurrencyMode::SingleProcess | ConcurrencyMode::SingleWriterProcess => {
+        ConcurrencyMode::ExclusiveWriter | ConcurrencyMode::SingleWriter => {
             Ok(database_writer_lock)
         }
-        ConcurrencyMode::MultiWriterProcess => {
+        ConcurrencyMode::MultiWriter => {
             storage.lock_range(byte_range(WRITER_BYTE))?;
 
             Ok(Some(Arc::new(WriterLock {
@@ -704,7 +704,7 @@ impl TransactionalMemory {
         concurrency_mode: ConcurrencyMode,
     ) -> Result<(), DatabaseError> {
         match concurrency_mode {
-            ConcurrencyMode::SingleProcess => Self::lock_whole_storage(storage, read_only),
+            ConcurrencyMode::ExclusiveWriter => Self::lock_whole_storage(storage, read_only),
             #[cfg(feature = "experimental-multiprocess")]
             mode => Self::lock_mode_bytes(storage, read_only, mode),
             // The shared modes are only reachable through the feature-gated setter
@@ -785,15 +785,16 @@ impl TransactionalMemory {
             storage.try_lock_shared_range(byte_range(SHARED_READER_BYTE))?
         } else {
             match concurrency_mode {
-                ConcurrencyMode::SingleProcess => unreachable!(),
-                ConcurrencyMode::SingleWriterProcess => {
+                ConcurrencyMode::ExclusiveWriter => unreachable!(),
+                ConcurrencyMode::SingleWriter => {
                     storage.try_lock_range(byte_range(SHARED_WRITER_BYTE))?
                         && storage.try_lock_range(byte_range(WRITER_BYTE))?
                 }
-                ConcurrencyMode::MultiWriterProcess => {
+                ConcurrencyMode::MultiWriter => {
                     storage.try_lock_shared_range(byte_range(SHARED_WRITER_BYTE))?
-                        // Ensure we didn't race with an Immutable open of the database
-                        && !storage.query_lock_range(byte_range(IMMUTABLE_READER_BYTE))?
+                        // A read-only exclusive-writer handle leaves the shared writer byte free,
+                        // so only this byte reveals one
+                        && !storage.query_lock_range(byte_range(WHOLE_FILE_READER_BYTE))?
                 }
             }
         };
@@ -1044,7 +1045,7 @@ impl TransactionalMemory {
         id: TransactionId,
         _header: &HeaderGuard<'_>,
     ) -> Result {
-        // Nothing to publish to: a single-process writers lock the whole file
+        // Nothing to publish to: an exclusive writer locks the whole file
         if !self.concurrency_mode.is_multi_process_writable() {
             return Ok(());
         }
@@ -1385,9 +1386,9 @@ impl TransactionalMemory {
     #[cfg(feature = "experimental-multiprocess")]
     fn externally_writable(&self) -> bool {
         match self.concurrency_mode {
-            ConcurrencyMode::SingleProcess => false,
-            ConcurrencyMode::SingleWriterProcess => self.read_only,
-            ConcurrencyMode::MultiWriterProcess => true,
+            ConcurrencyMode::ExclusiveWriter => false,
+            ConcurrencyMode::SingleWriter => self.read_only,
+            ConcurrencyMode::MultiWriter => true,
         }
     }
 
@@ -2548,7 +2549,7 @@ mod test {
             None,
             0,
             false,
-            crate::db::ConcurrencyMode::SingleProcess,
+            crate::db::ConcurrencyMode::ExclusiveWriter,
         )
         .unwrap();
 
@@ -2585,7 +2586,7 @@ mod test {
             None,
             0,
             false,
-            crate::db::ConcurrencyMode::SingleProcess,
+            crate::db::ConcurrencyMode::ExclusiveWriter,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();
@@ -2628,7 +2629,7 @@ mod test {
             Some(64 * page_size as u64),
             0,
             false,
-            crate::db::ConcurrencyMode::SingleProcess,
+            crate::db::ConcurrencyMode::ExclusiveWriter,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();
@@ -2677,7 +2678,7 @@ mod test {
             Some(64 * page_size as u64),
             0,
             false,
-            crate::db::ConcurrencyMode::SingleProcess,
+            crate::db::ConcurrencyMode::ExclusiveWriter,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();
@@ -2721,7 +2722,7 @@ mod test {
             Some(region_size),
             0,
             false,
-            crate::db::ConcurrencyMode::SingleProcess,
+            crate::db::ConcurrencyMode::ExclusiveWriter,
         )
         .unwrap();
         mem.reset_allocator_state().unwrap();
@@ -2839,12 +2840,12 @@ mod header_lock_test {
     #[test]
     fn a_read_only_handle_takes_shared_holds() {
         let tmpfile = crate::create_tempfile();
-        open(tmpfile.path(), ConcurrencyMode::SingleProcess).unwrap();
+        open(tmpfile.path(), ConcurrencyMode::ExclusiveWriter).unwrap();
 
-        let reader = open_read_only(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let reader = open_read_only(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
         let held = hold(&reader, false).unwrap();
 
-        let peer = open_read_only(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let peer = open_read_only(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
         drop(hold(&peer, false).unwrap());
         drop(held);
     }
@@ -2871,7 +2872,7 @@ mod header_lock_test {
 
         let tmpfile = crate::create_tempfile();
         let mut builder = Database::builder();
-        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
         builder.create(tmpfile.path()).unwrap();
         let db = builder.open(tmpfile.path()).unwrap();
         let peer = builder.open(tmpfile.path()).unwrap();
@@ -2896,7 +2897,7 @@ mod header_lock_test {
         use super::DB_HEADER_SIZE;
 
         let tmpfile = crate::create_tempfile();
-        let writer = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let writer = open(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
 
         let mut header = writer.state.lock().unwrap().header.clone();
         header.recovery_required = !header.recovery_required;
@@ -2915,8 +2916,8 @@ mod header_lock_test {
     #[test]
     fn the_hold_covers_the_write_reaching_the_file() {
         let tmpfile = crate::create_tempfile();
-        let writer = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
-        let reader = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let writer = open(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
+        let reader = open(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
 
         // Taken before the hold: another one in this process would wait on it
         let header = writer.state.lock().unwrap().header.clone();
@@ -2943,8 +2944,8 @@ mod header_lock_test {
     #[test]
     fn an_exclusive_hold_excludes_a_shared_one() {
         let tmpfile = crate::create_tempfile();
-        let writer = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
-        let reader = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let writer = open(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
+        let reader = open(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
 
         let guard = hold(&writer, true).unwrap();
         let (tx, rx) = mpsc::channel();
@@ -2967,8 +2968,8 @@ mod header_lock_test {
     #[test]
     fn shared_holds_admit_each_other() {
         let tmpfile = crate::create_tempfile();
-        let first = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
-        let second = open(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let first = open(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
+        let second = open(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
 
         let held = hold(&first, false).unwrap();
         let (tx, rx) = mpsc::channel();
@@ -2988,7 +2989,7 @@ mod header_lock_test {
     #[test]
     fn a_hold_does_not_puncture_the_whole_storage_lock() {
         let tmpfile = crate::create_tempfile();
-        let held = open(tmpfile.path(), ConcurrencyMode::SingleProcess).unwrap();
+        let held = open(tmpfile.path(), ConcurrencyMode::ExclusiveWriter).unwrap();
 
         for exclusive in [false, true] {
             let guard = hold(&held, exclusive).unwrap();
@@ -2996,7 +2997,7 @@ mod header_lock_test {
         }
 
         assert!(matches!(
-            open(tmpfile.path(), ConcurrencyMode::SingleProcess),
+            open(tmpfile.path(), ConcurrencyMode::ExclusiveWriter),
             Err(DatabaseError::DatabaseAlreadyOpen)
         ));
     }
@@ -3044,8 +3045,8 @@ mod lock_protocol_test {
         open_file(reopen(path), read_only, concurrency_mode)
     }
 
-    fn single_process(path: &Path, read_only: bool) -> Result<PagedCachedFile, DatabaseError> {
-        open(path, read_only, ConcurrencyMode::SingleProcess)
+    fn exclusive_writer(path: &Path, read_only: bool) -> Result<PagedCachedFile, DatabaseError> {
+        open(path, read_only, ConcurrencyMode::ExclusiveWriter)
     }
 
     fn refused(result: Result<PagedCachedFile, DatabaseError>) -> bool {
@@ -3066,17 +3067,17 @@ mod lock_protocol_test {
                 .unwrap()
         );
 
-        assert!(refused(single_process(tmpfile.path(), true)));
+        assert!(refused(exclusive_writer(tmpfile.path(), true)));
     }
 
     #[test]
-    fn single_process_locks_leave_backend_bytes_and_the_read_only_probe_free() {
+    fn exclusive_writer_locks_leave_backend_bytes_and_the_read_only_probe_free() {
         use crate::db::{BACKEND_LOCK_RANGE, SHARED_WRITER_BYTE, byte_range};
 
         let tmpfile = crate::create_tempfile();
         let observer = reopen(tmpfile.path());
         for read_only in [false, true] {
-            let storage = single_process(tmpfile.path(), read_only).unwrap();
+            let storage = exclusive_writer(tmpfile.path(), read_only).unwrap();
             for offset in [
                 0,
                 SHARED_WRITER_BYTE - 1,
@@ -3117,7 +3118,7 @@ mod lock_protocol_test {
             assert!(refused(open_file(
                 file,
                 read_only,
-                ConcurrencyMode::SingleProcess
+                ConcurrencyMode::ExclusiveWriter
             )));
             assert!(
                 holder
@@ -3138,11 +3139,11 @@ mod lock_protocol_test {
 
     #[cfg(not(feature = "experimental-api-5"))]
     #[test]
-    fn single_process_opens_exclude_older_whole_file_writers() {
+    fn exclusive_writer_opens_exclude_older_whole_file_writers() {
         let tmpfile = crate::create_tempfile();
         let older = reopen(tmpfile.path());
         for read_only in [false, true] {
-            let storage = single_process(tmpfile.path(), read_only).unwrap();
+            let storage = exclusive_writer(tmpfile.path(), read_only).unwrap();
             assert!(matches!(
                 older.try_lock(),
                 Err(std::fs::TryLockError::WouldBlock)
@@ -3151,7 +3152,7 @@ mod lock_protocol_test {
 
             older.try_lock().unwrap();
             #[cfg(not(windows))]
-            assert!(refused(single_process(tmpfile.path(), read_only)));
+            assert!(refused(exclusive_writer(tmpfile.path(), read_only)));
             #[cfg(windows)]
             {
                 // Older whole-file locks cover the query mutex, so retrying waits for them.
@@ -3161,7 +3162,7 @@ mod lock_protocol_test {
                 let path = tmpfile.path().to_owned();
                 let (result_tx, result_rx) = mpsc::channel();
                 let worker = std::thread::spawn(move || {
-                    result_tx.send(single_process(&path, read_only)).unwrap();
+                    result_tx.send(exclusive_writer(&path, read_only)).unwrap();
                 });
                 let while_locked = result_rx.recv_timeout(Duration::from_millis(100));
                 older.unlock().unwrap();
@@ -3181,11 +3182,11 @@ mod lock_protocol_test {
 
     #[cfg(not(feature = "experimental-api-5"))]
     #[test]
-    fn each_immutable_reader_excludes_older_whole_file_writers() {
+    fn each_whole_file_reader_excludes_older_whole_file_writers() {
         let tmpfile = crate::create_tempfile();
         let older = reopen(tmpfile.path());
-        let first = single_process(tmpfile.path(), true).unwrap();
-        let second = single_process(tmpfile.path(), true).unwrap();
+        let first = exclusive_writer(tmpfile.path(), true).unwrap();
+        let second = exclusive_writer(tmpfile.path(), true).unwrap();
         first.close().unwrap();
         assert!(matches!(
             older.try_lock(),
@@ -3205,10 +3206,7 @@ mod lock_protocol_test {
         if older.query_lock(0..=0).unwrap() {
             return;
         }
-        for mode in [
-            ConcurrencyMode::SingleWriterProcess,
-            ConcurrencyMode::MultiWriterProcess,
-        ] {
+        for mode in [ConcurrencyMode::SingleWriter, ConcurrencyMode::MultiWriter] {
             for read_only in [false, true] {
                 open(tmpfile.path(), read_only, mode)
                     .unwrap()
@@ -3223,20 +3221,20 @@ mod lock_protocol_test {
     #[cfg(feature = "experimental-multiprocess")]
     #[test]
     fn the_modes_exclude_each_other() {
-        use ConcurrencyMode::{MultiWriterProcess, SingleWriterProcess};
+        use ConcurrencyMode::{MultiWriter, SingleWriter};
 
         let tmpfile = crate::create_tempfile();
         for (held, joining, admitted) in [
-            (SingleWriterProcess, SingleWriterProcess, false),
-            (SingleWriterProcess, MultiWriterProcess, false),
-            (MultiWriterProcess, SingleWriterProcess, false),
-            (MultiWriterProcess, MultiWriterProcess, true),
+            (SingleWriter, SingleWriter, false),
+            (SingleWriter, MultiWriter, false),
+            (MultiWriter, SingleWriter, false),
+            (MultiWriter, MultiWriter, true),
         ] {
             let first = open(tmpfile.path(), false, held).unwrap();
             let second = open(tmpfile.path(), false, joining);
             assert_eq!(second.is_ok(), admitted, "{held:?} then {joining:?}");
 
-            let reader = open(tmpfile.path(), true, MultiWriterProcess).unwrap();
+            let reader = open(tmpfile.path(), true, MultiWriter).unwrap();
             reader.close().unwrap();
             if let Ok(second) = second {
                 second.close().unwrap();
@@ -3245,25 +3243,22 @@ mod lock_protocol_test {
         }
     }
 
-    /// A single-process handle joins nothing, so it and a multi-process one refuse each other --
+    /// A exclusive-writer handle joins nothing, so it and a multi-process one refuse each other --
     /// unless both are read-only, since neither holds a byte the other could find
     #[cfg(feature = "experimental-multiprocess")]
     #[test]
-    fn a_single_process_handle_and_a_multi_process_one_refuse_each_other() {
+    fn an_exclusive_writer_handle_and_a_multi_process_one_refuse_each_other() {
         let tmpfile = crate::create_tempfile();
-        for mode in [
-            ConcurrencyMode::SingleWriterProcess,
-            ConcurrencyMode::MultiWriterProcess,
-        ] {
+        for mode in [ConcurrencyMode::SingleWriter, ConcurrencyMode::MultiWriter] {
             for read_only in [false, true] {
-                let plain = single_process(tmpfile.path(), read_only).unwrap();
+                let plain = exclusive_writer(tmpfile.path(), read_only).unwrap();
                 assert!(refused(open(tmpfile.path(), false, mode)));
                 assert_eq!(refused(open(tmpfile.path(), true, mode)), !read_only);
                 plain.close().unwrap();
 
                 let held = open(tmpfile.path(), read_only, mode).unwrap();
-                assert!(refused(single_process(tmpfile.path(), false)));
-                assert_eq!(refused(single_process(tmpfile.path(), true)), !read_only);
+                assert!(refused(exclusive_writer(tmpfile.path(), false)));
+                assert_eq!(refused(exclusive_writer(tmpfile.path(), true)), !read_only);
                 held.close().unwrap();
             }
         }
@@ -3286,7 +3281,7 @@ mod lock_protocol_test {
         assert!(refused(open_file(
             file,
             false,
-            ConcurrencyMode::SingleWriterProcess
+            ConcurrencyMode::SingleWriter
         )));
 
         let observer = reopen(tmpfile.path());
@@ -3296,7 +3291,7 @@ mod lock_protocol_test {
         drop(kept_by_the_caller);
 
         holder.unlock_range(byte_range(WRITER_BYTE)).unwrap();
-        open(tmpfile.path(), false, ConcurrencyMode::SingleWriterProcess)
+        open(tmpfile.path(), false, ConcurrencyMode::SingleWriter)
             .unwrap()
             .close()
             .unwrap();
@@ -3571,7 +3566,12 @@ mod lock_failure_test {
     }
 
     fn open(read_only: bool, taking: Answer, querying: Answer) -> Result<(), DatabaseError> {
-        open_as(ConcurrencyMode::SingleProcess, read_only, taking, querying)
+        open_as(
+            ConcurrencyMode::ExclusiveWriter,
+            read_only,
+            taking,
+            querying,
+        )
     }
 
     fn failed(result: Result<(), DatabaseError>) -> bool {
@@ -3616,10 +3616,7 @@ mod lock_failure_test {
     #[cfg(feature = "experimental-multiprocess")]
     #[test]
     fn a_shared_mode_without_locks_fails_the_open() {
-        for mode in [
-            ConcurrencyMode::SingleWriterProcess,
-            ConcurrencyMode::MultiWriterProcess,
-        ] {
+        for mode in [ConcurrencyMode::SingleWriter, ConcurrencyMode::MultiWriter] {
             for read_only in [false, true] {
                 assert!(failed(open_as(
                     mode,
@@ -3635,7 +3632,7 @@ mod lock_failure_test {
     fn the_lock_is_released_at_close() {
         for taking in [Answer::Acquired, Answer::Unsupported] {
             let (storage, released) = storage(taking, Answer::Unsupported);
-            TransactionalMemory::lock_for_open(&storage, false, ConcurrencyMode::SingleProcess)
+            TransactionalMemory::lock_for_open(&storage, false, ConcurrencyMode::ExclusiveWriter)
                 .unwrap();
             storage.close().unwrap();
 
@@ -3677,7 +3674,7 @@ mod lock_failure_test {
                     let result = TransactionalMemory::lock_for_open(
                         &storage,
                         read_only,
-                        ConcurrencyMode::SingleProcess,
+                        ConcurrencyMode::ExclusiveWriter,
                     );
                     match answer {
                         Answer::Acquired => {
@@ -3712,7 +3709,7 @@ mod lock_failure_test {
                 let result = TransactionalMemory::lock_for_open(
                     &storage,
                     read_only,
-                    ConcurrencyMode::SingleProcess,
+                    ConcurrencyMode::ExclusiveWriter,
                 );
                 if answer == Answer::Refused {
                     assert!(matches!(result, Err(DatabaseError::DatabaseAlreadyOpen)));
@@ -3736,7 +3733,7 @@ mod lock_failure_test {
         assert!(failed(TransactionalMemory::lock_for_open(
             &storage,
             false,
-            ConcurrencyMode::SingleProcess
+            ConcurrencyMode::ExclusiveWriter
         )));
         assert_eq!(held.lock().unwrap().len(), 1);
         storage.close().unwrap();

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -15,7 +15,7 @@ mod shared_reader {
 
     fn shared() -> redb::Builder {
         let mut builder = Database::builder();
-        builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+        builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
         builder
     }
 
@@ -206,8 +206,8 @@ mod writer_byte {
     #[test]
     fn a_write_transaction_excludes_another_process() {
         let tmpfile = tempfile::NamedTempFile::new().unwrap();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
-        let peer = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
+        let peer = create(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
 
         let held = db.begin_write().unwrap();
 
@@ -232,8 +232,8 @@ mod writer_byte {
     #[test]
     fn an_aborted_transaction_releases_the_byte() {
         let tmpfile = tempfile::NamedTempFile::new().unwrap();
-        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
-        let peer = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
+        let peer = create(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
 
         db.begin_write().unwrap().abort().unwrap();
         // Dropped rather than aborted, which aborts through Drop
@@ -245,9 +245,9 @@ mod writer_byte {
 
     /// It locks the whole file, which covers the writer byte
     #[test]
-    fn a_single_process_transaction_does_not_puncture_the_whole_file_lock() {
+    fn an_exclusive_writer_transaction_does_not_puncture_the_whole_file_lock() {
         let tmpfile = tempfile::NamedTempFile::new().unwrap();
-        let db = create(tmpfile.path(), ConcurrencyMode::SingleProcess).unwrap();
+        let db = create(tmpfile.path(), ConcurrencyMode::ExclusiveWriter).unwrap();
 
         let write = db.begin_write().unwrap();
         {
@@ -273,11 +273,11 @@ fn the_concurrency_mode_excludes_incompatible_opens() {
     }
 
     let tmpfile = tempfile::NamedTempFile::new().unwrap();
-    let db = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+    let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
 
-    let peer = create(tmpfile.path(), ConcurrencyMode::MultiWriterProcess).unwrap();
+    let peer = create(tmpfile.path(), ConcurrencyMode::MultiWriter).unwrap();
     assert!(matches!(
-        create(tmpfile.path(), ConcurrencyMode::SingleWriterProcess),
+        create(tmpfile.path(), ConcurrencyMode::SingleWriter),
         Err(DatabaseError::DatabaseAlreadyOpen)
     ));
     assert!(matches!(
@@ -300,11 +300,11 @@ fn an_integrity_check_syncs_to_a_peers_commits() {
 
     let tmpfile = tempfile::NamedTempFile::new().unwrap();
     let mut db = Database::builder()
-        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .set_concurrency_mode(ConcurrencyMode::MultiWriter)
         .create(tmpfile.path())
         .unwrap();
     let peer = Database::builder()
-        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .set_concurrency_mode(ConcurrencyMode::MultiWriter)
         .open(tmpfile.path())
         .unwrap();
     let txn = peer.begin_write().unwrap();
@@ -328,7 +328,7 @@ fn an_integrity_check_syncs_to_a_peers_commits() {
     drop(db);
 
     let db = Database::builder()
-        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .set_concurrency_mode(ConcurrencyMode::MultiWriter)
         .open(tmpfile.path())
         .unwrap();
     let read = db.begin_read().unwrap();
@@ -351,7 +351,7 @@ fn a_corrupt_primary_is_not_repaired_from_under_a_peers_read() {
 
     let tmpfile = tempfile::NamedTempFile::new().unwrap();
     let mut db = Database::builder()
-        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .set_concurrency_mode(ConcurrencyMode::MultiWriter)
         .create(tmpfile.path())
         .unwrap();
     for key in [1, 2] {
@@ -360,7 +360,7 @@ fn a_corrupt_primary_is_not_repaired_from_under_a_peers_read() {
         txn.commit().unwrap();
     }
     let peer = Database::builder()
-        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .set_concurrency_mode(ConcurrencyMode::MultiWriter)
         .open_read_only(tmpfile.path())
         .unwrap();
     let read = peer.begin_read().unwrap();
@@ -406,11 +406,11 @@ fn an_integrity_check_waits_for_a_peers_write_transaction() {
 
     let tmpfile = tempfile::NamedTempFile::new().unwrap();
     let mut db = Database::builder()
-        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .set_concurrency_mode(ConcurrencyMode::MultiWriter)
         .create(tmpfile.path())
         .unwrap();
     let peer = Database::builder()
-        .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+        .set_concurrency_mode(ConcurrencyMode::MultiWriter)
         .open(tmpfile.path())
         .unwrap();
     let txn = peer.begin_write().unwrap();
@@ -444,7 +444,7 @@ mod peer_commits {
 
     fn open(path: &Path) -> Database {
         Database::builder()
-            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .set_concurrency_mode(ConcurrencyMode::MultiWriter)
             .open(path)
             .unwrap()
     }
@@ -453,7 +453,7 @@ mod peer_commits {
     /// repair it and commit.
     fn two_handles(path: &Path) -> (Database, Database) {
         Database::builder()
-            .set_concurrency_mode(ConcurrencyMode::MultiWriterProcess)
+            .set_concurrency_mode(ConcurrencyMode::MultiWriter)
             .create(path)
             .unwrap();
         (open(path), open(path))
@@ -721,10 +721,7 @@ fn file_backend_custom_open_supports_shared_modes() {
     use redb::{ReadableDatabase, ReadableTable, TableDefinition};
 
     const TABLE: TableDefinition<u64, u64> = TableDefinition::new("x");
-    for mode in [
-        ConcurrencyMode::SingleWriterProcess,
-        ConcurrencyMode::MultiWriterProcess,
-    ] {
+    for mode in [ConcurrencyMode::SingleWriter, ConcurrencyMode::MultiWriter] {
         let tmpfile = tempfile::NamedTempFile::new().unwrap();
         let mut builder = Database::builder();
         builder.set_concurrency_mode(mode);
@@ -742,7 +739,7 @@ fn file_backend_custom_open_supports_shared_modes() {
             Err(DatabaseError::DatabaseAlreadyOpen)
         ));
 
-        let peer = if mode == ConcurrencyMode::MultiWriterProcess {
+        let peer = if mode == ConcurrencyMode::MultiWriter {
             Some(open().unwrap())
         } else {
             assert!(matches!(open(), Err(DatabaseError::DatabaseAlreadyOpen)));
@@ -776,11 +773,11 @@ fn file_backend_custom_open_supports_shared_modes() {
     }
 }
 
-/// A backend without locks can only be used in single-process mode.
+/// A backend without locks can only be used in exclusive-writer mode.
 #[test]
 fn sharing_a_backend_without_locks_is_unsupported() {
     let mut builder = Database::builder();
-    builder.set_concurrency_mode(ConcurrencyMode::MultiWriterProcess);
+    builder.set_concurrency_mode(ConcurrencyMode::MultiWriter);
     let err = builder
         .create_with_backend(InMemoryBackend::new())
         .unwrap_err();
@@ -808,7 +805,7 @@ mod reclamation {
     fn a_readers_pin_survives_heavy_reclamation() {
         let tmpfile = tempfile::NamedTempFile::new().unwrap();
         let writer = Database::builder()
-            .set_concurrency_mode(ConcurrencyMode::SingleWriterProcess)
+            .set_concurrency_mode(ConcurrencyMode::SingleWriter)
             .create(tmpfile.path())
             .unwrap();
 
@@ -823,7 +820,7 @@ mod reclamation {
         txn.commit().unwrap();
 
         let reader = Database::builder()
-            .set_concurrency_mode(ConcurrencyMode::SingleWriterProcess)
+            .set_concurrency_mode(ConcurrencyMode::SingleWriter)
             .open_read_only(tmpfile.path())
             .unwrap();
         let pinned = reader.begin_read().unwrap();
@@ -901,10 +898,7 @@ mod compaction {
     /// A read transaction in another process is a transaction in progress, as a local one is
     #[test]
     fn compaction_refuses_a_peers_read_transaction() {
-        for mode in [
-            ConcurrencyMode::SingleWriterProcess,
-            ConcurrencyMode::MultiWriterProcess,
-        ] {
+        for mode in [ConcurrencyMode::SingleWriter, ConcurrencyMode::MultiWriter] {
             let tmpfile = tempfile::NamedTempFile::new().unwrap();
             let mut writer = create(tmpfile.path(), mode);
             insert(&writer, 0..1, &[1u8; 512]);
@@ -930,10 +924,7 @@ mod compaction {
     #[test]
     fn untyped_tables_pin_a_peers_snapshot_until_dropped() {
         const MULTIMAP: MultimapTableDefinition<u64, &[u8]> = MultimapTableDefinition::new("multi");
-        for mode in [
-            ConcurrencyMode::SingleWriterProcess,
-            ConcurrencyMode::MultiWriterProcess,
-        ] {
+        for mode in [ConcurrencyMode::SingleWriter, ConcurrencyMode::MultiWriter] {
             for multimap in [false, true] {
                 let tmpfile = tempfile::NamedTempFile::new().unwrap();
                 let mut writer = create(tmpfile.path(), mode);
@@ -997,10 +988,7 @@ mod compaction {
     /// that moved
     #[test]
     fn compaction_shrinks_a_file_a_peer_has_open() {
-        for mode in [
-            ConcurrencyMode::SingleWriterProcess,
-            ConcurrencyMode::MultiWriterProcess,
-        ] {
+        for mode in [ConcurrencyMode::SingleWriter, ConcurrencyMode::MultiWriter] {
             let tmpfile = tempfile::NamedTempFile::new().unwrap();
             let mut writer = create(tmpfile.path(), mode);
             let value = vec![7u8; 1024];


### PR DESCRIPTION
Reworked from the `Immutable` mode this PR first added, which turned out to be byte-for-byte `SingleProcess` + `open_read_only()`: the same `lock_whole_storage(shared)` ranges, both writability predicates false, the same unclean-file refusal. Its only content was refusing the writable entry points, and the design doc had been describing one protocol twice under two names.

The names were the actual problem. `SingleProcess` was half true of the default: a writer takes the whole-file lock exclusively, so it is alone, but read-only handles take it shared, so any number of them coexist. "Immutable" was that read-only face.

## What changes

`ConcurrencyMode` now names the regime a writer operates under, and whether a handle writes is chosen by `open()` against `open_read_only()`, not by the mode:

| before | after |
|---|---|
| `SingleProcess` | `ExclusiveWriter` |
| `SingleWriterProcess` | `SingleWriter` |
| `MultiWriterProcess` | `MultiWriter` |

`IMMUTABLE_READER_BYTE` becomes `WHOLE_FILE_READER_BYTE`, and `docs/design.md` folds the Immutable section into the exclusive writer one. The byte's job is unchanged and is now stated for what it is: read-only exclusive-writer handles hold it as part of their whole-file lock while leaving the shared writer byte free, so it is the one byte a `MultiWriter` open -- which takes only the shared writer byte -- must probe. A `SingleWriter` open needs no probe, since its exclusive `WRITER_BYTE` lock already fails under such a handle; the doc now says so instead of requiring the check of everything that takes the shared writer byte.

No lock offset changes and no handle's behavior changes. Prose comments and test names that said "single-process" follow the rename. All three variants now share the `Writer` suffix; `clippy::enum_variant_names` is suppressed on exported API and already allowed where the enum is not exported, and clippy passes in both configurations.

## Prior art, briefly

Separating the sharing regime from the handle's access is what SQL Server does (`SINGLE_USER`/`MULTI_USER` against `READ_ONLY`) and what .NET does (`FileShare` against `FileAccess`). The whole-file behavior itself -- exclusive for a writer, shared for readers -- is exactly bbolt's and DuckDB's read-only mode, neither of which has a separate "immutable". `SingleWriter`/`MultiWriter` follow HDF5's SWMR and BerkeleyDB's Concurrent and Transactional Data Stores. Where "immutable" does appear (SQLite's `immutable=1`, Datasette, `chattr +i`) it means "skip locking, nothing can change" -- stronger than a locked shared reader, so the name would have over-promised.

## Changelog

The old names only ever appeared in the unreleased 5.0.0 section, so its entries are updated in place rather than given a "renamed" line.

## Verification

`cargo fmt --all -- --check`; `cargo clippy --all --all-targets` under default features, `--all-features`, and `experimental-multiprocess`, all with `RUSTFLAGS=--deny warnings`; `cargo check --features experimental-api-5`; `cargo test --all --all-features` (25 binaries, 0 failures); `cargo doc --no-deps --all-features` resolves the renamed intra-doc links (one pre-existing `chrono` warning, untouched). A grep for the old names, `IMMUTABLE_READER`, and "immutable byte/mode/open/reader" across `src/`, `tests/`, `docs/`, and the changelog comes back empty.

The three Codex threads above are on the superseded implementation and stay resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qy3Dih4QKoKh59qcqxj5r