### PR TITLE
Keep aborted savepoint handles invalid across writer processes

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -640,6 +640,12 @@ write transaction, the writer reads the persistent savepoints out of the databas
 the highest savepoint id stored -- advancing its counter if needed -- and to discover the oldest
 transaction that must be kept for the persistent savepoints.
 
+The persistent savepoint counter is transactional, so another writer may reuse an id allocated
+by an aborted transaction. Each database handle assigns a monotonically increasing local id to
+each savepoint registration. A `Savepoint` handle retains that local id, which must match the
+current registration when it is restored. An aborted handle therefore stays invalid even if a
+replacement has the same persistent id and snapshot. These local ids are never stored in the file.
+
 ## Crashes
 
 The OS automatically releases file locks when a process crashes. No further recovery is required

--- a/src/db.rs
+++ b/src/db.rs
@@ -15,12 +15,10 @@ use crate::tree_store::{
 };
 use crate::types::{Key, Value};
 use crate::{
-    CompactionError, DatabaseError, ReadOnlyTable, ReadableTable, SavepointError, StorageError,
-    TableError,
+    CompactionError, DatabaseError, ReadOnlyTable, ReadableTable, StorageError, TableError,
 };
 use crate::{ReadTransaction, Result, WriteTransaction};
 use alloc::boxed::Box;
-use alloc::collections::BTreeMap;
 use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
