### PR TITLE
Reserve backend lock bytes and serialize Windows lock queries

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -489,12 +489,12 @@ shared and exclusive whole file locks, respectively.
 ## Immutable
 
 In this mode, multiple processes may open the database. Each takes a shared lock on the "immutable byte"
-and the rest of the database file, except for the "shared writer byte".
+and the rest of the database file, except for the "shared writer byte" and the backend-reserved bytes.
 
 ## Single process
 
 In this mode, only a single process may open the database. The process takes an exclusive lock on
-the entire database file.
+the entire database file except for the backend-reserved bytes.
 
 ## Multi-process with a single writer process
 
@@ -533,18 +533,22 @@ handled by in-process locks:
 
 The multi-process concurrency modes rely on file range locks and define the following byte ranges:
 
-| byte range              | description                        |
-|-------------------------|------------------------------------|
-| `0..320`                | header lock                        |
-| `2^62`                  | multi-process lock base (BASE)     |
-| `BASE`                  | writer byte                        |
-| `BASE + 1`              | shared writer byte                 |
-| `BASE + 2`              | shared reader byte                 |
-| `BASE + 3`              | immutable byte                     |
-| `BASE + 4`              | consistent byte                    |
-| `BASE + 5..BASE + 1024` | reserved                           |
-| `BASE + 1024`           | active transaction base (TXN_BASE) |
-| `TXN_BASE..2^63`        | active transaction range           |
+| byte range                | description                       |
+|---------------------------|-----------------------------------|
+| `0..320`                  | header lock                       |
+| `2^62`                    | multi-process lock base (BASE)     |
+| `BASE`                    | writer byte                       |
+| `BASE + 1`                | shared writer byte                |
+| `BASE + 2`                | shared reader byte                |
+| `BASE + 3`                | immutable byte                    |
+| `BASE + 4`                | consistent byte                   |
+| `BASE + 5..BASE + 896`     | reserved for the core             |
+| `BASE + 896..BASE + 1024`  | reserved for backend locking      |
+| `BASE + 1024`             | active transaction base (TXN_BASE) |
+| `TXN_BASE..2^63`           | active transaction range          |
+
+The backend-reserved bytes are for backend-specific functionality. redb core leaves them
+unlocked except during whole-file fallback, and never queries them.
 
 ### "writer byte"
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -28,7 +28,7 @@ use core::fmt::{Debug, Display, Formatter};
 
 use alloc::sync::Arc;
 use core::marker::PhantomData;
-use core::ops::Bound;
+use core::ops::{Bound, Range};
 #[cfg(not(redb_no_std))]
 use std::fs::{File, OpenOptions};
 #[cfg(not(redb_no_std))]
@@ -63,8 +63,11 @@ use log::{debug, warn};
 /// must describe a nonempty range. Implementations may reject offsets or lengths that their
 /// underlying locking API cannot represent with [`BackendError::Io`].
 ///
+/// redb never queries backend-reserved ranges and only locks them during whole-storage fallback.
+/// See the [design document](https://github.com/cberner/redb/blob/master/docs/design.md#lock-bytes).
+///
 /// Backends that support locking must support one of the following levels:
-/// 1) All representable ranges are supported. All concurrency modes will work.
+/// 1) All representable ranges requested by redb are supported. All concurrency modes will work.
 /// 2) Only whole-storage locks (`Unbounded, Unbounded` or `Included(0), Unbounded`) are
 ///    supported. Other ranges return [`BackendError::Unsupported`]. Only single-process
 ///    concurrency modes will work.
@@ -101,7 +104,7 @@ pub trait StorageBackend: 'static + Debug + Send + Sync {
         Ok(())
     }
 
-    /// Attempts to acquire an exclusive lock without waiting.
+    /// Attempts to acquire an exclusive byte-range lock.
     ///
     /// Returns `Ok(true)` on acquisition, `Ok(false)` on a conflicting lock, or an error.
     /// Defaults to [`BackendError::Unsupported`].
@@ -113,7 +116,7 @@ pub trait StorageBackend: 'static + Debug + Send + Sync {
         Err(BackendError::Unsupported)
     }
 
-    /// Attempts to acquire a shared lock without waiting.
+    /// Attempts to acquire a shared byte-range lock.
     ///
     /// Returns `Ok(true)` on acquisition, `Ok(false)` on a conflicting lock, or an error.
     /// Defaults to [`BackendError::Unsupported`].
