### PR TITLE
Keep local multi-writer commits in the read cache

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -3725,6 +3725,36 @@ mod active_transaction_test {
         }
     }
 
+    #[cfg(feature = "cache_metrics")]
+    #[test]
+    fn a_multi_writer_commit_keeps_its_read_cache() {
+        use crate::ReadableTable;
+
+        let tmpfile = crate::create_tempfile();
+        let db = create(tmpfile.path(), ConcurrencyMode::MultiWriter);
+        {
+            let read = db.begin_read().unwrap();
+            assert_eq!(
+                read.open_table(TABLE)
+                    .unwrap()
+                    .get(0)
+                    .unwrap()
+                    .unwrap()
+                    .value(),
+                0
+            );
+        }
+
+        let write = db.begin_write().unwrap();
+        write.open_table(TABLE).unwrap().insert(1, 1).unwrap();
+        write.commit().unwrap();
+        let cached_bytes = db.cache_stats().used_bytes();
+        assert!(cached_bytes > 0);
+
+        let _read = db.begin_read().unwrap();
+        assert_eq!(db.cache_stats().used_bytes(), cached_bytes);
+    }
+
     /// A savepoint holds a read transaction live, so its snapshot stays active for as long as
     /// the savepoint does. In the shared mode that supports an ephemeral one
     #[test]

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -785,6 +785,12 @@ impl PagedCachedFile {
         }
     }
 
+    // The caller holds the header lock across publishing this local commit and updating the tag.
+    #[cfg(feature = "experimental-multiprocess")]
+    pub(super) fn record_local_transaction_id(&self, transaction_id: TransactionId) {
+        *self.read_cache_transaction_id.lock().unwrap() = Some(transaction_id);
+    }
+
     pub(super) fn invalidate_cache_all(&self) {
         for cache_slot in 0..self.read_cache.len() {
             let mut lock = self.read_cache[cache_slot].write().unwrap();

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1847,6 +1847,11 @@ impl TransactionalMemory {
                 #[cfg(feature = "experimental-multiprocess")]
                 &hold,
             )?;
+            #[cfg(feature = "experimental-multiprocess")]
+            if self.concurrency_mode == ConcurrencyMode::MultiWriter {
+                // Writes invalidate the pages they replace, so retained pages remain valid.
+                self.storage.record_local_transaction_id(transaction_id);
+            }
         }
         self.storage.flush()?;
 


### PR DESCRIPTION
A `MultiWriter` handle advanced the file transaction ID on commit without updating its read-cache tag. The next `begin_read()` treated the handle's own commit like a peer commit and discarded the entire warm cache.

Record the local transaction ID while publishing the final header. Rewritten pages are already invalidated individually, so retained pages remain valid for the new snapshot.

The regression test warms the cache, commits through the same handle, and verifies that the next read retains the cached pages.

Test: `just test`