@@ -1796,24 +1794,12 @@ fn sync_persistent_savepoints(
     if let Some(next_id) = txn.next_persistent_savepoint_id()? {
         transaction_tracker.restore_savepoint_counter_state(next_id);
     }
-    let mut current = BTreeMap::new();
-    for id in txn.list_persistent_savepoints()? {
-        let savepoint = match txn.get_persistent_savepoint(id) {
-            Ok(savepoint) => savepoint,
-            Err(err) => match err {
-                SavepointError::InvalidSavepoint
-                | SavepointError::ImmediateDurabilityRequired
-                | SavepointError::EphemeralSavepointUnsupported => unreachable!(),
-                SavepointError::Storage(storage) => {
-                    return Err(storage);
-                }
-            },
-        };
+    let current = txn.persistent_savepoint_transactions()?;
+    #[cfg(feature = "experimental-multiprocess")]
+    for &transaction_id in current.values() {
         // The file names its persistent savepoints, so the transaction each points at is
         // untrusted: one outside the lock range would be tracked as a read this process holds
-        #[cfg(feature = "experimental-multiprocess")]
-        mem.check_active_transaction_id(savepoint.get_transaction_id())?;
-        current.insert(savepoint.get_id(), savepoint.get_transaction_id());
+        mem.check_active_transaction_id(transaction_id)?;
     }
     transaction_tracker.sync_persistent_savepoints(&current)
 }

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -45,6 +45,15 @@ impl TransactionId {
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 pub(crate) struct SavepointId(pub u64);
 
+// Unique within one tracker, including across aborted transactions and peer ID reuse.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub(crate) struct LocalSavepointId(u64);
+
+struct SavepointRegistration {
+    local_id: LocalSavepointId,
+    transaction_id: TransactionId,
+}
+
 impl SavepointId {
     pub(crate) fn next(self) -> SavepointId {
         SavepointId(self.0 + 1)
@@ -103,13 +112,14 @@ enum WriteSlotState {
 
 struct State {
     next_savepoint_id: SavepointId,
+    next_local_savepoint_id: LocalSavepointId,
     // reference count of read transactions per transaction id
     live_read_transactions: BTreeMap<TransactionId, u64>,
     // Subset of live_read_transactions which are persistent savepoints
     persistent_savepoint_references: BTreeMap<TransactionId, u64>,
     next_transaction_id: TransactionId,
     write_slot: WriteSlotState,
-    valid_savepoints: BTreeMap<SavepointId, TransactionId>,
+    valid_savepoints: BTreeMap<SavepointId, SavepointRegistration>,
     // Subset of valid_savepoints that are persistent
     persistent_savepoints: BTreeSet<SavepointId>,
     // Non-durable commits that are still in-memory, and waiting for a durable commit to get flushed
@@ -127,6 +137,21 @@ struct State {
 }
 
 impl State {
+    fn register_savepoint(
+        &mut self,
+        id: SavepointId,
+        transaction_id: TransactionId,
+    ) -> LocalSavepointId {
+        let local_id = self.next_local_savepoint_id;
+        self.next_local_savepoint_id = LocalSavepointId(local_id.0.checked_add(1).unwrap());
+        let registration = SavepointRegistration {
+            local_id,
+            transaction_id,
+        };
+        assert!(self.valid_savepoints.insert(id, registration).is_none());
+        local_id
+    }
+
     // The references to `id` that are reads, which the "active transaction byte" announces to the
     // other processes. Persistent savepoints are excluded
     #[cfg(feature = "experimental-multiprocess")]
@@ -248,6 +273,7 @@ impl TransactionTracker {
         Self {
             state: Mutex::new(State {
                 next_savepoint_id: SavepointId(0),
+                next_local_savepoint_id: LocalSavepointId(0),
                 live_read_transactions: BTreeMap::default(),
                 persistent_savepoint_references: BTreeMap::default(),
                 next_transaction_id,
@@ -454,20 +480,20 @@ impl TransactionTracker {
         let gone: Vec<SavepointId> = state
             .persistent_savepoints
             .iter()
-            .filter(|id| !current.contains_key(id))
+            .filter(|id| current.get(id) != Some(&state.valid_savepoints[id].transaction_id))
             .copied()
             .collect();
         for id in gone {
             state.persistent_savepoints.remove(&id);
-            let transaction = state.valid_savepoints.remove(&id).unwrap();
-            state.dereference_persistent_savepoint(transaction);
+            let registration = state.valid_savepoints.remove(&id).unwrap();
+            state.dereference_persistent_savepoint(registration.transaction_id);
         }
         for (&id, &transaction) in current {
             if state.valid_savepoints.contains_key(&id) {
                 continue;
             }
             state.reference_persistent_savepoint(transaction);
-            assert!(state.valid_savepoints.insert(id, transaction).is_none());
+            state.register_savepoint(id, transaction);
             state.persistent_savepoints.insert(id);
         }
 
@@ -482,7 +508,7 @@ impl TransactionTracker {
         id: SavepointId,
     ) {
         let mut state = self.state.lock().unwrap();
-        let transaction = *state.valid_savepoints.get(&id).unwrap();
+        let transaction = state.valid_savepoints.get(&id).unwrap().transaction_id;
         state.persistent_savepoints.insert(id);
         state.convert_reference_to_persistent_savepoint(mem, transaction);
     }
@@ -550,12 +576,15 @@ impl TransactionTracker {
         false
     }
 
-    pub(crate) fn allocate_savepoint(&self, transaction_id: TransactionId) -> SavepointId {
+    pub(crate) fn allocate_savepoint(
+        &self,
+        transaction_id: TransactionId,
+    ) -> (SavepointId, LocalSavepointId) {
         let mut state = self.state.lock().unwrap();
         let id = state.next_savepoint_id.next();
         state.next_savepoint_id = id;
-        state.valid_savepoints.insert(id, transaction_id);
-        id
+        let local_id = state.register_savepoint(id, transaction_id);
+        (id, local_id)
     }
 
     // Forgets the savepoint, leaving the transaction's reference to whoever owns it
@@ -578,12 +607,13 @@ impl TransactionTracker {
             .dereference_persistent_savepoint(transaction);
     }
 
-    pub(crate) fn is_valid_savepoint(&self, id: SavepointId) -> bool {
+    pub(crate) fn savepoint_local_id(&self, id: SavepointId) -> Option<LocalSavepointId> {
         self.state
             .lock()
             .unwrap()
             .valid_savepoints
-            .contains_key(&id)
+            .get(&id)
+            .map(|registration| registration.local_id)
     }
 
     pub(crate) fn list_savepoints_after(&self, id: SavepointId) -> Vec<SavepointId> {
@@ -627,7 +657,7 @@ impl TransactionTracker {
             .valid_savepoints
             .iter()
             .find(|(id, _)| !exclude.contains(id))
-            .map(|(id, txn_id)| (*id, *txn_id))
+            .map(|(id, registration)| (*id, registration.transaction_id))
     }
 
     pub(crate) fn oldest_local_referenced_transaction(&self) -> Option<TransactionId> {
@@ -693,5 +723,37 @@ mod test {
             Some(TransactionId::new(2)),
             tracker.oldest_unprocessed_non_durable_commit()
         );
+    }
+
+    #[test]
+    fn syncing_a_reused_savepoint_id_replaces_its_identity_and_reference() {
+        let tracker = TransactionTracker::new(TransactionId::new(3));
+        let id = SavepointId(1);
+        let old_transaction = TransactionId::new(1);
+        let new_transaction = TransactionId::new(2);
+        tracker
+            .sync_persistent_savepoints(&[(id, old_transaction)].into())
+            .unwrap();
+        let old_local_id = tracker.savepoint_local_id(id).unwrap();
+
+        tracker
+            .sync_persistent_savepoints(&[(id, new_transaction)].into())
+            .unwrap();
+        let new_local_id = tracker.savepoint_local_id(id).unwrap();
+        assert_ne!(old_local_id, new_local_id);
+        assert_eq!(
+            tracker.oldest_local_referenced_transaction(),
+            Some(new_transaction)
+        );
+
+        tracker
+            .sync_persistent_savepoints(&[(id, new_transaction)].into())
+            .unwrap();
+        assert_eq!(tracker.savepoint_local_id(id), Some(new_local_id));
+        tracker
+            .sync_persistent_savepoints(&BTreeMap::new())
+            .unwrap();
+        assert_eq!(tracker.oldest_local_referenced_transaction(), None);
+        assert_eq!(tracker.savepoint_local_id(id), None);
     }
 }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -6,7 +6,9 @@ use crate::multimap_table::ReadOnlyUntypedMultimapTable;
 use crate::sealed::Sealed;
 use crate::sync::Mutex;
 use crate::table::ReadOnlyUntypedTable;
-use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker};
+use crate::transaction_tracker::{
+    LocalSavepointId, SavepointId, TransactionId, TransactionTracker,
+};
 #[cfg(feature = "experimental-multiprocess")]
 use crate::tree_store::HeaderGuard;
 #[cfg(all(debug_assertions, not(redb_no_std)))]
@@ -1147,6 +1149,9 @@ impl WriteTransaction {
     /// This savepoint will exist until it is deleted with
     /// [`delete_persistent_savepoint()`](Self::delete_persistent_savepoint).
     ///
+    /// If this transaction is aborted, the savepoint and any handles obtained for it become
+    /// invalid.
+    ///
     /// Note that while a savepoint exists, pages that become unused after it was created are not freed.
     /// Therefore, the lifetime of a savepoint should be minimized.
     ///
@@ -1207,6 +1212,22 @@ impl WriteTransaction {
         Ok(value)
     }
 
+    // Read registrations without creating handles: the tracker may not have synced them yet.
+    pub(crate) fn persistent_savepoint_transactions(
+        &self,
+    ) -> Result<BTreeMap<SavepointId, TransactionId>> {
+        Ok(self
+            .read_existing_system_table(SAVEPOINT_TABLE, |table| {
+                let mut savepoints = BTreeMap::new();
+                for entry in table.range::<RangeFull, SavepointId>(&..)? {
+                    let (id, transaction_id) = entry?.value().get_ids()?;
+                    savepoints.insert(id, transaction_id);
+                }
+                Ok(savepoints)
+            })?
+            .unwrap_or_default())
+    }
+
     /// Get a persistent savepoint given its id
     pub fn get_persistent_savepoint(&self, id: u64) -> Result<Savepoint, SavepointError> {
         let Some(value) = self.read_existing_system_table(SAVEPOINT_TABLE, |table| {
@@ -1241,10 +1262,8 @@ impl WriteTransaction {
         }
         let mut table = system_tables.open_system_table(SAVEPOINT_TABLE)?;
         // Parse before removing, so that a corrupted record errors out without staging any change
-        let savepoint = if let Some(serialized) = table.get(SavepointId(id))? {
-            serialized
-                .value()
-                .to_savepoint(self.transaction_tracker.clone())?
+        let (savepoint_id, transaction_id) = if let Some(serialized) = table.get(SavepointId(id))? {
+            serialized.value().get_ids()?
         } else {
             return Ok(false);
         };
@@ -1252,7 +1271,7 @@ impl WriteTransaction {
         self.savepoint_state
             .lock()
             .unwrap()
-            .record_deleted(savepoint.get_id(), savepoint.get_transaction_id());
+            .record_deleted(savepoint_id, transaction_id);
         Ok(true)
     }
 
@@ -1271,14 +1290,14 @@ impl WriteTransaction {
         Ok(savepoints.into_iter())
     }
 
-    fn allocate_savepoint(&self) -> Result<(SavepointId, TransactionGuard)> {
+    fn allocate_savepoint(&self) -> Result<(SavepointId, LocalSavepointId, TransactionGuard)> {
         // Through the guard, so the savepoint's snapshot is held active like any other reader's
         let (transaction, _) =
             TransactionGuard::allocate_read(self.transaction_tracker.clone(), &self.mem)?;
-        let id = self
+        let (id, local_id) = self
             .transaction_tracker
             .allocate_savepoint(transaction.id());
-        Ok((id, transaction))
+        Ok((id, local_id, transaction))
     }
 
     /// Creates a snapshot of the current database state, which can be used to rollback the database
@@ -1309,7 +1328,7 @@ impl WriteTransaction {
         // allocation tracking -- leaving a live savepoint with tracking `Ignore`d. A later
         // `restore_savepoint()` would then fail to free this transaction's pages, leaking them
         // (reclaimed only by a full repair).
-        let (id, transaction) = {
+        let (id, local_id, transaction) = {
             let _tables = self.tables.lock().unwrap();
             if self.dirty.load(Ordering::Acquire) {
                 return Err(SavepointError::InvalidSavepoint);
@@ -1323,7 +1342,7 @@ impl WriteTransaction {
         );
 
         let root = self.mem.get_data_root();
-        let savepoint = Savepoint::new_ephemeral(&self.mem, id, transaction, root);
+        let savepoint = Savepoint::new_ephemeral(&self.mem, id, local_id, transaction, root);
 
         Ok(savepoint)
     }
@@ -1342,15 +1361,15 @@ impl WriteTransaction {
             return Err(SavepointError::InvalidSavepoint);
         }
 
-        if !self
+        let local_id = self
             .transaction_tracker
-            .is_valid_savepoint(savepoint.get_id())
-            || self
-                .savepoint_state
-                .lock()
-                .unwrap()
-                .is_invalidated(savepoint.get_id())
-        {
+            .savepoint_local_id(savepoint.get_id());
+        let invalidated = self
+            .savepoint_state
+            .lock()
+            .unwrap()
+            .is_invalidated(savepoint.get_id());
+        if local_id != Some(savepoint.get_local_id()) || invalidated {
             return Err(SavepointError::InvalidSavepoint);
         }
 
@@ -2742,6 +2761,12 @@ impl Drop for WriteTransaction {
             assert!(crate::panicking());
             self.mem.mark_needs_repair();
         }
+        // A failed commit or panic may skip abort_inner(). Retire any remaining registrations
+        // before releasing the writer lock, since peers can reuse their persistent IDs.
+        self.savepoint_state
+            .lock()
+            .unwrap()
+            .apply_on_abort(&self.transaction_tracker);
     }
 }
 

--- a/src/tree_store/page_store/savepoint.rs
+++ b/src/tree_store/page_store/savepoint.rs
@@ -1,5 +1,7 @@
 use crate::db::TransactionGuard;
-use crate::transaction_tracker::{SavepointId, TransactionId, TransactionTracker};
+use crate::transaction_tracker::{
+    LocalSavepointId, SavepointId, TransactionId, TransactionTracker,
+};
 use crate::tree_store::page_store::page_manager::FILE_FORMAT_VERSION3;
 use crate::tree_store::{BtreeHeader, TransactionalMemory};
 use crate::{Result, StorageError, TypeName, Value};
@@ -27,6 +29,7 @@ use core::mem::size_of;
 pub struct Savepoint {
     version: u8,
     id: SavepointId,
+    local_id: LocalSavepointId,
     // Each savepoint has an associated read transaction id to ensure that any pages it references
     // are not freed
     transaction: TransactionGuard,
@@ -37,11 +40,13 @@ impl Savepoint {
     pub(crate) fn new_ephemeral(
         mem: &TransactionalMemory,
         id: SavepointId,
+        local_id: LocalSavepointId,
         transaction: TransactionGuard,
         user_root: Option<BtreeHeader>,
     ) -> Self {
         Self {
             id,
+            local_id,
             version: mem.get_version(),
             transaction,
             user_root,
@@ -54,6 +59,10 @@ impl Savepoint {
 
     pub(crate) fn get_id(&self) -> SavepointId {
         self.id
+    }
+
+    pub(crate) fn get_local_id(&self) -> LocalSavepointId {
+        self.local_id
     }
 
     pub(crate) fn get_transaction_id(&self) -> TransactionId {
@@ -92,6 +101,13 @@ pub(crate) enum SerializedSavepoint<'a> {
     Owned(Vec<u8>),
 }
 
+struct PersistentSavepoint {
+    version: u8,
+    id: SavepointId,
+    transaction_id: TransactionId,
+    user_root: Option<BtreeHeader>,
+}
+
 impl SerializedSavepoint<'_> {
     pub(crate) fn from_savepoint(savepoint: &Savepoint) -> Self {
         assert_eq!(savepoint.version, FILE_FORMAT_VERSION3);
@@ -121,6 +137,30 @@ impl SerializedSavepoint<'_> {
         &self,
         transaction_tracker: Arc<TransactionTracker>,
     ) -> Result<Savepoint> {
+        let savepoint = self.parse()?;
+        let local_id = transaction_tracker
+            .savepoint_local_id(savepoint.id)
+            .ok_or_else(|| {
+                StorageError::Corrupted("Unregistered persistent savepoint".to_string())
+            })?;
+        Ok(Savepoint {
+            version: savepoint.version,
+            id: savepoint.id,
+            local_id,
+            user_root: savepoint.user_root,
+            transaction: TransactionGuard::new_read_unowned(
+                savepoint.transaction_id,
+                transaction_tracker,
+            ),
+        })
+    }
+
+    pub(crate) fn get_ids(&self) -> Result<(SavepointId, TransactionId)> {
+        let savepoint = self.parse()?;
+        Ok((savepoint.id, savepoint.transaction_id))
+    }
+
+    fn parse(&self) -> Result<PersistentSavepoint> {
         let data = self.data();
         let serialized_len =
             2 * size_of::<u8>() + 2 * size_of::<u64>() + BtreeHeader::serialized_size();
@@ -171,14 +211,11 @@ impl SerializedSavepoint<'_> {
         offset += BtreeHeader::serialized_size();
         debug_assert_eq!(offset, data.len());
 
-        Ok(Savepoint {
+        Ok(PersistentSavepoint {
             version,
             id: SavepointId(id),
             user_root,
-            transaction: TransactionGuard::new_read_unowned(
-                TransactionId::new(transaction_id),
-                transaction_tracker,
-            ),
+            transaction_id: TransactionId::new(transaction_id),
         })
     }
 }
@@ -225,6 +262,9 @@ mod test {
     #[test]
     fn corrupted_record_errors() {
         let tracker = Arc::new(TransactionTracker::new(TransactionId::new(1)));
+        tracker
+            .sync_persistent_savepoints(&[(SavepointId(1), TransactionId::new(1))].into())
+            .unwrap();
 
         let mut record = vec![FILE_FORMAT_VERSION3];
         record.extend(1u64.to_le_bytes());

--- a/tests/multiprocess_tests.rs
+++ b/tests/multiprocess_tests.rs
@@ -548,6 +548,85 @@ mod peer_commits {
         db.compact().unwrap();
     }
 
+    #[test]
+    fn an_aborted_savepoint_is_not_revived_by_a_peer() {
+        check_abandoned_savepoint(|txn| txn.abort().unwrap());
+    }
+
+    #[test]
+    fn a_dropped_transactions_savepoint_is_not_revived_by_a_peer() {
+        check_abandoned_savepoint(drop);
+    }
+
+    #[test]
+    fn a_panicked_transactions_savepoint_is_not_revived_by_a_peer() {
+        check_abandoned_savepoint(|txn| {
+            let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _txn = txn;
+                panic!("unwinding through the transaction");
+            }));
+            assert!(unwound.is_err());
+        });
+    }
+
+    fn check_abandoned_savepoint(abandon: impl Fn(redb::WriteTransaction)) {
+        for advance_snapshot in [false, true] {
+            let tmpfile = tempfile::NamedTempFile::new().unwrap();
+            let (mut db, peer) = two_handles(tmpfile.path());
+            insert(&db, 0);
+
+            let txn = db.begin_write().unwrap();
+            let id = txn.persistent_savepoint().unwrap();
+            let stale = txn.get_persistent_savepoint(id).unwrap();
+            abandon(txn);
+
+            if advance_snapshot {
+                insert(&peer, 1);
+            }
+            let txn = peer.begin_write().unwrap();
+            assert_eq!(txn.persistent_savepoint().unwrap(), id);
+            txn.commit().unwrap();
+
+            let mut txn = db.begin_write().unwrap();
+            assert!(matches!(
+                txn.restore_savepoint(&stale),
+                Err(redb::SavepointError::InvalidSavepoint)
+            ));
+            let replacement = txn.get_persistent_savepoint(id).unwrap();
+            let another_handle = txn.get_persistent_savepoint(id).unwrap();
+            txn.abort().unwrap();
+            drop(stale);
+
+            // Unchanged registrations retain their identity across peer commits and lookups.
+            insert(&peer, 2);
+            let mut txn = db.begin_write().unwrap();
+            txn.restore_savepoint(&replacement).unwrap();
+            txn.restore_savepoint(&another_handle).unwrap();
+            txn.commit().unwrap();
+            {
+                let read = peer.begin_read().unwrap();
+                let table = read.open_table(TABLE).unwrap();
+                assert_eq!(table.get(0).unwrap().unwrap().value(), 0);
+                assert_eq!(table.get(1).unwrap().is_some(), advance_snapshot);
+                assert!(table.get(2).unwrap().is_none());
+            }
+
+            let txn = peer.begin_write().unwrap();
+            assert!(txn.delete_persistent_savepoint(id).unwrap());
+            txn.commit().unwrap();
+            let mut txn = db.begin_write().unwrap();
+            assert!(matches!(
+                txn.restore_savepoint(&replacement),
+                Err(redb::SavepointError::InvalidSavepoint)
+            ));
+            txn.abort().unwrap();
+            drop(replacement);
+            drop(another_handle);
+            db.compact().unwrap();
+            assert!(db.check_integrity().unwrap());
+        }
+    }
+
     /// When the close's commit cannot sync to the file's latest commit, the close writes no
     /// shutdown header. Writing one would put this handle's stale header, marked clean, over
     /// that commit.


### PR DESCRIPTION
A `Savepoint` handle can outlive the aborted transaction that created its persistent savepoint. In `MultiWriterProcess`, a peer can reuse that persistent ID, making the stale handle valid again and allowing it to restore an obsolete snapshot that loses committed data.

Assign each savepoint registration a monotonically increasing local ID and validate it on restore. Unchanged registrations retain their identity across peer commits; replacements receive a fresh identity and the correct snapshot reference. Transaction drop retires unfinished registrations, including after a panic or failed commit. Public savepoint IDs and the file format are unchanged.

Regressions cover explicit abort, ordinary drop, and panic unwinding, with replacements at both the same and a newer snapshot. They also verify that valid handles survive repeated lookups and peer commits, and that deletion releases their references. The API and design docs describe the behavior.

Validation passed:

- `just test` (including all 25 multiprocess integration tests).
- 60-second transaction/savepoint fuzz smoke test: 27,091 runs without a failure.
- `no_std` compile with warnings denied.
- Both original audit reproducers now reject stale handles with `InvalidSavepoint`.