@@ -178,6 +181,9 @@ pub(crate) const FULL_RANGE: (Bound<u64>, Bound<u64>) = (Bound::Unbounded, Bound
 
 #[cfg_attr(not(any(windows, unix, target_os = "wasi")), allow(dead_code))]
 const LOCK_BASE: u64 = 1 << 62;
+/// Reserved for backend locking. Core only covers these bytes with a whole-storage fallback lock.
+pub(crate) const BACKEND_LOCK_RANGE: Range<u64> = LOCK_BASE + 896..LOCK_BASE + 1024;
+
 /// Held exclusively by the writing process in single-writer mode.
 #[cfg(feature = "experimental-multiprocess")]
 pub(crate) const WRITER_BYTE: u64 = LOCK_BASE;

--- a/src/tree_store/page_store/file_backend/optimized.rs
+++ b/src/tree_store/page_store/file_backend/optimized.rs
@@ -1,6 +1,10 @@
 use crate::BackendError;
-#[cfg(all(target_os = "linux", not(feature = "experimental-api-5")))]
-use crate::db::{SHARED_WRITER_BYTE, byte_range};
+#[cfg(any(
+    windows,
+    all(test, any(target_os = "linux", target_vendor = "apple")),
+    all(target_os = "linux", not(feature = "experimental-api-5"))
+))]
+use crate::db::{BACKEND_LOCK_RANGE, byte_range};
 use crate::{DatabaseError, Result, StorageBackend};
 use std::collections::HashSet;
 use std::fs::{File, TryLockError};
@@ -23,7 +27,42 @@ fn is_whole_storage(range: (Bound<u64>, Bound<u64>)) -> bool {
 
 #[cfg(all(target_os = "linux", not(feature = "experimental-api-5")))]
 fn needs_legacy_lock(range: (Bound<u64>, Bound<u64>)) -> bool {
-    range == (Bound::Excluded(SHARED_WRITER_BYTE), Bound::Unbounded)
+    range == (Bound::Included(BACKEND_LOCK_RANGE.end), Bound::Unbounded)
+}
+
+// Detects whether flock and byte-range locks share a namespace.
+#[cfg(all(target_os = "linux", not(feature = "experimental-api-5")))]
+const NAMESPACE_PROBE_BYTE: u64 = BACKEND_LOCK_RANGE.start;
+
+// Serializes Windows queries and lock retries to avoid conflicts with temporary query locks.
+#[cfg(any(windows, all(test, any(target_os = "linux", target_vendor = "apple"))))]
+const QUERY_BYTE: u64 = BACKEND_LOCK_RANGE.start + 1;
+
+#[cfg(any(windows, all(test, any(target_os = "linux", target_vendor = "apple"))))]
+fn validate_query_mutex_range(
+    range: (Bound<u64>, Bound<u64>),
+    whole_storage_allowed: bool,
+) -> io::Result<()> {
+    if whole_storage_allowed && is_whole_storage(range) {
+        return Ok(());
+    }
+    let starts_before_end = match range.0 {
+        Bound::Unbounded => true,
+        Bound::Included(start) => start < BACKEND_LOCK_RANGE.end,
+        Bound::Excluded(start) => start < BACKEND_LOCK_RANGE.end - 1,
+    };
+    let ends_after_start = match range.1 {
+        Bound::Unbounded => true,
+        Bound::Included(end) => end >= BACKEND_LOCK_RANGE.start,
+        Bound::Excluded(end) => end > BACKEND_LOCK_RANGE.start,
+    };
+    if starts_before_end && ends_after_start {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "lock range overlaps backend-reserved bytes",
+        ));
+    }
+    Ok(())
 }
 
 /// Stores a database as a file on-disk.
@@ -52,10 +91,8 @@ impl FileBackend {
         match self.lock_whole_file(shared) {
             Ok(false) => return Ok(false),
             Ok(true) => {
-                // Immutable opens leave this byte free, even when other immutable readers
-                // hold the rest of the file.
                 if !matches!(
-                    self.file.query_lock(byte_range(SHARED_WRITER_BYTE)),
+                    self.file.query_lock(byte_range(NAMESPACE_PROBE_BYTE)),
                     Ok(false)
                 ) {
                     self.unlock_whole_file()?;
@@ -72,13 +109,11 @@ impl FileBackend {
             return Ok(false);
         }
 
-        let acquired = if shared {
-            self.file.try_lock_shared_range(range)
-        } else {
-            self.file.try_lock_range(range)
-        };
+        #[cfg(windows)]
+        let acquired = self.try_lock_with_query_mutex(range, shared);
+        #[cfg(not(windows))]
+        let acquired = self.try_lock_native(range, shared);
         if matches!(acquired, Ok(true)) {
-            self.locked_ranges.lock().unwrap().insert(range);
             return acquired;
         }
 
@@ -92,6 +127,67 @@ impl FileBackend {
             }
             result => result,
         }
+    }
+
+    fn try_lock_native(&self, range: (Bound<u64>, Bound<u64>), shared: bool) -> io::Result<bool> {
+        let acquired = if shared {
+            self.file.try_lock_shared_range(range)?
+        } else {
+            self.file.try_lock_range(range)?
+        };
+        if acquired {
+            self.locked_ranges.lock().unwrap().insert(range);
+        }
+        Ok(acquired)
+    }
+
+    #[cfg(any(windows, all(test, any(target_os = "linux", target_vendor = "apple"))))]
+    fn try_lock_with_query_mutex(
+        &self,
+        range: (Bound<u64>, Bound<u64>),
+        shared: bool,
+    ) -> io::Result<bool> {
+        validate_query_mutex_range(range, true)?;
+        let acquired = self.try_lock_native(range, shared);
+        if !matches!(acquired, Ok(false)) || is_whole_storage(range) {
+            return acquired;
+        }
+
+        // A query may hold the requested range temporarily. Retry while queries are excluded.
+        let query_byte = byte_range(QUERY_BYTE);
+        self.lock(query_byte, false)?;
+        let acquired = self.try_lock_native(range, shared);
+        if let Err(err) = self.unlock_native_range(query_byte) {
+            if matches!(acquired, Ok(true)) {
+                self.unlock_native_range(range)?;
+            }
+            return Err(err);
+        }
+        acquired
+    }
+
+    #[cfg(any(windows, all(test, any(target_os = "linux", target_vendor = "apple"))))]
+    fn query_lock_with_mutex(&self, range: (Bound<u64>, Bound<u64>)) -> io::Result<bool> {
+        validate_query_mutex_range(range, false)?;
+        let query_byte = byte_range(QUERY_BYTE);
+        self.lock(query_byte, false)?;
+        let result = self.try_lock_native(range, false).and_then(|acquired| {
+            if acquired {
+                self.unlock_native_range(range)?;
+            }
+            Ok(!acquired)
+        });
+        let released = self.unlock_native_range(query_byte);
+        result.and_then(|conflict| released.map(|()| conflict))
+    }
+
+    fn unlock_native_range(&self, range: (Bound<u64>, Bound<u64>)) -> io::Result<()> {
+        // Update the record before another query can record its acquisition of the same byte.
+        // Retain failed unlocks for close() to retry.
+        let mut locked_ranges = self.locked_ranges.lock().unwrap();
+        self.file.unlock_range(range)?;
+        locked_ranges.remove(&range);
+        Ok(())
     }
 
     fn lock(&self, range: (Bound<u64>, Bound<u64>), shared: bool) -> io::Result<()> {
@@ -169,10 +265,14 @@ impl StorageBackend for FileBackend {
     }
 
     fn lock_range(&self, start: Bound<u64>, end: Bound<u64>) -> Result<(), BackendError> {
+        #[cfg(windows)]
+        validate_query_mutex_range((start, end), true)?;
         self.lock((start, end), false).map_err(BackendError::from)
     }
 
     fn lock_shared_range(&self, start: Bound<u64>, end: Bound<u64>) -> Result<(), BackendError> {
+        #[cfg(windows)]
+        validate_query_mutex_range((start, end), true)?;
         self.lock((start, end), true).map_err(BackendError::from)
     }
 
@@ -185,9 +285,7 @@ impl StorageBackend for FileBackend {
             return self.unlock_whole_file().map_err(BackendError::from);
         }
 
-        // Retain failed unlocks for close() to retry.
-        self.file.unlock_range(range)?;
-        self.locked_ranges.lock().unwrap().remove(&range);
+        self.unlock_native_range(range)?;
         #[cfg(all(target_os = "linux", not(feature = "experimental-api-5")))]
         if needs_legacy_lock(range) {
             self.unlock_whole_file()?;
@@ -196,6 +294,11 @@ impl StorageBackend for FileBackend {
     }
 
     fn query_lock_range(&self, start: Bound<u64>, end: Bound<u64>) -> Result<bool, BackendError> {
+        #[cfg(windows)]
+        return self
+            .query_lock_with_mutex((start, end))
+            .map_err(BackendError::from);
+        #[cfg(not(windows))]
         self.file
             .query_lock((start, end))
             .map_err(BackendError::from)
@@ -351,12 +454,16 @@ fn write_all_at(file: &File, mut buf: &[u8], mut offset: u64) -> io::Result<()> 
 
 #[cfg(all(test, any(target_os = "linux", target_vendor = "apple", windows)))]
 mod range_lock_tests {
-    use super::{Bound, FileBackend, RangeLock, StorageBackend};
-    use crate::db::FULL_RANGE;
+    use super::{Bound, FileBackend, QUERY_BYTE, RangeLock, StorageBackend};
+    use crate::db::{BACKEND_LOCK_RANGE, FULL_RANGE, byte_range};
     #[cfg(not(target_os = "linux"))]
     use std::fs::TryLockError;
     use std::fs::{File, OpenOptions};
+    use std::io;
     use std::path::Path;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
 
     // Offsets docs/design.md assigns: the header lock, the coordination bytes at BASE, the
     // transaction range, and the last addressable byte
@@ -430,6 +537,212 @@ mod range_lock_tests {
             file.unlock_range(byte).unwrap();
         }
         acquired
+    }
+
+    #[test]
+    fn file_backend_locks_cover_growth_outside_reserved_bytes() {
+        use std::ops::Bound::{Excluded, Included, Unbounded};
+
+        let tmpfile = crate::create_tempfile();
+        let backend = FileBackend::new(reopen(tmpfile.path())).unwrap();
+        let peer = FileBackend::new(reopen(tmpfile.path())).unwrap();
+        let ranges = [
+            (Included(BACKEND_LOCK_RANGE.end), Unbounded),
+            (Included(100), Excluded(BACKEND_LOCK_RANGE.start)),
+        ];
+        for (start, end) in ranges {
+            assert!(backend.try_lock_range(start, end).unwrap());
+        }
+        backend.set_len(4096).unwrap();
+        for offset in [100, 4095, i64::MAX as u64] {
+            assert!(
+                !peer
+                    .try_lock_range(Included(offset), Included(offset))
+                    .unwrap()
+            );
+        }
+        assert!(peer.try_lock_range(Included(99), Included(99)).unwrap());
+        peer.unlock_range(Included(99), Included(99)).unwrap();
+        for (start, end) in ranges {
+            backend.unlock_range(start, end).unwrap();
+        }
+        assert!(peer.try_lock_range(Included(4095), Included(4095)).unwrap());
+        peer.unlock_range(Included(4095), Included(4095)).unwrap();
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum QueryMutexOperation {
+        Query,
+        Exclusive,
+        Shared,
+    }
+
+    impl QueryMutexOperation {
+        fn run(self, backend: &FileBackend, range: (Bound<u64>, Bound<u64>)) -> io::Result<bool> {
+            // Exercise the Windows coordination on native range locks on other platforms too.
+            #[cfg(not(windows))]
+            match self {
+                Self::Query => backend.query_lock_with_mutex(range),
+                Self::Exclusive => backend.try_lock_with_query_mutex(range, false),
+                Self::Shared => backend.try_lock_with_query_mutex(range, true),
+            }
+            #[cfg(windows)]
+            match self {
+                Self::Query => backend.query_lock_range(range.0, range.1),
+                Self::Exclusive => backend.try_lock_range(range.0, range.1),
+                Self::Shared => backend.try_lock_shared_range(range.0, range.1),
+            }
+            .map_err(|err| match err {
+                crate::BackendError::Io(err) => err,
+                crate::BackendError::Unsupported => io::ErrorKind::Unsupported.into(),
+            })
+        }
+    }
+
+    #[test]
+    fn query_mutex_hides_temporary_query_locks() {
+        for operation in [
+            QueryMutexOperation::Query,
+            QueryMutexOperation::Exclusive,
+            QueryMutexOperation::Shared,
+        ] {
+            let tmpfile = crate::create_tempfile();
+            let holder = reopen(tmpfile.path());
+            let backend = FileBackend::new(reopen(tmpfile.path())).unwrap();
+            let range = byte_range(100);
+            holder.lock_range(byte_range(QUERY_BYTE)).unwrap();
+            holder.lock_range(range).unwrap();
+
+            let (started_tx, started_rx) = mpsc::channel();
+            let (result_tx, result_rx) = mpsc::channel();
+            let worker = thread::spawn(move || {
+                started_tx.send(()).unwrap();
+                result_tx.send(operation.run(&backend, range)).unwrap();
+                backend
+            });
+            started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            let while_locked = result_rx.recv_timeout(Duration::from_millis(100));
+            holder.unlock_range(range).unwrap();
+            let while_query_finishes = result_rx.recv_timeout(Duration::from_millis(100));
+            holder.unlock_range(byte_range(QUERY_BYTE)).unwrap();
+            let result = result_rx
+                .recv_timeout(Duration::from_secs(5))
+                .unwrap()
+                .unwrap();
+            let backend = worker.join().unwrap();
+
+            assert!(
+                matches!(while_locked, Err(mpsc::RecvTimeoutError::Timeout)),
+                "{operation:?}"
+            );
+            assert!(
+                matches!(while_query_finishes, Err(mpsc::RecvTimeoutError::Timeout)),
+                "{operation:?}"
+            );
+            assert_eq!(result, !matches!(operation, QueryMutexOperation::Query));
+            assert!(byte_is_free(&holder, QUERY_BYTE, true));
+            close(&backend);
+            assert!(byte_is_free(&holder, 100, true));
+        }
+    }
+
+    #[test]
+    fn query_mutex_keeps_successful_acquisitions_and_whole_storage_nonblocking() {
+        for whole_storage in [false, true] {
+            for operation in [QueryMutexOperation::Exclusive, QueryMutexOperation::Shared] {
+                let tmpfile = crate::create_tempfile();
+                let holder = reopen(tmpfile.path());
+                let backend = FileBackend::new(reopen(tmpfile.path())).unwrap();
+                let range = if whole_storage {
+                    FULL_RANGE
+                } else {
+                    byte_range(100)
+                };
+                holder.lock_range(byte_range(QUERY_BYTE)).unwrap();
+                let (result_tx, result_rx) = mpsc::channel();
+                let worker = thread::spawn(move || {
+                    result_tx.send(operation.run(&backend, range)).unwrap();
+                    backend
+                });
+                let result = result_rx.recv_timeout(Duration::from_secs(5));
+                holder.unlock_range(byte_range(QUERY_BYTE)).unwrap();
+                let result = result.unwrap().unwrap();
+                let backend = worker.join().unwrap();
+
+                assert_eq!(result, !whole_storage, "{operation:?}");
+                close(&backend);
+                assert!(byte_is_free(&holder, 100, true));
+            }
+        }
+    }
+
+    #[test]
+    fn query_mutex_is_released_after_conflicts_and_errors() {
+        let tmpfile = crate::create_tempfile();
+        let holder = reopen(tmpfile.path());
+        let backend = FileBackend::new(reopen(tmpfile.path())).unwrap();
+        let range = byte_range(100);
+        holder.lock_range(range).unwrap();
+        for operation in [
+            QueryMutexOperation::Query,
+            QueryMutexOperation::Exclusive,
+            QueryMutexOperation::Shared,
+        ] {
+            assert_eq!(
+                operation.run(&backend, range).unwrap(),
+                matches!(operation, QueryMutexOperation::Query)
+            );
+            assert!(byte_is_free(&holder, QUERY_BYTE, true));
+            assert!(!backend.file.try_lock_range(range).unwrap());
+            for invalid in [
+                (Bound::Included(200), Bound::Excluded(200)),
+                byte_range(BACKEND_LOCK_RANGE.start),
+                byte_range(BACKEND_LOCK_RANGE.end - 1),
+                (Bound::Included(100), Bound::Unbounded),
+            ] {
+                assert_eq!(
+                    operation.run(&backend, invalid).unwrap_err().kind(),
+                    io::ErrorKind::InvalidInput
+                );
+                assert!(byte_is_free(&holder, QUERY_BYTE, true));
+                assert!(byte_is_free(&holder, 200, true));
+            }
+        }
+        assert_eq!(
+            QueryMutexOperation::Query
+                .run(&backend, FULL_RANGE)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+        holder.unlock_range(range).unwrap();
+        assert!(backend.locked_ranges.lock().unwrap().is_empty());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn query_mutex_serializes_queries_on_the_same_backend() {
+        let tmpfile = crate::create_tempfile();
+        let backend = FileBackend::new(reopen(tmpfile.path())).unwrap();
+        let observer = reopen(tmpfile.path());
+        let barrier = std::sync::Barrier::new(4);
+        thread::scope(|scope| {
+            for _ in 0..4 {
+                scope.spawn(|| {
+                    barrier.wait();
+                    for _ in 0..100 {
+                        assert!(
+                            !backend
+                                .query_lock_range(Bound::Included(100), Bound::Included(100))
+                                .unwrap()
+                        );
+                    }
+                });
+            }
+        });
+        assert!(backend.locked_ranges.lock().unwrap().is_empty());
+        assert!(byte_is_free(&observer, QUERY_BYTE, true));
+        assert!(byte_is_free(&observer, 100, true));
     }
 
     /// A bounded range takes only the native byte-range lock.
@@ -671,7 +984,7 @@ mod range_lock_tests {
         let backend = FileBackend::new(file).unwrap();
 
         for range in [
-            (Bound::Included(BASE + 1024), Bound::Unbounded),
+            (Bound::Included(BASE + 1025), Bound::Unbounded),
             (Bound::Included(100), Bound::Unbounded),
             (Bound::Included(0), Bound::Unbounded),
             FULL_RANGE,
@@ -692,7 +1005,7 @@ mod range_lock_tests {
                 assert!(try_lock().unwrap());
                 observer.try_lock().unwrap();
                 observer.unlock().unwrap();
-                assert!(!byte_is_free(&observer, BASE + 1024, true));
+                assert!(!byte_is_free(&observer, BASE + 1025, true));
                 backend.unlock_range(range.0, range.1).unwrap();
             }
         }

--- a/src/tree_store/page_store/file_backend/range_lock.rs
+++ b/src/tree_store/page_store/file_backend/range_lock.rs
@@ -40,7 +40,7 @@ pub(crate) trait RangeLock {
 
     /// Whether an exclusive lock over the range would conflict with one already held.
     /// [`File::lock`] is included wherever it would in fact block a range lock
-    #[cfg_attr(feature = "experimental-api-5", allow(dead_code))]
+    #[cfg(any(not(windows), test))]
     fn query_lock(&self, _range: impl RangeBounds<u64>) -> io::Result<bool> {
         Err(unsupported())
     }
@@ -292,7 +292,8 @@ mod windows_imp {
             }
         }
 
-        // There is no query operation, so the range is acquired and released again to answer
+        // Test observers bypass FileBackend's query mutex to inspect its locks.
+        #[cfg(test)]
         fn query_lock(&self, range: impl RangeBounds<u64>) -> io::Result<bool> {
             let range = (range.start_bound().cloned(), range.end_bound().cloned());
             if try_lock(self, true, range)? {

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1,9 +1,9 @@
 use crate::CacheStats;
+use crate::db::{BACKEND_LOCK_RANGE, ConcurrencyMode, FULL_RANGE, SHARED_WRITER_BYTE, byte_range};
 #[cfg(feature = "experimental-multiprocess")]
 use crate::db::{
     CONSISTENT_BYTE, IMMUTABLE_READER_BYTE, SHARED_READER_BYTE, TXN_BASE, WRITER_BYTE,
 };
-use crate::db::{ConcurrencyMode, FULL_RANGE, SHARED_WRITER_BYTE, byte_range};
 use crate::io;
 use crate::sync::Mutex;
 use crate::transaction_tracker::TransactionId;
@@ -721,14 +721,18 @@ impl TransactionalMemory {
                 storage.try_lock_range(range)
             }
         };
-        let suffix_range = (Bound::Excluded(SHARED_WRITER_BYTE), Bound::Unbounded);
+        let suffix_range = (Bound::Included(BACKEND_LOCK_RANGE.end), Bound::Unbounded);
+        let middle_range = (
+            Bound::Excluded(SHARED_WRITER_BYTE),
+            Bound::Excluded(BACKEND_LOCK_RANGE.start),
+        );
         let prefix_end = if read_only {
             Bound::Excluded(SHARED_WRITER_BYTE)
         } else {
             Bound::Included(SHARED_WRITER_BYTE)
         };
         let prefix_range = (Bound::Unbounded, prefix_end);
-        let ranges = [suffix_range, prefix_range];
+        let ranges = [suffix_range, middle_range, prefix_range];
         for (taken, range) in ranges.iter().enumerate() {
             match try_lock(*range) {
                 Ok(true) => {}
@@ -3066,8 +3070,8 @@ mod lock_protocol_test {
     }
 
     #[test]
-    fn single_process_locks_cover_every_byte_except_the_read_only_probe() {
-        use crate::db::{SHARED_WRITER_BYTE, byte_range};
+    fn single_process_locks_leave_backend_bytes_and_the_read_only_probe_free() {
+        use crate::db::{BACKEND_LOCK_RANGE, SHARED_WRITER_BYTE, byte_range};
 
         let tmpfile = crate::create_tempfile();
         let observer = reopen(tmpfile.path());
@@ -3077,6 +3081,8 @@ mod lock_protocol_test {
                 0,
                 SHARED_WRITER_BYTE - 1,
                 SHARED_WRITER_BYTE + 1,
+                BACKEND_LOCK_RANGE.start - 1,
+                BACKEND_LOCK_RANGE.end,
                 i64::MAX as u64,
             ] {
                 assert!(observer.query_lock(byte_range(offset)).unwrap());
@@ -3085,6 +3091,8 @@ mod lock_protocol_test {
                 observer.query_lock(byte_range(SHARED_WRITER_BYTE)).unwrap(),
                 !read_only
             );
+            assert!(observer.try_lock_range(BACKEND_LOCK_RANGE).unwrap());
+            observer.unlock_range(BACKEND_LOCK_RANGE).unwrap();
             storage.close().unwrap();
             assert!(observer.try_lock_range(..).unwrap());
             observer.unlock_range(..).unwrap();
@@ -3142,7 +3150,31 @@ mod lock_protocol_test {
             storage.close().unwrap();
 
             older.try_lock().unwrap();
+            #[cfg(not(windows))]
             assert!(refused(single_process(tmpfile.path(), read_only)));
+            #[cfg(windows)]
+            {
+                // Older whole-file locks cover the query mutex, so retrying waits for them.
+                use std::sync::mpsc;
+                use std::time::Duration;
+
+                let path = tmpfile.path().to_owned();
+                let (result_tx, result_rx) = mpsc::channel();
+                let worker = std::thread::spawn(move || {
+                    result_tx.send(single_process(&path, read_only)).unwrap();
+                });
+                let while_locked = result_rx.recv_timeout(Duration::from_millis(100));
+                older.unlock().unwrap();
+                assert!(matches!(while_locked, Err(mpsc::RecvTimeoutError::Timeout)));
+                result_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .unwrap()
+                    .unwrap()
+                    .close()
+                    .unwrap();
+                worker.join().unwrap();
+            }
+            #[cfg(not(windows))]
             older.unlock().unwrap();
         }
     }
@@ -3274,7 +3306,7 @@ mod lock_protocol_test {
 #[cfg(test)]
 mod lock_failure_test {
     use super::TransactionalMemory;
-    use crate::db::{ConcurrencyMode, FULL_RANGE, SHARED_WRITER_BYTE};
+    use crate::db::{BACKEND_LOCK_RANGE, ConcurrencyMode, FULL_RANGE, SHARED_WRITER_BYTE};
     use crate::io;
     use crate::sync::Mutex;
     use crate::tree_store::InMemoryBackend;
@@ -3338,6 +3370,13 @@ mod lock_failure_test {
             let answer = if range == FULL_RANGE {
                 self.taking
             } else {
+                assert!(!overlaps(
+                    range,
+                    (
+                        Bound::Included(BACKEND_LOCK_RANGE.start),
+                        Bound::Excluded(BACKEND_LOCK_RANGE.end),
+                    ),
+                ));
                 self.partial_answers
                     .lock()
                     .unwrap()
@@ -3400,6 +3439,13 @@ mod lock_failure_test {
             start: Bound<u64>,
             end: Bound<u64>,
         ) -> Result<bool, BackendError> {
+            assert!(!overlaps(
+                (start, end),
+                (
+                    Bound::Included(BACKEND_LOCK_RANGE.start),
+                    Bound::Excluded(BACKEND_LOCK_RANGE.end),
+                ),
+            ));
             assert!(
                 self.held
                     .lock()
@@ -3497,7 +3543,11 @@ mod lock_failure_test {
             }
             let expected = if taking == Answer::Acquired {
                 vec![
-                    (Bound::Excluded(SHARED_WRITER_BYTE), Bound::Unbounded),
+                    (Bound::Included(BACKEND_LOCK_RANGE.end), Bound::Unbounded),
+                    (
+                        Bound::Excluded(SHARED_WRITER_BYTE),
+                        Bound::Excluded(BACKEND_LOCK_RANGE.start),
+                    ),
                     (Bound::Unbounded, Bound::Included(SHARED_WRITER_BYTE)),
                 ]
             } else {
@@ -3591,7 +3641,11 @@ mod lock_failure_test {
 
             let expected: Vec<(Bound<u64>, Bound<u64>)> = if taking == Answer::Acquired {
                 vec![
-                    (Bound::Excluded(SHARED_WRITER_BYTE), Bound::Unbounded),
+                    (Bound::Included(BACKEND_LOCK_RANGE.end), Bound::Unbounded),
+                    (
+                        Bound::Excluded(SHARED_WRITER_BYTE),
+                        Bound::Excluded(BACKEND_LOCK_RANGE.start),
+                    ),
                     (Bound::Unbounded, Bound::Included(SHARED_WRITER_BYTE)),
                 ]
             } else {
@@ -3604,7 +3658,7 @@ mod lock_failure_test {
     #[test]
     fn whole_storage_fallback_releases_partial_locks_and_skips_queries() {
         for read_only in [false, true] {
-            for partial_count in 0..=1 {
+            for partial_count in 0..=2 {
                 for answer in [
                     Answer::Acquired,
                     Answer::Refused,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -352,30 +352,6 @@ fn file_backend_lock_bounds_preserve_endpoints() {
 
 #[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
 #[test]
-fn file_backend_unbounded_lock_covers_growth() {
-    use std::ops::Bound::{Included, Unbounded};
-
-    let tmpfile = create_tempfile();
-    let backend = FileBackend::new(tmpfile.reopen().unwrap()).unwrap();
-    let peer = FileBackend::new(tmpfile.reopen().unwrap()).unwrap();
-    assert!(backend.try_lock_range(Included(100), Unbounded).unwrap());
-    backend.set_len(4096).unwrap();
-    for offset in [100, 4095, i64::MAX as u64] {
-        assert!(
-            !peer
-                .try_lock_range(Included(offset), Included(offset))
-                .unwrap()
-        );
-    }
-    assert!(peer.try_lock_range(Included(99), Included(99)).unwrap());
-    peer.unlock_range(Included(99), Included(99)).unwrap();
-    backend.unlock_range(Included(100), Unbounded).unwrap();
-    assert!(peer.try_lock_range(Included(4095), Included(4095)).unwrap());
-    peer.unlock_range(Included(4095), Included(4095)).unwrap();
-}
-
-#[cfg(any(target_os = "linux", target_vendor = "apple", windows))]
-#[test]
 fn file_backend_invalid_lock_bounds_leave_existing_locks_held() {
     use redb::BackendError;
     use std::ops::Bound::{Excluded, Included, Unbounded};


### PR DESCRIPTION
Windows lock queries temporarily acquire an exclusive range lock. Concurrent queries or nonblocking lock attempts can mistake that temporary lock for a persistent conflict.

Reserve `BASE + 896..BASE + 1024` for backend coordination, with the layout documented in `docs/design.md` and the constant kept internal. Core range locks leave these bytes free; only whole-storage fallback may lock them, and core queries never cover them. Document this guarantee in `StorageBackend`.

`FileBackend` uses `BASE + 896` for the Linux namespace probe and `BASE + 897` as the Windows query mutex. Queries hold the mutex while probing, and failed nonblocking acquisitions take it and retry before reporting a conflict. Successful acquisitions keep their fast path; whole-storage fallback bypasses this protocol. Internal coordination may wait, including when an older whole-file lock covers the query byte.

Validation:

- `just test`, including formatting, Clippy, and all-feature tests.
- Default-feature locking/FileBackend tests and 52 locking tests on i686 Linux.
- Standalone no_std runtime and locking API Rustdoc with warnings denied.
- Windows Clippy with default and all features, including the new concurrency tests. Native Windows execution is left to CI.
- 60-second fuzz smoke run: 26,598 executions without a failure.
- An injected stalled worker confirms that the concurrency test reports its timeout instead of hanging in `join()`.
